### PR TITLE
Fix repo url in rush config

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -17,7 +17,7 @@
   "gitPolicy": {},
   "repository": {
     "defaultBranch": "main",
-    "url": "https://github.com/Microsoft/cadl"
+    "url": "https://github.com/microsoft/cadl"
   },
   /**
    * Event hooks are customized script actions that Rush executes when specific events occur


### PR DESCRIPTION
Tiny PR to fix the URL for the repository in `rush.json`.