### PR TITLE
Set shared param definitions in components.parameters

### DIFF
--- a/common/changes/@cadl-lang/openapi3/fix-openapi3-ref-params_2021-10-23-21-25.json
+++ b/common/changes/@cadl-lang/openapi3/fix-openapi3-ref-params_2021-10-23-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Set shared param definitions in components.parameters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -699,6 +699,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     for (const [property, param] of params) {
       const key = getParameterKey(property, param);
 
+      root.components.parameters[key] = { ...param };
+
       for (const key of Object.keys(param)) {
         delete param[key];
       }

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -370,6 +370,17 @@
     }
   },
   "components": {
+    "parameters": {
+      "SetSignIdForKioskIdsRequest.sign_id": {
+        "name": "sign_id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "schemas": {
       "Kiosk": {
         "type": "object",

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -334,6 +334,97 @@
     }
   },
   "components": {
+    "parameters": {
+      "GetShelfRequest": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the shelf to retrieve.",
+        "schema": {
+          "type": "string",
+          "pattern": "shelves/\\w+"
+        }
+      },
+      "ListRequestBase.page_size": {
+        "name": "page_size",
+        "in": "query",
+        "required": false,
+        "description": "Requested page size. Server may return fewer shelves than requested.\nIf unspecified, server will pick an appropriate default.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "ListRequestBase.page_token": {
+        "name": "page_token",
+        "in": "query",
+        "required": false,
+        "description": "A token identifying a page of results the server should return.\nTypically, this is the value of\n[ListShelvesResponse.next_page_token][google.example.library.v1.ListShelvesResponse.next_page_token]\nreturned from the previous call to `ListShelves` method.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DeleteShelfRequest": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the shelf to delete.",
+        "schema": {
+          "type": "string",
+          "pattern": "shelves/\\w+"
+        }
+      },
+      "MergeShelvesRequest.name": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the shelf we're adding books to.",
+        "schema": {
+          "type": "string",
+          "pattern": "shelves/\\w+"
+        }
+      },
+      "CreateBookRequest.name": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the shelf in which the book is created.",
+        "schema": {
+          "type": "string",
+          "pattern": "shelves/\\w+"
+        }
+      },
+      "GetBookRequest": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the book to retrieve.",
+        "schema": {
+          "type": "string",
+          "pattern": "shelves/\\w+/books/\\w+"
+        }
+      },
+      "ListBooksRequest.name": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the shelf whose books we'd like to list.",
+        "schema": {
+          "type": "string",
+          "pattern": "shelves/\\w+"
+        }
+      },
+      "DeleteBookRequest": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the book to delete.",
+        "schema": {
+          "type": "string",
+          "pattern": "shelves/\\w+/books/\\w+"
+        }
+      }
+    },
     "schemas": {
       "Shelf": {
         "type": "object",

--- a/packages/samples/test/output/param-decorators/openapi.json
+++ b/packages/samples/test/output/param-decorators/openapi.json
@@ -72,6 +72,18 @@
     }
   },
   "components": {
+    "parameters": {
+      "NameParameter": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "Name parameter",
+        "schema": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9-]{3,24}$"
+        }
+      }
+    },
     "schemas": {
       "Thing": {
         "type": "object",

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -207,6 +207,17 @@
     }
   },
   "components": {
+    "parameters": {
+      "PetId": {
+        "name": "petId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "schemas": {
       "Error": {
         "type": "object",


### PR DESCRIPTION
This PR fixes a bug in the openapi3 generator that left out the shared parameter definitions that need to be generated into `components.parameters`.