### PR TITLE
Fix param default to be in schema

### DIFF
--- a/common/changes/@cadl-lang/openapi3/fix-param-default_2021-10-24-14-03.json
+++ b/common/changes/@cadl-lang/openapi3/fix-param-default_2021-10-24-14-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Fix param default to be in schema",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -683,14 +683,13 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     ph.required = !param.optional;
     ph.description = getDoc(program, param);
 
-    if (param.default) {
-      ph.default = getDefaultValue(param.default);
-    }
-
     // Apply decorators to the schema for the parameter.
     let schema = applyIntrinsicDecorators(param, getSchemaForType(param.type));
     if (param.type.kind === "Array") {
       schema.items = getSchemaForType(param.type.elementType);
+    }
+    if (param.default) {
+      schema.default = getDefaultValue(param.default);
     }
     ph.schema = schema;
   }

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -410,7 +410,7 @@ describe("openapi3: operations", () => {
       `
     );
 
-    deepStrictEqual(res.paths["/"].get.parameters[0].default, "defaultValue");
+    deepStrictEqual(res.paths["/"].get.parameters[0].schema.default, "defaultValue");
   });
 
   it("define operations with param with decorators", async () => {

--- a/packages/samples/test/output/optional/openapi.json
+++ b/packages/samples/test/output/optional/openapi.json
@@ -19,9 +19,9 @@
             "name": "queryString",
             "in": "query",
             "required": false,
-            "default": "defaultQueryString",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": "defaultQueryString"
             }
           }
         ],


### PR DESCRIPTION
This PR fixes the generation of `default` values for parameters, which must be in the `schema` in OpenAPI v3.