### PR TITLE
Define response body for primitive response type

### DIFF
--- a/common/changes/@cadl-lang/openapi3/primitive-response-bodies_2021-10-24-15-58.json
+++ b/common/changes/@cadl-lang/openapi3/primitive-response-bodies_2021-10-24-15-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Define response body for primitive response type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -392,19 +392,31 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   }
 
   function emitResponseObject(responseModel: Type, statusCode: string = "200") {
+    let contentType = "application/json";
     if (
       responseModel.kind === "Model" &&
       !responseModel.baseModel &&
       responseModel.properties.size === 0
     ) {
-      currentEndpoint.responses[204] = {
-        description: "No content",
-      };
+      const schema = mapCadlTypeToOpenAPI(responseModel);
+      if (schema) {
+        currentEndpoint.responses[statusCode] = {
+          description: getResponseDescription(responseModel, statusCode),
+          content: {
+            [contentType]: {
+              schema: schema,
+            },
+          },
+        };
+      } else {
+        currentEndpoint.responses[204] = {
+          description: "No content",
+        };
+      }
 
       return;
     }
 
-    let contentType = "application/json";
     let contentEntry: any = {};
     let headers: any = {};
 

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -465,6 +465,24 @@ describe("openapi3: responses", () => {
     ok(res.paths["/"].get.responses["200"].headers);
     ok(res.paths["/"].get.responses["200"].headers["e-tag"]);
   });
+
+  it("defines responses with primitive types", async () => {
+    const res = await openApiFor(
+      `
+      @resource("/")
+      namespace root {
+        @get()
+        op read(): string;
+      }
+      `
+    );
+    ok(res.paths["/"].get.responses["200"]);
+    ok(res.paths["/"].get.responses["200"].content);
+    strictEqual(
+      res.paths["/"].get.responses["200"].content["application/json"].schema.type,
+      "string"
+    );
+  });
 });
 
 async function oapiForModel(name: string, modelDef: string) {

--- a/packages/samples/test/output/nested/openapi.json
+++ b/packages/samples/test/output/nested/openapi.json
@@ -34,8 +34,15 @@
         "operationId": "SubB_DoSomething",
         "parameters": [],
         "responses": {
-          "204": {
-            "description": "No content"
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -120,8 +120,15 @@
         "summary": "Set Boolean value false",
         "parameters": [],
         "responses": {
-          "204": {
-            "description": "No content"
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
           },
           "default": {
             "description": "Error",
@@ -154,6 +161,16 @@
         "summary": "Get null Boolean value",
         "parameters": [],
         "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
           "204": {
             "description": "No content"
           },
@@ -176,8 +193,15 @@
         "summary": "Get invalid Boolean value",
         "parameters": [],
         "responses": {
-          "204": {
-            "description": "No content"
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
           },
           "default": {
             "description": "Error",


### PR DESCRIPTION
This PR adds support to the openapi3 emitter for operations that return a primitive type e.g. `string` or `int32`.