### PR TITLE
[WIP] OrderedMap 

### DIFF
--- a/packages/compiler/core/util.ts
+++ b/packages/compiler/core/util.ts
@@ -323,15 +323,15 @@ class CaseInsensitiveMap<T> extends Map<string, T> {
   }
 }
 
-interface OrderedMapKey {
-  key: string;
+interface OrderedMapKey<K> {
+  key: K;
 }
 
-export class OrderedMap<V> implements Map<string, V> {
-  #keys = new Map<string, OrderedMapKey>();
-  #values = new Map<OrderedMapKey, V>();
+export class OrderedMap<K, V> implements Map<K, V> {
+  #keys = new Map<K, OrderedMapKey<K>>();
+  #values = new Map<OrderedMapKey<K>, V>();
 
-  constructor(entries?: [string, V][]) {
+  constructor(entries?: [K, V][]) {
     if (entries) {
       for (const [key, value] of entries) {
         this.set(key, value);
@@ -344,7 +344,7 @@ export class OrderedMap<V> implements Map<string, V> {
     this.#values.clear();
   }
 
-  delete(key: string): boolean {
+  delete(key: K): boolean {
     const keyItem = this.#keys.get(key);
     if (keyItem) {
       this.#keys.delete(key);
@@ -353,22 +353,22 @@ export class OrderedMap<V> implements Map<string, V> {
     return false;
   }
 
-  forEach(callbackfn: (value: V, key: string, map: Map<string, V>) => void, thisArg?: any): void {
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void {
     this.#values.forEach((value, keyItem, map) => {
       callbackfn(value, keyItem.key, this);
     }, thisArg);
   }
-  get(key: string): V | undefined {
+  get(key: K): V | undefined {
     const keyItem = this.#keys.get(key);
     return keyItem ? this.#values.get(keyItem) : undefined;
   }
 
-  has(key: string): boolean {
+  has(key: K): boolean {
     const keyItem = this.#keys.get(key);
     return keyItem ? this.#values.has(keyItem) : false;
   }
 
-  set(key: string, value: V): this {
+  set(key: K, value: V): this {
     let keyItem = this.#keys.get(key);
     if (keyItem === undefined) {
       keyItem = { key };
@@ -383,13 +383,13 @@ export class OrderedMap<V> implements Map<string, V> {
     return this.#values.size;
   }
 
-  *entries(): IterableIterator<[string, V]> {
+  *entries(): IterableIterator<[K, V]> {
     for (const [k, v] of this.#values) {
       yield [k.key, v];
     }
   }
 
-  *keys(): IterableIterator<string> {
+  *keys(): IterableIterator<K> {
     for (const k of this.#values.keys()) {
       yield k.key;
     }
@@ -399,7 +399,7 @@ export class OrderedMap<V> implements Map<string, V> {
     return this.#values.values();
   }
 
-  [Symbol.iterator](): IterableIterator<[string, V]> {
+  [Symbol.iterator](): IterableIterator<[K, V]> {
     return this.entries();
   }
   [Symbol.toStringTag] = "OrderedMap";
@@ -410,7 +410,7 @@ export class OrderedMap<V> implements Map<string, V> {
    * @param newKey New key
    * @returns boolean if updated successfully.
    */
-  updateKey(existingKey: string, newKey: string): boolean {
+  updateKey(existingKey: K, newKey: K): boolean {
     const keyItem = this.#keys.get(existingKey);
     if (!keyItem) {
       return false;

--- a/packages/compiler/core/util.ts
+++ b/packages/compiler/core/util.ts
@@ -383,17 +383,22 @@ export class OrderedMap<V> implements Map<string, V> {
     return this.#values.size;
   }
 
-  entries(): IterableIterator<[string, V]> {
-    return [...this.#values.entries()].map(([k, v]) => [k.key, v])[Symbol.iterator]() as any;
+  *entries(): IterableIterator<[string, V]> {
+    for (const [k, v] of this.#values) {
+      yield [k.key, v];
+    }
   }
 
-  keys(): IterableIterator<string> {
-    return [...this.#values.keys()].map((x) => x.key)[Symbol.iterator]();
+  *keys(): IterableIterator<string> {
+    for (const k of this.#values.keys()) {
+      yield k.key;
+    }
   }
 
   values(): IterableIterator<V> {
     return this.#values.values();
   }
+
   [Symbol.iterator](): IterableIterator<[string, V]> {
     return this.entries();
   }

--- a/packages/compiler/core/util.ts
+++ b/packages/compiler/core/util.ts
@@ -409,6 +409,7 @@ export class OrderedMap<V> implements Map<string, V> {
       return false;
     }
     this.#keys.delete(existingKey);
+    keyItem.key = newKey;
     this.#keys.set(newKey, keyItem);
     return true;
   }

--- a/packages/compiler/core/util.ts
+++ b/packages/compiler/core/util.ts
@@ -331,9 +331,11 @@ export class OrderedMap<V> implements Map<string, V> {
   #keys = new Map<string, OrderedMapKey>();
   #values = new Map<OrderedMapKey, V>();
 
-  constructor(entries: [string, V][]) {
-    for (const [key, value] of entries) {
-      this.set(key, value);
+  constructor(entries?: [string, V][]) {
+    if (entries) {
+      for (const [key, value] of entries) {
+        this.set(key, value);
+      }
     }
   }
 

--- a/packages/compiler/test/util.test.ts
+++ b/packages/compiler/test/util.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "assert";
+import { deepStrictEqual } from "assert";
 import { OrderedMap } from "../core/util.js";
 
 describe("compiler: util", () => {

--- a/packages/compiler/test/util.test.ts
+++ b/packages/compiler/test/util.test.ts
@@ -1,0 +1,63 @@
+import { strictEqual } from "assert";
+import { OrderedMap } from "../core/util.js";
+
+describe("compiler: util", () => {
+  describe("OrderedMap", () => {
+    it("contrstruct map in order", () => {
+      const map = new OrderedMap([
+        ["a", "pos 1"],
+        ["b", "pos 2"],
+        ["c", "pos 3"],
+      ]);
+
+      strictEqual(
+        [...map.entries()],
+        [
+          ["a", "pos 1"],
+          ["b", "pos 2"],
+          ["c", "pos 3"],
+        ]
+      );
+    });
+
+    it("add new items at the end", () => {
+      const map = new OrderedMap([
+        ["a", "pos 1"],
+        ["b", "pos 2"],
+        ["c", "pos 3"],
+      ]);
+
+      map.set("aa", "pos 4");
+      strictEqual(
+        [...map.entries()],
+        [
+          ["a", "pos 1"],
+          ["b", "pos 2"],
+          ["c", "pos 3"],
+          ["aa", "pos 4"],
+        ]
+      );
+    });
+
+    it("keep order when renaming keys", () => {
+      const map = new OrderedMap([
+        ["a", "pos 1"],
+        ["b", "pos 2"],
+        ["c", "pos 3"],
+        ["d", "pos 4"],
+      ]);
+
+      map.updateKey("b", "renamed");
+
+      strictEqual(
+        [...map.entries()],
+        [
+          ["a", "pos 1"],
+          ["renamed", "pos 2"],
+          ["c", "pos 3"],
+          ["d", "pos 4"],
+        ]
+      );
+    });
+  });
+});

--- a/packages/compiler/test/util.test.ts
+++ b/packages/compiler/test/util.test.ts
@@ -21,7 +21,7 @@ describe("compiler: util", () => {
     });
 
     describe("set() should add items at the end", () => {
-      let map: OrderedMap<string>;
+      let map: OrderedMap<string, string>;
       beforeEach(() => {
         map = new OrderedMap([
           ["a", "pos 1"],

--- a/packages/compiler/test/util.test.ts
+++ b/packages/compiler/test/util.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from "assert";
+import { deepStrictEqual, strictEqual } from "assert";
 import { OrderedMap } from "../core/util.js";
 
 describe("compiler: util", () => {
@@ -10,7 +10,7 @@ describe("compiler: util", () => {
         ["c", "pos 3"],
       ]);
 
-      strictEqual(
+      deepStrictEqual(
         [...map.entries()],
         [
           ["a", "pos 1"],
@@ -20,23 +20,35 @@ describe("compiler: util", () => {
       );
     });
 
-    it("add new items at the end", () => {
-      const map = new OrderedMap([
-        ["a", "pos 1"],
-        ["b", "pos 2"],
-        ["c", "pos 3"],
-      ]);
-
-      map.set("aa", "pos 4");
-      strictEqual(
-        [...map.entries()],
-        [
+    describe("set() should add items at the end", () => {
+      let map: OrderedMap<string>;
+      beforeEach(() => {
+        map = new OrderedMap([
           ["a", "pos 1"],
           ["b", "pos 2"],
           ["c", "pos 3"],
-          ["aa", "pos 4"],
-        ]
-      );
+        ]);
+        map.set("aa", "pos 4");
+      });
+      it("entries() return items in order", () => {
+        deepStrictEqual(
+          [...map.entries()],
+          [
+            ["a", "pos 1"],
+            ["b", "pos 2"],
+            ["c", "pos 3"],
+            ["aa", "pos 4"],
+          ]
+        );
+      });
+
+      it("keys() return keys in order", () => {
+        deepStrictEqual([...map.keys()], ["a", "b", "c", "aa"]);
+      });
+
+      it("values() return values in order", () => {
+        deepStrictEqual([...map.values()], ["pos 1", "pos 2", "pos 3", "pos 4"]);
+      });
     });
 
     it("keep order when renaming keys", () => {
@@ -49,7 +61,7 @@ describe("compiler: util", () => {
 
       map.updateKey("b", "renamed");
 
-      strictEqual(
+      deepStrictEqual(
         [...map.entries()],
         [
           ["a", "pos 1"],


### PR DESCRIPTION
fix #970


Work in progress of making a custom map that support renaming keys without loosing order. This would unlock the ability to keep properties, memebers in order in projections


## Benchmark
Does seem to take a bit of a hit, my guess is the` #value` is much less efficient with object keys than string keys

```
Time Map 329
Time OrderedMap 1222
```

code used
```ts
function time(name: string, callback: () => void) {
      const start = new Date().getTime();
      callback();
      const end = new Date().getTime();
      console.log(`Time ${name}`, end - start);
    }
    function runBenchmark(map: Map<string, string>) {
      for (let i = 0; i < 10000; i++) {
        const key = i.toString();
        map.set(key, key);
      }
    }
    time("Map", () => {
      for (let i = 0; i < 1000; i++) {
        runBenchmark(new Map<string, string>());
      }
    });
    time("OrderedMap", () => {
      for (let i = 0; i < 1000; i++) {
        runBenchmark(new OrderedMap<string>());
      }
    });
```

Getting similar numbers if changing the number of items to `100` but runnning many more times. So number of items in the map doesn't affect much(as it should)
