### PR TITLE
(Core) Speed up PR validation on windows

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -22,7 +22,8 @@ jobs:
         inputs:
           version: 6.0.x
 
-      - script: echo '##vso[task.setvariable variable=TYPESPEC_VS_CI_BUILD;]true'
+      - script: |
+          echo ##vso[task.setvariable variable=TYPESPEC_VS_CI_BUILD;]true
         displayName: Enable official Visual Studio extension build
 
       - script: npx @microsoft/rush install

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -32,8 +32,14 @@ jobs:
       vmImage: $(imageName)
 
     steps:
-      - script: echo '##vso[task.setvariable variable=TYPESPEC_VS_CI_BUILD;]true'
+      - script: |
+          echo ##vso[task.setvariable variable=TYPESPEC_VS_CI_BUILD;]true
         displayName: Enable official Visual Studio extension build
+        condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+      - script: |
+          echo ##vso[task.setvariable variable=TYPESPEC_SKIP_DOCUSAURUS_BUILD;]true
+        displayName: Disable docusaurus build
         condition: eq(variables['Agent.OS'], 'Windows_NT')
 
       - template: pull-request-common.yml

--- a/eng/pipelines/pull-request-common.yml
+++ b/eng/pipelines/pull-request-common.yml
@@ -55,15 +55,14 @@ steps:
 
   - script: node common/scripts/install-run-rush.js check-format
     displayName: Check Formatting
+    condition: ne(variables['Agent.OS'], 'Windows_NT')
 
   - script: node common/scripts/install-run-rush.js lint --verbose
     displayName: Lint
+    condition: ne(variables['Agent.OS'], 'Windows_NT')
 
   - script: cd packages/samples && npm run regen-samples
     displayName: Regenerate Samples
-
-  - script: node common/scripts/install-run-rush.js regen-docs
-    displayName: Regenerate Reference Docs
 
   - script: node eng/scripts/check-for-changed-files.js
     displayName: Check Git Status For Changed Files

--- a/eng/scripts/helpers.js
+++ b/eng/scripts/helpers.js
@@ -46,7 +46,7 @@ export function npmForEach(cmd, options) {
 // We could use { shell: true } to let Windows find .cmd, but that causes other issues.
 // It breaks ENOENT checking for command-not-found and also handles command/args with spaces
 // poorly.
-const isCmdOnWindows = ["rush", "npm", "code", "code-insiders", tsc, prettier];
+const isCmdOnWindows = ["rush", "npm", "code", "code-insiders", "docusaurus", tsc, prettier];
 
 export class CommandFailedError extends Error {
   constructor(msg, proc) {

--- a/packages/website/.scripts/docusaurus-build.mjs
+++ b/packages/website/.scripts/docusaurus-build.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { run } from "../../../eng/scripts/helpers.js";
+
+if (process.env.TYPESPEC_SKIP_DOCUSAURUS_BUILD?.toLowerCase() === "true") {
+  console.log("Skipping docusaurus build: TYPESPEC_SKIP_DOCUSAURUS_BUILD=true");
+  process.exit(0);
+}
+
+run("docusaurus", ["build"]);

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "npm run regen-ref-docs && docusaurus build",
+    "build": "npm run regen-ref-docs && node  .scripts/docusaurus-build.mjs",
     "swizzle": "docusaurus swizzle",
     "clear": "docusaurus clear",
     "clean": "docusaurus clear",


### PR DESCRIPTION
We're running up against build timeout on Windows and it's getting in the way of team productivity.

This change does the following on Windows PR validation:

- Disable docusaurus build
- Disable formatting
- Disable linting

All of these will still be checked on Linux, where the build is currently 2X as fast, and none of them are likely to find a real Windows-specific issue in the product.

This change also disables the redundant regen-ref-docs step that is already performed during website build.

Devs can also skip the slow docusaurus build on their machines by setting environment variable TYPESPEC_SKIP_DOCUSAURUS_BUILD=true.