### PR TITLE
 Adding back all compiler exported public artifacts contains Cadl that got renamed to TypeSpec.

### DIFF
--- a/common/changes/@typespec/compiler/addingbackCadlExport_2023-02-28-06-15.json
+++ b/common/changes/@typespec/compiler/addingbackCadlExport_2023-02-28-06-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Adding back all compiler exported public artifacts contains Cadl that got renamed to TypeSpec.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -224,6 +224,9 @@ interface TypePrototype {
   projectionsByName(name: string): ProjectionStatementNode[];
 }
 
+/** @deprecated Use TypeSpecCompletionItem */
+export type CadlCompletionItem = TypeSpecCompletionItem;
+
 export interface TypeSpecCompletionItem {
   sym: Sym;
 

--- a/packages/compiler/core/decorator-utils.ts
+++ b/packages/compiler/core/decorator-utils.ts
@@ -14,7 +14,13 @@ import {
   Type,
 } from "./types.js";
 
+/** @deprecated Use TypeSpecValue */
+export type CadlValue = TypeSpecValue;
+
 export type TypeSpecValue = Type | string | number | boolean;
+
+/** @deprecated Use InferredTypeSpecValue */
+export type InferredCadlValue<K extends TypeKind> = InferredTypeSpecValue<K>;
 
 // prettier-ignore
 export type InferredTypeSpecValue<K extends TypeKind> = 
@@ -82,6 +88,10 @@ export function validateDecoratorTargetIntrinsic(
   }
   return true;
 }
+
+/** @deprecated use isTypeSpecValueTypeOf */
+export const isCadlValueTypeOf = isTypeSpecValueTypeOf;
+
 /**
  * Check if the given target is of any of the typespec types.
  * @param target Target to validate.
@@ -327,6 +337,9 @@ function prettyValue(program: Program, value: any) {
   }
   return value;
 }
+
+/** @deprecated use typespecTypeToJson */
+export const cadlTypeToJson = typespecTypeToJson;
 
 /**
  * Convert a typespec type to a serializable Json object.

--- a/packages/compiler/core/formatter.ts
+++ b/packages/compiler/core/formatter.ts
@@ -11,6 +11,9 @@ export function formatTypeSpec(code: string, prettierConfig?: prettier.Options):
   return output;
 }
 
+/** @deprecated use checkFormatTypeSpec */
+export const checkFormatCadl = checkFormatTypeSpec;
+
 /**
  * Check the given is correctly formatted.
  * @returns true if code is formatted correctly.

--- a/packages/compiler/core/index.ts
+++ b/packages/compiler/core/index.ts
@@ -7,7 +7,13 @@ export * from "./diagnostics.js";
 export * from "./emitter-utils.js";
 export * from "./formatter.js";
 export * from "./helpers/index.js";
-export { createTypeSpecLibrary, paramMessage, setTypeSpecNamespace } from "./library.js";
+export {
+  createCadlLibrary,
+  createTypeSpecLibrary,
+  paramMessage,
+  setCadlNamespace,
+  setTypeSpecNamespace,
+} from "./library.js";
 export * from "./manifest.js";
 export * from "./module-resolver.js";
 export * from "./node-host.js";
@@ -21,3 +27,6 @@ export * from "./types.js";
 export { DuplicateTracker, getSourceFileKindFromExt, Queue, TwoLevelMap } from "./util.js";
 import * as formatter from "../formatter/index.js";
 export const TypeSpecPrettierPlugin = formatter;
+
+/** @deprecated Use TypeSpecPrettierPlugin */
+export const CadlPrettierPlugin = TypeSpecPrettierPlugin;

--- a/packages/compiler/core/library.ts
+++ b/packages/compiler/core/library.ts
@@ -23,6 +23,9 @@ export function getLibraryUrlsLoaded(): Set<string> {
   return loadedUrls;
 }
 
+/** @deprecated use createTypeSpecLibrary */
+export const createCadlLibrary = createTypeSpecLibrary;
+
 /**
  * Create a new TypeSpec library definition.
  * @param lib Library definition.
@@ -95,6 +98,9 @@ export function paramMessage<T extends string[]>(
   template.keys = keys;
   return template;
 }
+
+/** @deprecated use setTypeSpecNamespace */
+export const setCadlNamespace = setTypeSpecNamespace;
 
 /**
  * Set the TypeSpec namespace for that function.

--- a/packages/compiler/core/manifest.ts
+++ b/packages/compiler/core/manifest.ts
@@ -4,6 +4,12 @@ import manifest from "../manifest.js";
 
 export const typespecVersion = manifest.version;
 
+/** @deprecated Use typespecVersion */
+export const cadlVersion = typespecVersion;
+
+/** @deprecated Use TypeSpecManifest */
+export type CadlManifest = TypeSpecManifest;
+
 export interface TypeSpecManifest {
   /**
    * Version of the tsp compiler.

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -535,6 +535,8 @@ export interface TypeInstantiationMap {
  */
 export enum SyntaxKind {
   TypeSpecScript,
+  /** @deprecated Use TypeSpecScript */
+  CadlScript = TypeSpecScript,
   JsSourceFile,
   ImportStatement,
   Identifier,

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -750,6 +750,9 @@ export interface ParseOptions {
   readonly docs?: boolean;
 }
 
+/** @deprecated Use TypeSpecScriptNode */
+export type CadlScriptNode = TypeSpecScriptNode;
+
 export interface TypeSpecScriptNode extends DeclarationNode, BaseNode {
   readonly kind: SyntaxKind.TypeSpecScript;
   readonly statements: readonly Statement[];
@@ -1660,6 +1663,12 @@ export type TypeOfDiagnostics<T extends DiagnosticMap<any>> = T extends Diagnost
   ? D
   : never;
 
+/** @deprecated Use TypeSpecLibraryDef */
+export type CadlLibraryDef<
+  T extends { [code: string]: DiagnosticMessages },
+  E extends Record<string, any> = Record<string, never>
+> = TypeSpecLibraryDef<T, E>;
+
 /**
  * Definition of a TypeSpec library
  */
@@ -1703,6 +1712,12 @@ export interface JSONSchemaValidator {
    */
   validate(config: unknown, target: SourceFile | typeof NoTarget): Diagnostic[];
 }
+
+/** @deprecated Use TypeSpecLibrary */
+export type CadlLibrary<
+  T extends { [code: string]: DiagnosticMessages },
+  E extends Record<string, any> = Record<string, never>
+> = TypeSpecLibrary<T, E>;
 
 export interface TypeSpecLibrary<
   T extends { [code: string]: DiagnosticMessages },

--- a/packages/compiler/server/language-config.ts
+++ b/packages/compiler/server/language-config.ts
@@ -98,3 +98,6 @@ export const TypeSpecLanguageConfiguration = {
     },
   ],
 } as const;
+
+/** @deprecated Use TypeSpecLanguageConfiguration */
+export const CadlLanguageConfiguration = TypeSpecLanguageConfiguration;

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "npm run regen-ref-docs && node  .scripts/docusaurus-build.mjs",
+    "build": "npm run regen-ref-docs && node  .scripts/docusaurus-build.mjs 2>&1",
     "swizzle": "docusaurus swizzle",
     "clear": "docusaurus clear",
     "clean": "docusaurus clear",


### PR DESCRIPTION
Searched based on all public types listed in the [ref-doc](https://microsoft.github.io/typespec/next/compiler/reference/js-api)