### PR TITLE
(Core) Stop treating models spread into parameters as unreferenced

### DIFF
--- a/common/changes/@typespec/openapi3/honor-param-ref_2023-02-28-16-54.json
+++ b/common/changes/@typespec/openapi3/honor-param-ref_2023-02-28-16-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Stop treating models spread into parameters as unreferenced.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -860,11 +860,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
 
     function processUnreferencedSchemas() {
       const addSchema = (type: Type) => {
-        if (
-          !processedSchemas.has(type) &&
-          !paramModels.has(type) &&
-          !shouldInline(program, type)
-        ) {
+        if (!processedSchemas.has(type) && !paramModels.has(type) && !shouldInline(program, type)) {
           getSchemaOrRef(type, Visibility.All);
         }
       };

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
@@ -365,21 +365,6 @@ components:
       required:
         - width
         - height
-    SetSignIdForKioskIdsRequest:
-      type: object
-      properties:
-        kiosk_ids:
-          type: array
-          items:
-            type: integer
-            format: int32
-          x-typespec-name: int32[]
-        sign_id:
-          type: integer
-          format: int32
-      required:
-        - kiosk_ids
-        - sign_id
     Sign:
       type: object
       properties:

--- a/packages/samples/test/output/grpc-library-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-library-example/openapi.yaml
@@ -331,16 +331,6 @@ components:
       description: A single book in the library.
       required:
         - name
-    CreateBookRequest:
-      type: object
-      properties:
-        book:
-          allOf:
-            - $ref: '#/components/schemas/Book'
-          description: The book to create.
-      description: Request message for LibraryService.CreateBook.
-      required:
-        - book
     CreateShelfRequest:
       type: object
       properties:
@@ -351,30 +341,10 @@ components:
       description: Request message for LibraryService.CreateShelf.
       required:
         - body
-    DeleteBookRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.DeleteBook.
-    DeleteShelfRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.DeleteShelf.
     Empty:
       type: object
       properties: {}
       description: No body returned
-    GetBookRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.GetBook.
-    GetShelfRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.GetShelf.
-    ListBooksRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.ListBooks.
     ListBooksResponse:
       type: object
       properties:
@@ -400,9 +370,6 @@ components:
       description: Response message for LibraryService.ListBooks.
       required:
         - books
-    ListRequestBase:
-      type: object
-      properties: {}
     ListResponseBase:
       type: object
       properties:
@@ -444,18 +411,6 @@ components:
       description: Response message for LibraryService.ListShelves.
       required:
         - shelves
-    MergeShelvesRequest:
-      type: object
-      properties:
-        other_shelf_name:
-          allOf:
-            - $ref: '#/components/schemas/shelf_name'
-          description: The name of the shelf we're removing books from and deleting.
-      description: |-
-        Describes the shelf being removed (other_shelf_name) and updated
-        (name) in this merge
-      required:
-        - other_shelf_name
     MoveBookRequest:
       type: object
       properties:

--- a/packages/samples/test/output/multiple-types-union/openapi.yaml
+++ b/packages/samples/test/output/multiple-types-union/openapi.yaml
@@ -25,9 +25,6 @@ components:
       schema:
         type: string
   schemas:
-    ApiVersionParam:
-      type: object
-      properties: {}
     Cat:
       type: object
       properties:

--- a/packages/samples/test/output/param-decorators/openapi.yaml
+++ b/packages/samples/test/output/param-decorators/openapi.yaml
@@ -58,16 +58,6 @@ components:
         format: UUID
         pattern: ^[a-zA-Z0-9-]{3,24}$
   schemas:
-    NameParameter:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Name parameter
-          format: UUID
-          pattern: ^[a-zA-Z0-9-]{3,24}$
-      required:
-        - name
     Thing:
       type: object
       properties:

--- a/packages/samples/test/output/petstore/openapi.yaml
+++ b/packages/samples/test/output/petstore/openapi.yaml
@@ -158,9 +158,6 @@ components:
       required:
         - name
         - age
-    PetId:
-      type: object
-      properties: {}
     PetListResults:
       type: object
       properties:

--- a/packages/samples/test/output/versioning/openapi.v1.yaml
+++ b/packages/samples/test/output/versioning/openapi.v1.yaml
@@ -36,9 +36,6 @@ components:
           - v1
           - v2
   schemas:
-    ApiVersionParam:
-      type: object
-      properties: {}
     Dog:
       type: object
       properties:

--- a/packages/samples/test/output/versioning/openapi.v2.yaml
+++ b/packages/samples/test/output/versioning/openapi.v2.yaml
@@ -36,9 +36,6 @@ components:
           - v1
           - v2
   schemas:
-    ApiVersionParam:
-      type: object
-      properties: {}
     Cat:
       type: object
       properties:


### PR DESCRIPTION
This was causing confusing duplication in the OpenAPI emit when a model was used only to spread into operation parameters and the default option to omit unreferenced types was enabled.

It further caused confusing diffs in the change in progress to use read visibility as the canonical visibility, so sending this out separately first to make that easier review.