### PR TITLE
Ensure versioning tests assert no diagnostics during projections.

### DIFF
--- a/common/changes/@typespec/versioning/fixVersioningTestBug_2023-03-02-21-06.json
+++ b/common/changes/@typespec/versioning/fixVersioningTestBug_2023-03-02-21-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/packages/versioning/test/versioned-dependencies.test.ts
+++ b/packages/versioning/test/versioned-dependencies.test.ts
@@ -909,5 +909,7 @@ describe("versioning: dependencies", () => {
 
 function runProjections(program: Program, rootNs: Namespace) {
   const versions = buildVersionProjections(program, rootNs);
-  return versions.map((x) => projectProgram(program, x.projections).projector);
+  const projectedPrograms = versions.map((x) => projectProgram(program, x.projections));
+  projectedPrograms.forEach((p) => expectDiagnosticEmpty(p.diagnostics));
+  return projectedPrograms.map((p) => p.projector);
 }


### PR DESCRIPTION
@nguerrera thanks for this. Luckily all of our versioning tests continue to pass with this change. This will protect our tests while I work on the enum thing.