### PR TITLE
Update dev dependency on ref-docs to allow strict version bump

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@typespec/ref-doc": "^0.1.0",
+    "@typespec/ref-doc": "~0.1.0",
     "@typespec/spec": "0.1.0",
     "@typespec/http": "~0.40.0",
     "@typespec/rest": "~0.40.0",


### PR DESCRIPTION
This is my best guess about why the version bump is failing in prepare-publish