### PR TITLE
Remove `emitters` option from tspconfig.yaml

### DIFF
--- a/common/changes/@typespec/compiler/compiler-removeEmittersOption_2023-03-03-22-08.json
+++ b/common/changes/@typespec/compiler/compiler-removeEmittersOption_2023-03-03-22-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "**Breaking Change**. Removes `emitters` option in cadl-project.yaml. Use `emit` and `options` instead.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/config/config-loader.ts
+++ b/packages/compiler/config/config-loader.ts
@@ -152,34 +152,8 @@ async function loadConfigFile(
     data = deepClone(defaultConfig) as TypeSpecRawConfig;
   }
 
-  let emit = data.emit;
-  let options = data.options;
-
-  // @deprecated Legacy backward compatibility of emitters option. To remove March Sprint.
-  if (data.emitters) {
-    diagnostics.push(
-      createDiagnostic({
-        code: "deprecated",
-        format: {
-          message:
-            "`emitters` options in tspconfig.yaml is deprecated use `emit` and `options` instead.",
-        },
-        target: NoTarget,
-      })
-    );
-    emit = [];
-    options = {};
-    for (const [name, emitterOptions] of Object.entries(data.emitters)) {
-      if (emitterOptions === true) {
-        emit.push(name);
-        options[name] = {};
-      } else if (emitterOptions === false) {
-      } else {
-        emit.push(name);
-        options[name] = emitterOptions;
-      }
-    }
-  }
+  const emit = data.emit;
+  const options = data.options;
 
   return omitUndefined({
     projectRoot: getDirectoryPath(filename),


### PR DESCRIPTION
Do not merge until after release.
Closes #1556.