### PR TITLE
Revert algolia to use cadl index

### DIFF
--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -157,7 +157,7 @@ const config = {
         // cspell:disable-next-line
         appId: "WQXW45O51C",
         apiKey: "9bfd71f94d516117e3022e788f2cc83c",
-        indexName: "typespec",
+        indexName: "cadl",
       },
     }),
 };


### PR DESCRIPTION
We unfortunatelly cannot rename a free docsearch algolia application, I updated the crawler url to typespec but we still have to use the index name called `cadl`. I requested a new application for typespec but that takes some time so in the meantime this is a good workaround