### PR TITLE
Fix website TypeSpec codeblock highlighting

### DIFF
--- a/packages/website/src/theme/prism-include-languages.ts
+++ b/packages/website/src/theme/prism-include-languages.ts
@@ -2,4 +2,5 @@ import typespecPrismDefinition from "./typespec-lang-prism";
 
 export default function prismIncludeLanguages(PrismObject) {
   PrismObject.languages.tsp = typespecPrismDefinition;
+  PrismObject.languages.typespec = typespecPrismDefinition;
 }


### PR DESCRIPTION
As we know support ` ```tsp ` and ` ```typespec ` the website was only configured to support `tsp` 