### PR TITLE
Fix highlighting of TypeSpec code in markdown in IDE

### DIFF
--- a/packages/typespec-vscode/.vscodeignore
+++ b/packages/typespec-vscode/.vscodeignore
@@ -10,7 +10,7 @@
 !dist/**/*.js.map
 !dist/**/language-configuration.json
 !extension-shim.js
-!markdown-tsp.json
+!markdown-typespec.json
 !README.md
 !ThirdPartyNotices.txt
 !LICENSE


### PR DESCRIPTION
The file was renamed differently in .vscodeignore and file system.