### PR TITLE
Fix `tsp code uninstall`

### DIFF
--- a/common/changes/@typespec/compiler/fix-code-uninstall_2023-03-21-20-22.json
+++ b/common/changes/@typespec/compiler/fix-code-uninstall_2023-03-21-20-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix `tsp code uninstall` not finding extension to uninstall.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/core/cli/cli.ts
+++ b/packages/compiler/core/cli/cli.ts
@@ -443,7 +443,7 @@ async function installVSCodeExtension(insiders: boolean, debug: boolean) {
 }
 
 async function uninstallVSCodeExtension(insiders: boolean, debug: boolean) {
-  await runCode(["--uninstall-extension", "microsoft.tsp-vscode"], insiders, debug);
+  await runCode(["--uninstall-extension", "microsoft.typespec-vscode"], insiders, debug);
 }
 
 function getVsixInstallerPath(): string {


### PR DESCRIPTION
The package ID used was renamed differently from the package itself.