### PR TITLE
Fix emitter framework scalar behavior and bundler bug

### DIFF
--- a/common/changes/@typespec/compiler/bugfix_2023-03-22-15-29.json
+++ b/common/changes/@typespec/compiler/bugfix_2023-03-22-15-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Bug: Emitter framework will now visit scalar declarations",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/bundler/src/vite-plugin.ts
+++ b/packages/bundler/src/vite-plugin.ts
@@ -122,7 +122,8 @@ function createImportMap(
   for (const [library, definition] of Object.entries(definitions)) {
     imports[library] = `./${folderName}/${library}/index.js`;
     for (const name of Object.keys(definition.exports)) {
-      imports[library + "/http"] = "./" + resolvePath(`./${folderName}/${library}`, name) + ".js";
+      imports[resolvePath(library, name)] =
+        "./" + resolvePath(`./${folderName}/${library}`, name) + ".js";
     }
   }
   const importMap = {

--- a/packages/compiler/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/emitter-framework/asset-emitter.ts
@@ -378,6 +378,10 @@ export function createAssetEmitter<T, TOptions extends object>(
           this.emitType(iface);
         }
       }
+
+      for (const scalar of namespace.scalars.values()) {
+        this.emitType(scalar);
+      }
     },
 
     emitModelProperties(model) {

--- a/packages/compiler/emitter-framework/type-emitter.ts
+++ b/packages/compiler/emitter-framework/type-emitter.ts
@@ -203,6 +203,11 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
         this.emitter.emitType(iface);
       }
     }
+
+    for (const scalar of namespace.scalars.values()) {
+      this.emitter.emitType(scalar);
+    }
+
     return this.emitter.result.none();
   }
 

--- a/packages/compiler/test/emitter-framework/emitter.test.ts
+++ b/packages/compiler/test/emitter-framework/emitter.test.ts
@@ -7,6 +7,7 @@ import {
   ModelProperty,
   Operation,
   Program,
+  Scalar,
   Type,
   Union,
 } from "../../core/index.js";
@@ -253,6 +254,24 @@ describe("typescript emitter", () => {
     `);
 
     assert.match(contents, /x: \[string, number\]/);
+  });
+
+  it("emits scalars", async () => {
+    class TestEmitter extends CodeTypeEmitter {
+      scalarDeclaration(scalar: Scalar, name: string): EmitterOutput<string> {
+        return super.scalarDeclaration(scalar, name);
+      }
+    }
+    await emitTypeSpec(
+      TestEmitter,
+      `
+      scalar X extends string;
+      scalar Y extends numeric;
+    `,
+      {
+        scalarDeclaration: 4,
+      }
+    );
   });
 
   it("emits models to a single file", async () => {


### PR DESCRIPTION
Previously, the emitter framework would only visit scalars if they were referenced. Now it will discover scalars and call your type emitter appropriately.

Also, the bundler had a hard-coded string for subpath exports, which is now fixed.