### PR TITLE
Prevent use of augment decorators on template instantiations

### DIFF
--- a/common/changes/@typespec/compiler/fixTemplateTarget_2023-03-27-17-15.json
+++ b/common/changes/@typespec/compiler/fixTemplateTarget_2023-03-27-17-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Prevent use of augment decorators on instantiated templates.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -467,6 +467,15 @@ export function createChecker(program: Program): Checker {
     for (const decNode of augmentDecorators) {
       const ref = resolveTypeReferenceSym(decNode.targetType, undefined);
       if (ref) {
+        let args: readonly Expression[] = [];
+        if (ref.declarations[0].kind === SyntaxKind.AliasStatement) {
+          const aliasNode = ref.declarations[0] as AliasStatementNode;
+          if (aliasNode.value.kind === SyntaxKind.TypeReference) {
+            args = aliasNode.value.arguments;
+          }
+        } else {
+          args = decNode.targetType.arguments;
+        }
         if (ref.flags & SymbolFlags.Namespace) {
           const links = getSymbolLinks(getMergedSymbol(ref));
           const type: Type & DecoratedType = links.type! as any;
@@ -475,7 +484,7 @@ export function createChecker(program: Program): Checker {
             type.decorators.push(decApp);
             applyDecoratorToType(program, decApp, type);
           }
-        } else if (decNode.targetType.arguments.length > 0 || ref.flags & SymbolFlags.LateBound) {
+        } else if (args.length > 0 || ref.flags & SymbolFlags.LateBound) {
           reportCheckerDiagnostic(
             createDiagnostic({
               code: "augment-decorator-target",

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -483,6 +483,18 @@ export function createChecker(program: Program): Checker {
               target: decNode.target,
             })
           );
+        }
+        if (ref.declarations.at(0)?.kind === SyntaxKind.ModelStatement) {
+          const node = ref.declarations.at(0) as ModelStatementNode;
+          if (node.templateParameters.length > 0) {
+            reportCheckerDiagnostic(
+              createDiagnostic({
+                code: "augment-decorator-target",
+                messageId: "noInstance",
+                target: decNode.target,
+              })
+            );
+          }
         } else {
           let list = augmentDecoratorsForSym.get(ref);
           if (list === undefined) {

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -465,8 +465,6 @@ export function createChecker(program: Program): Checker {
     );
 
     for (const decNode of augmentDecorators) {
-      const args = decNode.arguments;
-      const isTemplate = isTemplatedNode(decNode.targetType);
       const ref = resolveTypeReferenceSym(decNode.targetType, undefined);
       if (ref) {
         if (ref.flags & SymbolFlags.Namespace) {
@@ -477,7 +475,7 @@ export function createChecker(program: Program): Checker {
             type.decorators.push(decApp);
             applyDecoratorToType(program, decApp, type);
           }
-        } else if (ref.flags & SymbolFlags.LateBound) {
+        } else if (decNode.targetType.arguments.length > 0 || ref.flags & SymbolFlags.LateBound) {
           reportCheckerDiagnostic(
             createDiagnostic({
               code: "augment-decorator-target",
@@ -3073,18 +3071,6 @@ export function createChecker(program: Program): Checker {
     const sym = isMemberNode(node) ? getSymbolForMember(node) ?? node.symbol : node.symbol;
     const decorators: DecoratorApplication[] = [];
     const augmentDecoratorNodes = augmentDecoratorsForSym.get(sym) ?? [];
-    // // TODO: How to distinguish between instantiation and not?
-    // if (augmentDecoratorNodes.length > 0) {
-    //   if (isTemplatedNode(node)) {
-    //     reportCheckerDiagnostic(
-    //       createDiagnostic({
-    //         code: "augment-decorator-target",
-    //         messageId: "noInstance",
-    //         target: targetType,
-    //       })
-    //     );
-    //   }
-    // }
     const decoratorNodes = [
       ...augmentDecoratorNodes, // the first decorator will be executed at last, so augmented decorator should be placed at first.
       ...node.decorators,

--- a/packages/compiler/test/checker/augment-decorators.test.ts
+++ b/packages/compiler/test/checker/augment-decorators.test.ts
@@ -170,14 +170,16 @@ describe("compiler: checker: augment decorators", () => {
     it("interface", () => expectTarget(`@test("target") interface Foo { }`, "Foo"));
     it("operation in interface", () =>
       expectTarget(`interface Foo { @test("target") list(): void }`, "Foo.list"));
+    it("uninstantiated template", () => expectTarget(`@test("target") model Foo<T> { }`, "Foo"));
     it("emit diagnostic if target is instantiated template", async () => {
-      let customName: string | undefined;
-      let runOnTarget: Type | undefined;
-
       testHost.addJsFile("test.js", {
         $customName(_: any, t: Type, n: string) {
-          runOnTarget = t;
-          customName = n;
+          const runOnTarget: Type | undefined = t;
+          const customName: string | undefined = n;
+          if (runOnTarget) {
+          }
+          if (customName) {
+          }
         },
       });
 

--- a/packages/compiler/test/checker/augment-decorators.test.ts
+++ b/packages/compiler/test/checker/augment-decorators.test.ts
@@ -195,7 +195,7 @@ describe("compiler: checker: augment decorators", () => {
           @test
           op stringTest(): Foo<string>;
   
-          @@customName(Foo<T>, "Some foo thing");
+          @@customName(Foo, "Some foo thing");
           `
       );
       const [results, diagnostics] = await testHost.compileAndDiagnose("test.tsp");


### PR DESCRIPTION
Fix #1354.

Throws a diagnostic if any arguments are provided in the augment decorator.
**Error** `@@decorator(Foo<string>, "blah")`
**Error** `@@decorator(Foo<T>, "blah")`
**Okay** `@@decorator(Foo, "blah") // the template args left off`
