### PR TITLE
Fix Issue where template parameter type check wouldn't work if constraint is exact same type as next validation.

### DIFF
--- a/common/changes/@typespec/compiler/fix-enum-member-template-constraint_2023-03-28-17-22.json
+++ b/common/changes/@typespec/compiler/fix-enum-member-template-constraint_2023-03-28-17-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix Issue where template parameter type check wouldn't work if constraint is exact same type as next validation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -4514,11 +4514,10 @@ export function createChecker(program: Program): Checker {
     target: Type,
     diagnosticTarget: DiagnosticTarget
   ): [boolean, Diagnostic[]] {
-    if (source === target) return [true, []];
-
     if (source.kind === "TemplateParameter") {
       source = source.constraint ?? unknownType;
     }
+    if (source === target) return [true, []];
 
     const isSimpleTypeRelated = isSimpleTypeAssignableTo(source, target);
 

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -721,4 +721,20 @@ describe("compiler: checker: type relations", () => {
       );
     });
   });
+
+  describe("Template constraint", () => {
+    it("validate template usage using template constraint", async () => {
+      const diagnostics = await runner.diagnose(`
+        model Test<T extends TypeSpec.Reflection.EnumMember> {
+          t: Target<T>;
+        }
+        
+        model Target<T extends TypeSpec.Reflection.EnumMember> {
+          t: T;
+        }
+        `);
+
+      expectDiagnosticEmpty(diagnostics);
+    });
+  });
 });


### PR DESCRIPTION
```
import "@typespec/versioning";

using TypeSpec.Versioning;

model Foo<T extends TypeSpec.Reflection.EnumMember> {
  v1: string;

  @added(T)
  custom: string;
}
```
this was failing saying `T` wasn't assignable to an `EnumMember`

This is preventing a simple repro for  #1714