### PR TITLE
Fix #1671 overload validation in interfaces under projection

### DIFF
--- a/common/changes/@typespec/compiler/overload-int_2023-03-29-02-19.json
+++ b/common/changes/@typespec/compiler/overload-int_2023-03-29-02-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Allow overloads in interfaces to work under projection",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/openapi3/overload-int_2023-03-29-02-19.json
+++ b/common/changes/@typespec/openapi3/overload-int_2023-03-29-02-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Add tests for overloads within interfaces",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -934,8 +934,26 @@ export function $overload(context: DecoratorContext, target: Operation, overload
 
 function areOperationsInSameContainer(op1: Operation, op2: Operation): boolean {
   return op1.interface || op2.interface
-    ? op1.interface === op2.interface
+    ? equalsWithoutProjection(op1.interface, op2.interface)
     : op1.namespace === op2.namespace;
+}
+
+// note: because the 'interface' property of Operation types is projected after the
+// type is finalized, the target operation or overloadBase may reference an un-projected
+// interface at the time of decorator execution during projections.  This normalizes
+// the interfaces to their unprojected form before comparison.
+function equalsWithoutProjection(
+  interface1: Interface | undefined,
+  interface2: Interface | undefined
+): boolean {
+  if (interface1 === undefined || interface2 === undefined) return false;
+  return getBaseInterface(interface1) === getBaseInterface(interface2);
+}
+
+function getBaseInterface(int1: Interface): Interface {
+  return int1.projectionSource === undefined
+    ? int1
+    : getBaseInterface(int1.projectionSource as Interface);
 }
 
 /**

--- a/packages/openapi3/test/overloads.test.ts
+++ b/packages/openapi3/test/overloads.test.ts
@@ -95,4 +95,18 @@ describe("openapi3: overloads", () => {
       ok(res.paths["/uploadString"].post);
     });
   });
+
+  it("overloads work inside an interface", async () => {
+    const _ = await openApiFor(`
+      interface Foo {
+        op doStringOrInt(a?: string, b?: int32, c?: Record<string>): { @TypeSpec.Http.header("content-type") contenType: "application/text", @TypeSpec.Http.body data: string }| int32;
+      
+        @overload(Foo.doStringOrInt)
+        op doString(a: string): { @TypeSpec.Http.header("content-type") contenType: "application/text", @TypeSpec.Http.body data: string };
+      
+        @overload(Foo.doStringOrInt)
+        op doInt(b: int32): int32;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Note:  A more general fix would be to project the Operation.interface property before finalizing the type, but this would violate the order of finalization for contained/container items during projection.

There is a possibility of other decorators on contained types having similar issues - however, to do so, their execution would need to depend on the projected value of the container reference inside the type.