### PR TITLE
Improve performance of "rush" in pipelines

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -45,13 +45,13 @@ jobs:
           node-version: 18.x
 
       - name: Install dependencies
-        run: npx @microsoft/rush update
+        run: node common/scripts/install-run-rush.js update
 
       - name: Build necessary packages
-        run: npx @microsoft/rush build  --to @typespec/prettier-plugin-typespec
+        run: node common/scripts/install-run-rush.js build  --to @typespec/prettier-plugin-typespec
 
       - name: Format
-        run: npx @microsoft/rush format
+        run: node common/scripts/install-run-rush.js format
 
       - name: Commit
         run: |

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -48,7 +48,7 @@ jobs:
         run: node common/scripts/install-run-rush.js update
 
       - name: Build necessary packages
-        run: node common/scripts/install-run-rush.js build  --to @typespec/prettier-plugin-typespec
+        run: node common/scripts/install-run-rush.js build --to @typespec/prettier-plugin-typespec
 
       - name: Format
         run: node common/scripts/install-run-rush.js format

--- a/.github/workflows/website-gh-pages.yml
+++ b/.github/workflows/website-gh-pages.yml
@@ -32,10 +32,10 @@ jobs:
           node-version: 18.x
 
       - name: Install dependencies
-        run: npx @microsoft/rush update
+        run: node common/scripts/install-run-rush.js update
 
       - name: Build
-        run: npx @microsoft/rush build --to @typespec/website
+        run: node common/scripts/install-run-rush.js build --to @typespec/website
         env:
           TYPESPEC_WEBSITE_BASE_PATH: "/typespec/"
 

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -27,17 +27,17 @@ jobs:
           echo ##vso[task.setvariable variable=TYPESPEC_VS_CI_BUILD;]true
         displayName: Enable official Visual Studio extension build
 
-      - script: npx @microsoft/rush install
+      - script: node common/scripts/install-run-rush.js install
         displayName: Install JavaScript Dependencies
 
       - script: dotnet restore
         displayName: Restore .NET Dependencies
         workingDirectory: packages/typespec-vs
 
-      - script: npx @microsoft/rush rebuild --verbose
+      - script: node common/scripts/install-run-rush.js rebuild --verbose
         displayName: Build
 
-      - script: npx @microsoft/rush test-official
+      - script: node common/scripts/install-run-rush.js test-official
         displayName: Test
 
       - template: ./upload-coverage.yml
@@ -80,14 +80,14 @@ jobs:
       - script: echo '##vso[task.setvariable variable=TYPESPEC_VS_CI_BUILD;]true'
         displayName: Enable official Visual Studio extension build
 
-      - script: npx @microsoft/rush install
+      - script: node common/scripts/install-run-rush.js install
         displayName: Install JavaScript Dependencies
 
       - script: dotnet restore
         displayName: Restore .NET Dependencies
         workingDirectory: packages/typespec-vs
 
-      - script: npx @microsoft/rush rebuild --verbose
+      - script: node common/scripts/install-run-rush.js rebuild --verbose
         displayName: Build
 
       - script: node ./packages/internal-build-utils/cmd/cli.js bump-version-preview .

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -34,7 +34,7 @@ jobs:
         displayName: Restore .NET Dependencies
         workingDirectory: packages/typespec-vs
 
-      - script: node common/scripts/install-run-rush.js rebuild --verbose
+      - script: node common/scripts/install-run-rush.js rebuild --parallelism max --verbose
         displayName: Build
 
       - script: node common/scripts/install-run-rush.js test-official
@@ -87,7 +87,7 @@ jobs:
         displayName: Restore .NET Dependencies
         workingDirectory: packages/typespec-vs
 
-      - script: node common/scripts/install-run-rush.js rebuild --verbose
+      - script: node common/scripts/install-run-rush.js rebuild --parallelism max --verbose
         displayName: Build
 
       - script: node ./packages/internal-build-utils/cmd/cli.js bump-version-preview .

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -19,10 +19,10 @@ jobs:
           versionSpec: 16.x
         displayName: Install Node.js
 
-      - script: npx @microsoft/rush install
+      - script: node common/scripts/install-run-rush.js install
         displayName: Install JavaScript Dependencies
 
-      - script: npx @microsoft/rush rebuild --verbose
+      - script: node common/scripts/install-run-rush.js rebuild --verbose
         displayName: Build
 
       - task: AzureCLI@1

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -22,7 +22,7 @@ jobs:
       - script: node common/scripts/install-run-rush.js install
         displayName: Install JavaScript Dependencies
 
-      - script: node common/scripts/install-run-rush.js rebuild --verbose
+      - script: node common/scripts/install-run-rush.js rebuild --parallelism max --verbose
         displayName: Build
 
       - task: AzureCLI@1

--- a/eng/pipelines/pull-request-common.yml
+++ b/eng/pipelines/pull-request-common.yml
@@ -36,21 +36,6 @@ steps:
   - script: node common/scripts/install-run-rush.js test-official
     displayName: Test
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: "JUnit"
-      testResultsFiles: "packages/*/test-results.xml"
-      mergeTestResults: true
-      failTaskOnFailedTests: true
-      testRunTitle: "Test os: ${{ parameters.poolName }}, node: ${{ parameters.nodeVersion }}"
-    displayName: Publish test results
-    condition: or(failed(), ne(variables['Build.Reason'], 'PullRequest'))
-
-  - publish: ./packages/playground/test-results
-    artifact: "uitestresults-${{ parameters.poolName }}-node-${{ parameters.nodeVersion }}"
-    displayName: Publish UI tests artifacts
-    condition: failed()
-
   - template: ./upload-coverage.yml
 
   - script: node common/scripts/install-run-rush.js check-format
@@ -77,3 +62,26 @@ steps:
     # causing npx to try to download the unpublished version of the cli.
     condition: eq('${{ parameters.nodeVersion }}', '18.x')
     # condition: and(not(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/')), not(eq('${{ parameters.nodeVersion }}', '16.x')))
+
+  # Unlink node_modules folders to significantly improve performance of subsequent tasks
+  # which need to walk the directory tree (and are hardcoded to follow symlinks).
+  - script: node common/scripts/install-run-rush.js unlink
+    displayName: "Unlink dependencies"
+
+  # It's important for performance to pass "packages" as "searchFolder" to avoid looking under root "node_modules".
+  # PublishTestResults.searchFolder only supports absolute paths, not relative.
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: "JUnit"
+      searchFolder: "$(System.DefaultWorkingDirectory)/packages"
+      testResultsFiles: "*/test-results.xml"
+      mergeTestResults: true
+      failTaskOnFailedTests: true
+      testRunTitle: "Test os: ${{ parameters.poolName }}, node: ${{ parameters.nodeVersion }}"
+    displayName: Publish test results
+    condition: always()
+
+  - publish: ./packages/playground/test-results
+    artifact: "uitestresults-${{ parameters.poolName }}-node-${{ parameters.nodeVersion }}"
+    displayName: Publish UI tests artifacts
+    condition: always()

--- a/eng/pipelines/pull-request-common.yml
+++ b/eng/pipelines/pull-request-common.yml
@@ -84,4 +84,4 @@ steps:
   - publish: ./packages/playground/test-results
     artifact: "uitestresults-${{ parameters.poolName }}-node-${{ parameters.nodeVersion }}"
     displayName: Publish UI tests artifacts
-    condition: always()
+    condition: ne(variables['Agent.OS'], 'Windows_NT')

--- a/eng/pipelines/pull-request-common.yml
+++ b/eng/pipelines/pull-request-common.yml
@@ -30,7 +30,7 @@ steps:
     displayName: Restore .NET Dependencies
     workingDirectory: packages/typespec-vs
 
-  - script: node common/scripts/install-run-rush.js rebuild --verbose
+  - script: node common/scripts/install-run-rush.js rebuild --parallelism max --verbose
     displayName: Build
 
   - script: node common/scripts/install-run-rush.js test-official
@@ -57,7 +57,7 @@ steps:
     displayName: Check Formatting
     condition: ne(variables['Agent.OS'], 'Windows_NT')
 
-  - script: node common/scripts/install-run-rush.js lint --verbose
+  - script: node common/scripts/install-run-rush.js lint --parallelism max --verbose
     displayName: Lint
     condition: ne(variables['Agent.OS'], 'Windows_NT')
 


### PR DESCRIPTION
- Replace `npx @microsoft/rush` with `node common/scripts/install-run-rush.js`
  - Faster and more reliable
- Add `--parallelism max` to all parallel `rush` commands
  - Ensures max parallelism on all OS (Windows default is `cores - 1`)
- Run `rush unlink` before `PublishTestResults`
  - Significantly improves performance by deleting `node_modules` folders so they do not need to be searched
- Pass input `searchFolder` to `PublishTestResults`
  - Reduces number of folders that must be searched
- Move `PublishTestResults` to end of job
  - Must run after `rush unlink`, which must run after all `rush` commands are done
- Always publish test results, since it should now be much faster
