### PR TITLE
Always unlink dependencies before publishing test results

### DIFF
--- a/eng/pipelines/pull-request-common.yml
+++ b/eng/pipelines/pull-request-common.yml
@@ -67,6 +67,7 @@ steps:
   # which need to walk the directory tree (and are hardcoded to follow symlinks).
   - script: node common/scripts/install-run-rush.js unlink
     displayName: "Unlink dependencies"
+    condition: always()
 
   # It's important for performance to pass "packages" as "searchFolder" to avoid looking under root "node_modules".
   # PublishTestResults.searchFolder only supports absolute paths, not relative.


### PR DESCRIPTION
- Step should always run even if previous step is failed or cancelled
- Continuation of #1769
