### PR TITLE
Remove global state from linter library

### DIFF
--- a/common/changes/@typespec/lint/no-global-linter_2023-04-05-19-11.json
+++ b/common/changes/@typespec/lint/no-global-linter_2023-04-05-19-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/lint",
+      "comment": "Remove global state. **Breaking change** Rules from another library cannot be enabled on a LibraryLinter.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/lint"
+}

--- a/docs/extending-typespec/linters.md
+++ b/docs/extending-typespec/linters.md
@@ -76,7 +76,8 @@ When registering a rule, its name will be prefixed by the library named defined 
 Rules are by default just registered but not enabled. This allows a library to provide a set of linting rules for other libraries to use or a user to enable.
 
 ```ts
-// Note: the rule id here needs to be the fully qualified rule name prefixed with `<libraryname>/`
+// Note: The rule ID here needs to be the fully qualified rule name prefixed with the
+//       `<libraryname>/` prefix and it cannot be a rule provided by another library.
 linter.enableRule("my-library/no-model-doc");
 ```
 
@@ -96,8 +97,14 @@ The lint library still depends on `$onValidate` to run. For that each library pr
 
 ```ts
 export function $onValidate(program: Program) {
-  linter.autoEnableRules(); // Optional if you want to automatically enable your rules
-  linter.enableRules(["<library-name>/<rule-name>"]); // Alternatively enable rules explicitly. Must be the rule fully qualified name.
+  // Optional if you want to automatically enable your rules.
+  linter.autoEnableRules();
+
+  // Alternatively enable rules explicitly.
+  // Note: The rule IDs here needs to be the fully qualified rule names with the
+  //       `<libraryname>/` prefix and they cannot be rules provided by other libraries.
+  linter.enableRules(["<library-name>/<rule-name-1>", "<library-name>/<rule-name-2>]);
+
   linter.lintOnValidate(program);
 }
 ```

--- a/packages/lint/src/linter.ts
+++ b/packages/lint/src/linter.ts
@@ -10,18 +10,8 @@ import {
 import { LibraryLinter, Linter, LintRule, RegisterRuleOptions } from "./types.js";
 
 export function getLinter(library: TypeSpecLibrary<any, any>): LibraryLinter {
-  const linter = getLinterSingleton();
+  const linter = createLinter();
   return getLinterForLibrary(linter, library);
-}
-
-const linterSingletonKey = Symbol.for("@typespec/lint.singleton");
-function getLinterSingleton(): Linter {
-  let linter: Linter | undefined = (globalThis as any)[linterSingletonKey];
-  if (linter === undefined) {
-    linter = createLinter();
-    (globalThis as any)[linterSingletonKey] = linter;
-  }
-  return linter;
 }
 
 function getLinterForLibrary(linter: Linter, library: TypeSpecLibrary<any, any>): LibraryLinter {
@@ -113,14 +103,15 @@ function createLinter(): Linter {
   }
 
   function enableRule(name: string) {
-    compilerAssert(ruleMap.has(name), `Rule "${name}" is not registered. Cannot enable.`);
+    if (!ruleMap.has(name)) {
+      throw new Error(`Rule "${name}" is not registered. Cannot enable.`);
+    }
     enabledRules.add(name);
   }
 
   function enableRules(names: string[]) {
     for (const name of names) {
-      compilerAssert(ruleMap.has(name), `Rule "${name}"  is not registered. Cannot enable.`);
-      enabledRules.add(name);
+      enableRule(name);
     }
   }
 }


### PR DESCRIPTION
This caused issues depending on order things were run in a process. For example, it was causing tests to fail in test explorer when another libs tests ran first.

**Breaking change**: This removes the ability to enable a rule from another library on a LibraryLinter.