### PR TITLE
HotFix:  query format not accepting anything other than `csv` and `multi`

### DIFF
--- a/common/changes/@typespec/http/fix-query-format_2023-04-13-15-20.json
+++ b/common/changes/@typespec/http/fix-query-format_2023-04-13-15-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "**Fix** query format not accepting anything other than `csv` and `multi`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -104,9 +104,7 @@ export function $query(
       }
       const format = queryNameOrOptions.properties.get("format")?.type;
       if (format?.kind === "String") {
-        if (format.value === "multi" || format.value === "csv") {
-          options.format = format.value;
-        }
+        options.format = format.value as any; // That value should have already been validated by the TypeSpec dec
       }
     }
   }

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -210,16 +210,19 @@ describe("http: decorators", () => {
       strictEqual(getQueryParamName(runner.program, select), "$select");
     });
 
-    it("override query with QueryOptions", async () => {
-      const { selects } = await runner.compile(`
-          @put op test(@test @query({name: "$select", format: "csv"}) selects: string[]): string;
-        `);
-      deepStrictEqual(getQueryParamOptions(runner.program, selects), {
-        type: "query",
-        name: "$select",
-        format: "csv",
+    describe("change format for array value", () => {
+      ["csv", "tsv", "ssv", "pipes"].forEach((format) => {
+        it(`set query format to "${format}"`, async () => {
+          const { selects } = await runner.compile(`
+            op test(@test @query({name: "$select", format: "${format}"}) selects: string[]): string;
+          `);
+          deepStrictEqual(getQueryParamOptions(runner.program, selects), {
+            type: "query",
+            name: "$select",
+            format,
+          });
+        });
       });
-      strictEqual(getQueryParamName(runner.program, selects), "$select");
     });
   });
 


### PR DESCRIPTION
Hotfix fixing issue with april release with `@query({format` doing an additional check 