### PR TITLE
Fix `url` doc to not mention "URI"

### DIFF
--- a/common/changes/@typespec/compiler/fix-url-doc_2023-04-14-17-53.json
+++ b/common/changes/@typespec/compiler/fix-url-doc_2023-04-14-17-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix `url` doc to not mention \"URI\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/lib/lib.tsp
+++ b/packages/compiler/lib/lib.tsp
@@ -128,7 +128,7 @@ model Array<T> {}
 model Record<T> {}
 
 /**
- * Represent a URI string as described by https://url.spec.whatwg.org/#relative-url-string.
+ * Represent a URL string as described by https://url.spec.whatwg.org/
  */
 @format("url")
 scalar url extends string;


### PR DESCRIPTION
Also point to root of WHATWG doc, not the relative string sub-portion.