### PR TITLE
Migrate to native fetch and bump minimum node to 18.0

### DIFF
--- a/common/changes/@typespec/compiler/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/compiler/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/http/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/http/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/common/changes/@typespec/internal-build-utils/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/internal-build-utils/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/internal-build-utils",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@typespec/internal-build-utils"
+}

--- a/common/changes/@typespec/lint/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/lint/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/lint",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/lint"
+}

--- a/common/changes/@typespec/migrate/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/migrate/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/migrate",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/migrate"
+}

--- a/common/changes/@typespec/openapi/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/openapi/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi"
+}

--- a/common/changes/@typespec/openapi3/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/openapi3/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/common/changes/@typespec/rest/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/rest/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/rest",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/rest"
+}

--- a/common/changes/@typespec/versioning/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/@typespec/versioning/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/common/changes/tmlanguage-generator/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/tmlanguage-generator/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/common/changes/typespec-vs/migrate-native-fetch_2023-04-24-15-37.json
+++ b/common/changes/typespec-vs/migrate-native-fetch_2023-04-24-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "typespec-vs",
+      "comment": "**Breaking change** Minimum node version is now 18.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "typespec-vs"
+}

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -20,7 +20,7 @@
   "main": "dist/src/index.js",
   "tspMain": "dist/src/index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "bundle": "node ./dist/src/cli.js",

--- a/packages/compiler/core/node-host.ts
+++ b/packages/compiler/core/node-host.ts
@@ -1,6 +1,5 @@
 import { readdir, readFile, realpath, rm, stat, writeFile } from "fs/promises";
 import mkdirp from "mkdirp";
-import fetch from "node-fetch";
 import { fileURLToPath, pathToFileURL } from "url";
 import { createSourceFile } from "./diagnostics.js";
 import { createConsoleSink } from "./logger/index.js";
@@ -14,7 +13,7 @@ import { getSourceFileKindFromExt } from "./util.js";
  */
 export const NodeHost: CompilerHost = {
   readUrl: async (url: string) => {
-    const response = await fetch(url);
+    const response = await (globalThis as any).fetch(url);
     const text = await response.text();
     return createSourceFile(text, url);
   },

--- a/packages/compiler/core/node-host.ts
+++ b/packages/compiler/core/node-host.ts
@@ -7,13 +7,18 @@ import { joinPaths, resolvePath } from "./path-utils.js";
 import { CompilerHost, RmOptions } from "./types.js";
 import { getSourceFileKindFromExt } from "./util.js";
 
+declare global {
+  // Missing native fetch type https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924
+  function fetch(...args: any[]): Promise<any>;
+}
+
 /**
  * Implementation of the @see CompilerHost using the real file system.
  * This is the the CompilerHost used by TypeSpec CLI.
  */
 export const NodeHost: CompilerHost = {
   readUrl: async (url: string) => {
-    const response = await (globalThis as any).fetch(url);
+    const response = await fetch(url);
     const text = await response.text();
     return createSourceFile(text, url);
   },

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -44,7 +44,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "bin": {
     "tsp": "cmd/tsp.js",
@@ -80,7 +80,6 @@
     "mkdirp": "~2.1.6",
     "mustache": "~4.2.0",
     "prettier": "~2.8.7",
-    "node-fetch": "3.2.8",
     "prompts": "~2.4.1",
     "vscode-languageserver": "~8.1.0",
     "vscode-languageserver-textdocument": "~1.0.1",

--- a/packages/compiler/test/server/colorization.test.ts
+++ b/packages/compiler/test/server/colorization.test.ts
@@ -10,6 +10,17 @@ import { SemanticToken, SemanticTokenKind } from "../../server/serverlib.js";
 import { TypeSpecScope } from "../../server/tmlanguage.js";
 import { createTestServerHost } from "../../testing/test-server-host.js";
 
+// vscode-oniguruma depends on those type from the DOM library.
+// As we are only using this in this test it is better to not add the whole DOM library just for this.
+declare global {
+  type Response = any;
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace WebAssembly {
+    type WebAssemblyInstantiatedSource = any;
+    type ImportValue = any;
+  }
+}
+
 const { parseRawGrammar, Registry } = vscode_textmate;
 const { createOnigScanner, createOnigString, loadWASM } = vscode_oniguruma;
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -34,7 +34,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/internal-build-utils/package.json
+++ b/packages/internal-build-utils/package.json
@@ -22,7 +22,7 @@
     "typespec-build-tool": "cmd/cli.js"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -34,7 +34,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -22,7 +22,7 @@
     "typespec-migrate": "./dist/src/cli.js"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -34,7 +34,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -34,7 +34,7 @@
   },
   "tspMain": "dist/src/index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "main": "dist/src/lib.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./dist-dev ./temp ./typespecContents.json",

--- a/packages/playground/src/build-utils/index.ts
+++ b/packages/playground/src/build-utils/index.ts
@@ -22,7 +22,7 @@ export function definePlaygroundViteConfig(config: PlaygroundConfig): UserConfig
     },
     assetsInclude: [/\.tsp$/],
     optimizeDeps: {
-      exclude: ["node-fetch", "swagger-ui"],
+      exclude: ["swagger-ui"],
     },
     plugins: [
       (react as any)({

--- a/packages/ref-doc/package.json
+++ b/packages/ref-doc/package.json
@@ -34,7 +34,7 @@
   },
   "tspMain": "dist/src/index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -34,7 +34,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -20,7 +20,7 @@
   ],
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/tmlanguage-generator/package.json
+++ b/packages/tmlanguage-generator/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "dist/tmlanguage-generator.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",

--- a/packages/typespec-vs/package.json
+++ b/packages/typespec-vs/package.json
@@ -18,7 +18,7 @@
   ],
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "Microsoft.TypeSpec.VS.vsix"

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -34,7 +34,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",


### PR DESCRIPTION
fix #1846
fix #1847

This resolve a vulnerability with the version of node-fetch we were using and we couldn't update because of type issues
