### PR TITLE
Error when @versioned is used with @service({version:"X"})

### DIFF
--- a/common/changes/@typespec/openapi3/versioning-IncompatibleDecoratorUsage_2023-04-27-16-38.json
+++ b/common/changes/@typespec/openapi3/versioning-IncompatibleDecoratorUsage_2023-04-27-16-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/common/changes/@typespec/versioning/versioning-IncompatibleDecoratorUsage_2023-04-27-16-29.json
+++ b/common/changes/@typespec/versioning/versioning-IncompatibleDecoratorUsage_2023-04-27-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "Raise error if versioned spec specifies a single service version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -8,7 +8,7 @@ describe("openapi3: versioning", () => {
     const { v1, v2, v3 } = await openApiFor(
       `
       @versioned(Versions)
-      @service({title: "My Service", version: "hi"})
+      @service({title: "My Service"})
       namespace MyService {
         enum Versions {
           @useDependency(MyLibrary.Versions.A)

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -51,10 +51,10 @@ const libDef = {
         default: "@renamedFrom.oldName cannot be empty string.",
       },
     },
-    "incompatible-decorator-use": {
+    "no-service-fixed-version": {
       severity: "error",
       messages: {
-        default: paramMessage`Namespace '${"name"}' cannot be decorated with @versioned and @service({version: ${"version"}}). Remove the version argument from @service.`,
+        default: paramMessage`Namespace '${"name"}' specify a fixed service version with @service({version: ${"version"}}) while using `@versioned`. Remove the version argument from @service.`,
       },
     },
     "incompatible-versioned-reference": {

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -51,6 +51,12 @@ const libDef = {
         default: "@renamedFrom.oldName cannot be empty string.",
       },
     },
+    "incompatible-decorator-use": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Namespace '${"name"}' cannot be decorated with @versioned and @service({version: ${"version"}}). Remove the version argument from @service.`,
+      },
+    },
     "incompatible-versioned-reference": {
       severity: "error",
       messages: {

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -54,7 +54,7 @@ const libDef = {
     "no-service-fixed-version": {
       severity: "error",
       messages: {
-        default: paramMessage`Namespace '${"name"}' specify a fixed service version with @service({version: ${"version"}}) while using `@versioned`. Remove the version argument from @service.`,
+        default: paramMessage`Namespace '${"name"}' cannot specify a fixed service version with @service({version: ${"version"}}) while using @versioned. Remove the version argument from @service.`,
       },
     },
     "incompatible-versioned-reference": {

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -1,5 +1,6 @@
 import {
   getNamespaceFullName,
+  getService,
   getTypeName,
   isTemplateInstance,
   Namespace,
@@ -93,6 +94,18 @@ export function $onValidate(program: Program) {
         }
       },
       namespace: (namespace) => {
+        const [_, versionMap] = getVersions(program, namespace);
+        const serviceProps = getService(program, namespace);
+        if (serviceProps?.version !== undefined && versionMap !== undefined) {
+          reportDiagnostic(program, {
+            code: "incompatible-decorator-use",
+            format: {
+              name: getNamespaceFullName(namespace),
+              version: serviceProps.version,
+            },
+            target: namespace,
+          });
+        }
         const versionedNamespace = findVersionedNamespace(program, namespace);
         const dependencies = getVersionDependencies(program, namespace);
         if (dependencies === undefined) {

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -98,7 +98,7 @@ export function $onValidate(program: Program) {
         const serviceProps = getService(program, namespace);
         if (serviceProps?.version !== undefined && versionMap !== undefined) {
           reportDiagnostic(program, {
-            code: "incompatible-decorator-use",
+            code: "no-service-fixed-version",
             format: {
               name: getNamespaceFullName(namespace),
               version: serviceProps.version,

--- a/packages/versioning/test/incompatible-versioning.test.ts
+++ b/packages/versioning/test/incompatible-versioning.test.ts
@@ -7,6 +7,43 @@ import {
 } from "@typespec/compiler/testing";
 import { createVersioningTestHost, createVersioningTestRunner } from "./test-host.js";
 
+describe("versioning: incompatible use of decorators", () => {
+  let runner: BasicTestRunner;
+  let host: TestHost;
+  const imports: string[] = [];
+
+  beforeEach(async () => {
+    host = await createVersioningTestHost();
+    runner = createTestWrapper(host, {
+      wrapper: (code) => `
+      import "@typespec/versioning";
+      ${imports.map((i) => `import "${i}";`).join("\n")}
+      using TypeSpec.Versioning;
+      ${code}`,
+    });
+  });
+
+  it("emit diagnostic when @service({version: 'X'}) is used with @versioned", async () => {
+    const diagnostics = await runner.diagnose(`
+    @versioned(Versions)
+    @service({
+      title: "Widget Service",
+      version: "v3"
+    })
+    namespace DemoService;
+
+    enum Versions {
+      v1,
+      v2,
+    }
+    `);
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/versioning/incompatible-decorator-use",
+      severity: "error",
+    });
+  });
+});
+
 describe("versioning: validate incompatible references", () => {
   let runner: BasicTestRunner;
   let host: TestHost;

--- a/packages/versioning/test/incompatible-versioning.test.ts
+++ b/packages/versioning/test/incompatible-versioning.test.ts
@@ -38,7 +38,7 @@ describe("versioning: incompatible use of decorators", () => {
     }
     `);
     expectDiagnostics(diagnostics, {
-      code: "@typespec/versioning/incompatible-decorator-use",
+      code: "@typespec/versioning/no-service-fixed-version",
       severity: "error",
     });
   });


### PR DESCRIPTION
Fixes #1866 (for real this time!)

Because it is illogical and contrary to design to have a service version specified in conjunction with `@versioned`, here we raise an error diagnostic.

cc/ @iscai-msft