### PR TITLE
Fix migration package always loading current version of compiler

### DIFF
--- a/common/changes/@typespec/migrate/fix-migrate-compiler-version_2023-05-02-19-39.json
+++ b/common/changes/@typespec/migrate/fix-migrate-compiler-version_2023-05-02-19-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/migrate",
+      "comment": "Fix: always loading current version of compile",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/migrate"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -67,7 +67,7 @@ specifiers:
   '@typescript-eslint/parser': ^5.30.7
   '@typescript-eslint/utils': ~5.26.0
   '@typespec/compiler-v0.37': npm:@cadl-lang/compiler@0.37.0
-  '@typespec/compiler-v0.38': npm:@cadl-lang/compiler@0.38.0
+  '@typespec/compiler-v0.38': npm:@cadl-lang/compiler@0.38.5
   '@typespec/compiler-v0.40': npm:@cadl-lang/compiler@0.40.0
   '@typespec/compiler-v0.41': npm:@typespec/compiler@0.41.0
   '@typespec/compiler-v0.42': npm:@typespec/compiler@0.42.0
@@ -204,7 +204,7 @@ dependencies:
   '@typescript-eslint/parser': 5.58.0_eslint@8.38.0+typescript@5.0.4
   '@typescript-eslint/utils': 5.26.0_eslint@8.38.0+typescript@5.0.4
   '@typespec/compiler-v0.37': /@cadl-lang/compiler/0.37.0
-  '@typespec/compiler-v0.38': /@cadl-lang/compiler/0.38.0
+  '@typespec/compiler-v0.38': /@cadl-lang/compiler/0.38.5
   '@typespec/compiler-v0.40': /@cadl-lang/compiler/0.40.0
   '@typespec/compiler-v0.41': /@typespec/compiler/0.41.0
   '@typespec/compiler-v0.42': /@typespec/compiler/0.42.0
@@ -1829,8 +1829,8 @@ packages:
       yargs: 17.3.1
     dev: false
 
-  /@cadl-lang/compiler/0.38.0:
-    resolution: {integrity: sha512-SvKEbPdlNzkK7DWd/yM2+IiIVn593rv2bntzU+JY15LzbKmTDH6rrkArkr0nR7lMzcBXpBEEvU3vfRdeRrOTyg==}
+  /@cadl-lang/compiler/0.38.5:
+    resolution: {integrity: sha512-jd6a8TEp9ApBzekTb39aBPocYrkuqzsQbLTDcc/c6tA47Wmr87463MAXpeB80ziEsr15sccI01j3g63jt5W0Aw==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
@@ -16064,7 +16064,7 @@ packages:
     dev: false
 
   file:projects/migrate.tgz:
-    resolution: {integrity: sha512-f3WvrJGpREicOhpHF9DScH5LqpU0gzUkil1BlMhU83OhD0VP9Fbu2ATNjR2KnwDXafWjcphRLjzyO1pIQw9Ixg==, tarball: file:projects/migrate.tgz}
+    resolution: {integrity: sha512-9RqAwH5VVmuPxK0rRgSO4RUB8P3pGeLsYC478Vwchz32QazimcvfzI6EGLhZokz/gREugF3/UybmwtG+Cthu5A==, tarball: file:projects/migrate.tgz}
     name: '@rush-temp/migrate'
     version: 0.0.0
     dependencies:
@@ -16075,7 +16075,7 @@ packages:
       '@types/semver': 7.3.13
       '@types/yargs': 17.0.24
       '@typespec/compiler-v0.37': /@cadl-lang/compiler/0.37.0
-      '@typespec/compiler-v0.38': /@cadl-lang/compiler/0.38.0
+      '@typespec/compiler-v0.38': /@cadl-lang/compiler/0.38.5
       '@typespec/compiler-v0.40': /@cadl-lang/compiler/0.40.0
       '@typespec/compiler-v0.41': /@typespec/compiler/0.41.0
       '@typespec/compiler-v0.42': /@typespec/compiler/0.42.0
@@ -16134,7 +16134,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_rollup@3.4.0:
-    resolution: {integrity: sha512-ce4xC/dS51QetqunqwR9qPHo/KCndoEjznty+z0dZPtc7RRVqCj8vmDdYL1JYFiP1iD6JutD+uEFXZ7WK7X83w==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-ygpdRmhHmPjPFbPkwNYzjDxNGhnLAuBGJPnDFLKKrUyW3ReibPA58VPCPIKTrelIBA+uQaheppk1PHL/JWpk+w==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -16356,7 +16356,7 @@ packages:
     dev: false
 
   file:projects/website.tgz_@types+react@18.0.34:
-    resolution: {integrity: sha512-gfxpzTUoyhVb7yX9P2ZAyJnj54thZPT1qY9/0IAJFXNAkgvEHWHpCCFIVy4e3HcVuyUgTORyTcsLwZGyCCKwyg==, tarball: file:projects/website.tgz}
+    resolution: {integrity: sha512-WoApagobHBIschX0c1pp7CEcDDkaP7+hjv2+ukm2W2b6exkzBG5UcnqaClbH2kgxAWZ1asDmODHA+UoCNdC+2A==, tarball: file:projects/website.tgz}
     id: file:projects/website.tgz
     name: '@rush-temp/website'
     version: 0.0.0

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@typespec/compiler": "~0.43.0",
     "@typespec/compiler-v0.37": "npm:@cadl-lang/compiler@0.37.0",
-    "@typespec/compiler-v0.38": "npm:@cadl-lang/compiler@0.38.0",
+    "@typespec/compiler-v0.38": "npm:@cadl-lang/compiler@0.38.5",
     "@typespec/compiler-v0.40": "npm:@cadl-lang/compiler@0.40.0",
     "@typespec/compiler-v0.41": "npm:@typespec/compiler@0.41.0",
     "@typespec/compiler-v0.42": "npm:@typespec/compiler@0.42.0",

--- a/packages/migrate/src/migration-config.ts
+++ b/packages/migrate/src/migration-config.ts
@@ -19,23 +19,23 @@ export type TypeSpecCompilerV0_43 = TypeSpecCompilerCurrent;
 
 /** Defines the list of compiler versions will be used */
 export type TypeSpecCompilers = {
-  "0.37.0": TypeSpecCompilerV0_37;
-  "0.38.0": TypeSpecCompilerV0_38;
-  "0.40.0": TypeSpecCompilerV0_40;
-  "0.41.0": TypeSpecCompilerV0_41;
-  "0.42.0": TypeSpecCompilerV0_42;
-  "0.43.0": TypeSpecCompilerV0_43;
+  "0.37": TypeSpecCompilerV0_37;
+  "0.38": TypeSpecCompilerV0_38;
+  "0.40": TypeSpecCompilerV0_40;
+  "0.41": TypeSpecCompilerV0_41;
+  "0.42": TypeSpecCompilerV0_42;
+  "0.43": TypeSpecCompilerV0_43;
 };
 
 /** Please define the list of migration steps for each version.
  * Step sequence is respected */
 export const migrationConfigurations: MigrationStepsDictionary = {
-  "0.38.0": [migrateModelToScalar],
-  "0.41.0": [
+  "0.38": [migrateModelToScalar],
+  "0.41": [
     migrateCadlNameToTypeSpec,
     renameCadlFileNames,
     updatePackageVersion,
     migrateTspConfigFile,
   ],
-  "0.43.0": [migrateQueryHeaderRequiredFormat, migrateZonedDateTimeToUtcDateTime],
+  "0.43": [migrateQueryHeaderRequiredFormat, migrateZonedDateTimeToUtcDateTime],
 };

--- a/packages/migrate/src/migration-impl.ts
+++ b/packages/migrate/src/migration-impl.ts
@@ -202,8 +202,16 @@ function ContentMigration(
   const newContent = segments.join("");
 
   try {
+    if ("formatCadl" in toCompiler) {
+      // For migration before rename.
+      return [(toCompiler as any).formatCadl(newContent), true];
+    }
     return [(toCompiler as any).formatTypeSpec(newContent), true];
   } catch (e) {
+    console.log(
+      "TSP compiler",
+      Object.keys(toCompiler).filter((x) => x.startsWith("format"))
+    );
     // eslint-disable-next-line no-console
     console.error("Failed to format new code", e);
     return [newContent, true];

--- a/packages/migrate/src/migrations/v0.38/model-to-scalars.ts
+++ b/packages/migrate/src/migrations/v0.38/model-to-scalars.ts
@@ -14,8 +14,8 @@ import {
 export const migrateModelToScalar = createContentMigration({
   name: "Migrate Model To scalar",
   kind: MigrationKind.AstContentMigration,
-  from: "0.37.0",
-  to: "0.38.0",
+  from: "0.37",
+  to: "0.38",
   migrate: (
     { printNode, printNodes }: MigrationContext,
     compilerV37: TypeSpecCompilerV0_37,

--- a/packages/migrate/src/migrations/v0.41/typespec-rename.ts
+++ b/packages/migrate/src/migrations/v0.41/typespec-rename.ts
@@ -109,8 +109,8 @@ export const updatePackageVersion = createPackageVersionMigration({
 export const migrateCadlNameToTypeSpec = createContentMigration({
   name: "Migrate Model To scalar",
   kind: MigrationKind.AstContentMigration,
-  from: "0.40.0",
-  to: "0.41.0",
+  from: "0.40",
+  to: "0.41",
   migrate: (
     { printNode, printNodes }: MigrationContext,
     compilerV40: TypeSpecCompilerV0_40,

--- a/packages/migrate/src/migrations/v0.43/query-header-required-format.ts
+++ b/packages/migrate/src/migrations/v0.43/query-header-required-format.ts
@@ -10,8 +10,8 @@ import {
 export const migrateQueryHeaderRequiredFormat = createContentMigration({
   name: "Migrate Model To scalar",
   kind: MigrationKind.AstContentMigration,
-  from: "0.42.0",
-  to: "0.43.0",
+  from: "0.42",
+  to: "0.43",
   migrate: (
     { printNode, printNodes }: MigrationContext,
     compilerV37: TypeSpecCompilerV0_42,

--- a/packages/migrate/src/migrations/v0.43/zoned-date-time-to-utc-date-time.ts
+++ b/packages/migrate/src/migrations/v0.43/zoned-date-time-to-utc-date-time.ts
@@ -10,15 +10,15 @@ import {
 export const migrateZonedDateTimeToUtcDateTime = createContentMigration({
   name: "Migrate zonedDateTime to utcDateTime",
   kind: MigrationKind.AstContentMigration,
-  from: "0.42.0",
-  to: "0.43.0",
+  from: "0.42",
+  to: "0.43",
   migrate: (
     { printNode, printNodes }: MigrationContext,
-    compilerV37: TypeSpecCompilerV0_42,
+    compilerV42: TypeSpecCompilerV0_42,
     root: TypeSpecScriptNode
   ) => {
     const actions: AstContentMigrateAction[] = [];
-    visitRecursive(compilerV37, root, (node) => {
+    visitRecursive(compilerV42, root, (node) => {
       if (
         node.kind === SyntaxKind.TypeReference &&
         node.target.kind === SyntaxKind.Identifier &&


### PR DESCRIPTION
This PR actually broke the migration logic to resolve which version of the compiler to load https://github.com/microsoft/typespec/pull/1694

By adding `.0` it wouldn't find the version and then default to the current version.

This is causing issues for other PRs that add new elements to enum and require previous migration to compare `SyntaxKind`  correctly.