### PR TITLE
[protobuf] Enable publishing @typespec/protobuf

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -191,7 +191,7 @@
       "packageName": "@typespec/protobuf",
       "projectFolder": "packages/protobuf",
       "reviewCategory": "production",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@typespec/ref-doc",


### PR DESCRIPTION
I had this flag set to false during development. This PR sets it to true so the package can go to NPM. It's already in the playground.