### PR TITLE
Normalizing cwd before first use in getCompilerOptions()

### DIFF
--- a/common/changes/@typespec/compiler/patch-2_2023-05-05-03-28.json
+++ b/common/changes/@typespec/compiler/patch-2_2023-05-05-03-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Normalizing cwd before first use in getCompilerOptions()",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/core/cli/args.ts
+++ b/packages/compiler/core/cli/args.ts
@@ -6,9 +6,8 @@ import {
 import { EmitterOptions, TypeSpecConfig } from "../../config/types.js";
 import { createDiagnosticCollector } from "../index.js";
 import { CompilerOptions } from "../options.js";
-import { resolvePath } from "../path-utils.js";
+import { normalizePath, resolvePath } from "../path-utils.js";
 import { CompilerHost, Diagnostic } from "../types.js";
-import { deepClone, omitUndefined } from "../util.js";
 
 export interface CompileCliArgs {
   "output-dir"?: string;

--- a/packages/compiler/core/cli/args.ts
+++ b/packages/compiler/core/cli/args.ts
@@ -32,9 +32,11 @@ export async function getCompilerOptions(
   args: CompileCliArgs,
   env: Record<string, string | undefined>
 ): Promise<[CompilerOptions | undefined, readonly Diagnostic[]]> {
+  cwd = normalizePath(cwd);
+
   const diagnostics = createDiagnosticCollector();
   const pathArg = args["output-dir"] ?? args["output-path"];
-  const configPath = args["config"] ?? normalizePath(cwd);
+  const configPath = args["config"] ?? cwd;
 
   const config = await loadTypeSpecConfigForPath(host, configPath, "config" in args);
   if (config.diagnostics.length > 0) {

--- a/packages/compiler/core/cli/args.ts
+++ b/packages/compiler/core/cli/args.ts
@@ -8,6 +8,7 @@ import { createDiagnosticCollector } from "../index.js";
 import { CompilerOptions } from "../options.js";
 import { normalizePath, resolvePath } from "../path-utils.js";
 import { CompilerHost, Diagnostic } from "../types.js";
+import { deepClone, omitUndefined } from "../util.js";
 
 export interface CompileCliArgs {
   "output-dir"?: string;

--- a/packages/compiler/core/cli/args.ts
+++ b/packages/compiler/core/cli/args.ts
@@ -34,7 +34,7 @@ export async function getCompilerOptions(
 ): Promise<[CompilerOptions | undefined, readonly Diagnostic[]]> {
   const diagnostics = createDiagnosticCollector();
   const pathArg = args["output-dir"] ?? args["output-path"];
-  const configPath = args["config"] ?? cwd;
+  const configPath = args["config"] ?? normalizePath(cwd);
 
   const config = await loadTypeSpecConfigForPath(host, configPath, "config" in args);
   if (config.diagnostics.length > 0) {


### PR DESCRIPTION
So an output message like this:

```
Compilation completed successfully, output files are in D:\Projects\ATS-RP\src\TypeSpec\typespec/tsp-output.
                                                                                                ^
```

would turned into this:

```
Compilation completed successfully, output files are in D:\Projects\ATS-RP\src\TypeSpec\typespec\tsp-output.
                                                                                                ^
```