### PR TITLE
Fix openapi3 emitter to mark request body required

### DIFF
--- a/common/changes/@typespec/openapi3/fix-required-request-body_2023-05-05-00-07.json
+++ b/common/changes/@typespec/openapi3/fix-required-request-body_2023-05-05-00-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Fix openapi3 emitter to mark request body required",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/docs/standard-library/openapi/openapi.md
+++ b/docs/standard-library/openapi/openapi.md
@@ -57,7 +57,9 @@ The `in` field of a parameter is specified with an [(Http) `@query`, `@header`, 
 A parameter without one of these decorators is assumed to be passed in the request body.
 
 The request body parameter can also be explicitly decorated with an [(Http) `@body` decorator][http-body-decorator].
-In the absence of explicit `@body`, the set of parameters that are not marked `@header`, `@query`, or `@path` form the request body.
+In the absence of explicit `@body`, the set of parameters that are not marked `@header`, `@query`, or `@path` form the request body
+and this request body is defined as required. If the request body should be optional, the body must be declared as
+optional property with the `@body` decorator.
 
 [http-parameter-decorators]: ../rest/reference/decorators.md#data-types
 [http-body-decorator]: ../rest/reference/decorators.md#@TypeSpec.Http.body

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1077,6 +1077,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
 
     const requestBody: any = {
       description: body.parameter ? getDoc(program, body.parameter) : undefined,
+      required: body.parameter ? !body.parameter.optional : undefined,
       content: {},
     };
 

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1077,7 +1077,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
 
     const requestBody: any = {
       description: body.parameter ? getDoc(program, body.parameter) : undefined,
-      required: body.parameter ? !body.parameter.optional : undefined,
+      required: body.parameter ? !body.parameter.optional : true,
       content: {},
     };
 

--- a/packages/openapi3/test/metadata.test.ts
+++ b/packages/openapi3/test/metadata.test.ts
@@ -413,6 +413,7 @@ describe("openapi3: metadata", () => {
             },
           },
           requestBody: {
+            required: true,
             content: {
               "application/json": {
                 schema: {
@@ -447,6 +448,64 @@ describe("openapi3: metadata", () => {
           schema: { type: "string" },
         },
       },
+      schemas: {
+        Parameters: {
+          properties: {
+            h: {
+              type: "string",
+            },
+            p: {
+              type: "string",
+            },
+            q: {
+              type: "string",
+            },
+          },
+          required: ["q", "p", "h"],
+          type: "object",
+        },
+      },
+    });
+  });
+
+  it("Supports optional request bodies", async () => {
+    const res = await openApiFor(
+      `
+      model Parameters {
+        @query q: string;
+        @path p: string;
+        @header h: string;
+      }
+      @route("/batch") @post op batch(@body body?: Parameters[]): string;
+      `
+    );
+    deepStrictEqual(res.paths, {
+      "/batch": {
+        post: {
+          operationId: "batch",
+          parameters: [],
+          responses: {
+            "200": {
+              description: "The request has succeeded.",
+              content: { "application/json": { schema: { type: "string" } } },
+            },
+          },
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Parameters" },
+                  "x-typespec-name": "Parameters[]",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    deepStrictEqual(res.components, {
       schemas: {
         Parameters: {
           properties: {

--- a/packages/openapi3/test/metadata.test.ts
+++ b/packages/openapi3/test/metadata.test.ts
@@ -468,6 +468,67 @@ describe("openapi3: metadata", () => {
     });
   });
 
+  it("Constructs an implicit body from non-metadata parameters", async () => {
+    const res = await openApiFor(
+      `
+      @route("/test") @post op test(
+        @query q: string;
+        @header h: string;
+        foo: string;
+        bar: int32;
+      ): string;
+      `
+    );
+    deepStrictEqual(res.paths, {
+      "/test": {
+        post: {
+          operationId: "test",
+          parameters: [
+            {
+              name: "q",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+            },
+            {
+              name: "h",
+              in: "header",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "The request has succeeded.",
+              content: { "application/json": { schema: { type: "string" } } },
+            },
+          },
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  properties: {
+                    bar: {
+                      format: "int32",
+                      type: "integer",
+                    },
+                    foo: {
+                      type: "string",
+                    },
+                  },
+                  required: ["foo", "bar"],
+                  type: "object",
+                  "x-typespec-name": "(anonymous model)",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
   it("Supports optional request bodies", async () => {
     const res = await openApiFor(
       `
@@ -711,6 +772,7 @@ describe("openapi3: metadata", () => {
             },
           },
           requestBody: {
+            required: true,
             content: {
               "application/json": {
                 schema: {

--- a/packages/samples/test/output/binary/openapi.yaml
+++ b/packages/samples/test/output/binary/openapi.yaml
@@ -16,6 +16,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HasBytes'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -33,6 +34,7 @@ paths:
                 type: string
                 format: binary
       requestBody:
+        required: true
         content:
           application/octect-stream:
             schema:
@@ -51,6 +53,7 @@ paths:
                 type: string
                 format: binary
       requestBody:
+        required: true
         content:
           image/png:
             schema:
@@ -69,6 +72,7 @@ paths:
                 type: string
                 format: byte
       requestBody:
+        required: true
         content:
           text/plain:
             schema:

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
@@ -26,6 +26,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -145,6 +146,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -231,6 +233,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/grpc-library-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-library-example/openapi.yaml
@@ -27,6 +27,7 @@ paths:
                 $ref: '#/components/schemas/RpcStatus'
       requestBody:
         description: The shelf to create.
+        required: true
         content:
           application/json:
             schema:
@@ -155,6 +156,7 @@ paths:
                 $ref: '#/components/schemas/RpcStatus'
       requestBody:
         description: The book to create.
+        required: true
         content:
           application/json:
             schema:
@@ -222,6 +224,7 @@ paths:
                 $ref: '#/components/schemas/RpcStatus'
       requestBody:
         description: The name of the shelf we're removing books from and deleting.
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/nested/openapi.yaml
+++ b/packages/samples/test/output/nested/openapi.yaml
@@ -16,6 +16,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/nested/openapi.yaml
+++ b/packages/samples/test/output/nested/openapi.yaml
@@ -41,6 +41,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -57,6 +58,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/nullable/openapi.yaml
+++ b/packages/samples/test/output/nullable/openapi.yaml
@@ -22,6 +22,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HasNullables'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/optional/openapi.yaml
+++ b/packages/samples/test/output/optional/openapi.yaml
@@ -22,6 +22,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HasOptional'
       requestBody:
+        required: false
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/param-decorators/openapi.yaml
+++ b/packages/samples/test/output/param-decorators/openapi.yaml
@@ -42,6 +42,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Thing'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/petstore/openapi.yaml
+++ b/packages/samples/test/output/petstore/openapi.yaml
@@ -49,6 +49,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/rest/petstore/openapi.yaml
+++ b/packages/samples/test/output/rest/petstore/openapi.yaml
@@ -48,6 +48,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -77,6 +78,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -136,6 +138,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -200,6 +203,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -242,6 +246,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -271,6 +276,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -330,6 +336,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -394,6 +401,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -436,6 +444,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -523,6 +532,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/signatures/openapi.yaml
+++ b/packages/samples/test/output/signatures/openapi.yaml
@@ -23,6 +23,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDetails'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -69,6 +70,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDetails'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/testserver/body-boolean/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.yaml
@@ -42,6 +42,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -118,6 +119,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/testserver/body-complex/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-complex/openapi.yaml
@@ -36,6 +36,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -72,6 +73,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -108,6 +110,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -144,6 +147,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -180,6 +184,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -216,6 +221,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -252,6 +258,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -288,6 +295,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -324,6 +332,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -360,6 +369,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -396,6 +406,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -432,6 +443,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -468,6 +480,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/testserver/body-string/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-string/openapi.yaml
@@ -42,6 +42,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -85,6 +86,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -127,6 +129,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -167,6 +170,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -214,6 +218,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -259,6 +264,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -309,6 +315,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/testserver/body-time/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-time/openapi.yaml
@@ -37,6 +37,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/testserver/media-types/openapi.yaml
+++ b/packages/samples/test/output/testserver/media-types/openapi.yaml
@@ -18,6 +18,7 @@ paths:
                 type: string
       requestBody:
         description: Input parameter.
+        required: true
         content:
           application/pdf:
             schema:
@@ -50,6 +51,7 @@ paths:
                 type: string
       requestBody:
         description: Input parameter.
+        required: true
         content:
           text/plain:
             schema:

--- a/packages/samples/test/output/testserver/multiple-inheritance/openapi.yaml
+++ b/packages/samples/test/output/testserver/multiple-inheritance/openapi.yaml
@@ -44,6 +44,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -84,6 +85,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -124,6 +126,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -168,6 +171,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -208,6 +212,7 @@ paths:
               schema:
                 type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/packages/samples/test/output/visibility/openapi.yaml
+++ b/packages/samples/test/output/visibility/openapi.yaml
@@ -16,6 +16,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReadablePerson'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -31,6 +32,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReadablePerson'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -65,6 +67,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReadablePerson'
       requestBody:
+        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
This PR fixes the openapi3 generator to add `required: true` to required request bodies.

A test is included to verify that an optional request body is not marked required.

Fixes #1838.