### PR TITLE
Add validation to ensure date and numeric versions are in ascending order

### DIFF
--- a/common/changes/@typespec/versioning/versioning-orderLinterRule_2023-05-05-21-44.json
+++ b/common/changes/@typespec/versioning/versioning-orderLinterRule_2023-05-05-21-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "Add validation for numeric and date-based versions to be in ascending order.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -88,6 +88,25 @@ const libDef = {
         default: paramMessage`Property '${"name"}' marked with @madeOptional but is required. Should be '${"name"}?'`,
       },
     },
+    "versioned-dates-not-ascending": {
+      severity: "warning",
+      messages: {
+        default: "Date-based versions should be in ascending order.",
+      },
+    },
+    "versioned-dates-preview-first": {
+      severity: "warning",
+      messages: {
+        default:
+          "Date-based versions with a beta and non-beta version should list the beta version first.",
+      },
+    },
+    "versioned-numbers-not-ascending": {
+      severity: "warning",
+      messages: {
+        default: "Number-based versions should be in ascending order.",
+      },
+    },
   },
 } as const;
 export const { reportDiagnostic, createStateSymbol } = createTypeSpecLibrary(libDef);


### PR DESCRIPTION
Fixes https://github.com/Azure/typespec-azure/issues/2242

- versions backed my numbers must be in ascending order
- versions backed by dates must be in ascending order
- preview or beta versions (for date-based versions) must precede non-preview versions