### PR TITLE
Remove unnecessary uses of rekeyable maps in projections

### DIFF
--- a/common/changes/@typespec/compiler/unnecessary-rekeyable-projection_2023-05-10-15-12.json
+++ b/common/changes/@typespec/compiler/unnecessary-rekeyable-projection_2023-05-10-15-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/core/projector.ts
+++ b/packages/compiler/core/projector.ts
@@ -178,13 +178,13 @@ export function createProjector(
     }
 
     const projectedNs = shallowClone(ns, {
-      namespaces: createRekeyableMap(),
-      scalars: createRekeyableMap(),
-      models: createRekeyableMap(),
-      operations: createRekeyableMap(),
-      interfaces: createRekeyableMap(),
-      unions: createRekeyableMap(),
-      enums: createRekeyableMap(),
+      namespaces: new Map(),
+      scalars: new Map(),
+      models: new Map(),
+      operations: new Map(),
+      interfaces: new Map(),
+      unions: new Map(),
+      enums: new Map(),
       decorators: [],
     });
 


### PR DESCRIPTION
Namespace member ordering is implementation defined so this was unnecessary and rekeyable maps are slower and harder to debug.

The TS typing will force you to use rekeyable map where required. This was left over from mid-work on member ordering where I had put rekeyable in too many places in the typing.