### PR TITLE
Fix formatting issue with comment between decorator and op

### DIFF
--- a/common/changes/@typespec/compiler/fix-format-comment-op_2023-05-11-15-21.json
+++ b/common/changes/@typespec/compiler/fix-format-comment-op_2023-05-11-15-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: formatting of comment between decorator and `op` statement",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/formatter/print/comment-handler.ts
+++ b/packages/compiler/formatter/print/comment-handler.ts
@@ -64,6 +64,7 @@ function addStatementDecoratorComment(comment: CommentNode) {
     (enclosingNode.kind === SyntaxKind.NamespaceStatement ||
       enclosingNode.kind === SyntaxKind.ModelStatement ||
       enclosingNode.kind === SyntaxKind.EnumStatement ||
+      enclosingNode.kind === SyntaxKind.OperationStatement ||
       enclosingNode.kind === SyntaxKind.ModelProperty ||
       enclosingNode.kind === SyntaxKind.EnumMember ||
       enclosingNode.kind === SyntaxKind.UnionStatement)

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -574,6 +574,21 @@ model Bar {}
       });
     });
 
+    it("format comment between decorator and op statement", () => {
+      assertFormat({
+        code: `
+@foo
+  // comment
+op test(foo: string): void;
+`,
+        expected: `
+@foo
+// comment
+op test(foo: string): void;
+`,
+      });
+    });
+
     it("keeps comment in between decorators", () => {
       assertFormat({
         code: `


### PR DESCRIPTION
fix #1930 

Already had the logic for the other statements types but op was missed for some reason.