### PR TITLE
Fix decorator signature in docs

### DIFF
--- a/docs/standard-library/built-in-decorators.md
+++ b/docs/standard-library/built-in-decorators.md
@@ -11,7 +11,7 @@ toc_max_heading_level: 3
 Mark this type as deprecated
 
 ```typespec
-dec deprecated(target: unknown, message: string)
+@deprecated(message: string)
 ```
 
 #### Target
@@ -36,7 +36,7 @@ op Action<T>(): T;
 Specify the property to be used to discriminate this type.
 
 ```typespec
-dec discriminator(target: Model | Union, propertyName: string)
+@discriminator(propertyName: string)
 ```
 
 #### Target
@@ -72,7 +72,7 @@ model Dog extends Pet  {kind: "dog", bark: boolean}
 Attach a documentation string.
 
 ```typespec
-dec doc(target: unknown, doc: string, formatArgs?: object)
+@doc(doc: string, formatArgs?: object)
 ```
 
 #### Target
@@ -98,7 +98,7 @@ model Pet {}
 Specify how to encode the target type.
 
 ```typespec
-dec encode(target: Scalar | ModelProperty, encoding: string | EnumMember, encodedAs?: string | numeric)
+@encode(encoding: string | EnumMember, encodedAs?: string | numeric)
 ```
 
 #### Target
@@ -134,7 +134,7 @@ scalar myDateTime extends unixTimestamp;
 Specify that this model is an error type. Operations return error types when the operation has failed.
 
 ```typespec
-dec error(target: Model)
+@error
 ```
 
 #### Target
@@ -162,7 +162,7 @@ This differs from the `@pattern` decorator which is meant to specify a regular e
 The format names are open ended and are left to emitter to interpret.
 
 ```typespec
-dec format(target: string | bytes | ModelProperty, format: string)
+@format(format: string)
 ```
 
 #### Target
@@ -187,7 +187,7 @@ scalar uuid extends string;
 Specifies how a templated type should name their instances.
 
 ```typespec
-dec friendlyName(target: unknown, name: string, formatArgs?: unknown)
+@friendlyName(name: string, formatArgs?: unknown)
 ```
 
 #### Target
@@ -216,7 +216,7 @@ nextLink: string;
 A debugging decorator used to inspect a type.
 
 ```typespec
-dec inspectType(target: unknown, text: string)
+@inspectType(text: string)
 ```
 
 #### Target
@@ -234,7 +234,7 @@ dec inspectType(target: unknown, text: string)
 A debugging decorator used to inspect a type name.
 
 ```typespec
-dec inspectTypeName(target: unknown, text: string)
+@inspectTypeName(text: string)
 ```
 
 #### Target
@@ -252,7 +252,7 @@ dec inspectTypeName(target: unknown, text: string)
 Mark a model property as the key to identify instances of that type
 
 ```typespec
-dec key(target: ModelProperty, altName?: string)
+@key(altName?: string)
 ```
 
 #### Target
@@ -278,7 +278,7 @@ model Pet {
 Provide a set of known values to a string type.
 
 ```typespec
-dec knownValues(target: string | numeric | ModelProperty, values: Enum)
+@knownValues(values: Enum)
 ```
 
 #### Target
@@ -308,7 +308,7 @@ Invalid,
 Specify the maximum number of items this array should have.
 
 ```typespec
-dec maxItems(target: unknown[] | ModelProperty, value: integer)
+@maxItems(value: integer)
 ```
 
 #### Target
@@ -333,7 +333,7 @@ model Endpoints is string[];
 Specify the maximum length this string type should be.
 
 ```typespec
-dec maxLength(target: string | ModelProperty, value: integer)
+@maxLength(value: integer)
 ```
 
 #### Target
@@ -358,7 +358,7 @@ scalar Username extends string;
 Specify the maximum value this numeric type should be.
 
 ```typespec
-dec maxValue(target: numeric | ModelProperty, value: numeric)
+@maxValue(value: numeric)
 ```
 
 #### Target
@@ -384,7 +384,7 @@ Specify the maximum value this numeric type should be, exclusive of the given
 value.
 
 ```typespec
-dec maxValueExclusive(target: numeric | ModelProperty, value: numeric)
+@maxValueExclusive(value: numeric)
 ```
 
 #### Target
@@ -409,7 +409,7 @@ scalar distance is float64;
 Specify the minimum number of items this array should have.
 
 ```typespec
-dec minItems(target: unknown[] | ModelProperty, value: integer)
+@minItems(value: integer)
 ```
 
 #### Target
@@ -434,7 +434,7 @@ model Endpoints is string[];
 Specify the minimum length this string type should be.
 
 ```typespec
-dec minLength(target: string | ModelProperty, value: integer)
+@minLength(value: integer)
 ```
 
 #### Target
@@ -459,7 +459,7 @@ scalar Username extends string;
 Specify the minimum value this numeric type should be.
 
 ```typespec
-dec minValue(target: numeric | ModelProperty, value: numeric)
+@minValue(value: numeric)
 ```
 
 #### Target
@@ -485,7 +485,7 @@ Specify the minimum value this numeric type should be, exclusive of the given
 value.
 
 ```typespec
-dec minValueExclusive(target: numeric | ModelProperty, value: numeric)
+@minValueExclusive(value: numeric)
 ```
 
 #### Target
@@ -510,7 +510,7 @@ scalar distance is float64;
 Specify this operation is an overload of the given operation.
 
 ```typespec
-dec overload(target: Operation, overloadbase: Operation)
+@overload(overloadbase: Operation)
 ```
 
 #### Target
@@ -540,7 +540,7 @@ The following syntax is allowed: alternations (`|`), quantifiers (`?`, `*`, `+`,
 Advanced features like look-around, capture groups, and references are not supported.
 
 ```typespec
-dec pattern(target: string | bytes | ModelProperty, pattern: string)
+@pattern(pattern: string)
 ```
 
 #### Target
@@ -565,7 +565,7 @@ scalar LowerAlpha extends string;
 Provide an alternative name for this type.
 
 ```typespec
-dec projectedName(target: unknown, targetName: string, projectedName: string)
+@projectedName(targetName: string, projectedName: string)
 ```
 
 #### Target
@@ -593,7 +593,7 @@ expireAt: int32;
 Mark this string as a secret value that should be treated carefully to avoid exposure
 
 ```typespec
-dec secret(target: string | ModelProperty)
+@secret
 ```
 
 #### Target
@@ -616,7 +616,7 @@ scalar Password is string;
 Mark this namespace as describing a service and configure service properties.
 
 ```typespec
-dec service(target: Namespace, options?: ServiceOptions)
+@service(options?: ServiceOptions)
 ```
 
 #### Target
@@ -655,7 +655,7 @@ namespace PetStore;
 Typically a short, single-line description.
 
 ```typespec
-dec summary(target: unknown, summary: string)
+@summary(summary: string)
 ```
 
 #### Target
@@ -680,7 +680,7 @@ model Pet {}
 Attaches a tag to an operation, interface, or namespace. Multiple `@tag` decorators can be specified to attach multiple tags to a TypeSpec element.
 
 ```typespec
-dec tag(target: Namespace | Interface | Operation, tag: string)
+@tag(tag: string)
 ```
 
 #### Target
@@ -712,7 +712,7 @@ with standard emitters that interpret them as follows:
 See also: [Automatic visibility](https://microsoft.github.io/typespec/standard-library/http/operations#automatic-visibility)
 
 ```typespec
-dec visibility(target: ModelProperty, ...visibilities: string[])
+@visibility(...visibilities: string[])
 ```
 
 #### Target
@@ -743,7 +743,7 @@ name: string;
 Set the visibility of key properties in a model if not already set.
 
 ```typespec
-dec withDefaultKeyVisibility(target: Model, visibility: unknown)
+@withDefaultKeyVisibility(visibility: unknown)
 ```
 
 #### Target
@@ -761,7 +761,7 @@ dec withDefaultKeyVisibility(target: Model, visibility: unknown)
 Returns the model with any default values removed.
 
 ```typespec
-dec withoutDefaultValues(target: Model)
+@withoutDefaultValues
 ```
 
 #### Target
@@ -777,7 +777,7 @@ None
 Returns the model with the given properties omitted.
 
 ```typespec
-dec withoutOmittedProperties(target: Model, omit: string | Union)
+@withoutOmittedProperties(omit: string | Union)
 ```
 
 #### Target
@@ -795,7 +795,7 @@ dec withoutOmittedProperties(target: Model, omit: string | Union)
 Returns the model with non-updateable properties removed.
 
 ```typespec
-dec withUpdateableProperties(target: Model)
+@withUpdateableProperties
 ```
 
 #### Target
@@ -819,7 +819,7 @@ When using an emitter that applies visibility automatically, it is generally
 not necessary to use this decorator.
 
 ```typespec
-dec withVisibility(target: Model, ...visibilities: string[])
+@withVisibility(...visibilities: string[])
 ```
 
 #### Target

--- a/docs/standard-library/http/reference/decorators.md
+++ b/docs/standard-library/http/reference/decorators.md
@@ -13,7 +13,7 @@ toc_max_heading_level: 3
 Explicitly specify that this property is to be set as the body
 
 ```typespec
-dec TypeSpec.Http.body(target: ModelProperty)
+@TypeSpec.Http.body
 ```
 
 #### Target
@@ -36,7 +36,7 @@ op download(): {@body image: bytes};
 Specify the http verb for the target operation to be `DELETE`.
 
 ```typespec
-dec TypeSpec.Http.delete(target: Operation)
+@TypeSpec.Http.delete
 ```
 
 #### Target
@@ -58,7 +58,7 @@ None
 Specify the http verb for the target operation to be `GET`.
 
 ```typespec
-dec TypeSpec.Http.get(target: Operation)
+@TypeSpec.Http.get
 ```
 
 #### Target
@@ -80,7 +80,7 @@ None
 Specify the http verb for the target operation to be `HEAD`.
 
 ```typespec
-dec TypeSpec.Http.head(target: Operation)
+@TypeSpec.Http.head
 ```
 
 #### Target
@@ -102,7 +102,7 @@ None
 Specify this property is to be sent or received as an http header.
 
 ```typespec
-dec TypeSpec.Http.header(target: ModelProperty, headerNameOrOptions?: string | TypeSpec.Http.HeaderOptions)
+@TypeSpec.Http.header(headerNameOrOptions?: string | TypeSpec.Http.HeaderOptions)
 ```
 
 #### Target
@@ -127,7 +127,7 @@ op create(@header({name: "X-Color", format: "csv"}) colors: string[]): void;
 Specify if inapplicable metadata should be included in the payload for the given entity.
 
 ```typespec
-dec TypeSpec.Http.includeInapplicableMetadataInPayload(target: unknown, value: boolean)
+@TypeSpec.Http.includeInapplicableMetadataInPayload(value: boolean)
 ```
 
 #### Target
@@ -145,7 +145,7 @@ dec TypeSpec.Http.includeInapplicableMetadataInPayload(target: unknown, value: b
 Specify the http verb for the target operation to be `PATCH`.
 
 ```typespec
-dec TypeSpec.Http.patch(target: Operation)
+@TypeSpec.Http.patch
 ```
 
 #### Target
@@ -167,7 +167,7 @@ None
 Explicitly specify that this property is to be interpolated as a path parameter.
 
 ```typespec
-dec TypeSpec.Http.path(target: ModelProperty, paramName?: string)
+@TypeSpec.Http.path(paramName?: string)
 ```
 
 #### Target
@@ -192,7 +192,7 @@ op read(@path explicit: string, implicit: string): void;
 Specify the http verb for the target operation to be `POST`.
 
 ```typespec
-dec TypeSpec.Http.post(target: Operation)
+@TypeSpec.Http.post
 ```
 
 #### Target
@@ -214,7 +214,7 @@ None
 Specify the http verb for the target operation to be `PUT`.
 
 ```typespec
-dec TypeSpec.Http.put(target: Operation)
+@TypeSpec.Http.put
 ```
 
 #### Target
@@ -236,7 +236,7 @@ None
 Specify this property is to be sent as a query parameter.
 
 ```typespec
-dec TypeSpec.Http.query(target: ModelProperty, queryNameOrOptions?: string | TypeSpec.Http.QueryOptions)
+@TypeSpec.Http.query(queryNameOrOptions?: string | TypeSpec.Http.QueryOptions)
 ```
 
 #### Target
@@ -267,7 +267,7 @@ it will be used as a prefix to the route URI of the operation.
 `@route` can only be applied to operations, namespaces, and interfaces.
 
 ```typespec
-dec TypeSpec.Http.route(target: Namespace | Interface | Operation, path: string, options?: (anonymous model))
+@TypeSpec.Http.route(path: string, options?: (anonymous model))
 ```
 
 #### Target
@@ -293,7 +293,7 @@ op getWidget(@path id: string): Widget;
 Specify the endpoint for this service.
 
 ```typespec
-dec TypeSpec.Http.server(target: Namespace, url: string, description: string, parameters?: object)
+@TypeSpec.Http.server(url: string, description: string, parameters?: object)
 ```
 
 #### Target
@@ -341,7 +341,7 @@ op getWidget(@path id: string): Widget;
 ```
 
 ```typespec
-dec TypeSpec.Http.sharedRoute(target: Operation)
+@TypeSpec.Http.sharedRoute
 ```
 
 #### Target
@@ -357,7 +357,7 @@ None
 Specify the status code for this response. Property type must be a status code integer or a union of status code integer.
 
 ```typespec
-dec TypeSpec.Http.statusCode(target: ModelProperty)
+@TypeSpec.Http.statusCode
 ```
 
 #### Target
@@ -380,7 +380,7 @@ op create(): {@statusCode: 201 | 202}
 Specify this service authentication. See the [documentation in the Http library][https://microsoft.github.io/typespec/standard-library/rest/authentication] for full details.
 
 ```typespec
-dec TypeSpec.Http.useAuth(target: Namespace, auth: object | Union | object[])
+@TypeSpec.Http.useAuth(auth: object | Union | object[])
 ```
 
 #### Target

--- a/docs/standard-library/openapi/reference/decorators.md
+++ b/docs/standard-library/openapi/reference/decorators.md
@@ -14,7 +14,7 @@ Specify that this model is to be treated as the OpenAPI `default` response.
 This differs from the compiler built-in `@error` decorator as this does not necessarily represent an error.
 
 ```typespec
-dec OpenAPI.defaultResponse(target: Model)
+@OpenAPI.defaultResponse
 ```
 
 #### Target
@@ -39,7 +39,7 @@ op listPets(): Pet[] | PetStoreResponse;
 Attach some custom data to the OpenAPI element generated from this type.
 
 ```typespec
-dec OpenAPI.extension(target: unknown, key: string, value: unknown)
+@OpenAPI.extension(key: string, value: unknown)
 ```
 
 #### Target
@@ -66,7 +66,7 @@ op read(): string;
 Specify the OpenAPI `externalDocs` property for this type.
 
 ```typespec
-dec OpenAPI.externalDocs(target: unknown, url: string, description?: string)
+@OpenAPI.externalDocs(url: string, description?: string)
 ```
 
 #### Target
@@ -92,7 +92,7 @@ op listPets(): Pet[];
 Specify the OpenAPI `operationId` property for this operation.
 
 ```typespec
-dec OpenAPI.operationId(target: Operation, operationId: string)
+@OpenAPI.operationId(operationId: string)
 ```
 
 #### Target

--- a/docs/standard-library/protobuf/reference/decorators.md
+++ b/docs/standard-library/protobuf/reference/decorators.md
@@ -20,7 +20,7 @@ The field index of a Protobuf message must:
 - not fall within any range that was [marked reserved](#
 
 ```typespec
-dec TypeSpec.Protobuf.field(target: ModelProperty, index: uint32)
+@TypeSpec.Protobuf.field(index: uint32)
 ```
 
 #### Target
@@ -54,7 +54,7 @@ Messages can be detected automatically if either of the following two conditions
 This decorator will force the emitter to check and emit a model.
 
 ```typespec
-dec TypeSpec.Protobuf.message(target: object)
+@TypeSpec.Protobuf.message
 ```
 
 #### Target
@@ -71,7 +71,7 @@ Declares that a TypeSpec namespace constitutes a Protobuf package. The contents 
 single Protobuf file.
 
 ```typespec
-dec TypeSpec.Protobuf.package(target: Namespace, details?: TypeSpec.Protobuf.PackageDetails)
+@TypeSpec.Protobuf.package(details?: TypeSpec.Protobuf.PackageDetails)
 ```
 
 #### Target
@@ -108,7 +108,7 @@ See _[Protobuf Language Guide - Reserved Fields](https://protobuf.dev/programmin
 information.
 
 ```typespec
-dec TypeSpec.Protobuf.reserve(target: object, ...reservations: string | [uint32, uint32] | uint32[])
+@TypeSpec.Protobuf.reserve(...reservations: string | [uint32, uint32] | uint32[])
 ```
 
 #### Target
@@ -137,7 +137,7 @@ Declares that a TypeSpec interface constitutes a Protobuf service. The contents 
 a `service` declaration in the resulting Protobuf file.
 
 ```typespec
-dec TypeSpec.Protobuf.service(target: Interface)
+@TypeSpec.Protobuf.service
 ```
 
 #### Target
@@ -153,7 +153,7 @@ None
 Set the streaming mode of an operation. See [StreamMode](./data-types#TypeSpec.Protobuf.StreamMode) for more information.
 
 ```typespec
-dec TypeSpec.Protobuf.stream(target: Operation, mode: TypeSpec.Protobuf.StreamMode)
+@TypeSpec.Protobuf.stream(mode: TypeSpec.Protobuf.StreamMode)
 ```
 
 #### Target

--- a/docs/standard-library/rest/reference/decorators.md
+++ b/docs/standard-library/rest/reference/decorators.md
@@ -13,7 +13,7 @@ toc_max_heading_level: 3
 Specify this operation is an action. (Scoped to a resource item /pets/{petId}/my-action)
 
 ```typespec
-dec TypeSpec.Rest.action(target: Operation, name?: string)
+@TypeSpec.Rest.action(name?: string)
 ```
 
 #### Target
@@ -31,7 +31,7 @@ dec TypeSpec.Rest.action(target: Operation, name?: string)
 Defines the separator string that is inserted before the action name in auto-generated routes for actions.
 
 ```typespec
-dec TypeSpec.Rest.actionSeparator(target: Model | ModelProperty | Operation, seperator: / | : | /:)
+@TypeSpec.Rest.actionSeparator(seperator: / | : | /:)
 ```
 
 #### Target
@@ -49,7 +49,7 @@ dec TypeSpec.Rest.actionSeparator(target: Model | ModelProperty | Operation, sep
 This interface or operation should resolve its route automatically. To be used with resource types where the route segments area defined on the models.
 
 ```typespec
-dec TypeSpec.Rest.autoRoute(target: Interface | Operation)
+@TypeSpec.Rest.autoRoute
 ```
 
 #### Target
@@ -74,7 +74,7 @@ get(@segment("pets") @path id: string): void; //-> route: /pets/{id}
 Specify this operation is a collection action. (Scopped to a resource, /pets/my-action)
 
 ```typespec
-dec TypeSpec.Rest.collectionAction(target: Operation, resourceType: Model, name?: string)
+@TypeSpec.Rest.collectionAction(resourceType: Model, name?: string)
 ```
 
 #### Target
@@ -93,7 +93,7 @@ dec TypeSpec.Rest.collectionAction(target: Operation, resourceType: Model, name?
 Specify that this is a CreateOrReplace operation for a given resource.
 
 ```typespec
-dec TypeSpec.Rest.createsOrReplacesResource(target: Operation, resourceType: Model)
+@TypeSpec.Rest.createsOrReplacesResource(resourceType: Model)
 ```
 
 #### Target
@@ -111,7 +111,7 @@ dec TypeSpec.Rest.createsOrReplacesResource(target: Operation, resourceType: Mod
 Specify that this is a CreatesOrUpdate operation for a given resource.
 
 ```typespec
-dec TypeSpec.Rest.createsOrUpdatesResource(target: Operation, resourceType: Model)
+@TypeSpec.Rest.createsOrUpdatesResource(resourceType: Model)
 ```
 
 #### Target
@@ -129,7 +129,7 @@ dec TypeSpec.Rest.createsOrUpdatesResource(target: Operation, resourceType: Mode
 Specify that this is a Create operation for a given resource.
 
 ```typespec
-dec TypeSpec.Rest.createsResource(target: Operation, resourceType: Model)
+@TypeSpec.Rest.createsResource(resourceType: Model)
 ```
 
 #### Target
@@ -147,7 +147,7 @@ dec TypeSpec.Rest.createsResource(target: Operation, resourceType: Model)
 Specify that this is a Delete operation for a given resource.
 
 ```typespec
-dec TypeSpec.Rest.deletesResource(target: Operation, resourceType: Model)
+@TypeSpec.Rest.deletesResource(resourceType: Model)
 ```
 
 #### Target
@@ -165,7 +165,7 @@ dec TypeSpec.Rest.deletesResource(target: Operation, resourceType: Model)
 Specify that this is a List operation for a given resource.
 
 ```typespec
-dec TypeSpec.Rest.listsResource(target: Operation, resourceType: Model)
+@TypeSpec.Rest.listsResource(resourceType: Model)
 ```
 
 #### Target
@@ -183,7 +183,7 @@ dec TypeSpec.Rest.listsResource(target: Operation, resourceType: Model)
 Specify that this is a Read operation for a given resource.
 
 ```typespec
-dec TypeSpec.Rest.readsResource(target: Operation, resourceType: Model)
+@TypeSpec.Rest.readsResource(resourceType: Model)
 ```
 
 #### Target
@@ -201,7 +201,7 @@ dec TypeSpec.Rest.readsResource(target: Operation, resourceType: Model)
 Mark this model as a resource type with a name.
 
 ```typespec
-dec TypeSpec.Rest.resource(target: Model, collectionName: string)
+@TypeSpec.Rest.resource(collectionName: string)
 ```
 
 #### Target
@@ -219,7 +219,7 @@ dec TypeSpec.Rest.resource(target: Model, collectionName: string)
 Defines the preceding path segment for a
 
 ```typespec
-dec TypeSpec.Rest.segment(target: Model | ModelProperty | Operation, name: string)
+@TypeSpec.Rest.segment(name: string)
 ```
 
 #### Target
@@ -239,7 +239,7 @@ dec TypeSpec.Rest.segment(target: Model | ModelProperty | Operation, name: strin
 Returns the URL segment of a given model if it has `@segment` and `@key` decorator.
 
 ```typespec
-dec TypeSpec.Rest.segmentOf(target: Operation, type: Model)
+@TypeSpec.Rest.segmentOf(type: Model)
 ```
 
 #### Target
@@ -257,7 +257,7 @@ dec TypeSpec.Rest.segmentOf(target: Operation, type: Model)
 Specify that this is a Update operation for a given resource.
 
 ```typespec
-dec TypeSpec.Rest.updatesResource(target: Operation, resourceType: Model)
+@TypeSpec.Rest.updatesResource(resourceType: Model)
 ```
 
 #### Target

--- a/docs/standard-library/versioning/reference/decorators.md
+++ b/docs/standard-library/versioning/reference/decorators.md
@@ -13,7 +13,7 @@ toc_max_heading_level: 3
 Identifies when the target was added.
 
 ```typespec
-dec TypeSpec.Versioning.added(target: unknown, version: EnumMember)
+@TypeSpec.Versioning.added(version: EnumMember)
 ```
 
 #### Target
@@ -31,7 +31,7 @@ dec TypeSpec.Versioning.added(target: unknown, version: EnumMember)
 Identifies when a target was made optional.
 
 ```typespec
-dec TypeSpec.Versioning.madeOptional(target: unknown, version: EnumMember)
+@TypeSpec.Versioning.madeOptional(version: EnumMember)
 ```
 
 #### Target
@@ -49,7 +49,7 @@ dec TypeSpec.Versioning.madeOptional(target: unknown, version: EnumMember)
 Identifies when the target was removed.
 
 ```typespec
-dec TypeSpec.Versioning.removed(target: unknown, version: EnumMember)
+@TypeSpec.Versioning.removed(version: EnumMember)
 ```
 
 #### Target
@@ -67,7 +67,7 @@ dec TypeSpec.Versioning.removed(target: unknown, version: EnumMember)
 Identifies when the target has been renamed.
 
 ```typespec
-dec TypeSpec.Versioning.renamedFrom(target: unknown, version: EnumMember, oldName: string)
+@TypeSpec.Versioning.renamedFrom(version: EnumMember, oldName: string)
 ```
 
 #### Target
@@ -86,7 +86,7 @@ dec TypeSpec.Versioning.renamedFrom(target: unknown, version: EnumMember, oldNam
 Identifies when the target type changed.
 
 ```typespec
-dec TypeSpec.Versioning.typeChangedFrom(target: unknown, version: EnumMember, oldType: unknown)
+@TypeSpec.Versioning.typeChangedFrom(version: EnumMember, oldType: unknown)
 ```
 
 #### Target
@@ -105,7 +105,7 @@ dec TypeSpec.Versioning.typeChangedFrom(target: unknown, version: EnumMember, ol
 Identifies that a namespace or a given versioning enum member relies upon a versioned package.
 
 ```typespec
-dec TypeSpec.Versioning.useDependency(target: EnumMember | Namespace, ...versionRecords: EnumMember[])
+@TypeSpec.Versioning.useDependency(...versionRecords: EnumMember[])
 ```
 
 #### Target
@@ -123,7 +123,7 @@ dec TypeSpec.Versioning.useDependency(target: EnumMember | Namespace, ...version
 Identifies that the decorated namespace is versioned by the provided enum.
 
 ```typespec
-dec TypeSpec.Versioning.versioned(target: Namespace, versions: Enum)
+@TypeSpec.Versioning.versioned(versions: Enum)
 ```
 
 #### Target

--- a/packages/ref-doc/src/utils/type-signature.ts
+++ b/packages/ref-doc/src/utils/type-signature.ts
@@ -76,7 +76,9 @@ function getDecoratorSignature(type: Decorator) {
   const ns = getQualifier(type.namespace);
   const name = type.name.slice(1);
   const parameters = [type.target, ...type.parameters].map((x) => getFunctionParameterSignature(x));
-  return `dec ${ns}${name}(${parameters.join(", ")})`;
+  // pop the target parameter
+  parameters.pop();
+  return `@${ns}${name}(${parameters.join(", ")})`;
 }
 
 function getFunctionSignature(type: FunctionType) {

--- a/packages/ref-doc/src/utils/type-signature.ts
+++ b/packages/ref-doc/src/utils/type-signature.ts
@@ -75,10 +75,12 @@ function isReflectionType(type: Type): type is Model & { name: "" } {
 function getDecoratorSignature(type: Decorator) {
   const ns = getQualifier(type.namespace);
   const name = type.name.slice(1);
-  const parameters = [type.target, ...type.parameters].map((x) => getFunctionParameterSignature(x));
-  // pop the target parameter
-  parameters.pop();
-  return `@${ns}${name}(${parameters.join(", ")})`;
+  const parameters = [...type.parameters].map((x) => getFunctionParameterSignature(x));
+  let signature = `@${ns}${name}`;
+  if (parameters.length > 0) {
+    signature += `(${parameters.join(", ")})`;
+  }
+  return signature;
 }
 
 function getFunctionSignature(type: FunctionType) {


### PR DESCRIPTION
See #1548.

Replaces the "extern dec" form of a decorator with the actual usage form. 

`dec foo(target: unknown, name: string)`

becomes:
`@foo(name: string)`

**TODO**

- [x] typespec-azure PR (https://github.com/Azure/typespec-azure/pull/3030)