### PR TITLE
Remove misleading output dir from compilation success message

### DIFF
--- a/common/changes/@typespec/compiler/no-output-log_2023-05-22-20-27.json
+++ b/common/changes/@typespec/compiler/no-output-log_2023-05-22-20-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Remove misleading output dir from compilation success message",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/core/cli/cli.ts
+++ b/packages/compiler/core/cli/cli.ts
@@ -309,9 +309,7 @@ function compileInput(
       logDiagnosticCount(program.diagnostics);
     } else {
       if (printSuccess) {
-        log(
-          `Compilation completed successfully, output files are in ${compilerOptions.outputDir}.`
-        );
+        log("Compilation completed successfully.");
       }
     }
 


### PR DESCRIPTION
Fix #1450.

#1961 tracks follow-up work to add an option to trace all writes.