### PR TITLE
Decimal as number in OA3

### DIFF
--- a/common/changes/@typespec/openapi3/decimal-as-number_2023-05-23-18-26.json
+++ b/common/changes/@typespec/openapi3/decimal-as-number_2023-05-23-18-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1450,10 +1450,6 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         const base = getStdBaseScalar(type);
         compilerAssert(base, "not allowed to assign default to custom scalars");
 
-        if (base.name === "decimal" || base.name === "decimal128") {
-          return defaultType.valueAsString;
-        }
-
         return defaultType.value;
       case "Boolean":
         return defaultType.value;
@@ -1880,9 +1876,9 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       case "float32":
         return { type: "number", format: "float" };
       case "decimal":
-        return { type: "string", format: "decimal" };
+        return { type: "number", format: "decimal" };
       case "decimal128":
-        return { type: "string", format: "decimal128" };
+        return { type: "number", format: "decimal128" };
       case "string":
         return { type: "string" };
       case "boolean":

--- a/packages/openapi3/test/array.test.ts
+++ b/packages/openapi3/test/array.test.ts
@@ -98,16 +98,16 @@ describe("openapi3: Array", () => {
 
     deepStrictEqual(res.schemas.Pet.properties.decimals, {
       type: "array",
-      items: { type: "string", format: "decimal" },
+      items: { type: "number", format: "decimal" },
       "x-typespec-name": "decimal[]",
-      default: ["123", "456.7"],
+      default: [123, 456.7],
     });
 
     deepStrictEqual(res.schemas.Pet.properties.decimal128s, {
       type: "array",
-      items: { type: "string", format: "decimal128" },
+      items: { type: "number", format: "decimal128" },
       "x-typespec-name": "decimal128[]",
-      default: ["123", "456.7"],
+      default: [123, 456.7],
     });
   });
 
@@ -134,14 +134,14 @@ describe("openapi3: Array", () => {
       type: "array",
       items: {},
       "x-typespec-name": "[string, decimal]",
-      default: ["hi", "456.7"],
+      default: ["hi", 456.7],
     });
 
     deepStrictEqual(res.schemas.Pet.properties.decimal128s, {
       type: "array",
       items: {},
       "x-typespec-name": "[string, decimal128]",
-      default: ["hi", "456.7"],
+      default: ["hi", 456.7],
     });
   });
 });

--- a/packages/openapi3/test/primitive-types.test.ts
+++ b/packages/openapi3/test/primitive-types.test.ts
@@ -25,8 +25,8 @@ describe("openapi3: primitives", () => {
       ["plainTime", { type: "string", format: "time" }],
       ["duration", { type: "string", format: "duration" }],
       ["bytes", { type: "string", format: "byte" }],
-      ["decimal", { type: "string", format: "decimal" }],
-      ["decimal128", { type: "string", format: "decimal128" }],
+      ["decimal", { type: "number", format: "decimal" }],
+      ["decimal128", { type: "number", format: "decimal128" }],
     ];
 
     for (const [name, expectedSchema] of cases) {


### PR DESCRIPTION
After examining some real use cases of decimal, discussing with Timothee, and seeing what `@encode` can do, I felt like this was the more reasonable default. Probably an extremely common case for decimals is representing currency amounts. In such cases, float64s don't have an issue with normal amounts of currency, and sending raw numbers on the wire won't result in precision loss or any other such issues. Issues will crop up when doing mathematical operations on those currency amounts, but this feels far less common and anyway requires some careful design for languages without decimal types like JS.