### PR TITLE
Fix: `@encode` encoding doesn't override target type format

### DIFF
--- a/common/changes/@typespec/openapi3/fix-encode-format_2023-05-23-20-47.json
+++ b/common/changes/@typespec/openapi3/fix-encode-format_2023-05-23-20-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Fix: `@encode` encoding doesn't override target type format",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1674,7 +1674,9 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     if (encodeData) {
       const newType = getSchemaForScalar(encodeData.type);
       newTarget.type = newType.type;
-      newTarget.format = mergeFormatAndEncoding(newTarget.format, encodeData.encoding);
+      // If the target already has a format it takes priority. (e.g. int32)
+      newTarget.format =
+        newType.format ?? mergeFormatAndEncoding(newTarget.format, encodeData.encoding);
     }
 
     if (isString) {
@@ -1699,8 +1701,6 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         switch (encoding) {
           case "rfc3339":
             return "date-time";
-          case "unixTimestamp":
-            return "unix-timestamp";
           default:
             return `date-time-${encoding}`;
         }

--- a/packages/openapi3/test/primitive-types.test.ts
+++ b/packages/openapi3/test/primitive-types.test.ts
@@ -229,13 +229,8 @@ describe("openapi3: primitives", () => {
       it("set format to 'date-time-rfc7231' when encoding is rfc7231", () =>
         testEncode("utcDateTime", { type: "string", format: "date-time-rfc7231" }, "rfc7231"));
 
-      it("set type to integer and format to 'unixTimeStamp' when encoding is unixTimestamp", () =>
-        testEncode(
-          "utcDateTime",
-          { type: "integer", format: "unix-timestamp" },
-          "unixTimestamp",
-          "int32"
-        ));
+      it("set type to integer and format to 'int32' when encoding is unixTimestamp (unixTimestamp info is lost)", () =>
+        testEncode("utcDateTime", { type: "integer", format: "int32" }, "unixTimestamp", "int32"));
     });
 
     describe("offsetDateTime", () => {
@@ -248,8 +243,8 @@ describe("openapi3: primitives", () => {
     describe("duration", () => {
       it("set format to 'duration' by default", () =>
         testEncode("duration", { type: "string", format: "duration" }));
-      it("set interger with seconds format setting duration as seconds", () =>
-        testEncode("duration", { type: "integer", format: "seconds" }, "seconds", "int32"));
+      it("set interger with int32 format setting duration as seconds", () =>
+        testEncode("duration", { type: "integer", format: "int32" }, "seconds", "int32"));
     });
 
     describe("bytes", () => {

--- a/packages/openapi3/test/primitive-types.test.ts
+++ b/packages/openapi3/test/primitive-types.test.ts
@@ -252,7 +252,7 @@ describe("openapi3: primitives", () => {
     describe("bytes", () => {
       it("set format to 'base64' by default", () =>
         testEncode("bytes", { type: "string", format: "byte" }));
-      it("set interger with seconds format setting duration as seconds", () =>
+      it("set format to base64url when encoding bytes as base64url", () =>
         testEncode("bytes", { type: "string", format: "base64url" }, "base64url"));
     });
   });


### PR DESCRIPTION
fix https://github.com/Azure/typespec-azure/issues/3032