### PR TITLE
Update links in Http Authentication standard library docs

### DIFF
--- a/docs/standard-library/http/authentication.md
+++ b/docs/standard-library/http/authentication.md
@@ -41,7 +41,7 @@ Authentication can be configured using the `@useAuth` decorator on the service n
 
 ## Available security schemes
 
-Models can be found in https://github.com/microsoft/typespec/blob/main/packages/rest/lib/auth.tsp
+Models can be found in https://github.com/microsoft/typespec/blob/main/packages/http/lib/auth.tsp
 
 ### `BasicAuth`
 

--- a/docs/standard-library/http/authentication.md
+++ b/docs/standard-library/http/authentication.md
@@ -12,7 +12,7 @@ Notes:
 
 Authentication can be configured using the `@useAuth` decorator on the service namespace. The decorator accept a few options:
 
-- A security scheme(see options [here]). This means this is the security scheme to use to authenticate this service.
+- A security scheme (see options [here](https://github.com/microsoft/typespec/blob/main/packages/http/lib/auth.tsp)). This means this is the security scheme to use to authenticate this service.
 
 ```typespec
 @useAuth(Auth1)


### PR DESCRIPTION
The linked implementation file is in `/http`, not `/rest`. I took a guess that the `[here]` was intended to point there too, but let me know if there's a better target for it.