### PR TITLE
Pacakges with 0 changes will still release a `-dev.0` version

### DIFF
--- a/common/changes/@typespec/internal-build-utils/release-dev-0_2023-05-26-20-44.json
+++ b/common/changes/@typespec/internal-build-utils/release-dev-0_2023-05-26-20-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/internal-build-utils",
+      "comment": "Packages with no changes will still release a -dev.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@typespec/internal-build-utils"
+}

--- a/packages/internal-build-utils/src/prerelease.ts
+++ b/packages/internal-build-utils/src/prerelease.ts
@@ -125,9 +125,6 @@ function getDevVersionRange(manifest: BumpManifest) {
 }
 
 function getDevVersion(version: string, changeCount: number) {
-  if (changeCount === 0) {
-    return version;
-  }
   const nextVersion = getNextVersion(version);
   console.log(`Bumping version ${version} to ${nextVersion}-dev.${changeCount}`);
   return `${nextVersion}-dev.${changeCount}`;


### PR DESCRIPTION
This  is basically the same as the latest but with wider range acceptance(accept other dev versions)

Part of https://github.com/microsoft/typespec/issues/1984