### PR TITLE
Fix: Example in doc commment would only be rendered for decorators

### DIFF
--- a/docs/standard-library/built-in-decorators.md
+++ b/docs/standard-library/built-in-decorators.md
@@ -229,6 +229,7 @@ A debugging decorator used to inspect a type.
 | text | `scalar string` | Custom text to log |
 
 
+
 ### `@inspectTypeName` {#@inspectTypeName}
 
 A debugging decorator used to inspect a type name.
@@ -245,6 +246,7 @@ A debugging decorator used to inspect a type name.
 | Name | Type | Description |
 |------|------|-------------|
 | text | `scalar string` | Custom text to log |
+
 
 
 ### `@key` {#@key}
@@ -693,6 +695,7 @@ Attaches a tag to an operation, interface, or namespace. Multiple `@tag` decorat
 | tag | `scalar string` | Tag value |
 
 
+
 ### `@visibility` {#@visibility}
 
 Indicates that a property is only considered to be present or applicable ("visible") with
@@ -756,6 +759,7 @@ Set the visibility of key properties in a model if not already set.
 | visibility | `(intrinsic) unknown` | The desired default visibility value. If a key property already has a `visibility` decorator then the default visibility is not applied. |
 
 
+
 ### `@withOptionalProperties` {#@withOptionalProperties}
 
 Returns the model with required properties removed.
@@ -772,6 +776,7 @@ Returns the model with required properties removed.
 None
 
 
+
 ### `@withoutDefaultValues` {#@withoutDefaultValues}
 
 Returns the model with any default values removed.
@@ -786,6 +791,7 @@ Returns the model with any default values removed.
 
 #### Parameters
 None
+
 
 
 ### `@withoutOmittedProperties` {#@withoutOmittedProperties}
@@ -806,6 +812,7 @@ Returns the model with the given properties omitted.
 | omit | `union string \| Union` | List of properties to omit |
 
 
+
 ### `@withUpdateableProperties` {#@withUpdateableProperties}
 
 Returns the model with non-updateable properties removed.
@@ -820,6 +827,7 @@ Returns the model with non-updateable properties removed.
 
 #### Parameters
 None
+
 
 
 ### `@withVisibility` {#@withVisibility}

--- a/docs/standard-library/protobuf/reference/data-types.md
+++ b/docs/standard-library/protobuf/reference/data-types.md
@@ -34,6 +34,12 @@ model TypeSpec.Protobuf.Extern<Path, Name>
 | Path | the relative path to a `.proto` file to import                                           |
 | Name | the fully-qualified reference to the type this model represents within the `.proto` file |
 
+#### Examples
+
+```typespec
+model Widget is Extern<"path/to/test.proto", "test.Widget">;
+```
+
 ### `Map` {#TypeSpec.Protobuf.Map}
 
 A type representing a Protobuf `map`. Instances of this type in models will be converted to the built-in `map` type

--- a/packages/ref-doc/src/emitters/docusaurus.ts
+++ b/packages/ref-doc/src/emitters/docusaurus.ts
@@ -3,6 +3,7 @@ import {
   DecoratorRefDoc,
   EmitterOptionRefDoc,
   EnumRefDoc,
+  ExampleRefDoc,
   InterfaceRefDoc,
   ModelRefDoc,
   NamespaceRefDoc,
@@ -158,7 +159,7 @@ export function renderDecoratorFile(
       if (namespace.decorators.length === 0) {
         return undefined;
       }
-      const content = [];
+      const content: string[] = [];
       for (const dec of namespace.decorators) {
         content.push(renderDecoratorMarkdown(dec), "");
       }
@@ -195,16 +196,24 @@ function renderDecoratorMarkdown(dec: DecoratorRefDoc, headingLevel: number = 3)
     content.push(headings.hx(headingLevel + 1, "Parameters"), "None", "");
   }
 
-  if (dec.examples.length > 0) {
-    content.push(headings.hx(headingLevel + 1, "Examples"));
-    for (const example of dec.examples) {
-      if (example.title) {
-        content.push(headings.hx(headingLevel + 2, example.title));
-      }
-      content.push("", example.content, "");
-    }
+  content.push(renderExamples(dec.examples, headingLevel + 1));
+
+  return content.join("\n");
+}
+
+function renderExamples(examples: ExampleRefDoc[], headingLevel: number) {
+  const content = [];
+  if (examples.length === 0) {
+    return "";
   }
 
+  content.push(headings.hx(headingLevel, "Examples"));
+  for (const example of examples) {
+    if (example.title) {
+      content.push(headings.hx(headingLevel + 1, example.title));
+    }
+    content.push("", example.content, "");
+  }
   return content.join("\n");
 }
 
@@ -255,6 +264,8 @@ function renderOperationMarkdown(op: OperationRefDoc, headingLevel: number = 3) 
     content.push(renderTemplateParametersTable(op.templateParameters, headingLevel + 1));
   }
 
+  content.push(renderExamples(op.examples, headingLevel + 1));
+
   return content.join("\n");
 }
 
@@ -288,6 +299,8 @@ function renderInterfaceMarkdown(iface: InterfaceRefDoc, headingLevel: number = 
       content.push(renderOperationMarkdown(op, headingLevel + 1));
     }
   }
+
+  content.push(renderExamples(iface.examples, headingLevel + 1));
 
   return content.join("\n");
 }
@@ -348,6 +361,8 @@ function renderModel(model: ModelRefDoc, headingLevel: number = 3): string {
     content.push(renderTemplateParametersTable(model.templateParameters, headingLevel + 1));
   }
 
+  content.push(renderExamples(model.examples, headingLevel + 1));
+
   return content.join("\n");
 }
 
@@ -358,6 +373,7 @@ function renderEnum(e: EnumRefDoc, headingLevel: number = 3): string {
     e.doc,
     codeblock(e.signature, "typespec"),
     "",
+    renderExamples(e.examples, headingLevel + 1),
   ];
 
   return content.join("\n");
@@ -376,6 +392,8 @@ function renderUnion(union: UnionRefDoc, headingLevel: number = 3): string {
     content.push(renderTemplateParametersTable(union.templateParameters, headingLevel + 1));
   }
 
+  content.push(renderExamples(union.examples, headingLevel + 1));
+
   return content.join("\n");
 }
 
@@ -391,6 +409,8 @@ function renderScalar(scalar: ScalarRefDoc, headingLevel: number = 3): string {
   if (scalar.templateParameters) {
     content.push(renderTemplateParametersTable(scalar.templateParameters, headingLevel + 1));
   }
+
+  content.push(renderExamples(scalar.examples, headingLevel + 1));
 
   return content.join("\n");
 }

--- a/packages/ref-doc/src/extractor.ts
+++ b/packages/ref-doc/src/extractor.ts
@@ -412,12 +412,19 @@ function extractExamples(type: Type): ExampleRefDoc[] {
   const examples: ExampleRefDoc[] = [];
   for (const doc of type.node?.docs ?? []) {
     for (const dTag of doc.tags) {
+      if ((type as any).name === "url") {
+        console.log("Here too", dTag.kind === SyntaxKind.DocUnknownTag, dTag.tagName.sv);
+      }
       if (dTag.kind === SyntaxKind.DocUnknownTag) {
         if (dTag.tagName.sv === "example") {
           examples.push(extractExample(dTag));
         }
       }
     }
+  }
+
+  if ((type as any).name === "url") {
+    console.log("Extracting exmple for ", examples);
   }
   return examples;
 }

--- a/packages/ref-doc/src/extractor.ts
+++ b/packages/ref-doc/src/extractor.ts
@@ -412,9 +412,6 @@ function extractExamples(type: Type): ExampleRefDoc[] {
   const examples: ExampleRefDoc[] = [];
   for (const doc of type.node?.docs ?? []) {
     for (const dTag of doc.tags) {
-      if ((type as any).name === "url") {
-        console.log("Here too", dTag.kind === SyntaxKind.DocUnknownTag, dTag.tagName.sv);
-      }
       if (dTag.kind === SyntaxKind.DocUnknownTag) {
         if (dTag.tagName.sv === "example") {
           examples.push(extractExample(dTag));
@@ -423,9 +420,6 @@ function extractExamples(type: Type): ExampleRefDoc[] {
     }
   }
 
-  if ((type as any).name === "url") {
-    console.log("Extracting exmple for ", examples);
-  }
   return examples;
 }
 


### PR DESCRIPTION
We only had one problem in this repo but found this when trying to add new scalars in TypeSpec Azure