### PR TITLE
Fix IDE issue with package.json loading order

### DIFF
--- a/common/changes/@typespec/compiler/fix-package-json-read-order_2023-06-08-16-57.json
+++ b/common/changes/@typespec/compiler/fix-package-json-read-order_2023-06-08-16-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix IDE issue with squiggles in library code if the library had an entry point named something other than `main.tsp` and a library document was opened after another document that imported the library.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -1211,7 +1211,7 @@ export function createServer(host: ServerHost): Server {
       const pkgPath = joinPaths(dir, "package.json");
       const cached = await fileSystemCache.get(pkgPath);
 
-      if (cached) {
+      if (cached?.data) {
         pkg = cached.data;
       } else {
         [pkg] = await loadFile(

--- a/packages/compiler/test/server/server-file-handling.test.ts
+++ b/packages/compiler/test/server/server-file-handling.test.ts
@@ -43,6 +43,70 @@ describe("compiler: server: main file", () => {
     deepStrictEqual(host.getDiagnostics("./work/test.tsp"), [], "No diagnostics expected");
   });
 
+  it("finds tspMain in package.json that has already been read by something else", async () => {
+    const host = await createTestServerHost();
+
+    host.addTypeSpecFile(
+      "./lib/package.json",
+      JSON.stringify({
+        name: "test",
+        version: "1.0.0",
+        tspMain: "./entrypoint.tsp",
+      })
+    );
+
+    host.addTypeSpecFile(
+      "./lib/entrypoint.tsp",
+      `
+      import "./lib1.tsp";
+      import "./lib2.tsp";
+      `
+    );
+
+    host.addTypeSpecFile(
+      "./lib/lib1.tsp",
+      `
+      model Lib1 {}
+      `
+    );
+
+    host.addTypeSpecFile(
+      "./lib/lib2.tsp",
+      `
+      model Lib2 extends Lib1 {}
+      `
+    );
+
+    // First, open user document that loads library, reading it's
+    // package.json elsewhere than where the language server main file
+    // resolution happens, that caches package.json data.
+    const userDoc = host.addOrUpdateDocument(
+      "./test.tsp",
+      `
+      import "./lib";
+      model User extends Lib1 {}
+      `
+    );
+
+    // Second, open a doc in the lib after that
+    const libDoc = host.openDocument("./lib/lib2.tsp");
+
+    // Neither document should have any squiggles
+    await host.server.checkChange({ document: userDoc });
+    deepStrictEqual(
+      host.getDiagnostics("./test.tsp"),
+      [],
+      "No diagnostics expected in user document"
+    );
+
+    await host.server.checkChange({ document: libDoc });
+    deepStrictEqual(
+      host.getDiagnostics("./lib/lib2.tsp"),
+      [],
+      "No diagnostics expected in library document"
+    );
+  });
+
   it("works with standalone file", async () => {
     // NOTE: When no main.tsp is found, server uses the file itself as the
     // main file. This test stresses the main file searching loop to walk

--- a/packages/compiler/testing/test-server-host.ts
+++ b/packages/compiler/testing/test-server-host.ts
@@ -19,6 +19,7 @@ export interface TestServerHost extends ServerHost, TestFileSystem {
   logMessages: readonly string[];
   getOpenDocument(path: string): TextDocument | undefined;
   addOrUpdateDocument(path: string, content: string): TextDocument;
+  openDocument(path: string): TextDocument;
   getDiagnostics(path: string): readonly Diagnostic[];
   getURL(path: string): string;
 }
@@ -57,6 +58,10 @@ export async function createTestServerHost(options?: TestHostOptions & { workspa
       documents.set(url, document);
       fileSystem.addTypeSpecFile(path, ""); // force virtual file system to create directory where document lives.
       return document;
+    },
+    openDocument(path) {
+      const content = fileSystem.fs.get(resolveVirtualPath(path)) ?? "";
+      return this.addOrUpdateDocument(path, content);
     },
     getDiagnostics(path) {
       return diagnostics.get(this.getURL(path)) ?? [];


### PR DESCRIPTION
Due to how we handled caching, we would think that package.json for a library was empty if it got loaded before we opened a document in it. This meant that if the library had a tspMain other than main.tsp, things would fail.