### PR TITLE
Use canonical github microsoft/typespec org/repo casing (all lowercase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Using TypeSpec, you can create reusable patterns for all aspects of an API, alon
 
 You can try a work-in-progress build of the compiler by following the steps in
 the Getting Started section below. Please feel free to [file
-issues](https://github.com/Microsoft/typespec/issues) for any issues you encounter while
+issues](https://github.com/microsoft/typespec/issues) for any issues you encounter while
 using the preview.
 
 ## Try TypeSpec without installing anything

--- a/common/changes/@typespec/compiler/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/compiler/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/eslint-config-typespec/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/eslint-config-typespec/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/eslint-config-typespec",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/eslint-config-typespec"
+}

--- a/common/changes/@typespec/eslint-plugin/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/eslint-plugin/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/eslint-plugin"
+}

--- a/common/changes/@typespec/html-program-viewer/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/html-program-viewer/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/html-program-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/html-program-viewer"
+}

--- a/common/changes/@typespec/http/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/http/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/common/changes/@typespec/internal-build-utils/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/internal-build-utils/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/internal-build-utils",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/internal-build-utils"
+}

--- a/common/changes/@typespec/json-schema/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/json-schema/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/common/changes/@typespec/library-linter/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/library-linter/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/library-linter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/library-linter"
+}

--- a/common/changes/@typespec/lint/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/lint/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/lint",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/lint"
+}

--- a/common/changes/@typespec/migrate/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/migrate/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/migrate",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/migrate"
+}

--- a/common/changes/@typespec/openapi/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/openapi/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi"
+}

--- a/common/changes/@typespec/openapi3/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/openapi3/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/common/changes/@typespec/protobuf/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/protobuf/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/protobuf",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/protobuf"
+}

--- a/common/changes/@typespec/rest/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/rest/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/rest"
+}

--- a/common/changes/@typespec/versioning/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/@typespec/versioning/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/common/changes/tmlanguage-generator/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/tmlanguage-generator/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/common/changes/typespec-vs/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/typespec-vs/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "typespec-vs",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "typespec-vs"
+}

--- a/common/changes/typespec-vscode/canonical-repo-casing_2023-06-08-20-20.json
+++ b/common/changes/typespec-vscode/canonical-repo-casing_2023-06-08-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "typespec-vscode",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "typespec-vscode"
+}

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "Package to bundle a typespec library.",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/compiler/cmd/runner.ts
+++ b/packages/compiler/cmd/runner.ts
@@ -22,7 +22,7 @@ export async function runScript(relativePath: string, backupPath: string): Promi
     await import(scriptUrl);
   } else {
     throw new Error(
-      "Couldn't resolve TypeSpec compiler root. This is unexpected. Please file an issue at https://github.com/Microsoft/typespec."
+      "Couldn't resolve TypeSpec compiler root. This is unexpected. Please file an issue at https://github.com/microsoft/typespec."
     );
   }
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -5,13 +5,13 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec",

--- a/packages/compiler/server/language-config.ts
+++ b/packages/compiler/server/language-config.ts
@@ -26,7 +26,7 @@ export const TypeSpecLanguageConfiguration = {
     { open: "(", close: ")" },
     { open: '"', close: '"' },
   ],
-  // From https://github.com/Microsoft/vscode/blob/main/extensions/javascript/javascript-language-configuration.json
+  // From https://github.com/microsoft/vscode/blob/main/extensions/javascript/javascript-language-configuration.json
   indentationRules: {
     decreaseIndentPattern: {
       pattern: "^((?!.*?/\\*).*\\*/)?\\s*[\\}\\]].*$",

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -581,7 +581,7 @@ export function createServer(host: ServerHost): Server {
       if (location?.file) {
         document = (location.file as ServerSourceFile).document;
       } else {
-        // https://github.com/Microsoft/language-server-protocol/issues/256
+        // https://github.com/microsoft/language-server-protocol/issues/256
         //
         // LSP does not currently allow sending a diagnostic with no location so
         // we report diagnostics with no location on the document that changed to

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -394,7 +394,7 @@ describe("compiler: parser", () => {
 
   describe("numeric literals", () => {
     const good: [string, number][] = [
-      // Some questions remain here: https://github.com/Microsoft/typespec/issues/506
+      // Some questions remain here: https://github.com/microsoft/typespec/issues/506
       ["-0", -0],
       ["1e9999", Infinity],
       ["1e-9999", 0],

--- a/packages/eslint-config-typespec/package.json
+++ b/packages/eslint-config-typespec/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "scripts": {
     "build": "echo 'No build.'"

--- a/packages/eslint-plugin-typespec/package.json
+++ b/packages/eslint-plugin-typespec/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "Eslint plugin providing set of rules to be used in the JS/TS code of TypeSpec libraries",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/main/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/main/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/html-program-viewer/package.json
+++ b/packages/html-program-viewer/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec library for emitting an html view of the program.",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -3,15 +3,15 @@
   "version": "0.45.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec HTTP protocol binding",
-  "homepage": "https://github.com/Microsoft/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "homepage": "https://github.com/microsoft/typespec",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/internal-build-utils/package.json
+++ b/packages/internal-build-utils/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "Internal library to TypeSpec providing helpers to build.",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -3,15 +3,15 @@
   "version": "0.45.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec library for emitting TypeSpec to JSON Schema and converting JSON Schema to TypeSpec",
-  "homepage": "https://github.com/Microsoft/TypeSpec",
-  "readme": "https://github.com/Microsoft/TypeSpec/blob/master/README.md",
+  "homepage": "https://github.com/microsoft/typespec",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/TypeSpec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/TypeSpec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "TypeSpec",

--- a/packages/library-linter/package.json
+++ b/packages/library-linter/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec library for linting another library.",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "Helper ",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/main/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/main/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "Migration tool for typespec.",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/main/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/main/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec library providing OpenAPI concepts",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec library for emitting OpenAPI 3.0 from the TypeSpec REST protocol binding",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/playground-website/package.json
+++ b/packages/playground-website/package.json
@@ -9,10 +9,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,10 +9,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -3,15 +3,15 @@
   "version": "0.44.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec library and emitter for Protobuf (gRPC)",
-  "homepage": "https://github.com/Microsoft/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/main/packages/protobuf/README.md",
+  "homepage": "https://github.com/microsoft/typespec",
+  "readme": "https://github.com/microsoft/typespec/blob/main/packages/protobuf/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec",

--- a/packages/ref-doc/package.json
+++ b/packages/ref-doc/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec library for generating typespec docs",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec REST protocol binding",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -5,14 +5,14 @@
   "author": "Microsoft Corporation",
   "description": "Samples for TypeSpec",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/readme.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/readme.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec",

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -5,14 +5,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec Language Specification Source Code",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "type": "module",
   "scripts": {

--- a/packages/tmlanguage-generator/package.json
+++ b/packages/tmlanguage-generator/package.json
@@ -3,15 +3,15 @@
   "version": "0.4.1",
   "author": "Microsoft Corporation",
   "description": "Helper library to generate TextMate syntax highlighting tmLanguage files.",
-  "homepage": "https://github.com/Microsoft/typespec/tree/master/packages/tmlanguage-generator",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/packages/tmlanguage-generator/README.md",
+  "homepage": "https://github.com/microsoft/typespec/tree/master/packages/tmlanguage-generator",
+  "readme": "https://github.com/microsoft/typespec/blob/master/packages/tmlanguage-generator/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "textmate",

--- a/packages/typespec-vs/package.json
+++ b/packages/typespec-vs/package.json
@@ -4,14 +4,14 @@
   "version": "0.45.0",
   "description": "TypeSpec Language Support for Visual Studio",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/typespec-vs/src/source.extension.vsixmanifest
+++ b/packages/typespec-vs/src/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     <Identity Id="88b9492f-c019-492c-8aeb-f325a7e4cf23" Version="|%CurrentProject%;GetPackageVersionForVsixManifest|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>TypeSpec Language Support</DisplayName>
     <Description>TypeSpec Language Support for Visual Studio</Description>
-    <MoreInfo>https://github.com/Microsoft/typespec</MoreInfo>
+    <MoreInfo>https://github.com/microsoft/typespec</MoreInfo>
     <License>LICENSE</License>
   </Metadata>
   <Installation>

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec Language Support for VS Code",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -4,14 +4,14 @@
   "author": "Microsoft Corporation",
   "description": "TypeSpec library for declaring and emitting versioned APIs",
   "homepage": "https://microsoft.github.io/typespec",
-  "readme": "https://github.com/Microsoft/typespec/blob/master/README.md",
+  "readme": "https://github.com/microsoft/typespec/blob/master/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Microsoft/typespec.git"
+    "url": "git+https://github.com/microsoft/typespec.git"
   },
   "bugs": {
-    "url": "https://github.com/Microsoft/typespec/issues"
+    "url": "https://github.com/microsoft/typespec/issues"
   },
   "keywords": [
     "typespec"

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -108,7 +108,7 @@ const config = {
             position: "right",
           },
           {
-            href: "https://github.com/Microsoft/typespec",
+            href: "https://github.com/microsoft/typespec",
             position: "right",
             className: "header-github-link",
             "aria-label": "Github repository",


### PR DESCRIPTION
This was bugging me after reviewing #2035, but it's a completely separate and pre-existing issue that's extremely minor.

Turns out we have lots of github.com/**M**icrosoft and a bit of gihtub.com/**M**icrosoft/**T**ype**S**pec. 

Quick search and replace to use the same canonical microsoft/typespec everywhere.