### PR TITLE
Fix a typo in the style guide

### DIFF
--- a/docs/introduction/style-guide.md
+++ b/docs/introduction/style-guide.md
@@ -98,7 +98,7 @@ model Pet {
 model Cat extends Pet {}
 ```
 
-- Place no space between an operation/decorator/function name and the parmaeter list
+- Place no space between an operation/decorator/function name and the parameter list
 
 <!-- prettier-ignore -->
 ```typespec


### PR DESCRIPTION
This fixes a typo for the word "parameter" that was in the style guide of the docs page.