### PR TITLE
Make `resourceTypeForKeyParam` decorator private

### DIFF
--- a/common/changes/@typespec/library-linter/make-decorator-private_2023-06-20-06-09.json
+++ b/common/changes/@typespec/library-linter/make-decorator-private_2023-06-20-06-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/library-linter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/library-linter"
+}

--- a/common/changes/@typespec/rest/make-decorator-private_2023-06-15-17-55.json
+++ b/common/changes/@typespec/rest/make-decorator-private_2023-06-15-17-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/rest",
+      "comment": "Make internal `resourceTypeForKeyParam` decorator private",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/rest"
+}

--- a/packages/library-linter/src/linter.ts
+++ b/packages/library-linter/src/linter.ts
@@ -46,7 +46,6 @@ const excludeDecoratorSignature = new Set([
   "@indexer",
   "@test",
   "@list", // TODO check if we actually need this one https://github.com/microsoft/typespec/issues/1978
-  "@resourceTypeForKeyParam", // TODO check if we actually need this one https://github.com/microsoft/typespec/issues/1981
 ]);
 function validateDecoratorSignature(program: Program) {
   function navigate(sym: Sym) {

--- a/packages/rest/lib/rest-decorators.tsp
+++ b/packages/rest/lib/rest-decorators.tsp
@@ -131,4 +131,5 @@ namespace Private {
   extern dec validateHasKey(target: unknown, value: unknown);
   extern dec validateIsError(target: unknown, value: unknown);
   extern dec actionSegment(target: Operation, value: string);
+  extern dec resourceTypeForKeyParam(entity: ModelProperty, resourceType: Model);
 }

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -7,6 +7,7 @@ import {
   Model,
   ModelProperty,
   Program,
+  setTypeSpecNamespace,
   Type,
   validateDecoratorTarget,
 } from "@typespec/compiler";
@@ -76,6 +77,8 @@ export function $resourceTypeForKeyParam(
 
   context.program.stateMap(resourceTypeForKeyParamKey).set(entity, resourceType);
 }
+
+setTypeSpecNamespace("Private", $resourceTypeForKeyParam);
 
 export function getResourceTypeForKeyParam(
   program: Program,


### PR DESCRIPTION
Fixes #1981 by moving the decorator to a private sub-namespace.  This decorator is never used directly in TypeSpec libraries, only applied directly to types in TypeScript code, so we don't need to make any additional changes to adjust for this.  I've also tested it against `typespec-azure` and the build is green there too.