### PR TITLE
Fix annotation order

### DIFF
--- a/common/changes/@typespec/compiler/fix-annotation-order_2023-06-20-16-26.json
+++ b/common/changes/@typespec/compiler/fix-annotation-order_2023-06-20-16-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Allow annotations(Decorators, directives and doc comments) to be specified in any order",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -1,8 +1,9 @@
-import assert, { deepStrictEqual, strictEqual } from "assert";
+import assert, { deepStrictEqual, ok, strictEqual } from "assert";
 import { CharCode } from "../src/core/charcode.js";
 import { formatDiagnostic, logVerboseTestOutput } from "../src/core/diagnostics.js";
 import { hasParseError, parse, visitChildren } from "../src/core/parser.js";
 import {
+  IdentifierNode,
   Node,
   NodeFlags,
   ParseOptions,
@@ -10,6 +11,7 @@ import {
   SyntaxKind,
   TypeSpecScriptNode,
 } from "../src/core/types.js";
+import { DecorableNode } from "../src/formatter/print/types.js";
 import { DiagnosticMatch, expectDiagnostics } from "../src/testing/expect.js";
 
 describe("compiler: parser", () => {
@@ -910,6 +912,133 @@ describe("compiler: parser", () => {
     );
   });
 
+  describe("annotations order", () => {
+    function expectHasDocComment(script: TypeSpecScriptNode, content: string, index: number = 0) {
+      const docs = script.statements[0].docs;
+      strictEqual(docs?.[index].content[0].text, content);
+    }
+
+    function expectHasDirective(script: TypeSpecScriptNode, id: string) {
+      const directives = script.statements[0].directives;
+      ok(
+        directives?.some((x) => x.target.sv === id),
+        `Should have found a directive with id ${id} but only has ${directives?.map(
+          (x) => x.target.sv
+        )}`
+      );
+    }
+
+    function expectHasDecorator(script: TypeSpecScriptNode, id: string) {
+      const decorators = (script.statements[0] as DecorableNode).decorators;
+      ok(
+        decorators?.some((x) => (x.target as IdentifierNode).sv === id),
+        `Should have found a directive with id ${id} but only has ${decorators?.map(
+          (x) => (x.target as IdentifierNode).sv
+        )}`
+      );
+    }
+
+    parseEach([
+      [
+        `
+        /** doc, directive, decorator */
+        #suppress "a" "a"
+        @foo
+        model M {}
+        `,
+        (script) => {
+          expectHasDocComment(script, "doc, directive, decorator");
+          expectHasDirective(script, "suppress");
+          expectHasDecorator(script, "foo");
+        },
+      ],
+
+      [
+        `
+        #suppress "a" "a"
+        /** directive, doc, decorator */
+        @foo
+        model M {}
+        `,
+        (script) => {
+          expectHasDocComment(script, "directive, doc, decorator");
+          expectHasDirective(script, "suppress");
+          expectHasDecorator(script, "foo");
+        },
+      ],
+
+      [
+        `
+        #suppress "a" "a"
+        @foo
+        /** directive, decorator, doc */
+        model M {}
+        `,
+        (script) => {
+          expectHasDocComment(script, "directive, decorator, doc");
+          expectHasDirective(script, "suppress");
+          expectHasDecorator(script, "foo");
+        },
+      ],
+
+      [
+        `
+        /** doc, decorator, directive */
+        @foo
+        #suppress "a" "a"
+        model M {}
+        `,
+        (script) => {
+          expectHasDocComment(script, "doc, decorator, directive");
+          expectHasDirective(script, "suppress");
+          expectHasDecorator(script, "foo");
+        },
+      ],
+      [
+        `
+        @foo
+        /** decorator, doc, directive */
+        #suppress "a" "a"
+        model M {}
+        `,
+        (script) => {
+          expectHasDocComment(script, "decorator, doc, directive");
+          expectHasDirective(script, "suppress");
+          expectHasDecorator(script, "foo");
+        },
+      ],
+      [
+        `
+        @foo
+        #suppress "a" "a"
+        /** decorator, directive, doc */
+        model M {}
+        `,
+        (script) => {
+          expectHasDocComment(script, "decorator, directive, doc");
+          expectHasDirective(script, "suppress");
+          expectHasDecorator(script, "foo");
+        },
+      ],
+      [
+        `
+        /** first: doc, directive, doc, decorator, doc */
+        #suppress "a" "a"
+        /** second */
+        @foo
+        /** third */
+        model M {}
+        `,
+        (script) => {
+          expectHasDocComment(script, "first: doc, directive, doc, decorator, doc", 0);
+          expectHasDocComment(script, "second", 1);
+          expectHasDocComment(script, "third", 2);
+          expectHasDirective(script, "suppress");
+          expectHasDecorator(script, "foo");
+        },
+      ],
+    ]);
+  });
   describe("conflict marker", () => {
     // NOTE: Use of ${} to obfuscate conflict markers so that they're not
     // flagged while working on these tests.


### PR DESCRIPTION
fix [#1994](https://github.com/microsoft/typespec/issues/1994)

Underlying issue of doc comment not working on namespace was that the doc comment was after the decorators. This PR makes it that annotations(decorators, directives and doc comment) can be applied in any order with mix and match.

Issue https://github.com/microsoft/typespec/issues/2095 discuss the recommended formatting that we should maybe apply