### PR TITLE
Fix: Stack overflow crash when having circular reference with `op is` inside an interface. 

### DIFF
--- a/common/changes/@typespec/compiler/fix-op-in-interface-circular-ref_2023-06-20-17-03.json
+++ b/common/changes/@typespec/compiler/fix-op-in-interface-circular-ref_2023-06-20-17-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: Stack overflow crash when having circular reference with `op is` inside an interface. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -684,8 +684,13 @@ export function createChecker(program: Program): Checker {
       | OperationStatementNode
       | UnionStatementNode
   ): number {
+    const symbol =
+      node.kind === SyntaxKind.OperationStatement &&
+      node.parent?.kind === SyntaxKind.InterfaceStatement
+        ? getSymbolForMember(node)
+        : node.symbol;
     // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-    return node.symbol?.id!;
+    return symbol?.id!;
   }
 
   /**


### PR DESCRIPTION
fix [#2001](https://github.com/microsoft/typespec/issues/2001)