### PR TITLE
Initial implementation of \in and \implies expressions.

### DIFF
--- a/packages/compiler/core/scanner.ts
+++ b/packages/compiler/core/scanner.ts
@@ -88,6 +88,7 @@ export enum Token {
   LessThanEquals,
   GreaterThanEquals,
   AmpsersandAmpersand,
+  BigArrow,
   BarBar,
   EqualsEquals,
   ExclamationEquals,
@@ -209,6 +210,7 @@ export const TokenDisplay = getTokenDisplayTable([
   [Token.GreaterThanEquals, "'>='"],
   [Token.AmpsersandAmpersand, "'&&'"],
   [Token.BarBar, "'||'"],
+  [Token.BigArrow, "'==>'"],
   [Token.EqualsEquals, "'=='"],
   [Token.ExclamationEquals, "'!='"],
   [Token.EqualsGreaterThan, "'=>'"],
@@ -536,7 +538,9 @@ export function createScanner(
           if (atConflictMarker()) return scanConflictMarker();
           switch (lookAhead(1)) {
             case CharCode.Equals:
-              return next(Token.EqualsEquals, 2);
+              return lookAhead(2) === CharCode.GreaterThan
+                ? next(Token.BigArrow, 3)
+                : next(Token.EqualsEquals, 2);
             case CharCode.GreaterThan:
               return next(Token.EqualsGreaterThan, 2);
           }

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -763,6 +763,7 @@ export enum SyntaxKind {
   ProjectionBlockExpression,
   ProjectionMemberExpression,
   ProjectionLogicalExpression,
+  ProjectionMembershipExpression,
   ProjectionEqualityExpression,
   ProjectionUnaryExpression,
   ProjectionRelationalExpression,
@@ -1036,6 +1037,7 @@ export type Expression =
 export type ProjectionExpression =
   | ProjectionLogicalExpressionNode
   | ProjectionRelationalExpressionNode
+  | ProjectionMembershipExpressionNode
   | ProjectionEqualityExpressionNode
   | ProjectionUnaryExpressionNode
   | ProjectionArithmeticExpressionNode
@@ -1392,9 +1394,15 @@ export interface ProjectionExpressionStatementNode extends BaseNode {
 
 export interface ProjectionLogicalExpressionNode extends BaseNode {
   readonly kind: SyntaxKind.ProjectionLogicalExpression;
-  readonly op: "||" | "&&";
+  readonly op: "||" | "&&" | "==>";
   readonly left: ProjectionExpression;
   readonly right: ProjectionExpression;
+}
+
+export interface ProjectionMembershipExpressionNode extends BaseNode {
+  readonly kind: SyntaxKind.ProjectionMembershipExpression;
+  readonly left: ProjectionExpression;
+  readonly arguments: ProjectionExpression[];
 }
 
 export interface ProjectionRelationalExpressionNode extends BaseNode {

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -43,6 +43,7 @@ import {
   ProjectionLambdaParameterDeclarationNode,
   ProjectionLogicalExpressionNode,
   ProjectionMemberExpressionNode,
+  ProjectionMembershipExpressionNode,
   ProjectionModelExpressionNode,
   ProjectionModelPropertyNode,
   ProjectionModelSpreadPropertyNode,
@@ -286,6 +287,12 @@ export function printNode(
     case SyntaxKind.ProjectionArithmeticExpression:
       return printProjectionLeftRightExpression(
         path as AstPath<ProjectionLogicalExpressionNode>,
+        options,
+        print
+      );
+    case SyntaxKind.ProjectionMembershipExpression:
+      return printProjectionMembershipExpression(
+        path as AstPath<ProjectionMembershipExpressionNode>,
         options,
         print
       );
@@ -1514,6 +1521,17 @@ export function printProjectionLeftRightExpression(
 ) {
   const node = path.getValue();
   return [path.call(print, "left"), " ", node.op, " ", path.call(print, "right")];
+}
+
+export function printProjectionMembershipExpression(
+  path: AstPath<ProjectionMembershipExpressionNode>,
+  options: TypeSpecPrettierOptions,
+  print: PrettierChildPrint
+) {
+  const target = path.call(print, "left");
+  const params = printItemList(path, options, print, "arguments");
+
+  return [target, " ", "in", " ", "{", params, "}"];
 }
 
 export function printProjectionUnaryExpression(

--- a/packages/compiler/test/projection/projection-logic.test.ts
+++ b/packages/compiler/test/projection/projection-logic.test.ts
@@ -26,6 +26,93 @@ describe("compiler: projections: logic", () => {
     testHost = await createTestHost();
   });
 
+  it("projects logical implies", async () => {
+    const code = `
+      @test model Foo {
+        a: int32;
+        b: int16;
+        c: string;
+      }
+
+      #suppress "projections-are-experimental"
+      projection Foo#v {
+        to(version) {
+          if false ==> version >= 1 {
+            self::deleteProperty("a");
+          };
+
+          if true ==> version >= 1 {
+            self::deleteProperty("b");
+          };
+
+          if true ==> version >= 2 {
+            self::deleteProperty("c");
+          };
+        }
+      }
+    `;
+
+    const result2 = (await testProjection(code, [projection("v", 0)])) as Model;
+    strictEqual(result2.properties.size, 2);
+
+    const result1 = (await testProjection(code, [projection("v", 1)])) as Model;
+    strictEqual(result1.properties.size, 1);
+
+    const result0 = (await testProjection(code, [projection("v", 2)])) as Model;
+    strictEqual(result0.properties.size, 0);
+  });
+
+  it("projects logical member", async () => {
+    const code = `
+      @test model Foo {
+        a: int32;
+        b: int16;
+        c: string;
+      }
+
+      #suppress "projections-are-experimental"
+      projection Foo#v {
+        to(version) {
+          if version in {1, 2} {
+            self::deleteProperty("a");
+          };
+
+          if version >= 3 ==> !(version in {1, 2}) {
+            self::deleteProperty("b");
+          };
+        }
+      }
+    `;
+
+    const result1 = (await testProjection(code, [projection("v", 1)])) as Model;
+    strictEqual(result1.properties.size, 1);
+
+    const result3 = (await testProjection(code, [projection("v", 3)])) as Model;
+    strictEqual(result3.properties.size, 2);
+  });
+
+  it("projects logical member a string", async () => {
+    const code = `
+      @test model Foo {
+        a: int32;
+        b: int16;
+        c: string;
+      }
+
+      #suppress "projections-are-experimental"
+      projection Foo#v {
+        to(version) {
+          if "bob" in {"sam", "bob"} {
+            self::deleteProperty("a");
+          };
+        }
+      }
+    `;
+
+    const result3 = (await testProjection(code, [projection("v", 3)])) as Model;
+    strictEqual(result3.properties.size, 2);
+  });
+
   it("projects nested namespaces", async () => {
     const code = `
      namespace Bar.Baz;


### PR DESCRIPTION
Adding an implies `==>` and a membership operation `x in {...}` to the expression language.

These are key operators for validation and data quality checks (issue [#2041](https://github.com/microsoft/typespec/issues/2041)).

PR includes implementation + tests. No keywords introduced and should only impact expression language parsing/checking.