### PR TITLE
Implementation of validate for Model Statement and Scalar.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,12 +67,7 @@
       "request": "launch",
       "name": "Compile Scratch",
       "program": "${workspaceFolder}/packages/compiler/dist/core/cli/cli.js",
-      "args": [
-        "compile",
-        "../samples/scratch",
-        "--output-dir=temp/scratch-output",
-        "--emit=@typespec/openapi3"
-      ],
+      "args": ["compile", "C:\\Users\\marro\\Code\\Scratch\\tspsample\\validate1.tsp"],
       "smartStep": true,
       "sourceMaps": true,
       "skipFiles": ["<node_internals>/**/*.js"],

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -332,6 +332,12 @@ const diagnostics = {
       default: paramMessage`Model already has a property named ${"propName"}`,
     },
   },
+  "duplicate-validate": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Model already has a validate clause named ${"propName"}`,
+    },
+  },
   "override-property-mismatch": {
     severity: "error",
     messages: {

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -51,6 +51,7 @@ import {
   ModelPropertyNode,
   ModelSpreadPropertyNode,
   ModelStatementNode,
+  ModelValidateNode,
   Modifier,
   ModifierFlags,
   NamespaceStatementNode,
@@ -175,6 +176,16 @@ namespace ListKind {
     close: Token.CloseBrace,
     delimiter: Token.Semicolon,
     toleratedDelimiter: Token.Comma,
+  } as const;
+
+  export const ScalarValidates = {
+    ...PropertiesBase,
+    allowEmpty: false,
+    open: Token.OpenBrace,
+    close: Token.CloseBrace,
+    delimiter: Token.Semicolon,
+    toleratedDelimiter: Token.Semicolon,
+    toleratedDelimiterIsValid: false,
   } as const;
 
   export const InterfaceMembers = {
@@ -758,17 +769,25 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     const optionalExtends = parseOptionalModelExtends();
     const optionalIs = optionalExtends ? undefined : parseOptionalModelIs();
 
-    let properties: (ModelPropertyNode | ModelSpreadPropertyNode)[] = [];
+    let entries: (ModelPropertyNode | ModelSpreadPropertyNode | ModelValidateNode)[] = [];
     if (optionalIs) {
       const tok = expectTokenIsOneOf(Token.Semicolon, Token.OpenBrace);
       if (tok === Token.Semicolon) {
         nextToken();
       } else {
-        properties = parseList(ListKind.ModelProperties, parseModelPropertyOrSpread);
+        entries = parseList(ListKind.ModelProperties, parseModelPropertyOrSpreadOrValidate);
       }
     } else {
-      properties = parseList(ListKind.ModelProperties, parseModelPropertyOrSpread);
+      entries = parseList(ListKind.ModelProperties, parseModelPropertyOrSpreadOrValidate);
     }
+
+    const properties = entries.filter(
+      (e) => e.kind === SyntaxKind.ModelProperty || e.kind === SyntaxKind.ModelSpreadProperty
+    ) as (ModelPropertyNode | ModelSpreadPropertyNode)[];
+
+    const validates = entries.filter(
+      (e) => e.kind === SyntaxKind.ModelValidate
+    ) as ModelValidateNode[];
 
     return {
       kind: SyntaxKind.ModelStatement,
@@ -778,6 +797,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
       templateParameters,
       decorators,
       properties,
+      validates,
       ...finishNode(pos),
     };
   }
@@ -820,6 +840,15 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     return token() === Token.Ellipsis
       ? parseModelSpreadProperty(pos, decorators)
       : parseModelProperty(pos, decorators);
+  }
+
+  function parseModelPropertyOrSpreadOrValidate(
+    pos: number,
+    decorators: DecoratorExpressionNode[]
+  ) {
+    return token() === Token.Ellipsis
+      ? parseModelSpreadProperty(pos, decorators)
+      : parseModelPropertyOrValidate(pos, decorators);
   }
 
   function parseModelSpreadProperty(
@@ -866,6 +895,50 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     };
   }
 
+  function parseModelPropertyOrValidate(
+    pos: number,
+    decorators: DecoratorExpressionNode[]
+  ): ModelPropertyNode | ModelValidateNode {
+    const id = parseIdentifier({
+      message: "property",
+      allowStringLiteral: true,
+    });
+
+    if (id.sv === "validate" && token() === Token.Identifier) {
+      const vid = parseIdentifier({
+        message: "property",
+        allowStringLiteral: false,
+      });
+
+      parseExpected(Token.Colon);
+      const value = parseProjectionExpression();
+
+      return {
+        kind: SyntaxKind.ModelValidate,
+        id: vid,
+        decorators,
+        value,
+        ...finishNode(pos),
+      };
+    } else {
+      const optional = parseOptional(Token.Question);
+      parseExpected(Token.Colon);
+      const value = parseExpression();
+
+      const hasDefault = parseOptional(Token.Equals);
+      const defaultValue = hasDefault ? parseExpression() : undefined;
+      return {
+        kind: SyntaxKind.ModelProperty,
+        id,
+        decorators,
+        value,
+        optional,
+        default: defaultValue,
+        ...finishNode(pos),
+      };
+    }
+  }
+
   function parseScalarStatement(
     pos: number,
     decorators: DecoratorExpressionNode[]
@@ -876,9 +949,15 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
 
     const optionalExtends = parseOptionalScalarExtends();
 
+    let validates: ModelValidateNode[] = [];
+    if (token() === Token.OpenBrace) {
+      validates = parseList(ListKind.ScalarValidates, parseScalarValidate);
+    }
+
     return {
       kind: SyntaxKind.ScalarStatement,
       id,
+      validates,
       templateParameters,
       extends: optionalExtends,
       decorators,
@@ -891,6 +970,36 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
       return parseReferenceExpression();
     }
     return undefined;
+  }
+
+  function parseScalarValidate(
+    pos: number,
+    decorators: DecoratorExpressionNode[]
+  ): ModelValidateNode {
+    const id = parseIdentifier({
+      message: "property",
+      allowStringLiteral: true,
+    });
+
+    if (id.sv !== "validate" || token() !== Token.Identifier) {
+      error({ code: "token-expected", format: { token: "'validate'" } });
+    }
+
+    const vid = parseIdentifier({
+      message: "property",
+      allowStringLiteral: false,
+    });
+
+    parseExpected(Token.Colon);
+    const value = parseProjectionExpression();
+
+    return {
+      kind: SyntaxKind.ModelValidate,
+      id: vid,
+      decorators,
+      value,
+      ...finishNode(pos),
+    };
   }
 
   function parseEnumStatement(
@@ -2922,14 +3031,18 @@ export function visitChildren<T>(node: Node, cb: NodeCallback<T>): T | undefined
         visitEach(cb, node.templateParameters) ||
         visitNode(cb, node.extends) ||
         visitNode(cb, node.is) ||
-        visitEach(cb, node.properties)
+        visitEach(cb, node.properties) ||
+        visitEach(cb, node.validates)
       );
+    case SyntaxKind.ModelValidate:
+      return visitEach(cb, node.decorators) || visitNode(cb, node.id) || visitNode(cb, node.value);
     case SyntaxKind.ScalarStatement:
       return (
         visitEach(cb, node.decorators) ||
         visitNode(cb, node.id) ||
         visitEach(cb, node.templateParameters) ||
-        visitNode(cb, node.extends)
+        visitNode(cb, node.extends) ||
+        visitEach(cb, node.validates)
       );
     case SyntaxKind.UnionStatement:
       return (

--- a/packages/compiler/core/semantic-walker.ts
+++ b/packages/compiler/core/semantic-walker.ts
@@ -7,6 +7,7 @@ import {
   ListenerFlow,
   Model,
   ModelProperty,
+  ModelValidate,
   Namespace,
   Operation,
   Scalar,
@@ -256,6 +257,14 @@ function navigateModelTypeProperty(property: ModelProperty, context: NavigationC
   navigateTypeInternal(property.type, context);
 }
 
+function navigateModelTypeValidate(validate: ModelValidate, context: NavigationContext) {
+  if (checkVisited(context.visited, validate)) {
+    return;
+  }
+  if (context.emit("modelValidate", validate) === ListenerFlow.NoRecursion) return;
+  context.emit("exitModelValidate", validate);
+}
+
 function navigateScalarType(scalar: Scalar, context: NavigationContext) {
   if (checkVisited(context.visited, scalar)) {
     return;
@@ -343,6 +352,8 @@ function navigateTypeInternal(type: Type, context: NavigationContext) {
       return navigateScalarType(type, context);
     case "ModelProperty":
       return navigateModelTypeProperty(type, context);
+    case "ModelValidate":
+      return navigateModelTypeValidate(type, context);
     case "Namespace":
       return navigateNamespaceType(type, context);
     case "Interface":
@@ -422,6 +433,8 @@ const eventNames: Array<keyof SemanticNodeListener> = [
   "exitModel",
   "modelProperty",
   "exitModelProperty",
+  "modelValidate",
+  "exitModelValidate",
   "interface",
   "exitInterface",
   "enum",

--- a/packages/compiler/core/type-utils.ts
+++ b/packages/compiler/core/type-utils.ts
@@ -54,6 +54,7 @@ export function getParentTemplateNode(node: Node): (Node & TemplateDeclarationNo
       return node.templateParameters.length > 0 ? node : undefined;
     case SyntaxKind.OperationSignatureDeclaration:
     case SyntaxKind.ModelProperty:
+    case SyntaxKind.ModelValidate:
     case SyntaxKind.ModelExpression:
       return node.parent ? getParentTemplateNode(node.parent) : undefined;
     default:

--- a/packages/compiler/formatter/print/comment-handler.ts
+++ b/packages/compiler/formatter/print/comment-handler.ts
@@ -66,6 +66,7 @@ function addStatementDecoratorComment(comment: CommentNode) {
       enclosingNode.kind === SyntaxKind.EnumStatement ||
       enclosingNode.kind === SyntaxKind.OperationStatement ||
       enclosingNode.kind === SyntaxKind.ModelProperty ||
+      enclosingNode.kind === SyntaxKind.ModelValidate ||
       enclosingNode.kind === SyntaxKind.EnumMember ||
       enclosingNode.kind === SyntaxKind.UnionStatement)
   ) {

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -26,6 +26,7 @@ import {
   ModelPropertyNode,
   ModelSpreadPropertyNode,
   ModelStatementNode,
+  ModelValidateNode,
   NamespaceStatementNode,
   Node,
   NodeFlags,
@@ -170,6 +171,8 @@ export function printNode(
       return printModelExpression(path as AstPath<ModelExpressionNode>, options, print);
     case SyntaxKind.ModelProperty:
       return printModelProperty(path as AstPath<ModelPropertyNode>, options, print);
+    case SyntaxKind.ModelValidate:
+      return printModelValidate(path as AstPath<ModelValidateNode>, options, print);
     case SyntaxKind.DecoratorExpression:
       return printDecorator(path as AstPath<DecoratorExpressionNode>, options, print);
     case SyntaxKind.AugmentDecoratorStatement:
@@ -931,6 +934,7 @@ function printModelPropertiesBlock(
         | ProjectionModelPropertyNode
         | ProjectionModelSpreadPropertyNode
       )[];
+      validates?: readonly ModelValidateNode[];
     }
   >,
   options: TypeSpecPrettierOptions,
@@ -938,8 +942,9 @@ function printModelPropertiesBlock(
 ) {
   const node = path.getValue();
   const hasProperties = node.properties && node.properties.length > 0;
+  const hasValidates = node.validates && node.validates.length > 0;
   const nodeHasComments = hasComments(node, CommentCheckFlags.Dangling);
-  if (!hasProperties && !nodeHasComments) {
+  if (!hasProperties && !nodeHasComments && !hasValidates) {
     return "{}";
   }
   const tryInline = path.getParentNode()?.kind === SyntaxKind.TemplateParameterDeclaration;
@@ -952,6 +957,11 @@ function printModelPropertiesBlock(
       [seperator, lineDoc],
       path.map((x) => [print(x as any)], "properties")
     ),
+    /*
+    join(
+      [seperator, lineDoc],
+      path.map((x) => [print(x as any)], "validates")
+    ),*/
     hasProperties ? ifBreak(seperator) : "",
   ];
   if (nodeHasComments) {
@@ -1005,6 +1015,32 @@ export function printModelProperty(
     node.optional ? "?: " : ": ",
     path.call(print, "value"),
     node.default ? [" = ", path.call(print, "default")] : "",
+  ];
+}
+
+export function printModelValidate(
+  path: AstPath<ModelValidateNode>,
+  options: TypeSpecPrettierOptions,
+  print: PrettierChildPrint
+) {
+  const node = path.getValue();
+  const propertyIndex = path.stack[path.stack.length - 2];
+  const isNotFirst = typeof propertyIndex === "number" && propertyIndex > 0;
+  const { decorators, multiline } = printDecorators(
+    path as AstPath<DecorableNode>,
+    options,
+    print,
+    {
+      tryInline: true,
+    }
+  );
+  const id = printIdentifier(node.id, options);
+  return [
+    multiline && isNotFirst ? hardline : "",
+    printDirectives(path, options, print),
+    decorators,
+    id,
+    path.call(print, "value"),
   ];
 }
 
@@ -1069,14 +1105,44 @@ export function printScalarStatement(
   const heritage = node.extends
     ? [ifBreak(line, " "), "extends ", path.call(print, "extends")]
     : "";
+  const body = ""; //[" ", printScalarValidatesBlock(path, options, print)];
   return [
     printDecorators(path, options, print, { tryInline: false }).decorators,
     "scalar ",
     id,
     template,
     group(indent(["", heritage])),
+    body,
     ";",
   ];
+}
+
+function printScalarValidatesBlock(
+  path: AstPath<
+    Node & {
+      validates?: readonly ModelValidateNode[];
+    }
+  >,
+  options: TypeSpecPrettierOptions,
+  print: PrettierChildPrint
+) {
+  const node = path.getValue();
+  const hasValidates = node.validates && node.validates.length > 0;
+  if (!hasValidates) {
+    return "";
+  }
+  const tryInline = path.getParentNode()?.kind === SyntaxKind.TemplateParameterDeclaration;
+  const lineDoc = tryInline ? softline : hardline;
+  const seperator = isModelAValue(path) ? "," : ";";
+
+  const body: prettier.Doc = [
+    lineDoc,
+    join(
+      [seperator, lineDoc],
+      path.map((x) => [print(x as any)], "validates")
+    ),
+  ];
+  return group(["{", indent(body), lineDoc, "}"]);
 }
 
 export function printNamespaceStatement(

--- a/packages/compiler/server/symbol-structure.ts
+++ b/packages/compiler/server/symbol-structure.ts
@@ -54,6 +54,8 @@ export function getSymbolStructure(ast: TypeSpecScriptNode): DocumentSymbol[] {
         return getForModel(node);
       case SyntaxKind.ModelProperty:
         return createDocumentSymbol(node, getName(node.id), SymbolKind.Property);
+      case SyntaxKind.ModelValidate:
+        return createDocumentSymbol(node, getName(node.id), SymbolKind.Validate);
       case SyntaxKind.ModelSpreadProperty:
         return getForModelSpread(node);
       case SyntaxKind.UnionStatement:

--- a/packages/compiler/server/type-signature.ts
+++ b/packages/compiler/server/type-signature.ts
@@ -60,6 +60,8 @@ function getTypeSignature(type: Type | ValueType): string {
       return `(function parameter)\n${fence(getFunctionParameterSignature(type))}`;
     case "ModelProperty":
       return `(model property)\n${fence(getModelPropertySignature(type))}`;
+    case "ModelValidate":
+      return `(model validate)`;
     case "EnumMember":
       return `(enum member)\n${fence(getEnumMemberSignature(type))}`;
     case "TemplateParameter":

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -1,0 +1,93 @@
+import { strictEqual } from "assert";
+import { Model, Scalar } from "../../core/types.js";
+import { TestHost, createTestHost } from "../../testing/index.js";
+
+describe("compiler: validate", () => {
+  let testHost: TestHost;
+
+  beforeEach(async () => {
+    testHost = await createTestHost();
+  });
+
+  it("basic validate", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `  
+      @test model M {
+        ii: int64;
+
+        validate chkii: ii >= 0;
+      }
+      `
+    );
+
+    const { M } = (await testHost.compile("main.tsp")) as {
+      M: Model;
+    };
+
+    strictEqual(M.validates.size, 1);
+  });
+
+  it("validate x2", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `  
+      @test model M {
+        ii: int64;
+
+        validate chkiil: ii >= 0;
+        validate chkiih: ii < 100;
+      }
+      `
+    );
+
+    const { M } = (await testHost.compile("main.tsp")) as {
+      M: Model;
+    };
+
+    strictEqual(M.validates.size, 2);
+  });
+
+  it("basic validate with doc", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `  
+      @test model M {
+        ii: int64;
+
+        @doc("Check that ii is greater than or equal to 0")
+        validate chkii: ii >= 0;
+      }
+      `
+    );
+
+    const { M } = (await testHost.compile("main.tsp")) as {
+      M: Model;
+    };
+
+    strictEqual(M.validates.size, 1);
+    strictEqual(M.validates.get("chkii")?.decorators.length, 1);
+    strictEqual(M.validates.get("chkii")?.decorators[0].decorator.name, "$doc");
+    strictEqual(M.validates.get("chkii")?.decorators[0].args.length, 1);
+    strictEqual(
+      M.validates.get("chkii")?.decorators[0].args[0].jsValue,
+      "Check that ii is greater than or equal to 0"
+    );
+  });
+  it("basic scalar validate", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `  
+      @test scalar S extends int64 {
+        validate chkv: value >= 0;
+      }
+      `
+    );
+
+    const { S } = (await testHost.compile("main.tsp")) as {
+      S: Scalar;
+    };
+
+    strictEqual(S.validates.size, 1);
+  });
+});

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -156,7 +156,7 @@ describe("compiler: parser", () => {
     ]);
 
     parseErrorEach([
-      ["scalar uuid extends string { }", [/Statement expected./]],
+      ["scalar uuid extends string { }", [/Property expected./]],
       ["scalar uuid is string;", [/Statement expected./]],
     ]);
   });

--- a/packages/html-program-viewer/src/ui.tsx
+++ b/packages/html-program-viewer/src/ui.tsx
@@ -7,6 +7,7 @@ import {
   Interface,
   Model,
   ModelProperty,
+  ModelValidate,
   Namespace,
   Operation,
   Program,
@@ -175,6 +176,8 @@ const TypeUI: FunctionComponent<TypeUIProps> = ({ type }) => {
       return <ScalarUI type={type} />;
     case "ModelProperty":
       return <ModelPropertyUI type={type} />;
+    case "ModelValidate":
+      return <ModelValidateUI type={type} />;
     case "Union":
       return <UnionUI type={type} />;
     case "UnionVariant":
@@ -253,6 +256,7 @@ const ModelUI: FunctionComponent<{ type: Model }> = ({ type }) => {
         baseModel: "ref",
         derivedModels: "ref",
         properties: "nested",
+        validates: "nested",
         sourceModel: "ref",
       }}
     />
@@ -266,6 +270,7 @@ const ScalarUI: FunctionComponent<{ type: Scalar }> = ({ type }) => {
       properties={{
         baseScalar: "ref",
         derivedScalars: "ref",
+        validates: "nested",
       }}
     />
   );
@@ -281,6 +286,17 @@ const ModelPropertyUI: FunctionComponent<{ type: ModelProperty }> = ({ type }) =
         optional: "value",
         sourceProperty: "ref",
         default: "value",
+      }}
+    />
+  );
+};
+
+const ModelValidateUI: FunctionComponent<{ type: ModelValidate }> = ({ type }) => {
+  return (
+    <NamedTypeUI
+      type={type}
+      properties={{
+        model: "ref"
       }}
     />
   );
@@ -368,6 +384,7 @@ const TypeReference: FunctionComponent<{ type: Type }> = ({ type }) => {
     case "Interface":
     case "Enum":
     case "ModelProperty":
+    case "ModelValidate":
     case "Scalar":
       return <NamedTypeRef type={type} />;
     case "Model":

--- a/packages/ref-doc/src/utils/type-signature.ts
+++ b/packages/ref-doc/src/utils/type-signature.ts
@@ -51,6 +51,8 @@ export function getTypeSignature(type: Type | ValueType): string {
       return getFunctionParameterSignature(type);
     case "ModelProperty":
       return `(model property) ${`${type.name}: ${getTypeName(type.type)}`}`;
+    case "ModelValidate":
+      return `(model validate) ${`${type.name}`}`;
     case "EnumMember":
       return `(enum member) ${getEnumMemberSignature(type)}`;
     case "TemplateParameter":


### PR DESCRIPTION
Adds support for validate on Model Statements and Scalars (issue [#2041](https://github.com/microsoft/typespec/issues/2041)):
```
 model M {
    ii: int64;

    @doc("Check that ii is greater than or equal to 0")
    validate chkii: ii >= 0;
}
```

```
scalar S extends int64 {
    validate chkv: value >= 0;
}
```

Tests for basic functionality.
TODO: prettier formatting.