### PR TITLE
Playground: Provide a more reusable storage state

### DIFF
--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -1,6 +1,6 @@
 export { createBrowserHost } from "./browser-host.js";
 export { registerMonacoDefaultWorkers } from "./monaco-worker.js";
 export { registerMonacoLanguage } from "./services.js";
-export { createUrlStateStorate } from "./state-storage.js";
+export { createUrlStateStorage } from "./state-storage.js";
 export { PlaygroundSample } from "./types.js";
 export { filterEmitters } from "./utils.js";

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -1,6 +1,6 @@
 export { createBrowserHost } from "./browser-host.js";
 export { registerMonacoDefaultWorkers } from "./monaco-worker.js";
 export { registerMonacoLanguage } from "./services.js";
-export { getStateFromUrl, saveTypeSpecContentInQueryParameter } from "./state-storage.js";
+export { createUrlStateStorate } from "./state-storage.js";
 export { PlaygroundSample } from "./types.js";
 export { filterEmitters } from "./utils.js";

--- a/packages/playground/src/react/standalone.tsx
+++ b/packages/playground/src/react/standalone.tsx
@@ -30,7 +30,7 @@ export async function createReactPlayground(config: ReactPlaygroundConfig) {
       void navigator.clipboard.writeText(window.location.toString());
     },
   };
-  
+
   const App: FunctionComponent = () => {
     return <StyledPlayground {...options} />;
   };

--- a/packages/playground/src/react/standalone.tsx
+++ b/packages/playground/src/react/standalone.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { createBrowserHost } from "../browser-host.js";
 import { registerMonacoDefaultWorkers } from "../monaco-worker.js";
 import { registerMonacoLanguage } from "../services.js";
-import { StateStorage, createUrlStateStorate } from "../state-storage.js";
+import { StateStorage, createUrlStateStorage } from "../state-storage.js";
 import { filterEmitters } from "../utils.js";
 import { PlaygroundProps, PlaygroundSaveData, StyledPlayground } from "./playground.js";
 
@@ -25,8 +25,12 @@ export async function createReactPlayground(config: ReactPlaygroundConfig) {
     emitters,
     defaultContent: initialState.content,
     defaultSampleName: initialState.sampleName,
-    onSave: (value) => stateStorage.save(value),
+    onSave: (value) => {
+      stateStorage.save(value);
+      void navigator.clipboard.writeText(window.location.toString());
+    },
   };
+  
   const App: FunctionComponent = () => {
     return <StyledPlayground {...options} />;
   };
@@ -42,7 +46,7 @@ export async function renderReactPlayground(config: ReactPlaygroundConfig) {
 }
 
 export function createStandalonePlaygroundStateStorage(): StateStorage<PlaygroundSaveData> {
-  const stateStorage = createUrlStateStorate<PlaygroundSaveData>({
+  const stateStorage = createUrlStateStorage<PlaygroundSaveData>({
     content: {
       queryParam: "c",
       compress: "lz-base64",

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -1,10 +1,10 @@
 import { editor } from "monaco-editor";
 import { FunctionComponent } from "react";
-import { Editor, EditorCommand, useMonacoModel } from "./editor.js";
+import { Editor, useMonacoModel } from "./editor.js";
 
 export interface TypeSpecEditorProps {
   model: editor.IModel;
-  commands?: EditorCommand[];
+  actions?: editor.IActionDescriptor[];
 }
 
 export const TypeSpecEditor: FunctionComponent<TypeSpecEditorProps> = (props) => {
@@ -17,7 +17,7 @@ export const TypeSpecEditor: FunctionComponent<TypeSpecEditorProps> = (props) =>
     },
   };
   // Add shortcuts
-  return <Editor model={props.model} commands={props.commands} options={options}></Editor>;
+  return <Editor model={props.model} actions={props.actions} options={options}></Editor>;
 };
 
 export const OutputEditor: FunctionComponent<{ filename: string; value: string }> = ({

--- a/packages/playground/src/state-storage.ts
+++ b/packages/playground/src/state-storage.ts
@@ -22,7 +22,7 @@ export interface UrlStorageItem {
  * @param schema Schema of the data to be serialized in the query
  * @returns
  */
-export function createUrlStateStorate<const T extends object>(
+export function createUrlStateStorage<const T extends object>(
   schema: UrlStorageSchema<T>
 ): StateStorage<T> {
   return { load, save };

--- a/packages/playground/src/state-storage.ts
+++ b/packages/playground/src/state-storage.ts
@@ -1,26 +1,70 @@
 import lzutf8 from "lzutf8";
-// import { PlaygroundDefaultState } from "./components/playground.js";
-type PlaygroundDefaultState = any;
-export async function saveTypeSpecContentInQueryParameter(content: string) {
-  const compressed = lzutf8.compress(content, { outputEncoding: "Base64" });
-  history.pushState(null, "", window.location.pathname + "?c=" + encodeURIComponent(compressed));
-  await navigator.clipboard.writeText(window.location.toString());
+
+export interface StateStorage<T extends {}> {
+  load(): Partial<T>;
+  save(t: Partial<T>): void;
 }
 
-export function getStateFromUrl(): PlaygroundDefaultState {
-  if (window.location.search.length === 0) {
-    return {};
-  }
-  const parsed = new URLSearchParams(window.location.search);
+export type UrlStorageSchema<T> = {
+  [key in keyof T]: UrlStorageItem;
+};
 
-  const state: PlaygroundDefaultState = {};
-  const content = parsed.get("c");
-  if (content) {
-    state.content = lzutf8.decompress(content, { inputEncoding: "Base64" });
+export interface UrlStorageItem {
+  /** Name of the query parameter where the data will be serialized. */
+  queryParam: string;
+
+  /** Encoding the data should be compressed with. If undefined param will not be compressed. */
+  compress?: "lz-base64";
+}
+
+/**
+ * Generic storage mechanism for data in the playground.
+ * @param schema Schema of the data to be serialized in the query
+ * @returns
+ */
+export function createUrlStateStorate<const T extends {}>(
+  schema: UrlStorageSchema<T>
+): StateStorage<T> {
+  return { load, save };
+
+  function load(): Partial<T> {
+    const result: Record<string, string> = {};
+    const parsed = new URLSearchParams(window.location.search);
+    for (const [key, query] of Object.entries<UrlStorageItem>(schema)) {
+      const value = parsed.get(query.queryParam);
+
+      if (value) {
+        if (query.compress) {
+          try {
+            result[key] = lzutf8.decompress(value, { inputEncoding: "Base64" });
+          } catch (e) {
+            console.error(
+              `Error decompressing query parameter ${query.queryParam} with content:`,
+              value
+            );
+          }
+        } else {
+          result[key] = value;
+        }
+      }
+    }
+    return result as Partial<T>;
   }
-  const sample = parsed.get("sample");
-  if (sample) {
-    state.sampleName = sample;
+
+  function save(data: T) {
+    const params = new URLSearchParams();
+    for (const [key, query] of Object.entries<UrlStorageItem>(schema)) {
+      const value = (data as any)[key];
+
+      if (value) {
+        if (query.compress) {
+          const compressed = lzutf8.compress(value, { outputEncoding: "Base64" });
+          params.append(query.queryParam, compressed);
+        } else {
+          params.append(query.queryParam, value);
+        }
+      }
+    }
+    history.pushState(null, "", window.location.pathname + "?" + params.toString());
   }
-  return state;
 }

--- a/packages/playground/src/state-storage.ts
+++ b/packages/playground/src/state-storage.ts
@@ -1,6 +1,6 @@
 import lzutf8 from "lzutf8";
 
-export interface StateStorage<T extends {}> {
+export interface StateStorage<T extends object> {
   load(): Partial<T>;
   save(t: Partial<T>): void;
 }
@@ -22,7 +22,7 @@ export interface UrlStorageItem {
  * @param schema Schema of the data to be serialized in the query
  * @returns
  */
-export function createUrlStateStorate<const T extends {}>(
+export function createUrlStateStorate<const T extends object>(
   schema: UrlStorageSchema<T>
 ): StateStorage<T> {
   return { load, save };
@@ -38,6 +38,7 @@ export function createUrlStateStorate<const T extends {}>(
           try {
             result[key] = lzutf8.decompress(value, { inputEncoding: "Base64" });
           } catch (e) {
+            // eslint-disable-next-line no-console
             console.error(
               `Error decompressing query parameter ${query.queryParam} with content:`,
               value


### PR DESCRIPTION
Progress towards #1842
Provide a few helpers that will help a custom playground to define it own storage.

Also expose `sampleName` which in the standalone playground is able to be saved as long as it wasn't modified