### PR TITLE
Fix JS imports not working when debugging language server

### DIFF
--- a/packages/compiler/src/formatter/print/needs-parens.ts
+++ b/packages/compiler/src/formatter/print/needs-parens.ts
@@ -1,5 +1,5 @@
 import { AstPath } from "prettier";
-import { Node, SyntaxKind } from "../../core/index.js";
+import { Node, SyntaxKind } from "../../core/types.js";
 import { TypeSpecPrettierOptions } from "./types.js";
 
 /**


### PR DESCRIPTION
The issue results from cylces in runtime imports, but for reasons that are not understood yet, this only impacts the language server is run in development mode and uses entrypoints/server.js directly.

The fix here is the smallest possible: revert a change to an import that was made inadvertently when compiler source was recently moved under src/.

Will file follow-up issue to lint and/or test to prevent this from happening again.