### PR TITLE
Fix formatting issue with comment between decorator and scalar or interface

### DIFF
--- a/common/changes/@typespec/compiler/fix-formatting-issue_2023-06-23-17-48.json
+++ b/common/changes/@typespec/compiler/fix-formatting-issue_2023-06-23-17-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix formatting issue with comment between decorator and scalar or interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/formatter/print/comment-handler.ts
+++ b/packages/compiler/src/formatter/print/comment-handler.ts
@@ -76,6 +76,8 @@ function addStatementDecoratorComment({ comment }: CommentContext) {
       enclosingNode.kind === SyntaxKind.ModelStatement ||
       enclosingNode.kind === SyntaxKind.EnumStatement ||
       enclosingNode.kind === SyntaxKind.OperationStatement ||
+      enclosingNode.kind === SyntaxKind.ScalarStatement ||
+      enclosingNode.kind === SyntaxKind.InterfaceStatement ||
       enclosingNode.kind === SyntaxKind.ModelProperty ||
       enclosingNode.kind === SyntaxKind.EnumMember ||
       enclosingNode.kind === SyntaxKind.UnionStatement)

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -1001,81 +1001,33 @@ interface Foo {
       });
     });
 
-    it("format comment between decorator and namespace statement", () => {
-      assertFormat({
-        code: `
+    describe("format comment between decorator and statement", () => {
+      [
+        ["blockless namespace", "namespace Bar;"],
+        ["flattened blockless namespace", "namespace Foo.Bar;"],
+        ["block namespace", "namespace Bar {\n\n}"],
+        ["flattened block namespace", "namespace Foo.Bar {\n\n}"],
+        ["model", "model Bar {}"],
+        ["op", "op test(foo: string): void;"],
+        ["scalar", "scalar foo;"],
+        ["interface", "interface Foo {}"],
+        ["union", "union Foo {}"],
+        ["enum", "enum Foo {}"],
+      ].forEach(([name, code]) => {
+        it(name, () => {
+          assertFormat({
+            code: `
 @foo
-   // comment
-namespace Bar;
+    // comment
+${code}
 `,
-        expected: `
-@foo
-// comment
-namespace Bar;
-`,
-      });
-    });
-
-    it("format comment between decorator and flattened blockless namespace statement", () => {
-      assertFormat({
-        code: `
-@foo
-   // comment
-namespace Foo.Bar;
-`,
-        expected: `
+            expected: `
 @foo
 // comment
-namespace Foo.Bar;
+${code}
 `,
-      });
-    });
-
-    it("format comment between decorator and flattened block namespace statement", () => {
-      assertFormat({
-        code: `
-@foo
-   // comment
-namespace Foo.Bar {
-}
-`,
-        expected: `
-@foo
-// comment
-namespace Foo.Bar {
-
-}
-`,
-      });
-    });
-
-    it("format comment between decorator and model statement", () => {
-      assertFormat({
-        code: `
-@foo
-  // comment
-model Bar {}
-`,
-        expected: `
-@foo
-// comment
-model Bar {}
-`,
-      });
-    });
-
-    it("format comment between decorator and op statement", () => {
-      assertFormat({
-        code: `
-@foo
-  // comment
-op test(foo: string): void;
-`,
-        expected: `
-@foo
-// comment
-op test(foo: string): void;
-`,
+          });
+        });
       });
     });
 


### PR DESCRIPTION
fix #2094

Fix issue that would format 
```
@dec
// comment
scalar bar extends string;
```
into
```
@dec
scalar // comment
bar extends string;
```

Still applied to 
- scalar
- interface

Other statements had it handled correctly already.

Also cleanup the test for those issues.