### PR TITLE
Fix JsonSchema namespace

### DIFF
--- a/common/changes/@typespec/json-schema/json-schema-namespace_2023-06-24-07-59.json
+++ b/common/changes/@typespec/json-schema/json-schema-namespace_2023-06-24-07-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "Breaking change: the namespace has been corrected to TypeSpec.JsonSchema.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/packages/json-schema/lib/main.tsp
+++ b/packages/json-schema/lib/main.tsp
@@ -1,6 +1,6 @@
 import "../dist/src/index.js";
 
-namespace JsonSchema;
+namespace TypeSpec.JsonSchema;
 
 /**
  * Add to namespaces to emit models within that namespace to JSON schema.

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -17,7 +17,7 @@ import { JsonSchemaEmitter } from "./json-schema-emitter.js";
 import { JSONSchemaEmitterOptions, createStateSymbol } from "./lib.js";
 
 export { $lib } from "./lib.js";
-export const namespace = "JsonSchema";
+export const namespace = "TypeSpec.JsonSchema";
 export type JsonSchemaDeclaration = Model | Union | Enum | Scalar;
 
 const jsonSchemaKey = createStateSymbol("JsonSchema");

--- a/packages/json-schema/test/utils.ts
+++ b/packages/json-schema/test/utils.ts
@@ -30,8 +30,8 @@ export async function emitSchema(
   }
 
   code = testOptions.emitNamespace
-    ? `import "@typespec/json-schema"; using JsonSchema; @jsonSchema namespace test; ${code}`
-    : `import "@typespec/json-schema"; using JsonSchema; ${code}`;
+    ? `import "@typespec/json-schema"; using TypeSpec.JsonSchema; @jsonSchema namespace test; ${code}`
+    : `import "@typespec/json-schema"; using TypeSpec.JsonSchema; ${code}`;
   const host = await getHostForCadlFile(code);
   const emitter = createAssetEmitter(host.program, JsonSchemaEmitter, {
     emitterOutputDir: "cadl-output",

--- a/packages/playground-website/samples/json-schema.tsp
+++ b/packages/playground-website/samples/json-schema.tsp
@@ -1,6 +1,6 @@
 import "@typespec/json-schema";
 
-using JsonSchema;
+using TypeSpec.JsonSchema;
 
 @jsonSchema
 namespace Schemas;
@@ -8,19 +8,14 @@ namespace Schemas;
 model Person {
   /** The person's first name. */
   firstName: string;
-
   /** The person's last name. */
   lastName: string;
-
   /** Age in years which must be equal to or greater than zero. */
   @minValue(0) age: int32;
-
   /** Person address */
   address: Address;
-
   /** List of nick names */
   @uniqueItems nickNames?: string[];
-
   /** List of cars person owns */
   cars?: Car[];
 }
@@ -34,10 +29,8 @@ model Address {
 model Car {
   /** Kind of car */
   kind: "ev" | "ice";
-
   /** Brand of the car */
   brand: string;
-
   /** Model of the car */
   `model`: string;
 }

--- a/packages/playground-website/samples/json-schema.tsp
+++ b/packages/playground-website/samples/json-schema.tsp
@@ -8,14 +8,19 @@ namespace Schemas;
 model Person {
   /** The person's first name. */
   firstName: string;
+
   /** The person's last name. */
   lastName: string;
+
   /** Age in years which must be equal to or greater than zero. */
   @minValue(0) age: int32;
+
   /** Person address */
   address: Address;
+
   /** List of nick names */
   @uniqueItems nickNames?: string[];
+
   /** List of cars person owns */
   cars?: Car[];
 }
@@ -29,8 +34,10 @@ model Address {
 model Car {
   /** Kind of car */
   kind: "ev" | "ice";
+
   /** Brand of the car */
   brand: string;
+
   /** Model of the car */
   `model`: string;
 }

--- a/packages/typespec-vscode/ThirdPartyNotices.txt
+++ b/packages/typespec-vscode/ThirdPartyNotices.txt
@@ -12,7 +12,7 @@ granted herein, whether by implication, estoppel or otherwise.
 2. brace-expansion version 2.0.1 (https://github.com/juliangruber/brace-expansion)
 3. lru-cache version 6.0.0 (https://github.com/isaacs/node-lru-cache)
 4. minimatch version 5.1.6 (https://github.com/isaacs/minimatch)
-5. semver version 7.3.8 (https://github.com/npm/node-semver)
+5. semver version 7.5.1 (https://github.com/npm/node-semver)
 6. yallist version 4.0.0 (https://github.com/isaacs/yallist)
 
 

--- a/packages/typespec-vscode/ThirdPartyNotices.txt
+++ b/packages/typespec-vscode/ThirdPartyNotices.txt
@@ -12,7 +12,7 @@ granted herein, whether by implication, estoppel or otherwise.
 2. brace-expansion version 2.0.1 (https://github.com/juliangruber/brace-expansion)
 3. lru-cache version 6.0.0 (https://github.com/isaacs/node-lru-cache)
 4. minimatch version 5.1.6 (https://github.com/isaacs/minimatch)
-5. semver version 7.5.1 (https://github.com/npm/node-semver)
+5. semver version 7.3.8 (https://github.com/npm/node-semver)
 6. yallist version 4.0.0 (https://github.com/isaacs/yallist)
 
 


### PR DESCRIPTION
It was unfortunately not put into the TypeSpec namespace. I think we ought to just fix this though it is breaking.