### PR TITLE
Fix: Doc comment `/** */` should override base type doc in `model is` or `op is`

### DIFF
--- a/common/changes/@typespec/compiler/doc-comment-override-model-is_2023-06-28-18-22.json
+++ b/common/changes/@typespec/compiler/doc-comment-override-model-is_2023-06-28-18-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: Doc comment `/** */` should override base type doc in `model is` or `op is`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3229,6 +3229,7 @@ export function createChecker(program: Program): Checker {
       }
     }
 
+    // Doc comment should always be the first decorator in case an explicit @doc must override it.
     const docComment = extractMainDoc(targetType);
     if (docComment) {
       decorators.unshift({

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3216,6 +3216,7 @@ export function createChecker(program: Program): Checker {
   ) {
     const sym = isMemberNode(node) ? getSymbolForMember(node) ?? node.symbol : node.symbol;
     const decorators: DecoratorApplication[] = [];
+
     const augmentDecoratorNodes = augmentDecoratorsForSym.get(sym) ?? [];
     const decoratorNodes = [
       ...augmentDecoratorNodes, // the first decorator will be executed at last, so augmented decorator should be placed at first.
@@ -3228,6 +3229,13 @@ export function createChecker(program: Program): Checker {
       }
     }
 
+    const docComment = extractMainDoc(targetType);
+    if (docComment) {
+      decorators.unshift({
+        decorator: $docFromComment,
+        args: [{ value: program.checker.createLiteralType(docComment), jsValue: docComment }],
+      });
+    }
     return decorators;
   }
 
@@ -5451,13 +5459,6 @@ function finishTypeForProgramAndChecker<T extends Type>(
   typeDef: T
 ): T {
   if ("decorators" in typeDef) {
-    const docComment = extractMainDoc(typeDef);
-    if (docComment) {
-      typeDef.decorators.unshift({
-        decorator: $docFromComment,
-        args: [{ value: program.checker.createLiteralType(docComment), jsValue: docComment }],
-      });
-    }
     for (const decApp of typeDef.decorators) {
       applyDecoratorToType(program, decApp, typeDef);
     }

--- a/packages/compiler/test/checker/doc-comment.test.ts
+++ b/packages/compiler/test/checker/doc-comment.test.ts
@@ -86,6 +86,62 @@ describe("compiler: checker: doc comments", () => {
     strictEqual(getDoc(runner.program, Foo), "This is the actual doc.");
   });
 
+  describe("override model is comment", () => {
+    it("override another doc comment", async () => {
+      const { Foo } = (await runner.compile(`
+    
+    /** Base comment */
+    model Base {}
+
+    /** Override comment */
+    @test model Foo is Base {}
+    `)) as { Foo: Model };
+
+      strictEqual(getDoc(runner.program, Foo), "Override comment");
+    });
+
+    it("override @doc", async () => {
+      const { Foo } = (await runner.compile(`
+    
+    @doc("Base comment")
+    model Base {}
+
+    /** Override comment */
+    @test model Foo is Base {}
+    `)) as { Foo: Model };
+
+      strictEqual(getDoc(runner.program, Foo), "Override comment");
+    });
+  });
+
+  describe("override op is comment", () => {
+    it("override another doc comment", async () => {
+      const { foo } = (await runner.compile(`
+    
+    /** Base comment */
+    op base(): void;
+
+    /** Override comment */
+    @test op foo is base;
+    `)) as { foo: Operation };
+
+      strictEqual(getDoc(runner.program, foo), "Override comment");
+    });
+
+    it("override @doc", async () => {
+      const { foo } = (await runner.compile(`
+    
+    @doc("Base comment")
+    op base(): void;
+
+    /** Override comment */
+    @test op foo is base;
+    `)) as { foo: Operation };
+
+      strictEqual(getDoc(runner.program, foo), "Override comment");
+    });
+  });
+
   it("using @param in doc comment of operation applies doc on the parameters", async () => {
     const { addUser } = (await runner.compile(`
     

--- a/packages/samples/test/output/rest/petstore/openapi.yaml
+++ b/packages/samples/test/output/rest/petstore/openapi.yaml
@@ -618,7 +618,7 @@ components:
           type: string
         notes:
           type: string
-      description: The template for adding optional properties.
+      description: Resource create or update operation model.
     Insurance:
       type: object
       properties:
@@ -645,7 +645,7 @@ components:
         deductible:
           type: integer
           format: int32
-      description: The template for adding optional properties.
+      description: Resource create or update operation model.
     Owner:
       type: object
       properties:
@@ -684,7 +684,7 @@ components:
         age:
           type: integer
           format: int32
-      description: The template for adding updateable properties.
+      description: Resource create operation model.
       required:
         - name
         - age
@@ -696,7 +696,7 @@ components:
         age:
           type: integer
           format: int32
-      description: The template for adding optional properties.
+      description: Resource create or update operation model.
     Pet:
       type: object
       properties:
@@ -750,7 +750,7 @@ components:
         ownerId:
           type: integer
           format: int64
-      description: The template for adding updateable properties.
+      description: Resource create operation model.
       required:
         - name
         - age
@@ -781,7 +781,7 @@ components:
         ownerId:
           type: integer
           format: int64
-      description: The template for adding optional properties.
+      description: Resource create or update operation model.
     Toy:
       type: object
       properties:


### PR DESCRIPTION
fix #2127