### PR TITLE
Add support for enum member references to emitter framework

### DIFF
--- a/common/changes/@typespec/compiler/enum-member-refs_2023-06-29-17-38.json
+++ b/common/changes/@typespec/compiler/enum-member-refs_2023-06-29-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Emitter Framework: add support for emitting enum member references.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/json-schema/enum-member-refs_2023-06-29-17-38.json
+++ b/common/changes/@typespec/json-schema/enum-member-refs_2023-06-29-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "Add support for enum member references.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/packages/compiler/src/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/src/emitter-framework/asset-emitter.ts
@@ -182,6 +182,8 @@ export function createAssetEmitter<T, TOptions extends object>(
     emitTypeReference(target): EmitEntity<T> {
       if (target.kind === "ModelProperty") {
         return invokeTypeEmitter("modelPropertyReference", target);
+      } else if (target.kind === "EnumMember") {
+        return invokeTypeEmitter("enumMemberReference", target);
       }
 
       incomingReferenceContext = context.referenceContext ?? null;

--- a/packages/compiler/src/emitter-framework/type-emitter.ts
+++ b/packages/compiler/src/emitter-framework/type-emitter.ts
@@ -378,6 +378,16 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.emitTypeReference(property.type);
   }
 
+  /**
+   * Emit an enum member reference (e.g. as created by the `SomeEnum.member` syntax
+   * in TypeSpec). By default, this will emit nothing.
+   *
+   * @param property the enum member
+   */
+  enumMemberReference(member: EnumMember): EmitterOutput<T> {
+    return this.emitter.result.none();
+  }
+
   arrayDeclaration(array: Model, name: string, elementType: Type): EmitterOutput<T> {
     this.emitter.emitType(array.indexer!.value);
     return this.emitter.result.none();

--- a/packages/compiler/test/emitter-framework/emitter.test.ts
+++ b/packages/compiler/test/emitter-framework/emitter.test.ts
@@ -62,6 +62,11 @@ union UnionDecl {
   x: int32;
   y: string;
 }
+
+enum MyEnum {
+  a: "hi";
+  b: "bye";
+}
 `;
 
 class SingleFileEmitter extends TypeScriptInterfaceEmitter {
@@ -283,7 +288,6 @@ describe("emitter-framework: typescript emitter", () => {
         prop2: MyEnum.b;
       }
     `);
-    console.log(contents);
     assert.match(contents, /prop: MyEnum.a/);
     assert.match(contents, /prop2: MyEnum.b/);
   });
@@ -394,7 +398,7 @@ describe("emitter-framework: typescript emitter", () => {
       "UnionDecl.ts",
       "MyInterface.ts",
     ].forEach((file) => {
-      assert(files.has(file));
+      assert(files.has(file), `emits ${file}`);
     });
   });
 

--- a/packages/compiler/test/emitter-framework/emitter.test.ts
+++ b/packages/compiler/test/emitter-framework/emitter.test.ts
@@ -62,10 +62,6 @@ union UnionDecl {
   x: int32;
   y: string;
 }
-enum MyEnum {
-  a: "hi";
-  b: "bye";
-}
 `;
 
 class SingleFileEmitter extends TypeScriptInterfaceEmitter {
@@ -273,6 +269,23 @@ describe("emitter-framework: typescript emitter", () => {
     `);
 
     assert.match(contents, /x: \[string, number\]/);
+  });
+
+  it("emits enum member references", async () => {
+    const contents = await emitTypeSpecToTs(`
+      enum MyEnum {
+        a: "hi";
+        b: "bye";
+      }
+      
+      model EnumReference {
+        prop: MyEnum.a;
+        prop2: MyEnum.b;
+      }
+    `);
+    console.log(contents);
+    assert.match(contents, /prop: MyEnum.a/);
+    assert.match(contents, /prop2: MyEnum.b/);
   });
 
   it("emits scalars", async () => {

--- a/packages/compiler/test/emitter-framework/typescript-emitter.ts
+++ b/packages/compiler/test/emitter-framework/typescript-emitter.ts
@@ -211,6 +211,10 @@ export class TypeScriptInterfaceEmitter extends CodeTypeEmitter {
     `;
   }
 
+  enumMemberReference(member: EnumMember): EmitterOutput<string> {
+    return `${this.emitter.emitDeclarationName(member.enum)}.${member.name}`;
+  }
+
   unionDeclaration(union: Union, name: string): EmitterOutput<string> {
     return this.emitter.result.declaration(
       name,

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -2,6 +2,7 @@ import {
   BooleanLiteral,
   emitFile,
   Enum,
+  EnumMember,
   getDeprecated,
   getDirectoryPath,
   getDoc,
@@ -193,6 +194,18 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
     });
     this.#applyConstraints(en, withConstraints);
     return this.#createDeclaration(en, name, withConstraints);
+  }
+
+  enumMemberReference(member: EnumMember): EmitterOutput<Record<string, any>> {
+    // would like to dispatch to the same `literal` codepaths but enum members aren't literal types
+    switch (typeof member.value) {
+      case "undefined":
+        return { type: "string", const: member.name };
+      case "string":
+        return { type: "string", const: member.value };
+      case "number":
+        return { type: "number", const: member.value };
+    }
   }
 
   unionDeclaration(union: Union, name: string): EmitterOutput<object> {

--- a/packages/json-schema/test/enums.test.ts
+++ b/packages/json-schema/test/enums.test.ts
@@ -62,4 +62,24 @@ describe("emitting enums", () => {
     const Foo = schemas["Foo.json"];
     assert.strictEqual(Foo["x-foo"], "foo");
   });
+
+  it("handles enum member refs", async () => {
+    const schemas = await emitSchema(`
+      enum Foo {
+        a: "hi";
+        b: 2;
+        c;
+      }
+
+      model Bar {
+        a: Foo.a;
+        b: Foo.b;
+        c: Foo.c;
+      }
+    `);
+    const Bar = schemas["Bar.json"];
+    assert.deepStrictEqual(Bar.properties.a, { type: "string", const: "hi" });
+    assert.deepStrictEqual(Bar.properties.b, { type: "number", const: 2 });
+    assert.deepStrictEqual(Bar.properties.c, { type: "string", const: "c" });
+  });
 });


### PR DESCRIPTION
The emitter framework did not handle enum member references. This PR adds support for them in the emitter framework (following a similar pattern to model references). It also adds support for them in the JSON Schema emitter, which simply emits the value inline (rather than doing any magic with $ref + json paths, which seems overkill).

Fixes #2135.