### PR TITLE
Implement JSON Schema Record<unknown>, Record<A | B>, and fix many emitter framework bugs

### DIFF
--- a/common/changes/@typespec/compiler/record-unknown_2023-07-01-18-17.json
+++ b/common/changes/@typespec/compiler/record-unknown_2023-07-01-18-17.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Emitter Framework: Add new `TypeEmitter` methods for scalar instantiation.",
+      "type": "none"
+    },
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Emitter Framework: Fix that context was set incorrectly for some `TypeEmitter` methods, and add missing context methods for model properties, enum members, and union variants.",
+      "type": "none"
+    },
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Emitter Framework: Fix that some context methods were not being passed the expected parameters.",
+      "type": "none"
+    },
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Emitter Framework: Breaking change: Add support for templates instantiated with types without declared names. In such cases, `TypeEmitter`'s declarationName method may return `undefined`, and so the various `*Instantiation` methods might be called with an undefined name, and `AssetEmitter`'s `emitDeclarationName` method might return undefined.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/json-schema/record-unknown_2023-07-01-18-17.json
+++ b/common/changes/@typespec/json-schema/record-unknown_2023-07-01-18-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "Support templates instantiated with intrinsic types and type expressions.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/packages/compiler/src/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/src/emitter-framework/asset-emitter.ts
@@ -1,7 +1,6 @@
 import {
   compilerAssert,
   EmitContext,
-  IntrinsicType,
   isTemplateDeclaration,
   joinPaths,
   Model,
@@ -20,16 +19,16 @@ import {
   EmitEntity,
   EmitterResult,
   EmitterState,
+  LexicalTypeStackEntry,
   NamespaceScope,
   NoEmit,
   RawCode,
   Scope,
   SourceFile,
   SourceFileScope,
+  TypeEmitterMethod,
   TypeSpecDeclaration,
 } from "./types.js";
-
-type EndingWith<Names, Name extends string> = Names extends `${infer _X}${Name}` ? Names : never;
 
 export function createAssetEmitter<T, TOptions extends object>(
   program: Program,
@@ -45,6 +44,7 @@ export function createAssetEmitter<T, TOptions extends object>(
   };
   const typeId = CustomKeyMap.objectKeyer();
   const contextId = CustomKeyMap.objectKeyer();
+  const entryId = CustomKeyMap.objectKeyer();
 
   // This is effectively a seen set, ensuring that we don't emit the same
   // type with the same context twice. So the map stores a triple of:
@@ -81,9 +81,11 @@ export function createAssetEmitter<T, TOptions extends object>(
   // referenced with reference context set we need to get its declaration
   // context again. So we use the context's context as a key. Context must
   // be interned, see createInterner for more details.
-  const knownContexts = new CustomKeyMap<[Type, ContextState], ContextState>(([type, context]) => {
-    return `${typeId.getKey(type)}-${contextId.getKey(context)}`;
-  });
+  const knownContexts = new CustomKeyMap<[LexicalTypeStackEntry, ContextState], ContextState>(
+    ([entry, context]) => {
+      return `${entryId.getKey(entry)}-${contextId.getKey(context)}`;
+    }
+  );
 
   // The stack of types that the currently emitted type is lexically
   // contained in. This gets pushed to when we visit a type that is
@@ -93,7 +95,7 @@ export function createAssetEmitter<T, TOptions extends object>(
   // an alias to a model expression, the alias is lexically outside the
   // model, but in the type graph we will consider it to be lexically inside
   // whatever references the alias.
-  let lexicalTypeStack: Type[] = [];
+  let lexicalTypeStack: LexicalTypeStackEntry[] = [];
 
   // Internally, context is is split between lexicalContext and
   // referenceContext because when a reference is made, we carry over
@@ -288,7 +290,7 @@ export function createAssetEmitter<T, TOptions extends object>(
       }
     },
 
-    emitDeclarationName(type): string {
+    emitDeclarationName(type): string | undefined {
       return typeEmitter.declarationName!(type);
     },
 
@@ -297,10 +299,13 @@ export function createAssetEmitter<T, TOptions extends object>(
     },
 
     emitType(type) {
-      const key = typeEmitterKey(type);
+      const declName =
+        isDeclaration(type) && type.kind !== "Namespace" ? typeEmitter.declarationName(type) : null;
+      let key = typeEmitterKey(type);
       let args: any[];
       switch (key) {
         case "scalarDeclaration":
+        case "scalarInstantiation":
         case "modelDeclaration":
         case "modelInstantiation":
         case "operationDeclaration":
@@ -309,21 +314,19 @@ export function createAssetEmitter<T, TOptions extends object>(
         case "enumDeclaration":
         case "unionDeclaration":
         case "unionInstantiation":
-          const declarationName = typeEmitter.declarationName(type as TypeSpecDeclaration);
-          args = [declarationName];
+          args = [declName];
           break;
 
         case "arrayDeclaration":
-          const arrayDeclName = typeEmitter.declarationName(type as TypeSpecDeclaration);
           const arrayDeclElement = (type as Model).indexer!.value;
-          args = [arrayDeclName, arrayDeclElement];
+          args = [declName, arrayDeclElement];
           break;
         case "arrayLiteral":
           const arrayLiteralElement = (type as Model).indexer!.value;
           args = [arrayLiteralElement];
           break;
         case "intrinsic":
-          args = [(type as IntrinsicType).name];
+          args = [declName];
           break;
         default:
           args = [];
@@ -380,7 +383,7 @@ export function createAssetEmitter<T, TOptions extends object>(
     },
 
     emitModelProperties(model) {
-      const res = typeEmitter.modelProperties(model);
+      const res = invokeTypeEmitter("modelProperties", model);
       if (res instanceof EmitterResult) {
         return res as any;
       } else {
@@ -406,6 +409,11 @@ export function createAssetEmitter<T, TOptions extends object>(
 
     emitInterfaceOperation(operation) {
       const name = typeEmitter.declarationName(operation);
+      if (name === undefined) {
+        // the general approach of invoking the expression form doesn't work here
+        // because typespec doesn't have operation expressions.
+        compilerAssert(false, "Unnamed operations are not supported");
+      }
       return invokeTypeEmitter("interfaceOperationDeclaration", operation, name);
     },
 
@@ -437,23 +445,16 @@ export function createAssetEmitter<T, TOptions extends object>(
    * emit result. Also if a type emitter returns just a T or a
    * Placeholder<T>, it will convert that to a RawCode result.
    */
-  function invokeTypeEmitter<
-    TMethod extends keyof Omit<
-      TypeEmitter<T, TOptions>,
-      | "sourceFile"
-      | "declarationName"
-      | "reference"
-      | "emitValue"
-      | "writeOutput"
-      | EndingWith<keyof TypeEmitter<T, TOptions>, "Context">
-    >
-  >(method: TMethod, ...args: Parameters<TypeEmitter<T, TOptions>[TMethod]>): EmitEntity<T> {
+  function invokeTypeEmitter<TMethod extends TypeEmitterMethod>(
+    method: TMethod,
+    ...args: Parameters<TypeEmitter<T, TOptions>[TMethod]>
+  ): EmitEntity<T> {
     const type = args[0];
     let entity: EmitEntity<T>;
     let emitEntityKey: [string, Type, ContextState];
     let cached = false;
 
-    withTypeContext(type, () => {
+    withTypeContext(method, args, () => {
       emitEntityKey = [method, type, context];
       const seenEmitEntity = typeToEmitEntity.get(emitEntityKey);
 
@@ -513,21 +514,39 @@ export function createAssetEmitter<T, TOptions extends object>(
    * to take into account the current context and any incoming reference
    * context.
    */
-  function setContextForType(type: Type) {
-    let newTypeStack;
+  function setContextForType<TMethod extends TypeEmitterMethod>(
+    method: TMethod,
+    args: Parameters<TypeEmitter<T, TOptions>[TMethod]>
+  ) {
+    const type = args[0];
+    let newTypeStack: LexicalTypeStackEntry[];
 
     // if we've walked into a new declaration, reset the lexical type stack
     // to the lexical containers of the current type.
-    if (isDeclaration(type)) {
-      newTypeStack = [type];
+    if (
+      isDeclaration(type) &&
+      type.kind !== "Intrinsic" &&
+      method !== "interfaceDeclarationOperations" &&
+      method !== "interfaceOperationDeclaration" &&
+      method !== "operationParameters" &&
+      method !== "operationReturnType" &&
+      method !== "modelProperties" &&
+      method !== "enumMembers" &&
+      method !== "tupleLiteralValues" &&
+      method !== "unionVariants"
+    ) {
+      newTypeStack = [interner.intern({ method, args: interner.intern(args) })];
       let ns = type.namespace;
       while (ns) {
         if (ns.name === "") break;
-        newTypeStack.unshift(ns);
+        newTypeStack.unshift(interner.intern({ method: "namespace", args: interner.intern([ns]) }));
         ns = ns.namespace;
       }
     } else {
-      newTypeStack = [...lexicalTypeStack, type];
+      newTypeStack = [
+        ...lexicalTypeStack,
+        interner.intern({ method, args: interner.intern(args) }),
+      ];
     }
 
     lexicalTypeStack = newTypeStack;
@@ -543,10 +562,10 @@ export function createAssetEmitter<T, TOptions extends object>(
     // and merging in context for each of the lexical containers.
     context = programContext;
 
-    for (const contextChainEntry of lexicalTypeStack) {
+    for (const entry of lexicalTypeStack) {
       // when we're at the top of the lexical context stack (i.e. we are back
       // to the type we passed in), bring in any incoming reference context.
-      if (contextChainEntry === type && incomingReferenceContext) {
+      if (entry.args[0] === type && incomingReferenceContext) {
         context = interner.intern({
           lexicalContext: context.lexicalContext,
           referenceContext: interner.intern({
@@ -557,26 +576,35 @@ export function createAssetEmitter<T, TOptions extends object>(
         incomingReferenceContext = null;
       }
 
-      const seenContext = knownContexts.get([contextChainEntry, context]);
+      const seenContext = knownContexts.get([entry, context]);
       if (seenContext) {
         context = seenContext;
         continue;
       }
 
-      // invoke the context methods
-      const key = typeEmitterKey(contextChainEntry);
+      const lexicalKey = entry.method + "Context";
+      const referenceKey = entry.method + "ReferenceContext";
 
-      const lexicalKey = key + "Context";
-      const referenceKey = typeEmitterKey(contextChainEntry) + "ReferenceContext";
+      if (keyHasContext(entry.method)) {
+        compilerAssert(
+          (typeEmitter as any)[lexicalKey],
+          `TypeEmitter doesn't have a method named ${lexicalKey}`
+        );
+      }
 
-      compilerAssert(
-        (typeEmitter as any)[lexicalKey],
-        `TypeEmitter doesn't have a method named ${lexicalKey}`
-      );
+      if (keyHasReferenceContext(entry.method)) {
+        compilerAssert(
+          (typeEmitter as any)[lexicalKey],
+          `TypeEmitter doesn't have a method named ${referenceKey}`
+        );
+      }
 
-      const newContext = (typeEmitter as any)[lexicalKey](contextChainEntry);
-      const newReferenceContext = keyHasReferenceContext(key)
-        ? (typeEmitter as any)[referenceKey](contextChainEntry)
+      const newContext = keyHasContext(entry.method)
+        ? (typeEmitter as any)[lexicalKey](...entry.args)
+        : {};
+
+      const newReferenceContext = keyHasReferenceContext(entry.method)
+        ? (typeEmitter as any)[referenceKey](...entry.args)
         : {};
 
       // assemble our new reference and lexical contexts.
@@ -591,7 +619,7 @@ export function createAssetEmitter<T, TOptions extends object>(
         }),
       });
 
-      knownContexts.set([contextChainEntry, context], newContextState);
+      knownContexts.set([entry, context], newContextState);
       context = newContextState;
     }
   }
@@ -599,11 +627,15 @@ export function createAssetEmitter<T, TOptions extends object>(
   /**
    * Invoke the callback with the proper context for a given type.
    */
-  function withTypeContext(type: Type, cb: () => void) {
+  function withTypeContext<TMethod extends TypeEmitterMethod>(
+    method: TMethod,
+    args: Parameters<TypeEmitter<T, TOptions>[TMethod]>,
+    cb: () => void
+  ) {
     const oldContext = context;
     const oldTypeStack = lexicalTypeStack;
 
-    setContextForType(type);
+    setContextForType(method, args);
     cb();
 
     context = oldContext;
@@ -646,6 +678,7 @@ export function createAssetEmitter<T, TOptions extends object>(
         }
 
         return "modelDeclaration";
+
       case "Namespace":
         return "namespace";
       case "ModelProperty":
@@ -683,7 +716,12 @@ export function createAssetEmitter<T, TOptions extends object>(
       case "Tuple":
         return "tupleLiteral";
       case "Scalar":
-        return "scalarDeclaration";
+        if (type.templateMapper) {
+          return "scalarInstantiation";
+        } else {
+          return "scalarDeclaration";
+        }
+
       case "Intrinsic":
         return "intrinsic";
       default:
@@ -695,15 +733,19 @@ export function createAssetEmitter<T, TOptions extends object>(
   }
 }
 
-function isDeclaration(
-  type: Type
-): type is Exclude<TypeSpecDeclaration, IntrinsicType> | Namespace {
+/**
+ * Returns true if the given type is a declaration or an instantiation of a declaration.
+ * @param type
+ * @returns
+ */
+function isDeclaration(type: Type): type is TypeSpecDeclaration | Namespace {
   switch (type.kind) {
     case "Namespace":
     case "Interface":
     case "Enum":
     case "Operation":
     case "Scalar":
+    case "Intrinsic":
       return true;
 
     case "Model":
@@ -760,13 +802,21 @@ function createInterner() {
   };
 }
 
+const noContext = new Set<string>(["modelPropertyReference"]);
+
+function keyHasContext(key: keyof TypeEmitter<any, any>) {
+  return !noContext.has(key);
+}
 const noReferenceContext = new Set<string>([
+  ...noContext,
   "booleanLiteral",
   "stringLiteral",
   "numericLiteral",
   "scalarDeclaration",
+  "scalarInstantiation",
   "enumDeclaration",
   "enumMember",
+  "enumMembers",
   "intrinsic",
 ]);
 

--- a/packages/compiler/src/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/src/emitter-framework/asset-emitter.ts
@@ -695,7 +695,9 @@ export function createAssetEmitter<T, TOptions extends object>(
   }
 }
 
-function isDeclaration(type: Type): type is TypeSpecDeclaration | Namespace {
+function isDeclaration(
+  type: Type
+): type is Exclude<TypeSpecDeclaration, IntrinsicType> | Namespace {
   switch (type.kind) {
     case "Namespace":
     case "Interface":

--- a/packages/compiler/src/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/src/emitter-framework/asset-emitter.ts
@@ -303,7 +303,7 @@ export function createAssetEmitter<T, TOptions extends object>(
     emitType(type) {
       const declName =
         isDeclaration(type) && type.kind !== "Namespace" ? typeEmitter.declarationName(type) : null;
-      let key = typeEmitterKey(type);
+      const key = typeEmitterKey(type);
       let args: any[];
       switch (key) {
         case "scalarDeclaration":

--- a/packages/compiler/src/emitter-framework/type-emitter.ts
+++ b/packages/compiler/src/emitter-framework/type-emitter.ts
@@ -653,13 +653,13 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  declarationName(declarationType: TypeSpecDeclaration): string {
+  declarationName(declarationType: TypeSpecDeclaration): string | undefined {
     compilerAssert(
       declarationType.name !== undefined,
       "Can't emit a declaration that doesn't have a name."
     );
 
-    if (declarationType.kind === "Enum") {
+    if (declarationType.kind === "Enum" || declarationType.kind === "Intrinsic") {
       return declarationType.name;
     }
 
@@ -681,6 +681,7 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
         case "Operation":
         case "Enum":
         case "Union":
+        case "Intrinsic":
           const declName = this.emitter.emitDeclarationName(t);
           return declName[0].toUpperCase() + declName.slice(1);
         default:

--- a/packages/compiler/src/emitter-framework/type-emitter.ts
+++ b/packages/compiler/src/emitter-framework/type-emitter.ts
@@ -289,19 +289,21 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
    * Set reference context for a model declaration.
    * @param model
    */
-  modelDeclarationReferenceContext(model: Model): Context {
+  modelDeclarationReferenceContext(model: Model, name: string): Context {
     return {};
   }
 
   /**
-   * Emit a model instantiation (e.g. as created by `Foo<string>` syntax in
-   * TypeSpec).
+   * Emit a model instantiation (e.g. as created by `Box<string>` syntax in
+   * TypeSpec). In some cases, `name` is undefined because a good name could
+   * not be found for the instantiation. This often occurs with for instantiations
+   * involving type expressions like `Box<string | int32>`.
    *
    * @param model
    * @param name The name of the instantiation as retrieved from the
    * `declarationName` method.
    */
-  modelInstantiation(model: Model, name: string): EmitterOutput<T> {
+  modelInstantiation(model: Model, name: string | undefined): EmitterOutput<T> {
     if (model.baseModel) {
       this.emitter.emitType(model.baseModel);
     }
@@ -313,7 +315,7 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
    * Set lexical context for a model instantiation.
    * @param model
    */
-  modelInstantiationContext(model: Model): Context {
+  modelInstantiationContext(model: Model, name: string | undefined): Context {
     return {};
   }
 
@@ -321,7 +323,7 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
    * Set reference context for a model declaration.
    * @param model
    */
-  modelInstantiationReferenceContext(model: Model): Context {
+  modelInstantiationReferenceContext(model: Model, name: string | undefined): Context {
     return {};
   }
 
@@ -336,6 +338,14 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
       this.emitter.emitModelProperty(prop);
     }
     return this.emitter.result.none();
+  }
+
+  modelPropertiesContext(model: Model): Context {
+    return {};
+  }
+
+  modelPropertiesReferenceContext(model: Model): Context {
+    return {};
   }
 
   /**
@@ -383,11 +393,11 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  arrayDeclarationContext(array: Model): Context {
+  arrayDeclarationContext(array: Model, name: string, elementType: Type): Context {
     return {};
   }
 
-  arrayDeclarationReferenceContext(array: Model): Context {
+  arrayDeclarationReferenceContext(array: Model, name: string, elementType: Type): Context {
     return {};
   }
 
@@ -395,11 +405,11 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  arrayLiteralContext(array: Model): Context {
+  arrayLiteralContext(array: Model, elementType: Type): Context {
     return {};
   }
 
-  arrayLiteralReferenceContext(array: Model): Context {
+  arrayLiteralReferenceContext(array: Model, elementType: Type): Context {
     return {};
   }
 
@@ -410,7 +420,15 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  scalarDeclarationContext(scalar: Scalar): Context {
+  scalarDeclarationContext(scalar: Scalar, name: string): Context {
+    return {};
+  }
+
+  scalarInstantiation(scalar: Scalar, name: string | undefined): EmitterOutput<T> {
+    return this.emitter.result.none();
+  }
+
+  scalarInstantiationContext(scalar: Scalar, name: string | undefined): Context {
     return {};
   }
 
@@ -418,9 +436,10 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  intrinsicContext(intrinsic: IntrinsicType): Context {
+  intrinsicContext(intrinsic: IntrinsicType, name: string): Context {
     return {};
   }
+
   booleanLiteralContext(boolean: BooleanLiteral): Context {
     return {};
   }
@@ -452,11 +471,11 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  operationDeclarationContext(operation: Operation): Context {
+  operationDeclarationContext(operation: Operation, name: string): Context {
     return {};
   }
 
-  operationDeclarationReferenceContext(operation: Operation): Context {
+  operationDeclarationReferenceContext(operation: Operation, name: string): Context {
     return {};
   }
 
@@ -489,11 +508,11 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  interfaceDeclarationContext(iface: Interface): Context {
+  interfaceDeclarationContext(iface: Interface, name: string): Context {
     return {};
   }
 
-  interfaceDeclarationReferenceContext(iface: Interface): Context {
+  interfaceDeclarationReferenceContext(iface: Interface, name: string): Context {
     return {};
   }
 
@@ -511,11 +530,11 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  interfaceOperationDeclarationContext(operation: Operation): Context {
+  interfaceOperationDeclarationContext(operation: Operation, name: string): Context {
     return {};
   }
 
-  interfaceOperationDeclarationReferenceContext(operation: Operation): Context {
+  interfaceOperationDeclarationReferenceContext(operation: Operation, name: string): Context {
     return {};
   }
 
@@ -524,7 +543,7 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  enumDeclarationContext(en: Enum): Context {
+  enumDeclarationContext(en: Enum, name: string): Context {
     return {};
   }
 
@@ -533,6 +552,10 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
       this.emitter.emitType(member);
     }
     return this.emitter.result.none();
+  }
+
+  enumMembersContext(en: Enum): Context {
+    return {};
   }
 
   enumMember(member: EnumMember): EmitterOutput<T> {
@@ -561,11 +584,11 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return this.emitter.result.none();
   }
 
-  unionInstantiationContext(union: Union): Context {
+  unionInstantiationContext(union: Union, name: string): Context {
     return {};
   }
 
-  unionInstantiationReferenceContext(union: Union): Context {
+  unionInstantiationReferenceContext(union: Union, name: string): Context {
     return {};
   }
 
@@ -587,6 +610,14 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
       this.emitter.emitType(variant);
     }
     return this.emitter.result.none();
+  }
+
+  unionVariantsContext(): Context {
+    return {};
+  }
+
+  unionVariantsReferenceContext(): Context {
+    return {};
   }
 
   unionVariant(variant: UnionVariant): EmitterOutput<T> {
@@ -673,6 +704,8 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
       return declarationType.name;
     }
 
+    let unspeakable = false;
+
     const parameterNames = declarationType.templateMapper.args.map((t) => {
       switch (t.kind) {
         case "Model":
@@ -682,15 +715,25 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
         case "Enum":
         case "Union":
         case "Intrinsic":
+          if (!t.name) {
+            unspeakable = true;
+            return undefined;
+          }
           const declName = this.emitter.emitDeclarationName(t);
+          if (declName === undefined) {
+            unspeakable = true;
+            return undefined;
+          }
           return declName[0].toUpperCase() + declName.slice(1);
         default:
-          compilerAssert(
-            false,
-            `Can't get a declaration name for non-declaration type ${t.kind} used to instantiate a template.`
-          );
+          unspeakable = true;
+          return undefined;
       }
     });
+
+    if (unspeakable) {
+      return undefined;
+    }
 
     return declarationType.name + parameterNames.join("");
   }
@@ -730,6 +773,14 @@ export class CodeTypeEmitter<TOptions extends object = Record<string, never>> ex
     return builder.reduce();
   }
 
+  interfaceDeclarationOperationsContext(iface: Interface): Context {
+    return {};
+  }
+
+  interfaceDeclarationOperationsReferenceContext(iface: Interface): Context {
+    return {};
+  }
+
   enumMembers(en: Enum): EmitterOutput<string> {
     const builder = new StringBuilder();
     let i = 0;
@@ -759,6 +810,14 @@ export class CodeTypeEmitter<TOptions extends object = Record<string, never>> ex
       builder.push(code`${this.emitter.emitTypeReference(v)}${i < tuple.values.length ? "," : ""}`);
     }
     return builder.reduce();
+  }
+
+  tupleLiteralValuesContext(tuple: Tuple): Context {
+    return {};
+  }
+
+  tupleLiteralValuesReferenceContext(tuple: Tuple): Context {
+    return {};
   }
 
   reference(

--- a/packages/compiler/src/emitter-framework/types.ts
+++ b/packages/compiler/src/emitter-framework/types.ts
@@ -12,6 +12,7 @@ import {
   Union,
 } from "../core/index.js";
 import { Placeholder } from "./placeholder.js";
+import { TypeEmitter } from "./type-emitter.js";
 type AssetEmitterOptions<TOptions extends object> = {
   noEmit: boolean;
   emitterOutputDir: string;
@@ -28,7 +29,7 @@ export interface AssetEmitter<T, TOptions extends object = Record<string, unknow
   getOptions(): AssetEmitterOptions<TOptions>;
   getProgram(): Program;
   emitTypeReference(type: Type): EmitEntity<T>;
-  emitDeclarationName(type: TypeSpecDeclaration): string;
+  emitDeclarationName(type: TypeSpecDeclaration): string | undefined;
   emitType(type: Type): EmitEntity<T>;
   emitProgram(options?: { emitGlobalNamespace?: boolean; emitTypeSpecNamespace?: boolean }): void;
   emitModelProperties(model: Model): EmitEntity<T>;
@@ -145,7 +146,14 @@ export type AssetTagFactory = {
   (value: string): AssetTagInstance;
 };
 
-export type TypeSpecDeclaration = Model | Interface | Union | Operation | Enum | Scalar | IntrinsicType;
+export type TypeSpecDeclaration =
+  | Model
+  | Interface
+  | Union
+  | Operation
+  | Enum
+  | Scalar
+  | IntrinsicType;
 
 export interface ContextState {
   lexicalContext: Record<string, any>;
@@ -155,7 +163,24 @@ export interface ContextState {
 export type Context = Record<string, any>;
 export type ESRecord = Record<string, any> & { _record: true };
 
+type EndingWith<Names, Name extends string> = Names extends `${infer _X}${Name}` ? Names : never;
+
+export type TypeEmitterMethod = keyof Omit<
+  TypeEmitter<any, any>,
+  | "sourceFile"
+  | "declarationName"
+  | "reference"
+  | "emitValue"
+  | "writeOutput"
+  | EndingWith<keyof TypeEmitter<any, any>, "Context">
+>;
+
+export interface LexicalTypeStackEntry {
+  method: TypeEmitterMethod;
+  args: any[];
+}
+
 export interface EmitterState {
-  lexicalTypeStack: Type[];
+  lexicalTypeStack: LexicalTypeStackEntry[];
   context: ContextState;
 }

--- a/packages/compiler/src/emitter-framework/types.ts
+++ b/packages/compiler/src/emitter-framework/types.ts
@@ -1,6 +1,7 @@
 import {
   Enum,
   Interface,
+  IntrinsicType,
   Model,
   ModelProperty,
   Operation,
@@ -144,7 +145,7 @@ export type AssetTagFactory = {
   (value: string): AssetTagInstance;
 };
 
-export type TypeSpecDeclaration = Model | Interface | Union | Operation | Enum | Scalar;
+export type TypeSpecDeclaration = Model | Interface | Union | Operation | Enum | Scalar | IntrinsicType;
 
 export interface ContextState {
   lexicalContext: Record<string, any>;

--- a/packages/compiler/test/emitter-framework/context.test.ts
+++ b/packages/compiler/test/emitter-framework/context.test.ts
@@ -3,7 +3,7 @@ import { Model, ModelProperty, Namespace, Program } from "../../src/core/index.j
 import { CodeTypeEmitter, Context, EmitterOutput } from "../../src/emitter-framework/index.js";
 import { emitTypeSpec } from "./host.js";
 
-describe("emitter-framework: emitter context", () => {
+describe.only("emitter-framework: emitter context", () => {
   describe("program context", () => {
     it("should be initialized to empty state", async () => {
       class Emitter extends CodeTypeEmitter {

--- a/packages/compiler/test/emitter-framework/context.test.ts
+++ b/packages/compiler/test/emitter-framework/context.test.ts
@@ -3,7 +3,7 @@ import { Model, ModelProperty, Namespace, Program } from "../../src/core/index.j
 import { CodeTypeEmitter, Context, EmitterOutput } from "../../src/emitter-framework/index.js";
 import { emitTypeSpec } from "./host.js";
 
-describe.only("emitter-framework: emitter context", () => {
+describe("emitter-framework: emitter context", () => {
   describe("program context", () => {
     it("should be initialized to empty state", async () => {
       class Emitter extends CodeTypeEmitter {

--- a/packages/compiler/test/emitter-framework/emitter.test.ts
+++ b/packages/compiler/test/emitter-framework/emitter.test.ts
@@ -93,7 +93,7 @@ async function emitTypeSpecToTs(code: string) {
   return sf.text;
 }
 
-describe("emitter-framework: typescript emitter", () => {
+describe.only("emitter-framework: typescript emitter", () => {
   it("emits models", async () => {
     const contents = await emitTypeSpecToTs(`
       model A {
@@ -399,6 +399,7 @@ describe("emitter-framework: typescript emitter", () => {
 
       modelDeclarationContext(model: Model): Context {
         const name = this.emitter.emitDeclarationName(model);
+        if (!name) return {};
         const nsName = name.slice(0, 1);
         let nsScope = this.nsByName.get(nsName);
         if (!nsScope) {

--- a/packages/compiler/test/emitter-framework/emitter.test.ts
+++ b/packages/compiler/test/emitter-framework/emitter.test.ts
@@ -94,7 +94,7 @@ async function emitTypeSpecToTs(code: string) {
   return sf.text;
 }
 
-describe.only("emitter-framework: typescript emitter", () => {
+describe("emitter-framework: typescript emitter", () => {
   it("emits models", async () => {
     const contents = await emitTypeSpecToTs(`
       model A {

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -499,6 +499,9 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
         return { type: "null" };
       case "unknown":
         return {};
+      case "never":
+      case "void":
+        return { not: {} };
     }
 
     throw new Error("Unknown intrinsic type " + name);

--- a/packages/json-schema/test/models.test.ts
+++ b/packages/json-schema/test/models.test.ts
@@ -180,7 +180,7 @@ describe("emitting models", () => {
     });
   });
 
-  it.only("handles instantiations of type expressions", async () => {
+  it("handles instantiations of type expressions", async () => {
     const schemas = await emitSchema(
       `
         model A { x: int32 }

--- a/packages/json-schema/test/models.test.ts
+++ b/packages/json-schema/test/models.test.ts
@@ -135,4 +135,40 @@ describe("emitting models", () => {
     });
     assert.deepStrictEqual(schemas["HasProp.json"].properties.x, { $ref: "RecordString.json" });
   });
+
+  it("handles instantiations of intrinsics", async () => {
+    const schemas = await emitSchema(
+      `
+        model Test {
+          "never": Record<never>;
+          "unknown": Record<unknown>;
+          "void": Record<void>;
+          "null": Record<null>;
+        }
+      `,
+      { emitAllRefs: true }
+    );
+
+    assert.deepStrictEqual(schemas["RecordNever.json"].additionalProperties, { not: {} });
+    assert.deepStrictEqual(schemas["RecordUnknown.json"].additionalProperties, {});
+    assert.deepStrictEqual(schemas["RecordVoid.json"].additionalProperties, { not: {} });
+    assert.deepStrictEqual(schemas["RecordNull.json"].additionalProperties, { type: "null" });
+  });
+
+  it.only("handles instantiations of type expressions", async () => {
+    const schemas = await emitSchema(
+      `
+        model A { x: int32 }
+        model B { y: int32 }
+        model Test {
+          "union": Record<int32 | int16>;
+          "intersection": Record<A & B>;
+          "instantiation": Record<Record<int32>>;
+        }
+      `,
+      { emitAllRefs: true }
+    );
+
+    console.log(JSON.stringify(schemas, null, 4));
+  });
 });

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -427,7 +427,7 @@ OperationSignature :
   OperationSignatureReference
 
 OperationStatement :
-    DecoratorList? `op` Identifier TemplateArguments? OperationSignature `;`
+    DecoratorList? `op` Identifier TemplateParameters? OperationSignature `;`
 
 Expression :
     UnionExpressionOrHigher


### PR DESCRIPTION
What started as a simple fix resulted in falling off a cliff of bug after bug I had to chase down.

This fixes #2091 by handling intrinsic names while instantiating templates. `never` is represented by the schema `{ not: {} }` which I think is appropriate.

This fixes unspeakable instantiations like `Record<A | B>` by allowing TypeEmitter's `declarationName` to return `undefined` when a declaration's name is unspeakable. As a result, the various `[thing]Instantiation` methods might get called with an undefined name, and `emitter.emitDeclarationName` might return undefined. If subclasses have a different opinion on what names are speakable in their emitter output, they can override `declarationName` to handle that.

This is technically a breaking change, but applying the Stenberg Calculus we can observe that the only cases where a runtime error would now occur are cases where we would fail to generate a name and crash anyway. Additionally, compile-time breakage is limited to manual calls to `emitDeclarationName` because the type signature of subclasses won't change - they will still contain `name: string` which is allowed as a subtype of `name: string | undefined`, and usage of `emitDeclarationName` should be rare.

I noticed two related problems - some emitter context methods declared that they took a name but the name was not actually passed, and some emitter context methods did not declare or pass a name when they should. This PR calculates arguments once and passes the same set of arguments to the context methods and emit methods.

I then discovered that context was being set incorrectly when calling an emitter method that didn't correspond to the type itself. (e.g. `modelProperties`, which is called with the model as the first parameter). This was due to two different reasons. First, because we considered this a new declaration and reset the context stack, which is fixed by checking that type emitter method we're trying to call before resetting the context stack. Second, because we only put the type on the lexical context stack and not the method, so we when re-establishing context we would have no way of knowing what actual emitter method was called, so again a `model` on the stack looked like a declaration and not a call to `modelProperties`. This is fixed by interning and storing the type emitter method and its arguments in the lexical context stack.

All that fixed, we began calling context methods appropriately which showed a few context methods were missing from TypeEmitter. These have been added.

Lastly, the emitter framework did not have methods for scalar instantiations, so I added those.

 I will work on adding tests to validate the bugs I uncovered above.