### PR TITLE
Fix emit of bundled schemas when has references and is used multiple times

### DIFF
--- a/common/changes/@typespec/json-schema/js-fix-duplicate-def_2023-07-04-21-12.json
+++ b/common/changes/@typespec/json-schema/js-fix-duplicate-def_2023-07-04-21-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "Fix a bug that could result in a schema being bundled more than once.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -522,6 +522,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
 
     for (const sf of sourceFiles) {
       const emittedSf = this.emitter.emitSourceFile(sf);
+
       if (sf.meta.shouldEmit) {
         toEmit.push(emittedSf);
       }

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -522,7 +522,6 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
 
     for (const sf of sourceFiles) {
       const emittedSf = this.emitter.emitSourceFile(sf);
-
       if (sf.meta.shouldEmit) {
         toEmit.push(emittedSf);
       }
@@ -558,7 +557,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
         throw new Error("Emit error - multiple decls in single schema per file mode");
       }
 
-      content = decls[0].value;
+      content = { ...decls[0].value };
 
       if (sourceFile.meta.bundledRefs.length > 0) {
         // bundle any refs, including refs of refs

--- a/packages/json-schema/test/bundling.test.ts
+++ b/packages/json-schema/test/bundling.test.ts
@@ -49,7 +49,7 @@ describe("bundling", () => {
     assert.strictEqual(schemas["Bar.json"].$id, "Bar.json");
   });
 
-  it.only("doesn't create duplicate defs for transitive references", async () => {
+  it("doesn't create duplicate defs for transitive references", async () => {
     const schemas = await emitSchema(
       `
       model A {}

--- a/packages/json-schema/test/utils.ts
+++ b/packages/json-schema/test/utils.ts
@@ -23,7 +23,7 @@ export async function getHostForCadlFile(contents: string, decorators?: Record<s
 export async function emitSchema(
   code: string,
   options: JSONSchemaEmitterOptions = {},
-  testOptions: { emitNamespace: boolean } = { emitNamespace: true }
+  testOptions: { emitNamespace?: boolean; emitTypes?: string[] } = { emitNamespace: true }
 ) {
   if (!options["file-type"]) {
     options["file-type"] = "json";
@@ -37,7 +37,14 @@ export async function emitSchema(
     emitterOutputDir: "cadl-output",
     options,
   } as any);
-  emitter.emitType(host.program.resolveTypeReference("test")[0]!);
+  if (testOptions.emitTypes === undefined) {
+    emitter.emitType(host.program.resolveTypeReference("test")[0]!);
+  } else {
+    for (const name of testOptions.emitTypes) {
+      emitter.emitType(host.program.resolveTypeReference(name)[0]!);
+    }
+  }
+
   await emitter.writeOutput();
   const schemas: Record<string, any> = {};
   const files = await emitter.getProgram().host.readDir("./cadl-output");


### PR DESCRIPTION
The first time such schemas were emitted, `emitSourceFile` polluted its definition, so all subsequent references would include the pollution.