### PR TITLE
Fix: `getNameType` for union should include namespace

### DIFF
--- a/common/changes/@typespec/compiler/fix-union-unique_2023-07-10-12-44.json
+++ b/common/changes/@typespec/compiler/fix-union-unique_2023-07-10-12-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "**Fix** `getTypeName` include namespace prefix for unions as well",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/helpers/type-name-utils.ts
+++ b/packages/compiler/src/core/helpers/type-name-utils.ts
@@ -10,6 +10,7 @@ import {
   Operation,
   Scalar,
   Type,
+  Union,
   ValueType,
 } from "../types.js";
 
@@ -39,9 +40,7 @@ export function getTypeName(type: Type | ValueType, options?: TypeNameOptions): 
     case "EnumMember":
       return `${getEnumName(type.enum, options)}.${getIdentifierName(type.name, options)}`;
     case "Union":
-      return type.name
-        ? getIdentifierName(type.name, options)
-        : [...type.variants.values()].map((x) => getTypeName(x.type, options)).join(" | ");
+      return getUnionName(type, options);
     case "UnionVariant":
       return getTypeName(type.type, options);
     case "Tuple":
@@ -137,6 +136,14 @@ function getModelName(model: Model, options: TypeNameOptions | undefined) {
     // regular old model.
     return modelName;
   }
+}
+
+function getUnionName(type: Union, options: TypeNameOptions | undefined): string {
+  const nsPrefix = getNamespacePrefix(type.namespace, options);
+  const typeName = type.name
+    ? getIdentifierName(type.name, options)
+    : [...type.variants.values()].map((x) => getTypeName(x.type, options)).join(" | ");
+  return nsPrefix + typeName;
 }
 
 /**

--- a/packages/compiler/test/helpers/type-name-utils.test.ts
+++ b/packages/compiler/test/helpers/type-name-utils.test.ts
@@ -45,6 +45,12 @@ describe("compiler: TypeNameUtils", () => {
       ));
   });
 
+  describe("union", () => {
+    it("simple named union", () => assertNameFor(`@test("target") union Pet {}`, "Pet"));
+    it("include namespace qualifier", () =>
+      assertNameFor(`namespace Foo { @test("target") union Pet {} }`, "Foo.Pet"));
+  });
+
   describe("Standard library", () => {
     async function getNameForRef(ref: string) {
       const runner = await createTestRunner();


### PR DESCRIPTION
fix [#2136](https://github.com/microsoft/typespec/issues/2136)