### PR TITLE
Fix: Compiler mismatch compare

### DIFF
--- a/common/changes/@typespec/compiler/fix-compiler-mismatch-compare_2023-07-12-18-55.json
+++ b/common/changes/@typespec/compiler/fix-compiler-mismatch-compare_2023-07-12-18-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: Compiler version mismatch error would fire incorrectly",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -996,15 +996,15 @@ export async function compile(
 
     const expected = resolvePath(
       await host.realpath(host.fileURLToPath(import.meta.url)),
-      "../index.js"
+      "../../../.."
     );
 
-    if (actual.mainFile !== expected && MANIFEST.version !== actual.manifest.version) {
+    if (actual.path !== expected && MANIFEST.version !== actual.manifest.version) {
       const betterTypeSpecServerPath = actual.path;
       program.reportDiagnostic(
         createDiagnostic({
           code: "compiler-version-mismatch",
-          format: { basedir: baseDir, betterTypeSpecServerPath, actual: actual.mainFile, expected },
+          format: { basedir: baseDir, betterTypeSpecServerPath, actual: actual.path, expected },
           target: NoTarget,
         })
       );


### PR DESCRIPTION
After moving the compiler source under `src/` the check was actually comparing different paths `src/core/index.js` vs `src/index.js`. This fix it and compare the package root which is a more accurate comparaison anyway.

I don't think this deserve an hotfix as this is a very edge case where you would actually be using the same compiler path but somehow resolve to 2 version which happened locally as I didn't rebuild the manifest. This is realistically not ever going to happen to an outside user.