### PR TITLE
Add docs for default encoding, discriminator or content type negotiation

### DIFF
--- a/docs/standard-library/discriminated-types.md
+++ b/docs/standard-library/discriminated-types.md
@@ -1,0 +1,100 @@
+# Discriminated types
+
+TypeSpec allows you to represent unions and inheritance however when sending types over the wire many languages need a way to discriminate between the various union variants or model hierarchy.
+
+TypeSpec provide the [`@discriminator` decorator](./built-in-decorators#@discriminator) to be able to help with this pattern.
+
+### Using polymorphism
+
+#### `string` discriminator
+
+```typespec
+@discriminator("kind")
+model Pet {
+  name: string;
+  weight?: float32;
+}
+model Cat extends Pet {
+  kind: "cat";
+  meow: int32;
+}
+model Dog extends Pet {
+  kind: "dog";
+  bark: string;
+}
+```
+
+#### `enum` discriminator
+
+```typespec
+enum PetKind {
+  cat,
+  dog,
+}
+
+@discriminator("kind")
+model Pet {
+  kind: PetKind;
+  name: string;
+  weight?: float32;
+}
+model Cat extends Pet {
+  kind: PetKind.cat;
+  meow: int32;
+}
+model Dog extends Pet {
+  kind: PetKind.dog;
+  bark: string;
+}
+```
+
+#### Nested discriminator
+
+```tsp
+@discriminator("kind")
+model Pet {
+  name: string;
+  weight?: float32;
+}
+
+@discriminator("breed")
+model Cat extends Pet {
+  kind: "cat";
+  meow: int32;
+}
+
+@discriminator("breed")
+model Siamese extends Pet {
+  breed: "siamese";
+}
+
+@discriminator("breed")
+model Bengal extends Pet {
+  breed: "bengal";
+}
+
+model Dog extends Pet {
+  kind: "dog";
+  bark: string;
+}
+```
+
+### Using unions
+
+```typespec
+@discriminator("kind")
+union Pet {
+  cat: Cat,
+  dog: Dog,
+}
+
+model Cat {
+  kind: "cat";
+  meow: int32;
+}
+
+model Dog {
+  kind: "dog";
+  bark: string;
+}
+```

--- a/docs/standard-library/discriminated-types.md
+++ b/docs/standard-library/discriminated-types.md
@@ -64,12 +64,12 @@ model Cat extends Pet {
 }
 
 @discriminator("breed")
-model Siamese extends Pet {
+model Siamese extends Cat {
   breed: "siamese";
 }
 
 @discriminator("breed")
-model Bengal extends Pet {
+model Bengal extends Cat {
   breed: "bengal";
 }
 

--- a/docs/standard-library/discriminated-types.md
+++ b/docs/standard-library/discriminated-types.md
@@ -1,6 +1,6 @@
 # Discriminated types
 
-TypeSpec allows you to represent unions and inheritance however when sending types over the wire many languages need a way to discriminate between the various union variants or model hierarchy.
+TypeSpec can express unions and inheritance. However, when sending types over the wire many languages need a way to discriminate between the various union variants or models in an inheritance hierarchy.
 
 TypeSpec provide the [`@discriminator` decorator](./built-in-decorators#@discriminator) to be able to help with this pattern.
 

--- a/docs/standard-library/discriminated-types.md
+++ b/docs/standard-library/discriminated-types.md
@@ -53,6 +53,7 @@ model Dog extends Pet {
 ```tsp
 @discriminator("kind")
 model Pet {
+  kind: string;
   name: string;
   weight?: float32;
 }
@@ -60,6 +61,7 @@ model Pet {
 @discriminator("breed")
 model Cat extends Pet {
   kind: "cat";
+  breed: string;
   meow: int32;
 }
 

--- a/docs/standard-library/http/content-types.md
+++ b/docs/standard-library/http/content-types.md
@@ -1,0 +1,102 @@
+# Content types
+
+## Default behavior
+
+Depending on the body of the operation http library will assume different content types:
+
+- `bytes`: `application/octet-stream`
+- `string`: `text/plain`
+- otherwise `application/json`
+
+**Examples:**
+
+```typespec
+op download(): bytes; // response content type is application/octet-stream
+op upload(@body file: bytes): void; // request content type is application/octet-stream
+op getContent(): string; // response content type is text/plain
+op getPet(): {
+  // response content type is application/json
+  name: string;
+};
+```
+
+## Specify content type
+
+The content type for an operation can be specified by including a header parameter named `contentType`.
+
+#### Request content type
+
+```typespec
+op uploadImage(@header contentType: "image/png", @body image: bytes): void;
+```
+
+#### Response content type:
+
+```typespec
+op downloadImage(): {
+  @header contentType: "image/png";
+  @body image: bytes;
+};
+```
+
+#### Multiple content types
+
+If there is multiples content types for the same body, they can be specified using a union of string.
+
+```typespec
+op uploadImage(@header contentType: "image/png" | "image/jpeg", @body image: bytes): void;
+```
+
+## Content type negotiation
+
+There could be cases where you might the same endpoint to return different content depending on the content type requested. This can be achieved in 2 ways:
+
+- using shared routes where different content response is represented as a different operation that share the same endpoint
+- using overloads where each different content response is an overload.
+
+For example assuming there is an api that lets you download the avatar as a `png` or `jpeg` which is decided by what `Accept` header is sent.
+
+### Option 1: Using shared route
+
+```tsp
+model PngImage {
+  @header contentType: "image/png";
+  @body image: bytes;
+}
+
+model JpegImage {
+  @header contentType: "image/jpeg";
+  @body image: bytes;
+}
+
+@route("/avatar")
+@sharedRoute
+op getAvatarAsPng(@header accept: "image/png"): PngImage;
+
+@route("/avatar")
+@sharedRoute
+op getAvatarAsJpeg(@header accept: "image/jpeg"): JpegImage;
+```
+
+### Option 2: Using overload
+
+```tsp
+model PngImage {
+  @header contentType: "image/png";
+  @body image: bytes;
+}
+
+model JpegImage {
+  @header contentType: "image/jpeg";
+  @body image: bytes;
+}
+
+@route("/avatar")
+op getAvatar(@header accept: "image/png" | "image/jpeg"): PngImage | JpegImage;
+
+@overload(getAvatar)
+op getAvatarAsPng(@header accept: "image/png"): PngImage;
+
+@overload(getAvatar)
+op getAvatarAsJpeg(@header accept: "image/jpeg"): JpegImage;
+```

--- a/docs/standard-library/http/encoding.md
+++ b/docs/standard-library/http/encoding.md
@@ -1,0 +1,126 @@
+# Encoding of types
+
+This document describe how the http library interpret TypeSpec built-in types and how to configure
+
+## `bytes`
+
+**Default behavior:**
+
+- `bytes` are serialized as `base64` when used inside a model serialized as JSON
+- In request or response body it represent a binary payload.
+
+Use `@encode` to configure
+
+```tsp
+model Pet {
+  icon: bytes; // Serialize as base64
+  @encode(BytesKnownEncoding.base64url) // Serialize as base64url
+  other: bytes;
+}
+
+op read(): Pet;
+
+op download(): bytes; // Return application/octet-stream
+op upload(@body data: bytes): void; // Accept application/octet-stream
+```
+
+## `utcDatetime` and `offsetDateTime`
+
+**Default behavior:**
+
+- Encoded as `rfc7231` when used in a header
+- Encoded as `rfc3339` otherwise.
+
+Use `@encode` to configure.
+
+<table>
+<tr><td>TypeSpec</td><td>Example payload</td></tr>
+<tr>
+<td>
+
+```tsp
+model User {
+  // Headers
+  @header("Created-At") createdAtHeader: utcDateTime;
+
+  @header("Created-At-Rfc3339")
+  @encode(DateTimeKnownEncoding.rfc3339)
+  createdAtHeaderRfc3339Encoding: utcDateTime;
+
+  // In Json payload
+  createdAt: utcDateTime; // rfc3339
+
+  updatedAt: offsetDateTime; // rfc3339
+
+  @encode(DateTimeKnownEncoding.rfc7231)
+  createdAtPretty: utcDateTime; // rfc7231
+
+  @encode(DateTimeKnownEncoding.rfc7231)
+  updatedAtPretty: offsetDateTime; // rfc7231
+
+  @encode(DateTimeKnownEncoding.unixTimestamp, int32)
+  createdAtUnix: utcDateTime; // rfc7231
+}
+```
+
+</td>
+<td>
+
+```yaml
+Created-At: Wed, 12 Oct 2022 07:20:50 GMT
+Created-At-Rfc3339: 2022-10-12T07:20:50.52Z
+```
+
+```json
+{
+  "createdAt": "2022-10-12T07:20:50.52Z",
+  "updatedAt": "2022-10-25T07:20:50.52+07:00",
+  "createdAtPretty": "Wed, 12 Oct 2022 07:20:50 GMT",
+  "updatedAtPretty": "Tue, 25 Oct 2022 00:20:50 GMT",
+  "createdAtUnix": 1665559250520
+}
+```
+
+</td>
+</tr>
+</table>
+
+## `duration`
+
+**Default behavior:**
+
+- Encoded as `ISO8601`
+
+Use `@encode` to configure.
+
+<table>
+<tr><td>TypeSpec</td><td>Example payload</td></tr>
+<tr>
+<td>
+
+```tsp
+model User {
+  runtime: duration; // ISO8601
+
+  @encode(DurationKnownEncoding.seconds, int32)
+  runtimeInSecondsInt: duration; // in seconds as an int32
+
+  @encode(DurationKnownEncoding.seconds, float32)
+  runtimeInSecondsFloat: duration; // in seconds as a float32
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "runtime": "PT5M5S",
+  "runtimeInSecondsInt": "305",
+  "runtimeInSecondsFloatx": "305.0"
+}
+```
+
+</td>
+</tr>
+</table>

--- a/docs/standard-library/http/encoding.md
+++ b/docs/standard-library/http/encoding.md
@@ -117,7 +117,7 @@ model User {
 {
   "runtime": "PT5M5S",
   "runtimeInSecondsInt": "305",
-  "runtimeInSecondsFloatx": "305.0"
+  "runtimeInSecondsFloat": "305.0"
 }
 ```
 

--- a/docs/standard-library/http/operations.md
+++ b/docs/standard-library/http/operations.md
@@ -6,6 +6,13 @@ title: Operations
 
 ## Operation verb
 
+**Default behavior:**
+
+- If `@post` operation has a request body
+- `@get` otherwise
+
+**Configure:**
+
 You can use one of the [verb decorators](./reference/decorators.md): `@get`, `@put`, etc.
 
 ## Route
@@ -119,14 +126,25 @@ namespace Pets {
 
 ## Status codes
 
+**Default behavior:**
+
+- `4xx,5xx` if response is marked with `@error`
+- `200` otherwise
+
+**Configure:**
+
 Use the `@header` decorator on a property named `statusCode` to declare a status code for a response. Generally, setting this to just `int32` isn't particularly useful. Instead, use number literal types to create a discriminated union of response types. Let's add status codes to our responses, and add a 404 response to our read endpoint.
 
 ```typespec
 @route("/pets")
 namespace Pets {
+  @error
+  model Error {
+    code: string;
+  }
+
   op list(@query skip: int32, @query top: int32): {
-    @statusCode statusCode: 200;
-    @body pets: Pet[];
+    @body pets: Pet[]; // statusCode: 200 Implicit
   };
   op read(@path petId: int32, @header ifMatch?: string): {
     @statusCode statusCode: 200;
@@ -137,41 +155,13 @@ namespace Pets {
   };
   op create(@body pet: Pet): {
     @statusCode statusCode: 204;
-  };
-}
-```
-
-## Polymorphism with discriminators
-
-A pattern often used in REST APIs is to define a request or response body as having one of several different shapes, with a property called the
-"discriminator" indicating which actual shape is used for a particular instance.
-TypeSpec supports this pattern with the `@discriminator` decorator of the Rest library.
-
-The `@discriminator` decorator takes one argument, the name of the discriminator property, and should be placed on the
-model for the request or response body. The different shapes are then defined by separate models that `extend` this request or response model.
-The discriminator property is defined in the "child" models with the value or values that indicate an instance that conforms to its shape.
-
-As an example, a `Pet` model that allows instances that are either a `Cat` or a `Dog` can be defined with
-
-```typespec
-@discriminator("kind")
-model Pet {
-  name: string;
-  weight?: float32;
-}
-model Cat extends Pet {
-  kind: "cat";
-  meow: int32;
-}
-model Dog extends Pet {
-  kind: "dog";
-  bark: string;
+  } | Error; //statusCode: 4xx,5xx as Error use `@error` decorator
 }
 ```
 
 ## Content type
 
-### Defaults
+### Default behavior
 
 Depending on the body of the operation http library will assume different content types:
 
@@ -179,7 +169,7 @@ Depending on the body of the operation http library will assume different conten
 - `string`: `text/plain`
 - an `object` or anything else: `application/json`
 
-Examples:
+**Examples:**
 
 ```typespec
 op download(): bytes; // response content type is application/octet-stream

--- a/docs/standard-library/http/operations.md
+++ b/docs/standard-library/http/operations.md
@@ -161,6 +161,8 @@ namespace Pets {
 
 ## Content type
 
+[See content types docs](./content-types.md)
+
 ### Default behavior
 
 Depending on the body of the operation http library will assume different content types:

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -88,6 +88,7 @@ const sidebars = {
           "standard-library/http/cheat-sheet",
           "standard-library/http/authentication",
           "standard-library/http/operations",
+          "standard-library/http/content-types",
           "standard-library/http/encoding",
         ]),
         createLibraryReferenceStructure("json-schema", "JSON Schema", []),

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -83,10 +83,12 @@ const sidebars = {
           dirName: `standard-library/reference`,
         },
         "standard-library/projected-names",
+        "standard-library/discriminated-types",
         createLibraryReferenceStructure("http", "Http", [
           "standard-library/http/cheat-sheet",
           "standard-library/http/authentication",
           "standard-library/http/operations",
+          "standard-library/http/encoding",
         ]),
         createLibraryReferenceStructure("json-schema", "JSON Schema", []),
         createLibraryReferenceStructure("rest", "Rest", [


### PR DESCRIPTION
fix #1960 (Discriminator docs)
fix #1920 (Default interpretations)
partial work for https://github.com/Azure/typespec-azure/issues/2960


## Move discriminator doc to compiler

Moved and expanded the small discriminator doc present in the http library. As discriminator is a compiler decorator and there is nothing specific about http.
https://cadlwebsite.z1.web.core.windows.net/prs/2181/next/standard-library/discriminated-types


## Add documentation on how types are encoded in http 

Describe the default behaviors as well as how to configure
https://cadlwebsite.z1.web.core.windows.net/prs/2181/next/standard-library/http/encoding

## Add content negotiation docs

Add general http docs on how to define different content negotiation
https://cadlwebsite.z1.web.core.windows.net/prs/2181/next/standard-library/http/content-types
