### PR TITLE
Prettier plugin needs to be a dependency of ref-doc so it builds in the right order

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1135,6 +1135,9 @@ importers:
       '@typespec/eslint-config-typespec':
         specifier: workspace:~0.46.0
         version: link:../eslint-config-typespec
+      '@typespec/prettier-plugin-typespec':
+        specifier: workspace:~0.46.0
+        version: link:../prettier-plugin-typespec
       c8:
         specifier: ~8.0.0
         version: 8.0.0

--- a/packages/ref-doc/package.json
+++ b/packages/ref-doc/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@typespec/compiler": "workspace:~0.46.0",
     "@typespec/eslint-config-typespec": "workspace:~0.46.0",
+    "@typespec/prettier-plugin-typespec": "workspace:~0.46.0",
     "@types/mocha": "~10.0.1",
     "@types/node": "~18.11.9",
     "@types/prettier": "2.6.0",


### PR DESCRIPTION
This is making the gh-pages pipeline fail right now