### PR TITLE
Add tests making sure linter integrate with program diagnostics

### DIFF
--- a/common/changes/@typespec/compiler/test-linter-integration_2023-07-25-00-15.json
+++ b/common/changes/@typespec/compiler/test-linter-integration_2023-07-25-00-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/test/core/linter.test.ts
+++ b/packages/compiler/test/core/linter.test.ts
@@ -154,7 +154,7 @@ describe("compiler: linter", () => {
         "node_modules/my-lib/package.json": JSON.stringify({ name: "my-lib", tspMain: "main.tsp" }),
         "node_modules/my-lib/main.tsp": "model Foo {}",
       };
-      const linter = await createTestLinter(files, {
+      const linter = await createTestLinterAndEnableRules(files, {
         rules: [noModelFoo],
       });
       expectDiagnosticEmpty(linter.lint());


### PR DESCRIPTION
Those tests were missing and because the rule tester runs outside of the program flow you can't test diagnostics in there. So adding those tests to make sure this work when integrated