### PR TITLE
Fix: `warn-as-error` was ignored in the configuration file

### DIFF
--- a/common/changes/@typespec/compiler/fix-warn-as-erorr_2023-07-25-20-21.json
+++ b/common/changes/@typespec/compiler/fix-warn-as-erorr_2023-07-25-20-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "**Fix** `warn-as-error` in `tspconfig.yaml` was ignored",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/cli/actions/compile/args.ts
+++ b/packages/compiler/src/core/cli/actions/compile/args.ts
@@ -60,7 +60,11 @@ export async function getCompilerOptions(
     emit: args.emit ?? config.emit,
     options: resolveEmitterOptions(config, cliOptions),
   };
-  const cliOutputDir = pathArg ? resolvePath(cwd, pathArg) : undefined;
+  const cliOutputDir = pathArg
+    ? pathArg.startsWith("{")
+      ? pathArg
+      : resolvePath(cwd, pathArg)
+    : undefined;
 
   const expandedConfig = diagnostics.pipe(
     expandConfigVariables(configWithCliArgs, {

--- a/packages/compiler/src/core/cli/cli.ts
+++ b/packages/compiler/src/core/cli/cli.ts
@@ -110,12 +110,10 @@ async function main() {
           })
           .option("warn-as-error", {
             type: "boolean",
-            default: false,
             describe: "Treat warnings as errors and return non-zero exit code if there are any.",
           })
           .option("no-emit", {
             type: "boolean",
-            default: false,
             describe: "Run emitters but do not emit any output.",
           })
           .option("arg", {


### PR DESCRIPTION
fix [#2190](https://github.com/microsoft/typespec/issues/2190)

Add a few more tests as well to the cli/config -> compiler options resolution