### PR TITLE
Emit diagnostic for an unresolved metatype property reference

### DIFF
--- a/common/changes/@typespec/compiler/fix-member-expression-spread_2023-07-26-10-19.json
+++ b/common/changes/@typespec/compiler/fix-member-expression-spread_2023-07-26-10-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Emit diagnostic for an unresolved metatype property reference",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -2206,6 +2206,17 @@ export function createChecker(program: Program): Checker {
 
   function resolveMetaProperty(node: MemberExpressionNode, base: Sym) {
     const resolved = resolveIdentifierInTable(node.id, base.metatypeMembers);
+    if (!resolved) {
+      reportCheckerDiagnostic(
+        createDiagnostic({
+          code: "invalid-ref",
+          messageId: "metaProperty",
+          format: { kind: getMemberKindName(base.declarations[0]), id: node.id.sv },
+          target: node,
+        })
+      );
+    }
+
     return resolved;
   }
 
@@ -2214,6 +2225,8 @@ export function createChecker(program: Program): Checker {
       case SyntaxKind.ModelStatement:
       case SyntaxKind.ModelExpression:
         return "Model";
+      case SyntaxKind.ModelProperty:
+        return "ModelProperty";
       case SyntaxKind.EnumStatement:
         return "Enum";
       case SyntaxKind.InterfaceStatement:

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -323,6 +323,7 @@ const diagnostics = {
       inDecorator: paramMessage`Cannot resolve ${"id"} in decorator`,
       underNamespace: paramMessage`Namespace ${"namespace"} doesn't have member ${"id"}`,
       underContainer: paramMessage`${"kind"} doesn't have member ${"id"}`,
+      metaProperty: paramMessage`${"kind"} doesn't have meta property ${"id"}`,
       node: paramMessage`Cannot resolve '${"id"}' in node ${"nodeName"} since it has no members. Did you mean to use "::" instead of "."?`,
     },
   },

--- a/packages/compiler/test/checker/references.test.ts
+++ b/packages/compiler/test/checker/references.test.ts
@@ -595,5 +595,39 @@ describe("compiler: references", () => {
         `,
         ref: "testOp::parameters.select",
       }));
+
+    it("emits a diagnostic when referencing a non-existent meta type property", async () => {
+      testHost.addTypeSpecFile(
+        "main.tsp",
+        `
+        model A {
+          name: string;
+        }
+
+        model B {
+          a: A;
+        }
+
+        model Spread {
+          ... B.a::type;
+        }
+
+        op testOp(...B::foo): void;
+        `
+      );
+
+      const diagnostics = await testHost.diagnose("./main.tsp");
+
+      expectDiagnostics(diagnostics, [
+        {
+          code: "invalid-ref",
+          message: `ModelProperty doesn't have meta property type`,
+        },
+        {
+          code: "invalid-ref",
+          message: `Model doesn't have meta property foo`,
+        },
+      ]);
+    });
   });
 });

--- a/packages/compiler/test/checker/references.test.ts
+++ b/packages/compiler/test/checker/references.test.ts
@@ -608,10 +608,6 @@ describe("compiler: references", () => {
           a: A;
         }
 
-        model Spread {
-          ... B.a::type;
-        }
-
         op testOp(...B::foo): void;
         `
       );
@@ -621,11 +617,36 @@ describe("compiler: references", () => {
       expectDiagnostics(diagnostics, [
         {
           code: "invalid-ref",
-          message: `ModelProperty doesn't have meta property type`,
+          message: `Model doesn't have meta property foo`,
         },
+      ]);
+    });
+
+    // Error should be removed when this is fixed https://github.com/microsoft/typespec/issues/2213
+    it("(TEMP) emits a diagnostic when referencing a non-resolved meta type property", async () => {
+      testHost.addTypeSpecFile(
+        "main.tsp",
+        `
+        model A {
+          name: string;
+        }
+
+        model B {
+          a: A;
+        }
+
+        model Spread {
+          ... B.a::type;
+        }
+        `
+      );
+
+      const diagnostics = await testHost.diagnose("./main.tsp");
+
+      expectDiagnostics(diagnostics, [
         {
           code: "invalid-ref",
-          message: `Model doesn't have meta property foo`,
+          message: `ModelProperty doesn't have meta property type`,
         },
       ]);
     });


### PR DESCRIPTION
This PR fixes #2163 by adding a diagnostic which is emitted when a metatype property reference cannot be resolved.  It appears that a diagnostic was intended to be added here but it was left out!

**Another aspect to this issue:** it appears that metatype properties are not bound on types until after all members are bound, meaning that they are not available to be used directly in TypeSpec code.  For example:

```
model A {
  name: string;
}

model B {
  a: A;
}

@test("target")
model Spread {
  ... B.a::type;
}
```

After compiling this file, the `Spread` model will have no properties because the `type` metatype property of `B.a` cannot be resolved at that time.

Is that the desired/expected behavior?