### PR TITLE
Allow library dependency versions to be specified in init templates

### DIFF
--- a/common/changes/@typespec/compiler/template-library-versions_2023-07-27-13-35.json
+++ b/common/changes/@typespec/compiler/template-library-versions_2023-07-27-13-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Allow library dependency versions to be specified in init templates using the form `{ name: \"the-lib\", version: \"1.0.0\" }`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/init/init-template.ts
+++ b/packages/compiler/src/init/init-template.ts
@@ -31,7 +31,7 @@ export interface InitTemplate {
   /**
    * List of libraries to include
    */
-  libraries: string[];
+  libraries: InitTemplateLibrary[];
 
   /**
    * Config
@@ -55,6 +55,36 @@ export interface InitTemplate {
   files?: InitTemplateFile[];
 }
 
+/**
+ * Describes a library dependency that will be added to the generated project.
+ */
+export type InitTemplateLibrary = string | InitTemplateLibrarySpec;
+
+/**
+ * Describes a library dependency that will be added to the generated project.
+ */
+export interface InitTemplateLibrarySpec {
+  /**
+   * The npm package name of the library.
+   */
+  name: string;
+
+  /**
+   *  The npm-style version string as it would appear in package.json.
+   */
+  version?: string;
+}
+
+export const InitTemplateLibrarySpecSchema: JSONSchemaType<InitTemplateLibrarySpec> = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    name: { type: "string" },
+    version: { type: "string", nullable: true },
+  },
+  required: ["name"],
+};
+
 export const InitTemplateSchema: JSONSchemaType<InitTemplate> = {
   type: "object",
   additionalProperties: false,
@@ -62,7 +92,12 @@ export const InitTemplateSchema: JSONSchemaType<InitTemplate> = {
     title: { type: "string" },
     description: { type: "string" },
     compilerVersion: { type: "string" },
-    libraries: { type: "array", items: { type: "string" } },
+    libraries: {
+      type: "array",
+      items: {
+        oneOf: [{ type: "string" }, InitTemplateLibrarySpecSchema],
+      },
+    },
     skipCompilerPackage: { type: "boolean", nullable: true },
     config: { nullable: true, ...TypeSpecConfigJsonSchema },
     inputs: {

--- a/packages/compiler/src/init/init.ts
+++ b/packages/compiler/src/init/init.ts
@@ -12,9 +12,14 @@ import { createJSONSchemaValidator } from "../core/schema-validator.js";
 import { CompilerHost, Diagnostic, NoTarget, SourceFile } from "../core/types.js";
 import { readUrlOrPath, resolveRelativeUrlOrPath } from "../core/util.js";
 import { MANIFEST } from "../manifest.js";
-import { InitTemplate, InitTemplateFile, InitTemplateSchema } from "./init-template.js";
+import {
+  InitTemplate,
+  InitTemplateFile,
+  InitTemplateLibrarySpec,
+  InitTemplateSchema,
+} from "./init-template.js";
 
-interface ScaffoldingConfig extends InitTemplate {
+export interface ScaffoldingConfig extends InitTemplate {
   /**
    * Path where this template was loaded from.
    */
@@ -38,7 +43,7 @@ interface ScaffoldingConfig extends InitTemplate {
   /**
    * List of libraries to include
    */
-  libraries: string[];
+  libraries: InitTemplateLibrarySpec[];
 
   /**
    * A flag to indicate not adding @typespec/compiler package to package.json.
@@ -94,6 +99,24 @@ const normalizePackageName = function () {
   };
 };
 
+export function makeScaffoldingConfig(config: Partial<ScaffoldingConfig>): ScaffoldingConfig {
+  return {
+    title: config.title ?? "",
+    description: config.description ?? "",
+    compilerVersion: config.compilerVersion ?? "",
+    templateUri: config.templateUri ?? ".",
+    libraries: config.libraries ?? [],
+    name: config.name ?? "",
+    directory: config.directory ?? "",
+    skipCompilerPackage: config.skipCompilerPackage ?? false,
+    folderName: config.folderName ?? "",
+    parameters: config.parameters ?? {},
+    normalizeVersion: config.normalizeVersion ?? normalizeVersion,
+    toLowerCase: config.toLowerCase ?? toLowerCase,
+    normalizePackageName: config.normalizePackageName ?? normalizePackageName,
+  };
+}
+
 export async function initTypeSpecProject(
   host: CompilerHost,
   directory: string,
@@ -132,7 +155,7 @@ export async function initTypeSpecProject(
 
   const libraries = await selectLibraries(template);
   const parameters = await promptCustomParameters(template);
-  const scaffoldingConfig: ScaffoldingConfig = {
+  const scaffoldingConfig = makeScaffoldingConfig({
     ...template,
     templateUri: url?.finalUrl ?? ".",
     libraries,
@@ -144,8 +167,11 @@ export async function initTypeSpecProject(
     normalizeVersion,
     toLowerCase,
     normalizePackageName,
-  };
+  });
   await scaffoldNewProject(host, scaffoldingConfig);
+
+  // eslint-disable-next-line no-console
+  console.log("TypeSpec init completed. You can run `tsp install` now to install dependencies.");
 
   // eslint-disable-next-line no-console
   console.log("Project created successfully.");
@@ -324,12 +350,24 @@ async function validateTemplate(template: any, templatesUrl: TemplatesUrl): Prom
   return true;
 }
 
-async function selectLibraries(template: InitTemplate): Promise<string[]> {
+function getLibrarySpec(library: string | InitTemplateLibrarySpec): InitTemplateLibrarySpec {
+  return typeof library === "string" ? { name: library } : library;
+}
+
+async function getLibraryVersion(library: InitTemplateLibrarySpec): Promise<string> {
+  // TODO: Resolve 'latest' version from npm, issue #1919
+  return library.version || "latest";
+}
+
+async function selectLibraries(template: InitTemplate): Promise<InitTemplateLibrarySpec[]> {
   if (template.libraries.length === 0) {
     return [];
   }
 
-  const libraryChoices = template.libraries.map((x) => ({ name: x, description: "" }));
+  const libraryChoices = template.libraries.map((x) => ({
+    ...getLibrarySpec(x),
+    description: "",
+  }));
 
   const { libraries } = await prompts({
     type: "multiselect",
@@ -339,7 +377,7 @@ async function selectLibraries(template: InitTemplate): Promise<string[]> {
       return {
         title: x.name,
         description: x.description,
-        value: x.name,
+        value: x,
         selected: true,
       };
     }),
@@ -354,9 +392,6 @@ export async function scaffoldNewProject(host: CompilerHost, config: Scaffolding
   await writeConfig(host, config);
   await writeMain(host, config);
   await writeFiles(host, config);
-
-  // eslint-disable-next-line no-console
-  console.log("TypeSpec init completed. You can run `tsp install` now to install dependencies.");
 }
 
 async function writePackageJson(host: CompilerHost, config: ScaffoldingConfig) {
@@ -370,7 +405,7 @@ async function writePackageJson(host: CompilerHost, config: ScaffoldingConfig) {
   }
 
   for (const library of config.libraries) {
-    dependencies[library] = "latest";
+    dependencies[library.name] = await getLibraryVersion(library);
   }
 
   const packageJson: NodePackage = {
@@ -405,10 +440,10 @@ async function writeMain(host: CompilerHost, config: ScaffoldingConfig) {
   const dependencies: Record<string, string> = {};
 
   for (const library of config.libraries) {
-    dependencies[library] = "latest";
+    dependencies[library.name] = await getLibraryVersion(library);
   }
 
-  const lines = [...config.libraries.map((x) => `import "${x}";`), ""];
+  const lines = [...config.libraries.map((x) => `import "${x.name}";`), ""];
   const content = lines.join("\n");
 
   return host.writeFile(joinPaths(config.directory, "main.tsp"), formatTypeSpec(content));

--- a/packages/compiler/src/init/init.ts
+++ b/packages/compiler/src/init/init.ts
@@ -356,7 +356,7 @@ function getLibrarySpec(library: string | InitTemplateLibrarySpec): InitTemplate
 
 async function getLibraryVersion(library: InitTemplateLibrarySpec): Promise<string> {
   // TODO: Resolve 'latest' version from npm, issue #1919
-  return library.version || "latest";
+  return library.version ?? "latest";
 }
 
 async function selectLibraries(template: InitTemplate): Promise<InitTemplateLibrarySpec[]> {

--- a/packages/compiler/test/init/init-template.test.ts
+++ b/packages/compiler/test/init/init-template.test.ts
@@ -4,13 +4,17 @@ import {
   makeScaffoldingConfig,
   scaffoldNewProject,
 } from "../../src/init/init.js";
-import { TestHost, createTestHost } from "../../src/testing/index.js";
+import { TestHost, createTestHost, resolveVirtualPath } from "../../src/testing/index.js";
 
 describe("compiler: init: templates", () => {
   let testHost: TestHost;
   beforeEach(async () => {
     testHost = await createTestHost();
   });
+
+  function getOutputFile(path: string): string | undefined {
+    return testHost.fs.get(resolveVirtualPath(path));
+  }
 
   async function runTemplate(config: Partial<ScaffoldingConfig>): Promise<void> {
     await scaffoldNewProject(
@@ -38,13 +42,13 @@ describe("compiler: init: templates", () => {
         libraries: [{ name: "foo", version: "~1.2.3" }, { name: "bar" }],
       });
 
-      deepStrictEqual(JSON.parse(testHost.fs.get("/test/package.json")! as any).dependencies, {
+      deepStrictEqual(JSON.parse(getOutputFile("package.json")!).dependencies, {
         "@typespec/compiler": "latest",
         foo: "~1.2.3",
         bar: "latest",
       });
 
-      strictEqual(testHost.fs.get("/test/main.tsp")!, 'import "foo";\nimport "bar";\n');
+      strictEqual(getOutputFile("main.tsp")!, 'import "foo";\nimport "bar";\n');
     });
   });
 });

--- a/packages/compiler/test/init/init-template.test.ts
+++ b/packages/compiler/test/init/init-template.test.ts
@@ -1,0 +1,50 @@
+import { deepStrictEqual, strictEqual } from "assert";
+import {
+  ScaffoldingConfig,
+  makeScaffoldingConfig,
+  scaffoldNewProject,
+} from "../../src/init/init.js";
+import { TestHost, createTestHost } from "../../src/testing/index.js";
+
+describe("compiler: init: templates", () => {
+  let testHost: TestHost;
+  beforeEach(async () => {
+    testHost = await createTestHost();
+  });
+
+  async function runTemplate(config: Partial<ScaffoldingConfig>): Promise<void> {
+    await scaffoldNewProject(
+      testHost.compilerHost,
+      makeScaffoldingConfig({
+        title: "Test Template",
+        name: "test-template",
+        folderName: "test-template",
+        description: "This is only a test.",
+        files: [
+          {
+            path: "./main.tsp",
+            destination: "main.tsp",
+            skipGeneration: false,
+          },
+        ],
+        ...config,
+      })
+    );
+  }
+
+  describe("libraries", () => {
+    it("templates can contain specific library versions to use", async () => {
+      await runTemplate({
+        libraries: [{ name: "foo", version: "~1.2.3" }, { name: "bar" }],
+      });
+
+      deepStrictEqual(JSON.parse(testHost.fs.get("/test/package.json")! as any).dependencies, {
+        "@typespec/compiler": "latest",
+        foo: "~1.2.3",
+        bar: "latest",
+      });
+
+      strictEqual(testHost.fs.get("/test/main.tsp")!, 'import "foo";\nimport "bar";\n');
+    });
+  });
+});


### PR DESCRIPTION
This change fixes #1934 by expanding the init template schema to allow library dependency versions to be specified.  I also added a basic unit test to validate that the `package.json` file gets generated with the desired versions.  More work will be needed to make the scaffolding logic more testable, but this is a good starting point for now.

For example:

```json
  "with-library-versions": {
    "title": "Test template with library versions",
    "description": "This template specifies two libraries with versions and one without",
    "libraries": [
      {
        "name": "library1",
        "version": "1.0.0"
      },
      {
        "name": "library2",
        "version": "^2.0.0"
      },
      "library3"
    ],
    "skipCompilerPackage": true,
    "config": {},
    "files": [
      {
        "path": "./main.tsp",
        "destination": "main.tsp"
      }
    ]
  }
```