### PR TITLE
Fix some issues with not reporting deprecation on template constraints

### DIFF
--- a/common/changes/@typespec/compiler/fix-deprecation-extends_2023-07-28-15-40.json
+++ b/common/changes/@typespec/compiler/fix-deprecation-extends_2023-07-28-15-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix some issues with not reporting deprecation on template constraints",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}


### PR DESCRIPTION
fix #2216

There was 2 issues:
- The check to make sure it wasn't reporting in template instance was preventing it from reporting for template constraint in instances
- We were not checking the template parameters of a template declaration but only when we start using it (that never worked before either)
  - Fixing this also makes it that we show errors in template if the parameter is not used.