### PR TITLE
Handle general encodings for utcDateTime

### DIFF
--- a/common/changes/@typespec/openapi3/encode-for-date-time_2023-08-04-19-52.json
+++ b/common/changes/@typespec/openapi3/encode-for-date-time_2023-08-04-19-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Handle general encodings for utcDateTime",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/docs/standard-library/http/encoding.md
+++ b/docs/standard-library/http/encoding.md
@@ -59,7 +59,7 @@ model User {
   updatedAtPretty: offsetDateTime; // rfc7231
 
   @encode(DateTimeKnownEncoding.unixTimestamp, int32)
-  createdAtUnix: utcDateTime; // rfc7231
+  createdAtUnix: utcDateTime; // unixTime
 }
 ```
 

--- a/docs/standard-library/openapi3/openapi.md
+++ b/docs/standard-library/openapi3/openapi.md
@@ -267,26 +267,26 @@ that a union should be emitted as a `oneOf` rather than `anyOf`.
 
 When working with the `@encode` decorator the rule is as follow. Given the 3 values `encoding`, `encodeAs` and `realType` where `@encode(encoding, encodeAs) _: realType`:
 
-1. Is one of those special cases:
-
-   - `unixTimestamp` encoding will produce `type: integer, format: unixtime`
-   - encoding a `utcDateTime` or `offsetDateTime` will produce this format `date-time-<encoding>` (e.g. `date-time-rfc7231` for `rfc7231` encoding)
-
-2. When `encodeAs` is specified, it will be used to generate the corresponding schema (e.g. encoding as `int32` will produce an `type: integer, format: int32` )
-
-3. Otherwise use the `encoding` as the format
+1. If `realType` is `utcDateTime` or `offsetDateTime`:
+   - `encoding` of `rfc3339` will produce `type: string, format: date-time`
+   - `encoding` of `rfc7231` will produce `type: string, format: http-date`
+1. If `realType` is `utcDateTime` and `encoding` is `unixTimestamp`:
+   - `encodeAs` of any integer type will produce `type: integer, format: unixtime`
+1. If the schema of encodeAs produces a `format` use it (e.g. encoding as `int32` will produce an `type: integer, format: integer` )
+1. Otherwise use the `encoding` as the format
 
 **Summary table**
 
-| encoding                                         | Openapi3                                  | Swagger 2.0 (autorest)                    |
-| ------------------------------------------------ | ----------------------------------------- | ----------------------------------------- |
-| `@encode("seconds", int32) _: duration`          | `type: integer, format: int32`            | `type: integer, format: int32`            |
-| `@encode("seconds", float32) _: duration`        | `type: number, format: float32`           | `type: number, format: float32`           |
-| `@encode("ISO8601") _: duration`                 | `type: number, format: duration`          | `type: number, format: duration`          |
-| `@encode("unixTimestamp", int32) _: utcDateTime` | `type: integer, format: unixtime`         | `type: integer, format: unixtime`         |
-| `@encode("unixTimestamp", int64) _: utcDateTime` | `type: integer, format: unixtime`         | `type: integer, format: unixtime`         |
-| `@encode("rfc3339") _: utcDateTime`              | `type: string, format: date-time`         | `type: string, format: date-time`         |
-| `@encode("rfc7231") _: utcDateTime`              | `type: string, format: date-time-rfc7321` | `type: string, format: date-time-rfc7321` |
+| encoding                                         | Openapi3                          | Swagger 2.0 (autorest)            |
+| ------------------------------------------------ | --------------------------------- | --------------------------------- |
+| `@encode("seconds", int32) _: duration`          | `type: integer, format: int32`    | `type: integer, format: int32`    |
+| `@encode("seconds", float32) _: duration`        | `type: number, format: float32`   | `type: number, format: float32`   |
+| `@encode("ISO8601") _: duration`                 | `type: number, format: duration`  | `type: number, format: duration`  |
+| `@encode("unixTimestamp", int32) _: utcDateTime` | `type: integer, format: unixtime` | `type: integer, format: unixtime` |
+| `@encode("unixTimestamp", int64) _: utcDateTime` | `type: integer, format: unixtime` | `type: integer, format: unixtime` |
+| `@encode("rfc3339") _: utcDateTime`              | `type: string, format: date-time` | `type: string, format: date-time` |
+| `@encode("rfc7231") _: utcDateTime`              | `type: string, format: http-date` | `type: string, format: http-date` |
+| `@encode("http-date") _: utcDateTime`            | `type: string, format: http-date` | `type: string, format: http-date` |
 
 ## Security Definitions
 

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1791,8 +1791,10 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
             return "date-time";
           case "unixTimestamp":
             return "unixtime";
+          case "rfc7231":
+            return "http-date";
           default:
-            return `date-time-${encoding}`;
+            return encoding;
         }
       case "duration":
         switch (encoding) {

--- a/packages/openapi3/test/primitive-types.test.ts
+++ b/packages/openapi3/test/primitive-types.test.ts
@@ -234,22 +234,26 @@ describe("openapi3: primitives", () => {
       it("set format to 'date-time' by default", () =>
         testEncode("utcDateTime", { type: "string", format: "date-time" }));
       it("set format to 'date-time-rfc7231' when encoding is rfc7231", () =>
-        testEncode("utcDateTime", { type: "string", format: "date-time-rfc7231" }, "rfc7231"));
-
-      it("set type to integer and format to 'int32' when encoding is unixTimestamp (unixTimestamp info is lost)", () =>
-        testEncode(
-          "utcDateTime",
-          { type: "integer", format: "unixtime" },
-          "unixTimestamp",
-          "int32"
-        ));
+        testEncode("utcDateTime", { type: "string", format: "http-date" }, "rfc7231"));
+      it("set format to 'http-date' when encoding is http-date", () =>
+        testEncode("utcDateTime", { type: "string", format: "http-date" }, "http-date"));
+      it("set type to integer and format to 'unixtime' when encoding is unixTimestamp (unixTimestamp info is lost)", async () => {
+        const expected: OpenAPI3Schema = { type: "integer", format: "unixtime" };
+        await testEncode("utcDateTime", expected, "unixTimestamp", "integer");
+        await testEncode("utcDateTime", expected, "unixTimestamp", "int32");
+        await testEncode("utcDateTime", expected, "unixTimestamp", "int64");
+        await testEncode("utcDateTime", expected, "unixTimestamp", "int8");
+        await testEncode("utcDateTime", expected, "unixTimestamp", "uint8");
+      });
     });
 
     describe("offsetDateTime", () => {
       it("set format to 'date-time' by default", () =>
         testEncode("offsetDateTime", { type: "string", format: "date-time" }));
       it("set format to 'date-time-rfc7231' when encoding is rfc7231", () =>
-        testEncode("offsetDateTime", { type: "string", format: "date-time-rfc7231" }, "rfc7231"));
+        testEncode("offsetDateTime", { type: "string", format: "http-date" }, "rfc7231"));
+      it("set format to 'http-date' when encoding is http-date", () =>
+        testEncode("offsetDateTime", { type: "string", format: "http-date" }, "http-date"));
     });
 
     describe("duration", () => {

--- a/packages/samples/test/output/encoding/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/encoding/@typespec/openapi3/openapi.yaml
@@ -37,7 +37,7 @@ components:
               format: date-time
             rfc7231:
               type: string
-              format: date-time-rfc7231
+              format: http-date
             rfc7231ViaScalar:
               $ref: '#/components/schemas/myRfc7231DateTime'
             unixtime:
@@ -94,7 +94,7 @@ components:
         - bytes
     myRfc7231DateTime:
       type: string
-      format: date-time-rfc7231
+      format: http-date
     myUnixTimestamp:
       type: integer
       format: unixtime


### PR DESCRIPTION
This PR revises the logic for encodings on utcDateTime and offsetDateTime to set the `format` to the `encoding` value for any unrecognized values. For backward compatibility, a special case is added for `rfc7231` which maps to `format: date-time-rfc7231`.

Tests and docs are updated.

## Update

Revised this PR to map rfc7231 to http-date in the openapi3 emitter.