### PR TITLE
Fix: Jsonschema crash when using interface inside namespace with `@jsonSchema`

### DIFF
--- a/common/changes/@typespec/compiler/fix-type-emitter-missing-methods_2023-08-07-23-59.json
+++ b/common/changes/@typespec/compiler/fix-type-emitter-missing-methods_2023-08-07-23-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: TypeEmitter missing interfaces methods causing crash",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/json-schema/fix-type-emitter-missing-methods_2023-08-07-23-59.json
+++ b/common/changes/@typespec/json-schema/fix-type-emitter-missing-methods_2023-08-07-23-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "Fix: Crash when using interfaces inside a `@jsonSchema` namespace",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/packages/compiler/src/emitter-framework/type-emitter.ts
+++ b/packages/compiler/src/emitter-framework/type-emitter.ts
@@ -489,6 +489,22 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     return {};
   }
 
+  interfaceDeclarationOperationsContext(iface: Interface): Context {
+    return {};
+  }
+
+  interfaceDeclarationOperationsReferenceContext(iface: Interface): Context {
+    return {};
+  }
+
+  interfaceOperationDeclarationContext(operation: Operation, name: string): Context {
+    return {};
+  }
+
+  interfaceOperationDeclarationReferenceContext(operation: Operation, name: string): Context {
+    return {};
+  }
+
   operationParameters(operation: Operation, parameters: Model): EmitterOutput<T> {
     return this.emitter.result.none();
   }
@@ -538,14 +554,6 @@ export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
     this.emitter.emitOperationReturnType(operation);
 
     return this.emitter.result.none();
-  }
-
-  interfaceOperationDeclarationContext(operation: Operation, name: string): Context {
-    return {};
-  }
-
-  interfaceOperationDeclarationReferenceContext(operation: Operation, name: string): Context {
-    return {};
   }
 
   enumDeclaration(en: Enum, name: string): EmitterOutput<T> {
@@ -781,14 +789,6 @@ export class CodeTypeEmitter<TOptions extends object = Record<string, never>> ex
       );
     }
     return builder.reduce();
-  }
-
-  interfaceDeclarationOperationsContext(iface: Interface): Context {
-    return {};
-  }
-
-  interfaceDeclarationOperationsReferenceContext(iface: Interface): Context {
-    return {};
   }
 
   enumMembers(en: Enum): EmitterOutput<string> {

--- a/packages/json-schema/test/interfaces.test.ts
+++ b/packages/json-schema/test/interfaces.test.ts
@@ -1,0 +1,12 @@
+import { deepStrictEqual } from "assert";
+import { emitSchema } from "./utils.js";
+
+describe("jsonschema: interfaces", () => {
+  it("emit nothing", async () => {
+    const schemas = await emitSchema(`
+      interface Foo {}
+    `);
+
+    deepStrictEqual(schemas, {});
+  });
+});


### PR DESCRIPTION
fix #2259

The blank interface methods were on the `CodeTYpeEmitter` instead of the base `TypeEmitter`