### PR TITLE
Fix `--watch` completely broken

### DIFF
--- a/common/changes/@typespec/compiler/fix-watch-broken_2023-08-08-16-57.json
+++ b/common/changes/@typespec/compiler/fix-watch-broken_2023-08-08-16-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/cli/actions/compile/compile.ts
+++ b/packages/compiler/src/core/cli/actions/compile/compile.ts
@@ -26,7 +26,7 @@ export async function compileAction(
   }
   const cliOptions = await getCompilerOptionsOrExit(host, entrypoint, args);
 
-  if (cliOptions.watchForChanges) {
+  if (args.watch) {
     await compileWatch(host, entrypoint, cliOptions);
   } else {
     await compileOnce(host, entrypoint, cliOptions);

--- a/packages/compiler/src/core/options.ts
+++ b/packages/compiler/src/core/options.ts
@@ -46,7 +46,6 @@ export interface CompilerOptions {
   nostdlib?: boolean;
   noEmit?: boolean;
   additionalImports?: string[];
-  /** @deprecated This option does nothing. */
   watchForChanges?: boolean;
   warningAsError?: boolean;
 

--- a/packages/compiler/src/core/options.ts
+++ b/packages/compiler/src/core/options.ts
@@ -46,6 +46,7 @@ export interface CompilerOptions {
   nostdlib?: boolean;
   noEmit?: boolean;
   additionalImports?: string[];
+  /** @deprecated This option does nothing. */
   watchForChanges?: boolean;
   warningAsError?: boolean;
 


### PR DESCRIPTION
I think this was caused by the new `getCompilerOptions` helper which changed how the watch option was loaded.