### PR TITLE
Fix crash when `using` a non namespace type

### DIFF
--- a/common/changes/@typespec/compiler/fix-crash-using-non-namespace_2023-08-08-17-32.json
+++ b/common/changes/@typespec/compiler/fix-crash-using-non-namespace_2023-08-08-17-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix crash when `using` non-namespace",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -440,6 +440,7 @@ export function createChecker(program: Program): Checker {
 
       if (!(sym.flags & SymbolFlags.Namespace)) {
         reportCheckerDiagnostic(createDiagnostic({ code: "using-invalid-ref", target: using }));
+        continue;
       }
 
       const namespaceSym = getMergedSymbol(sym)!;

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -256,9 +256,6 @@ const diagnostics = {
     severity: "error",
     messages: {
       default: "Using must refer to a namespace",
-      decorator: "Can't use a decorator",
-      function: "Can't use a function",
-      projection: "Can't use a projection",
     },
   },
   "invalid-type-ref": {

--- a/packages/compiler/test/checker/using.test.ts
+++ b/packages/compiler/test/checker/using.test.ts
@@ -484,4 +484,31 @@ describe("compiler: using statements", () => {
     );
     await testHost.compile("./");
   });
+
+  describe("emit diagnostic when using non-namespace types", () => {
+    [
+      ["model", "model Target {}"],
+      ["enum", "enum Target {}"],
+      ["union", "union Target {}"],
+      ["scalar", "scalar Target;"],
+      ["interface", "interface Target {}"],
+      ["operation", "op Target(): void;"],
+    ].forEach(([name, code]) => {
+      it(name, async () => {
+        testHost.addTypeSpecFile(
+          "main.tsp",
+          `
+          using Target;
+          ${code}
+        `
+        );
+
+        const diagnostics = await testHost.diagnose("./");
+        expectDiagnostics(diagnostics, {
+          code: "using-invalid-ref",
+          message: "Using must refer to a namespace",
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
fix [#2226](https://github.com/microsoft/typespec/issues/2226)