### PR TITLE
[compiler/core] Fix ICE in 'using'

### DIFF
--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -440,6 +440,7 @@ export function createChecker(program: Program): Checker {
 
       if (!(sym.flags & SymbolFlags.Namespace)) {
         reportCheckerDiagnostic(createDiagnostic({ code: "using-invalid-ref", target: using }));
+        continue;
       }
 
       const namespaceSym = getMergedSymbol(sym)!;

--- a/packages/compiler/test/checker/using.test.ts
+++ b/packages/compiler/test/checker/using.test.ts
@@ -484,4 +484,24 @@ describe("compiler: using statements", () => {
     );
     await testHost.compile("./");
   });
+
+  it("cannot use a model", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      model M {}
+
+      using M;
+    `);
+
+    const diagnostics = await testHost.diagnose("./");
+
+    expectDiagnostics(diagnostics, {
+      code: "using-invalid-ref",
+      file: /main\.tsp$/,
+      message: "Using must refer to a namespace",
+      severity: "error",
+      pos: 25
+    })
+  });
 });


### PR DESCRIPTION
A missing `continue` was causing the compiler to throw an ICE when a `using` statement refers to something that isn't a namespace (such as a Model).

Closes #2226