### PR TITLE
Hot Fix: `--config` is being ignored

### DIFF
--- a/common/changes/@typespec/compiler/fix-config-option_2023-08-10-08-29.json
+++ b/common/changes/@typespec/compiler/fix-config-option_2023-08-10-08-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "fix(config): --config is not adopted",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/compiler/fix-config-option_2023-08-10-08-29.json
+++ b/common/changes/@typespec/compiler/fix-config-option_2023-08-10-08-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@typespec/compiler",
-      "comment": "fix(config): --config is not adopted",
+      "comment": "**Fix**: `--config` flag was being ignored.",
       "type": "patch"
     }
   ],

--- a/packages/compiler/src/config/config-to-options.ts
+++ b/packages/compiler/src/config/config-to-options.ts
@@ -47,9 +47,8 @@ export async function resolveCompilerOptions(
 
   const entrypointStat = await host.stat(options.entrypoint);
   const configPath =
-    options.configPath ?? entrypointStat.isDirectory()
-      ? options.entrypoint
-      : getDirectoryPath(options.entrypoint);
+    options.configPath ??
+    (entrypointStat.isDirectory() ? options.entrypoint : getDirectoryPath(options.entrypoint));
   const config = await loadTypeSpecConfigForPath(host, configPath);
   config.diagnostics.forEach((x) => diagnostics.add(x));
 

--- a/packages/compiler/src/config/config-to-options.ts
+++ b/packages/compiler/src/config/config-to-options.ts
@@ -1,7 +1,7 @@
 import { createDiagnosticCollector, getDirectoryPath, normalizePath } from "../core/index.js";
 import { CompilerOptions } from "../core/options.js";
 import { CompilerHost, Diagnostic } from "../core/types.js";
-import { deepClone, omitUndefined } from "../core/util.js";
+import { deepClone, doIO, omitUndefined } from "../core/util.js";
 import { expandConfigVariables } from "./config-interpolation.js";
 import { loadTypeSpecConfigForPath, validateConfigPathsAbsolute } from "./config-loader.js";
 import { EmitterOptions, TypeSpecConfig } from "./types.js";
@@ -45,10 +45,10 @@ export async function resolveCompilerOptions(
   const cwd = normalizePath(options.cwd ?? process.cwd());
   const diagnostics = createDiagnosticCollector();
 
-  const entrypointStat = await host.stat(options.entrypoint);
+  const entrypointStat = await doIO(host.stat, options.entrypoint, (diag) => diagnostics.add(diag));
   const configPath =
     options.configPath ??
-    (entrypointStat.isDirectory() ? options.entrypoint : getDirectoryPath(options.entrypoint));
+    (entrypointStat?.isDirectory() ? options.entrypoint : getDirectoryPath(options.entrypoint));
   const config = await loadTypeSpecConfigForPath(host, configPath);
   config.diagnostics.forEach((x) => diagnostics.add(x));
 

--- a/packages/compiler/test/config/resolve-compiler-option.test.ts
+++ b/packages/compiler/test/config/resolve-compiler-option.test.ts
@@ -1,0 +1,45 @@
+import { deepStrictEqual } from "assert";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { resolveCompilerOptions } from "../../src/config/index.js";
+import { NodeHost } from "../../src/core/node-host.js";
+import { resolvePath } from "../../src/index.js";
+import { expectDiagnosticEmpty, expectDiagnostics } from "../../src/testing/expect.js";
+
+const scenarioRoot = resolvePath(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../test/config/scenarios"
+);
+
+describe("compiler: resolve compiler options", () => {
+  const tspOutputPath = resolvePath(`${process.cwd()}/tsp-output`);
+  describe("specifying explicit config file", () => {
+    const resolveOptions = async (path: string) => {
+      const fullPath = resolvePath(scenarioRoot, path);
+      return await resolveCompilerOptions(NodeHost, {
+        entrypoint: fullPath, // not really used here
+        configPath: fullPath,
+      });
+    };
+
+    it("loads config at the given path", async () => {
+      const [options, diagnostics] = await resolveOptions("custom/myConfig.yaml");
+      expectDiagnosticEmpty(diagnostics);
+
+      deepStrictEqual(options, {
+        config: resolvePath(scenarioRoot, "custom/myConfig.yaml"),
+        emit: ["openapi"],
+        options: {},
+        outputDir: tspOutputPath,
+      });
+    });
+
+    it("emit diagnostics", async () => {
+      const [_, diagnostics] = await resolveOptions("not-found.yaml");
+      expectDiagnostics(diagnostics, {
+        code: "file-not-found",
+        message: `File ${resolvePath(scenarioRoot, "not-found.yaml")} not found.`,
+      });
+    });
+  });
+});


### PR DESCRIPTION
- fix an expression typo when determining the value of `configPath`
- add test cases

fix #2277