### PR TITLE
Add `@parameterVisibility` and `@returnVisibility` decorators

### DIFF
--- a/common/changes/@typespec/compiler/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
+++ b/common/changes/@typespec/compiler/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@typespec/compiler",
-      "comment": "Added decorators `@parameterVisibility` and `@returnVisibility`. Added methods `getParameterVisibility` and `getReturnVisibility`. ",
+      "comment": "Added decorators `@parameterVisibility` and `@returnTypeVisibility`. Added methods `getParameterVisibility` and `getReturnTypeVisibility`. ",
       "type": "none"
     }
   ],

--- a/common/changes/@typespec/compiler/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
+++ b/common/changes/@typespec/compiler/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Added decorators `@parameterVisibility` and `@returnVisibility`. Added methods `getParameterVisibility` and `getReturnVisibility`. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/http/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
+++ b/common/changes/@typespec/http/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@typespec/http",
-      "comment": "**BREAKING** Changed signature of `getRequestVisibility` to now require a `Program` and an `HttpOperation` since the visibility now involves more than simply the operation verb.",
+      "comment": "Deprecated `getRequestVisibility`. Added methods `getDefaultVisibilityForVerb` and `resolveRequestVisibility`. Use either depending on the situation.",
       "type": "none"
     }
   ],

--- a/common/changes/@typespec/http/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
+++ b/common/changes/@typespec/http/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "**BREAKING** Changed signature of `getRequestVisibility` to now require a `Program` and an `HttpOperation` since the visibility now involves more than simply the operation verb.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/common/changes/@typespec/openapi3/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
+++ b/common/changes/@typespec/openapi3/compiler-ParameterReturnVisibility_2023-08-11-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Fixed issue where parameters on a PATCH request marked with visibility \"create\" did not appear.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/compiler/lib/decorators.tsp
+++ b/packages/compiler/lib/decorators.tsp
@@ -560,4 +560,4 @@ extern dec parameterVisibility(target: Operation, ...visibilities: valueof strin
  * Sets which visibilities apply to the return type for the given operation.
  * @param visibilities List of visibility strings which apply to this operation.
  */
-extern dec returnVisibility(target: Operation, ...visibilities: valueof string[]);
+extern dec returnTypeVisibility(target: Operation, ...visibilities: valueof string[]);

--- a/packages/compiler/lib/decorators.tsp
+++ b/packages/compiler/lib/decorators.tsp
@@ -549,3 +549,15 @@ extern dec inspectType(target: unknown, text: valueof string);
  * @param text Custom text to log
  */
 extern dec inspectTypeName(target: unknown, text: valueof string);
+
+/**
+ * Sets which visibilities apply to parameters for the given operation.
+ * @param visibilities List of visibility strings which apply to this operation.
+ */
+extern dec parameterVisibility(target: Operation, ...visibilities: valueof string[]);
+
+/**
+ * Sets which visibilities apply to the return type for the given operation.
+ * @param visibilities List of visibility strings which apply to this operation.
+ */
+extern dec returnVisibility(target: Operation, ...visibilities: valueof string[]);

--- a/packages/compiler/lib/lib.tsp
+++ b/packages/compiler/lib/lib.tsp
@@ -187,7 +187,7 @@ model OmitDefaults<T> {
 }
 
 /**
- * Applies a visiblity setting to a collection of properties.
+ * Applies a visibility setting to a collection of properties.
  * @template T An object whose properties are spread.
  * @template Visibility The visibility to apply to all properties.
  */

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -1237,9 +1237,15 @@ export function $parameterVisibility(
   entity: Operation,
   ...visibilities: string[]
 ) {
+  validateDecoratorUniqueOnNode(context, entity, $parameterVisibility);
   context.program.stateMap(parameterVisibilityKey).set(entity, visibilities);
 }
 
+/**
+ * Returns the visibilities of the parameters of the given operation, if provided with `@parameterVisibility`.
+ *
+ * @see $parameterVisibility
+ */
 export function getParameterVisibility(program: Program, entity: Operation): string[] | undefined {
   return program.stateMap(parameterVisibilityKey).get(entity);
 }
@@ -1251,9 +1257,15 @@ export function $returnVisibility(
   entity: Operation,
   ...visibilities: string[]
 ) {
+  validateDecoratorUniqueOnNode(context, entity, $returnVisibility);
   context.program.stateMap(returnVisibilityKey).set(entity, visibilities);
 }
 
+/**
+ * Returns the visibilities of the return type of the given operation, if provided with `@returnVisibility`.
+ *
+ * @see $returnVisibility
+ */
 export function getReturnVisibility(program: Program, entity: Operation): string[] | undefined {
   return program.stateMap(returnVisibilityKey).get(entity);
 }

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -1244,7 +1244,7 @@ export function $parameterVisibility(
 /**
  * Returns the visibilities of the parameters of the given operation, if provided with `@parameterVisibility`.
  *
- * @see $parameterVisibility
+ * @see {@link $parameterVisibility}
  */
 export function getParameterVisibility(program: Program, entity: Operation): string[] | undefined {
   return program.stateMap(parameterVisibilityKey).get(entity);
@@ -1264,7 +1264,7 @@ export function $returnTypeVisibility(
 /**
  * Returns the visibilities of the return type of the given operation, if provided with `@returnTypeVisibility`.
  *
- * @see $returnTypeVisibility
+ * @see {@link $returnTypeVisibility}
  */
 export function getReturnTypeVisibility(program: Program, entity: Operation): string[] | undefined {
   return program.stateMap(returnTypeVisibilityKey).get(entity);

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -1250,22 +1250,22 @@ export function getParameterVisibility(program: Program, entity: Operation): str
   return program.stateMap(parameterVisibilityKey).get(entity);
 }
 
-const returnVisibilityKey = createStateSymbol("returnVisibility");
+const returnTypeVisibilityKey = createStateSymbol("returnTypeVisibility");
 
-export function $returnVisibility(
+export function $returnTypeVisibility(
   context: DecoratorContext,
   entity: Operation,
   ...visibilities: string[]
 ) {
-  validateDecoratorUniqueOnNode(context, entity, $returnVisibility);
-  context.program.stateMap(returnVisibilityKey).set(entity, visibilities);
+  validateDecoratorUniqueOnNode(context, entity, $returnTypeVisibility);
+  context.program.stateMap(returnTypeVisibilityKey).set(entity, visibilities);
 }
 
 /**
- * Returns the visibilities of the return type of the given operation, if provided with `@returnVisibility`.
+ * Returns the visibilities of the return type of the given operation, if provided with `@returnTypeVisibility`.
  *
- * @see $returnVisibility
+ * @see $returnTypeVisibility
  */
-export function getReturnVisibility(program: Program, entity: Operation): string[] | undefined {
-  return program.stateMap(returnVisibilityKey).get(entity);
+export function getReturnTypeVisibility(program: Program, entity: Operation): string[] | undefined {
+  return program.stateMap(returnTypeVisibilityKey).get(entity);
 }

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -1229,3 +1229,31 @@ export function getDiscriminator(program: Program, entity: Type): Discriminator 
 export function getDiscriminatedTypes(program: Program): [Model | Union, Discriminator][] {
   return [...program.stateMap(discriminatorKey).entries()] as any;
 }
+
+const parameterVisibilityKey = createStateSymbol("parameterVisibility");
+
+export function $parameterVisibility(
+  context: DecoratorContext,
+  entity: Operation,
+  ...visibilities: string[]
+) {
+  context.program.stateMap(parameterVisibilityKey).set(entity, visibilities);
+}
+
+export function getParameterVisibility(program: Program, entity: Operation): string[] | undefined {
+  return program.stateMap(parameterVisibilityKey).get(entity);
+}
+
+const returnVisibilityKey = createStateSymbol("returnVisibility");
+
+export function $returnVisibility(
+  context: DecoratorContext,
+  entity: Operation,
+  ...visibilities: string[]
+) {
+  context.program.stateMap(returnVisibilityKey).set(entity, visibilities);
+}
+
+export function getReturnVisibility(program: Program, entity: Operation): string[] | undefined {
+  return program.stateMap(returnVisibilityKey).get(entity);
+}

--- a/packages/http/src/metadata.ts
+++ b/packages/http/src/metadata.ts
@@ -173,12 +173,28 @@ function getDefaultVisibilityForVerb(verb: HttpVerb): Visibility {
 }
 
 /**
+ * Determines the visibility to use for a request with the given verb.
+ *
+ * - GET | HEAD => Visibility.Query
+ * - POST => Visibility.Update
+ * - PUT => Visibility.Create | Update
+ * - DELETE => Visibility.Delete
+ * @param verb The HTTP verb for the operation.
+ * @deprecated Use `resolveRequestVisibility` instead, or if you only want the default visibility for a verb, `getDefaultVisibilityForVerb`.
+ * @returns The applicable parameter visibility or visibilities for the request.
+ */
+export function getRequestVisibility(verb: HttpVerb): Visibility {
+  return getDefaultVisibilityForVerb(verb);
+}
+
+/**
  * Returns the applicable parameter visibility or visibilities for the request if `@requestVisibility` was used.
  * Otherwise, returns the default visibility based on the HTTP verb for the operation.
+ * @param operation The TypeSpec Operation for the request.
  * @param verb The HTTP verb for the operation.
  * @returns The applicable parameter visibility or visibilities for the request.
  */
-export function getRequestVisibility(
+export function resolveRequestVisibility(
   program: Program,
   operation: Operation,
   verb: HttpVerb

--- a/packages/http/src/metadata.ts
+++ b/packages/http/src/metadata.ts
@@ -2,9 +2,11 @@ import {
   compilerAssert,
   DiagnosticCollector,
   getEffectiveModelType,
+  getParameterVisibility,
   isVisible as isVisibleCore,
   Model,
   ModelProperty,
+  Operation,
   Program,
   Queue,
   TwoLevelMap,
@@ -41,12 +43,19 @@ export enum Visibility {
    * and therefore no metadata is applicable.
    */
   Item = 1 << 20,
+
+  /**
+   * Additional flag to indicate when the verb is path and therefore
+   * will have fields made optional if request visibility includes update.
+   */
+  Patch = 1 << 21,
 }
 
 const visibilityToArrayMap: Map<Visibility, string[]> = new Map();
 function visibilityToArray(visibility: Visibility): readonly string[] {
-  // Item flag is not a real visibility.
+  // Item and Patch flags are not real visibilities.
   visibility &= ~Visibility.Item;
+  visibility &= ~Visibility.Patch;
 
   let result = visibilityToArrayMap.get(visibility);
   if (!result) {
@@ -74,6 +83,34 @@ function visibilityToArray(visibility: Visibility): readonly string[] {
 
   return result;
 }
+function arrayToVisibility(array: readonly string[] | undefined): Visibility | undefined {
+  if (!array) {
+    return undefined;
+  }
+  let value = Visibility.None;
+  for (const item of array) {
+    switch (item) {
+      case "read":
+        value |= Visibility.Read;
+        break;
+      case "create":
+        value |= Visibility.Create;
+        break;
+      case "update":
+        value |= Visibility.Update;
+        break;
+      case "delete":
+        value |= Visibility.Delete;
+        break;
+      case "query":
+        value |= Visibility.Query;
+        break;
+      default:
+        return undefined;
+    }
+  }
+  return value;
+}
 
 /**
  * Provides a naming suffix to create a unique name for a type with this
@@ -96,7 +133,7 @@ export function getVisibilitySuffix(
 ) {
   let suffix = "";
 
-  if ((visibility & ~Visibility.Item) !== canonicalVisibility) {
+  if ((visibility & ~Visibility.Item & ~Visibility.Patch) !== canonicalVisibility) {
     const visibilities = visibilityToArray(visibility);
     suffix += visibilities.map((v) => v[0].toUpperCase() + v.slice(1)).join("Or");
   }
@@ -116,7 +153,7 @@ export function getVisibilitySuffix(
  * - PUT => Visibility.Create | Update
  * - DELETE => Visibility.Delete
  */
-export function getRequestVisibility(verb: HttpVerb): Visibility {
+function getDefaultVisibilityForVerb(verb: HttpVerb): Visibility {
   switch (verb) {
     case "get":
     case "head":
@@ -133,6 +170,28 @@ export function getRequestVisibility(verb: HttpVerb): Visibility {
       const _assertNever: never = verb;
       compilerAssert(false, "unreachable");
   }
+}
+
+/**
+ * Returns the applicable parameter visibility or visibilities for the request if `@requestVisibility` was used.
+ * Otherwise, returns the default visibility based on the HTTP verb for the operation.
+ * @param verb The HTTP verb for the operation.
+ * @returns The applicable parameter visibility or visibilities for the request.
+ */
+export function getRequestVisibility(
+  program: Program,
+  operation: Operation,
+  verb: HttpVerb
+): Visibility {
+  const parameterVisibility = arrayToVisibility(getParameterVisibility(program, operation));
+  const defaultVisibility = getDefaultVisibilityForVerb(verb);
+  let visibility = parameterVisibility ?? defaultVisibility;
+  // If the verb is PATCH, then we need to add the patch flag to the visibility in order for
+  // later processes to properly apply it
+  if (verb === "patch") {
+    visibility |= Visibility.Patch;
+  }
+  return visibility;
 }
 
 /**
@@ -465,8 +524,13 @@ export function createMetadataInfo(program: Program, options?: MetadataInfoOptio
   }
 
   function isOptional(property: ModelProperty, visibility: Visibility): boolean {
-    // Properties are only made optional for update visibility
-    return property.optional || visibility === Visibility.Update;
+    // Properties are made optional for patch requests if the visibility includes
+    // update, but not for array elements with the item flag since you must provide
+    // all array elements with required properties, even in a patch.
+    const hasUpdate = (visibility & Visibility.Update) !== 0;
+    const isPatch = (visibility & Visibility.Patch) !== 0;
+    const isItem = (visibility & Visibility.Item) !== 0;
+    return property.optional || (hasUpdate && isPatch && !isItem);
   }
 
   function isPayloadProperty(

--- a/packages/http/src/parameters.ts
+++ b/packages/http/src/parameters.ts
@@ -16,7 +16,7 @@ import {
   isBody,
 } from "./decorators.js";
 import { createDiagnostic } from "./lib.js";
-import { gatherMetadata, getRequestVisibility, isMetadata } from "./metadata.js";
+import { gatherMetadata, isMetadata, resolveRequestVisibility } from "./metadata.js";
 import {
   HttpOperation,
   HttpOperationParameter,
@@ -59,7 +59,7 @@ function getOperationParametersForVerb(
   knownPathParamNames: string[]
 ): [HttpOperationParameters, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
-  const visibility = getRequestVisibility(program, operation, verb);
+  const visibility = resolveRequestVisibility(program, operation, verb);
   const rootPropertyMap = new Map<ModelProperty, ModelProperty>();
   const metadata = gatherMetadata(
     program,

--- a/packages/http/src/parameters.ts
+++ b/packages/http/src/parameters.ts
@@ -59,7 +59,7 @@ function getOperationParametersForVerb(
   knownPathParamNames: string[]
 ): [HttpOperationParameters, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
-  const visibility = getRequestVisibility(verb);
+  const visibility = getRequestVisibility(program, operation, verb);
   const rootPropertyMap = new Map<ModelProperty, ModelProperty>();
   const metadata = gatherMetadata(
     program,

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -124,6 +124,12 @@ const EmitterOptionsSchema: JSONSchemaType<OpenAPI3EmitterOptions> = {
 export const libDef = {
   name: "@typespec/openapi3",
   diagnostics: {
+    "inconsistent-shared-route-request-visibility": {
+      severity: "error",
+      messages: {
+        default: "All operations with `@sharedRoutes` must have the same `@requestVisibility`.",
+      },
+    },
     "invalid-server-variable": {
       severity: "error",
       messages: {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -681,7 +681,17 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     currentEndpoint.description = shared.description;
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
-    // TODO: this is probably not a good assumption?
+    // Error out if shared routes do not have consistent `@parameterVisibility`. We can
+    // lift this restriction in the future if a use case develops.
+    const visibilities = shared.operations.map((op) => {
+      return http.resolveRequestVisibility(program, op, verb);
+    });
+    if (visibilities.some((v) => v !== visibilities[0])) {
+      reportDiagnostic(program, {
+        code: "inconsistent-shared-route-request-visibility",
+        target: ops[0],
+      });
+    }
     const visibility = http.resolveRequestVisibility(program, shared.operations[0], verb);
     emitEndpointParameters(shared.parameters.parameters, visibility);
     if (shared.bodies) {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -682,7 +682,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
     // TODO: this is probably not a good assumption?
-    const visibility = http.getRequestVisibility(program, shared.operations[0], verb);
+    const visibility = http.resolveRequestVisibility(program, shared.operations[0], verb);
     emitEndpointParameters(shared.parameters.parameters, visibility);
     if (shared.bodies) {
       if (shared.bodies.length === 1) {
@@ -730,7 +730,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     currentEndpoint.description = getDoc(program, operation.operation);
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
-    const visibility = http.getRequestVisibility(program, operation.operation, verb);
+    const visibility = http.resolveRequestVisibility(program, operation.operation, verb);
     emitEndpointParameters(parameters.parameters, visibility);
     emitRequestBody(parameters.body, visibility);
     emitResponses(operation.responses);

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -681,7 +681,8 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     currentEndpoint.description = shared.description;
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
-    const visibility = http.getRequestVisibility(verb);
+    // TODO: this is probably not a good assumption?
+    const visibility = http.getRequestVisibility(program, shared.operations[0], verb);
     emitEndpointParameters(shared.parameters.parameters, visibility);
     if (shared.bodies) {
       if (shared.bodies.length === 1) {
@@ -729,7 +730,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     currentEndpoint.description = getDoc(program, operation.operation);
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
-    const visibility = http.getRequestVisibility(verb);
+    const visibility = http.getRequestVisibility(program, operation.operation, verb);
     emitEndpointParameters(parameters.parameters, visibility);
     emitRequestBody(parameters.body, visibility);
     emitResponses(operation.responses);

--- a/packages/openapi3/test/metadata.test.ts
+++ b/packages/openapi3/test/metadata.test.ts
@@ -2,6 +2,121 @@ import { deepStrictEqual } from "assert";
 import { openApiFor } from "./test-host.js";
 
 describe("openapi3: metadata", () => {
+  it("will expose create visibility properties on PATCH model using @requestVisibility", async () => {
+    const res = await openApiFor(`
+      model M {
+        @visibility("read") r: string;
+        @visibility("read", "create") rc?: string;
+        @visibility("read", "update", "create") ruc?: string;
+      }
+      @parameterVisibility("create", "update")
+      @route("/") @patch op createOrUpdate(...M): M; 
+    `);
+
+    const response = res.paths["/"].patch.responses["200"].content["application/json"].schema;
+    const request = res.paths["/"].patch.requestBody.content["application/json"].schema;
+
+    deepStrictEqual(response, { $ref: "#/components/schemas/M" });
+    deepStrictEqual(request, { $ref: "#/components/schemas/MCreateOrUpdate" });
+    deepStrictEqual(res.components.schemas, {
+      M: {
+        type: "object",
+        properties: {
+          r: { type: "string", readOnly: true },
+          rc: { type: "string" },
+          ruc: { type: "string" },
+        },
+        required: ["r"],
+      },
+      MCreateOrUpdate: {
+        type: "object",
+        properties: {
+          rc: { type: "string" },
+          ruc: { type: "string" },
+        },
+      },
+    });
+  });
+
+  it("will expose create visibility properties on PUT model", async () => {
+    const res = await openApiFor(`
+      model M {
+        @visibility("read") r: string;
+        @visibility("read", "create") rc?: string;
+        @visibility("read", "update", "create") ruc?: string;
+      }
+      @route("/") @put op createOrUpdate(...M): M; 
+    `);
+
+    const response = res.paths["/"].put.responses["200"].content["application/json"].schema;
+    const request = res.paths["/"].put.requestBody.content["application/json"].schema;
+
+    deepStrictEqual(response, { $ref: "#/components/schemas/M" });
+    deepStrictEqual(request, { $ref: "#/components/schemas/M" });
+    deepStrictEqual(res.components.schemas, {
+      M: {
+        type: "object",
+        properties: {
+          r: { type: "string", readOnly: true },
+          rc: { type: "string" },
+          ruc: { type: "string" },
+        },
+        required: ["r"],
+      },
+    });
+  });
+
+  it("ensures properties are required for array updates", async () => {
+    const res = await openApiFor(`
+      model Person {
+        @visibility("read") id: string;
+        @visibility("create") secret: string;
+        name: string;
+      
+        @visibility("read", "create")
+        test: string;
+      
+        @visibility("other", "read", "update")
+        other: string;
+      
+        @visibility("read", "create", "update")
+        relatives: PersonRelative[];
+      }
+      
+      model PersonRelative {
+        person: Person;
+        relationship: string;
+      }
+      @route("/") @patch op update(...Person): Person; 
+    `);
+
+    const response = res.paths["/"].patch.responses["200"].content["application/json"].schema;
+    const request = res.paths["/"].patch.requestBody.content["application/json"].schema;
+
+    deepStrictEqual(response, { $ref: "#/components/schemas/Person" });
+    deepStrictEqual(request, { $ref: "#/components/schemas/PersonUpdate" });
+    deepStrictEqual(res.components.schemas.PersonUpdateItem, {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        other: { type: "string" },
+        relatives: {
+          type: "array",
+          items: { $ref: "#/components/schemas/PersonRelativeUpdateItem" },
+        },
+      },
+      required: ["name", "other", "relatives"],
+    });
+    deepStrictEqual(res.components.schemas.PersonRelativeUpdateItem, {
+      type: "object",
+      properties: {
+        person: { $ref: "#/components/schemas/PersonUpdateItem" },
+        relationship: { type: "string" },
+      },
+      required: ["person", "relationship"],
+    });
+  });
+
   it("can make properties optional", async () => {
     const res = await openApiFor(`
       model Widget { 

--- a/packages/openapi3/test/shared-routes.test.ts
+++ b/packages/openapi3/test/shared-routes.test.ts
@@ -394,4 +394,37 @@ describe("openapi3: shared routes", () => {
       },
     });
   });
+
+  it("should warn if shared routes differ by `@parameterVisibility`", async () => {
+    const diagnostics = await diagnoseOpenApiFor(
+      `
+      @service({title: "My Service"})
+      namespace Foo {
+        model Resource {
+          @visibility("read")
+          @key
+          id: string;
+
+          @visibility("create", "update")
+          name: string;
+        }
+
+        @sharedRoute
+        @route("/foo")
+        @parameterVisibility("read")
+        op op1Foo(...Resource): Resource[];
+
+        @sharedRoute
+        @route("/foo")
+        @parameterVisibility("create")
+        op op2Foo(...Resource): Resource[];
+      }
+      `
+    );
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@typespec/openapi3/inconsistent-shared-route-request-visibility",
+      },
+    ]);
+  });
 });

--- a/packages/samples/specs/rest-metadata-emitter/rest-metadata-emitter-sample.ts
+++ b/packages/samples/specs/rest-metadata-emitter/rest-metadata-emitter-sample.ts
@@ -19,9 +19,7 @@ import {
   getVisibilitySuffix,
   HttpOperation,
   HttpOperationBody,
-  HttpOperationParameters,
   HttpOperationResponse,
-  HttpVerb,
   Visibility,
 } from "@typespec/http";
 import { buildVersionProjections } from "@typespec/versioning";
@@ -102,19 +100,20 @@ export async function $onEmit(context: EmitContext): Promise<void> {
     function emitOperation(operation: HttpOperation) {
       writeLine(`op: ${operation.verb.toUpperCase()} ${operation.path}`);
       indent();
-      emitRequest(operation.parameters, operation.verb);
+      emitRequest(program, operation);
       emitResponses(operation.responses);
       unindent();
     }
 
-    function emitRequest(parameters: HttpOperationParameters, verb: HttpVerb) {
+    function emitRequest(program: Program, operation: HttpOperation) {
+      const parameters = operation.parameters;
       if (parameters.parameters.length === 0 && !parameters.body) {
         // no request data
         return;
       }
 
       // Map the verb to a visibility for the request.
-      const visibility = getRequestVisibility(verb);
+      const visibility = getRequestVisibility(program, operation.operation, operation.verb);
 
       writeLine("request:");
       indent();

--- a/packages/samples/specs/rest-metadata-emitter/rest-metadata-emitter-sample.ts
+++ b/packages/samples/specs/rest-metadata-emitter/rest-metadata-emitter-sample.ts
@@ -15,11 +15,11 @@ import {
 import {
   createMetadataInfo,
   getHttpService,
-  getRequestVisibility,
   getVisibilitySuffix,
   HttpOperation,
   HttpOperationBody,
   HttpOperationResponse,
+  resolveRequestVisibility,
   Visibility,
 } from "@typespec/http";
 import { buildVersionProjections } from "@typespec/versioning";
@@ -113,7 +113,7 @@ export async function $onEmit(context: EmitContext): Promise<void> {
       }
 
       // Map the verb to a visibility for the request.
-      const visibility = getRequestVisibility(program, operation.operation, operation.verb);
+      const visibility = resolveRequestVisibility(program, operation.operation, operation.verb);
 
       writeLine("request:");
       indent();


### PR DESCRIPTION
Fixes #2186.

- Core: Adds `@parameterVisibility` and `@returnVisibility` and the corresponding helper methods `getParameterVisibility` and `getReturnVisibility`.
- Http: **BREAKING CHANGE** deprecates `getRequestVisibility`. Adds `getDefaultVisibilityForVerb` (which does the same thing) and `resolveRequestVisibility` which combines the verb with any use of `@parameterVisibility` to get the actual visibility.
- OpenAPI3: Updated emitter to make use of `@parameterVisibility`.

**TODO**:
- [x] Azure companion PR (https://github.com/Azure/typespec-azure/pull/3400)
- [x] Resolve `@returnVisibility` vs. `@returnTypeVisibility`.
- [x] Figure out what to do with shared routes...