### PR TITLE
Remove reference to `object` from built-in types

### DIFF
--- a/docs/language-basics/built-in-types.md
+++ b/docs/language-basics/built-in-types.md
@@ -48,7 +48,6 @@ Built in types are related to each other according to the rules described in [ty
 | `string`    | A sequence of textual characters                                                           |
 | `boolean`   | Boolean with `true` and `false` values                                                     |
 | `null`      | Null value                                                                                 |
-| `object`    | Represent any structured model.(With properties)                                           |
 | `Array<T>`  | Array model type, equivalent to `T[]`                                                      |
 | `Record<T>` | Model with string properties where all the properties have type `T`                        |
 | `unknown`   | A top type in TypeSpec that all types can be assigned to.                                  |


### PR DESCRIPTION
It is deprecated and shouldn't be used