### PR TITLE
Ensure that `getRequestVIsibility` includes `Visibility.Patch` for patch operations

### DIFF
--- a/common/changes/@typespec/http/metadataFix_2023-08-21-21-48.json
+++ b/common/changes/@typespec/http/metadataFix_2023-08-21-21-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/packages/http/src/metadata.ts
+++ b/packages/http/src/metadata.ts
@@ -176,7 +176,8 @@ function getDefaultVisibilityForVerb(verb: HttpVerb): Visibility {
  * Determines the visibility to use for a request with the given verb.
  *
  * - GET | HEAD => Visibility.Query
- * - POST => Visibility.Update
+ * - POST => Visibility.Create
+ * - PATCH => Visibility.Update
  * - PUT => Visibility.Create | Update
  * - DELETE => Visibility.Delete
  * @param verb The HTTP verb for the operation.
@@ -184,7 +185,13 @@ function getDefaultVisibilityForVerb(verb: HttpVerb): Visibility {
  * @returns The applicable parameter visibility or visibilities for the request.
  */
 export function getRequestVisibility(verb: HttpVerb): Visibility {
-  return getDefaultVisibilityForVerb(verb);
+  let visibility = getDefaultVisibilityForVerb(verb);
+  // If the verb is PATCH, then we need to add the patch flag to the visibility in order for
+  // later processes to properly apply it
+  if (verb === "patch") {
+    visibility |= Visibility.Patch;
+  }
+  return visibility;
 }
 
 /**

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -1,4 +1,4 @@
-import { ModelProperty, Namespace } from "@typespec/compiler";
+import { ModelProperty, Namespace, Operation } from "@typespec/compiler";
 import {
   BasicTestRunner,
   expectDiagnosticEmpty,
@@ -21,6 +21,7 @@ import {
   isQueryParam,
   isStatusCode,
 } from "../src/decorators.js";
+import { Visibility, getRequestVisibility, resolveRequestVisibility } from "../src/metadata.js";
 import { createHttpTestRunner } from "./test-host.js";
 
 describe("http: decorators", () => {
@@ -835,6 +836,34 @@ describe("http: decorators", () => {
       strictEqual(
         includeInapplicableMetadataInPayload(runner.program, M.properties.get("p")!),
         true
+      );
+    });
+  });
+
+  describe("@parameterVisibility", () => {
+    it("ensures getRequestVisibility and resolveRequestVisibility return the same value for default PATCH operations", async () => {
+      const { testPatch } = await runner.compile(`
+      @patch
+      @test op testPatch(): void;
+      `);
+      deepStrictEqual(
+        // eslint-disable-next-line deprecation/deprecation
+        getRequestVisibility("patch"),
+        resolveRequestVisibility(runner.program, testPatch as Operation, "patch")
+      );
+    });
+
+    it("ensures getRequestVisibility and resolveRequestVisibility return expected values for customized PATCH operations", async () => {
+      const { testPatch } = await runner.compile(`
+      @parameterVisibility("create", "update")
+      @patch
+      @test op testPatch(): void;
+      `);
+      // eslint-disable-next-line deprecation/deprecation
+      deepStrictEqual(getRequestVisibility("patch"), Visibility.Update | Visibility.Patch);
+      deepStrictEqual(
+        resolveRequestVisibility(runner.program, testPatch as Operation, "patch"),
+        Visibility.Update | Visibility.Create | Visibility.Patch
       );
     });
   });


### PR DESCRIPTION
Fix #2308.