### PR TITLE
Fix: Shared route body should use `anyOf` instead of `oneOf`

### DIFF
--- a/common/changes/@typespec/openapi3/fix-oneof_2023-09-05-20-13.json
+++ b/common/changes/@typespec/openapi3/fix-oneof_2023-09-05-20-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Use `anyOf` instead of `oneOf` for shared route with different request/response bodies",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -870,7 +870,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
           obj.content[contentType] = { schema: schema[0] };
         } else {
           obj.content[contentType] = {
-            schema: { oneOf: schema },
+            schema: { anyOf: schema },
           };
         }
       }
@@ -1056,7 +1056,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         content[contentType] = { schema: schemaArray[0] };
       } else {
         content[contentType] = {
-          schema: { oneOf: schemaArray },
+          schema: { anyOf: schemaArray },
         };
       }
     }

--- a/packages/openapi3/test/return-types.test.ts
+++ b/packages/openapi3/test/return-types.test.ts
@@ -624,7 +624,7 @@ describe("openapi3: return types", () => {
           content: {
             "application/json": {
               schema: {
-                oneOf: [
+                anyOf: [
                   {
                     $ref: "#/components/schemas/A",
                   },
@@ -653,7 +653,7 @@ describe("openapi3: return types", () => {
           content: {
             "application/json": {
               schema: {
-                oneOf: [
+                anyOf: [
                   {
                     $ref: "#/components/schemas/A",
                   },
@@ -692,7 +692,7 @@ describe("openapi3: return types", () => {
           content: {
             "application/json": {
               schema: {
-                oneOf: [
+                anyOf: [
                   {
                     $ref: "#/components/schemas/A",
                   },

--- a/packages/openapi3/test/shared-routes.test.ts
+++ b/packages/openapi3/test/shared-routes.test.ts
@@ -209,7 +209,7 @@ describe("openapi3: shared routes", () => {
         content: {
           "application/json": {
             schema: {
-              oneOf: [
+              anyOf: [
                 {
                   type: "integer",
                   format: "int32",
@@ -255,7 +255,7 @@ describe("openapi3: shared routes", () => {
       content: {
         "application/json": {
           schema: {
-            oneOf: [
+            anyOf: [
               {
                 type: "integer",
                 format: "int32",
@@ -273,7 +273,7 @@ describe("openapi3: shared routes", () => {
       content: {
         "application/json": {
           schema: {
-            oneOf: [
+            anyOf: [
               {
                 type: "integer",
                 format: "int32",
@@ -315,7 +315,7 @@ describe("openapi3: shared routes", () => {
       content: {
         "application/json": {
           schema: {
-            oneOf: [
+            anyOf: [
               {
                 properties: {
                   a: { $ref: "#/components/schemas/A" },
@@ -358,7 +358,7 @@ describe("openapi3: shared routes", () => {
       content: {
         "application/json": {
           schema: {
-            oneOf: [
+            anyOf: [
               {
                 type: "integer",
                 format: "int32",
@@ -377,7 +377,7 @@ describe("openapi3: shared routes", () => {
         content: {
           "application/json": {
             schema: {
-              oneOf: [
+              anyOf: [
                 {
                   type: "integer",
                   format: "int32",


### PR DESCRIPTION
fix [#2303](https://github.com/microsoft/typespec/issues/2303)

We don't know if those bodies are mutually exclusive so `anyOf` is more correct.