### PR TITLE
Temporarily pin Node 20 to 20.5 to avoid Babel error

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -15,6 +15,8 @@ jobs:
       vmImage: windows-2022
     steps:
       - template: ./templates/install.yml
+        parameters:
+          nodeVersion: "20.5"
       - template: ./templates/build.yml
 
       - script: node common/scripts/install-run-rush.js test-official --parallelism max --verbose
@@ -48,6 +50,8 @@ jobs:
       vmImage: windows-2022
     steps:
       - template: ./templates/install.yml
+        parameters:
+          nodeVersion: "20.5"
       - template: ./templates/build.yml
 
       - script: node ./packages/internal-build-utils/cmd/cli.js bump-version-preview .

--- a/eng/pipelines/jobs/publish-artifacts.yml
+++ b/eng/pipelines/jobs/publish-artifacts.yml
@@ -15,6 +15,8 @@ jobs:
         submodules: true
 
       - template: ../templates/install.yml
+        parameters:
+          nodeVersion: "20.5"
       - template: ../templates/build.yml
 
       - script: node ./packages/internal-build-utils/cmd/cli.js bump-version-pr . --pr $(System.PullRequest.PullRequestNumber) --buildNumber $(Build.BuildNumber)

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -40,12 +40,12 @@ jobs:
         "Linux - Node 20.x":
           pool: azsdk-pool-mms-ubuntu-2004-general
           imageName: ubuntu-20.04
-          nodeVersion: "20.x"
+          nodeVersion: "20.5"
 
         "Windows - Node 20.x":
           pool: azsdk-pool-mms-win-2022-general
           imageName: windows-2022
-          nodeVersion: "20.x"
+          nodeVersion: "20.5"
 
     pool:
       name: $(pool)


### PR DESCRIPTION
It looks like CI is failing due to an issue with Babel.js conflicting with Node 20.6:

https://github.com/babel/babel/issues/15927
https://github.com/vitejs/vite/issues/14299

For now, let's try pinning Node 20.x to 20.5 until the issue gets fixed in Babel.

Comparable `typespec-azure` repo PR: https://github.com/Azure/typespec-azure/pull/3502

Issue https://github.com/Azure/typespec-azure/issues/3504 tracks the work to un-pin the Node version.