### PR TITLE
Fix: Crash when comparing recursive models

### DIFF
--- a/common/changes/@typespec/compiler/fix-relation-recursive-types_2023-09-06-21-08.json
+++ b/common/changes/@typespec/compiler/fix-relation-recursive-types_2023-09-06-21-08.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@typespec/compiler",
-      "comment": "Fix: Crash with when comparing relation between recursive types",
+      "comment": "Fix: Crash with when relating recursive types",
       "type": "none"
     }
   ],

--- a/common/changes/@typespec/compiler/fix-relation-recursive-types_2023-09-06-21-08.json
+++ b/common/changes/@typespec/compiler/fix-relation-recursive-types_2023-09-06-21-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: Crash with when comparing relation between recursive types",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -633,6 +633,35 @@ describe("compiler: checker: type relations", () => {
         }
       );
     });
+
+    describe("recursive models", () => {
+      it("compare recursive models", async () => {
+        await expectTypeAssignable({
+          source: "A",
+          target: "B",
+          commonCode: `
+          model A { a: A }
+          model B { a: B }
+        `,
+        });
+      });
+
+      it("emit diagnostic if they don't match", async () => {
+        const { related, diagnostics } = await checkTypeAssignable({
+          source: "A",
+          target: "B",
+          commonCode: `
+        model A { a: A }
+        model B { a: B, b: B }
+      `,
+        });
+        ok(!related);
+        expectDiagnostics(diagnostics, {
+          code: "missing-property",
+          message: "Property 'b' is missing on type 'A' but required in 'B'",
+        });
+      });
+    });
   });
 
   describe("Array target", () => {


### PR DESCRIPTION
fix [#1991](https://github.com/microsoft/typespec/issues/1991)

Compiler would get into a infinite recursion when comparing recursive models. 
```tsp 
model A {
  a: A;
}

model B {
  a: B;
}
model Test<T extends A> {}

alias T1 = Test<B>;
```