### PR TITLE
Fix: Compiler freeze when using invalid token between doc comment and next statement/node

### DIFF
--- a/common/changes/@typespec/compiler/fix-doc-freeze_2023-09-06-22-33.json
+++ b/common/changes/@typespec/compiler/fix-doc-freeze_2023-09-06-22-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: Compiler freeze when using invalid token between doc comment and type",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/parser.ts
+++ b/packages/compiler/src/core/parser.ts
@@ -2596,6 +2596,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
 
     const items: T[] = [];
     while (true) {
+      const startingPos = tokenPos();
       const { pos, docs, directives, decorators } = parseAnnotations({
         skipParsingDocNodes: Boolean(kind.invalidAnnotationTarget),
       });
@@ -2670,7 +2671,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
         parseExpected(kind.delimiter);
       }
 
-      if (pos === tokenPos()) {
+      if (startingPos === tokenPos()) {
         // Error recovery: we've inserted everything during this loop iteration
         // and haven't made any progress. Assume that the current token is a bad
         // representation of the end of the the list that we're trying to get

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -323,6 +323,7 @@ describe("compiler: parser", () => {
   describe("recovery", () => {
     parseErrorEach([
       [`model M { ]`, [/Property expected/]],
+      [`model M { /** */ */ prop: string }`, [/Property expected/]],
       [
         `
         @dec1 @dec2 import "foo";


### PR DESCRIPTION
fix [#2338](https://github.com/microsoft/typespec/issues/2338)

Issue was when parsing a list we'd get stuck when there is doc comment as the doc comment would change the tracking position and we wouldn't realize the parsing list is not making progress.