### PR TITLE
Clarify default encoding responsability

### DIFF
--- a/docs/standard-library/http/encoding.md
+++ b/docs/standard-library/http/encoding.md
@@ -9,6 +9,10 @@ This document describe how the http library interpret TypeSpec built-in types an
 - `bytes` are serialized as `base64` when used inside a model serialized as JSON
 - In request or response body it represent a binary payload.
 
+:::note
+This behavior is only a specification and MUST be respected by the emitter. The http library DOES NOT automatically apply the `@encode("base64")` when used inside a JSON model.
+:::
+
 Use `@encode` to configure
 
 ```tsp
@@ -30,6 +34,10 @@ op upload(@body data: bytes): void; // Accept application/octet-stream
 
 - Encoded as `rfc7231` when used in a header
 - Encoded as `rfc3339` otherwise.
+
+:::note
+This behavior is only a specification and MUST be respected by the emitter. The http library DOES NOT automatically apply the `@encode("rfc7231")` on `utcDatetime` and `offsetDateTime` when used in a header.
+:::
 
 Use `@encode` to configure.
 


### PR DESCRIPTION
fix [#2256](https://github.com/microsoft/typespec/issues/2256)
