### PR TITLE
Correct rest → http peer dependency & OpenAPI does not depend on REST

### DIFF
--- a/common/changes/@typespec/openapi/2391-rest-http-peer-dep_2023-09-19-00-29.json
+++ b/common/changes/@typespec/openapi/2391-rest-http-peer-dep_2023-09-19-00-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi",
+      "comment": "Removes `@typespec/rest` as a `peerDependency`. Relates to #2391",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi"
+}

--- a/common/changes/@typespec/openapi3/2391-rest-http-peer-dep_2023-09-19-00-29.json
+++ b/common/changes/@typespec/openapi3/2391-rest-http-peer-dep_2023-09-19-00-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Removes `@typespec/rest` as a `peerDependency`. Relates to #2391",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/common/changes/@typespec/rest/2391-rest-http-peer-dep_2023-09-19-00-29.json
+++ b/common/changes/@typespec/rest/2391-rest-http-peer-dep_2023-09-19-00-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/rest",
+      "comment": "Correct rest → http peer dependency. Fixes #2391",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/rest"
+}

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -54,8 +54,7 @@
   ],
   "peerDependencies": {
     "@typespec/compiler": "workspace:~0.48.0",
-    "@typespec/http": "workspace:~0.48.0",
-    "@typespec/rest": "workspace:~0.48.0"
+    "@typespec/http": "workspace:~0.48.0"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.1",

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -59,7 +59,6 @@
     "@typespec/versioning": "workspace:~0.48.0",
     "@typespec/compiler": "workspace:~0.48.0",
     "@typespec/http": "workspace:~0.48.0",
-    "@typespec/rest": "workspace:~0.48.0",
     "@typespec/openapi": "workspace:~0.48.0"
   },
   "devDependencies": {

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -53,7 +53,8 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@typespec/compiler": "workspace:~0.48.0"
+    "@typespec/compiler": "workspace:~0.48.0",
+    "@typespec/http": "workspace:~0.48.0"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.1",


### PR DESCRIPTION
### ℹ️ Overview

Includes two commits, one to fix #2391 and a second related to the same issue.

#### Correct rest → http peer dependency

Fixes #2391

Updates `@typespec/rest` to have a `peerDependency` on `@typespec/http`.
Leftover from the rest/http split.

#### OpenAPI does not depend on REST

Relates to #2391.

Removes `@typespec/rest` as a `peerDependency` for `@typespec/openapi`
and `@typespec/openapi3`. The OpenAPI packages only depend on HTTP
functionality, not the higher-level REST concepts.

The packages still have `@typespec/rest` as a `devDependency` for test
cases (test host).

### 📝 Notes

N/A - Commit message suffices

### 🧪 Testing

Ran rush scripts. Did not attempt an `npm link` and install or something. (So, no testing really.)