### PR TITLE
Give playground iframe clipboard write access

### DIFF
--- a/packages/website/src/pages/playground.tsx
+++ b/packages/website/src/pages/playground.tsx
@@ -16,6 +16,7 @@ export default function Playground() {
           <iframe
             title="TypeSpec Playground"
             src="https://cadlplayground.z22.web.core.windows.net"
+            allow="clipboard-write"
             style={{
               height: "100%",
               width: "100%",


### PR DESCRIPTION
fix https://github.com/Azure/typespec-azure/issues/3494

This does a basic fix of when you click save it does copy the playground url to the clipboard. It doesn't actuall update the docs url with the information though. To resolve that we probably need to consume the playground component directly