### PR TITLE
Fixed issue with discriminated union mappings with visibilities

### DIFF
--- a/common/changes/@typespec/openapi3/fix-discriminated-union-mapping-wrongly-mutated_2023-09-15-00-39.json
+++ b/common/changes/@typespec/openapi3/fix-discriminated-union-mapping-wrongly-mutated_2023-09-15-00-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Fix: Correctly generate discriminated union mapping property with multiple visibilities involved",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1467,7 +1467,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     if (discriminator) {
       // the decorator validates that all the variants will be a model type
       // with the discriminator field present.
-      schema.discriminator = discriminator;
+      schema.discriminator = { ...discriminator };
       // Diagnostic already reported in compiler for unions
       const discriminatedUnion = ignoreDiagnostics(getDiscriminatedUnion(union, discriminator));
       if (discriminatedUnion.variants.size > 0) {

--- a/packages/openapi3/test/union-schema.test.ts
+++ b/packages/openapi3/test/union-schema.test.ts
@@ -298,6 +298,74 @@ describe("openapi3: union type", () => {
     ok(res.schemas.X.properties.prop.nullable);
   });
 
+  it("handles discriminated union mapping with multiple visibilites", async () => {
+    const res = await openApiFor(`
+      model A {
+        type: "ay";
+        a: string;
+        @visibility("create")
+        onACreate: string;
+      }
+
+      model B {
+        type: "bee";
+        b: string;
+        @visibility("create")
+        onBCreate: string;
+      }
+
+      @discriminator("type")
+      union AorB {
+        a: A,
+        b: B
+      }
+
+      model Data {
+        thing: AorB
+      }
+
+      @get
+      op getFoo(): Data;
+      @post
+      op postFoo(@body data: Data): Data;
+    `);
+
+    deepStrictEqual(res.components.schemas.AorB, {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/A",
+        },
+        {
+          $ref: "#/components/schemas/B",
+        },
+      ],
+      discriminator: {
+        propertyName: "type",
+        mapping: {
+          ay: "#/components/schemas/A",
+          bee: "#/components/schemas/B",
+        },
+      },
+    });
+    deepStrictEqual(res.components.schemas.AorBCreate, {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/ACreate",
+        },
+        {
+          $ref: "#/components/schemas/BCreate",
+        },
+      ],
+      discriminator: {
+        propertyName: "type",
+        mapping: {
+          ay: "#/components/schemas/ACreate",
+          bee: "#/components/schemas/BCreate",
+        },
+      },
+    });
+  });
+
   it("throws diagnostics for empty enum definitions", async () => {
     const diagnostics = await diagnoseOpenApiFor(`union Pet {}`);
 

--- a/packages/openapi3/test/union-schema.test.ts
+++ b/packages/openapi3/test/union-schema.test.ts
@@ -298,7 +298,7 @@ describe("openapi3: union type", () => {
     ok(res.schemas.X.properties.prop.nullable);
   });
 
-  it("handles discriminated union mapping with multiple visibilites", async () => {
+  it("handles discriminated union mapping with multiple visibilities", async () => {
     const res = await openApiFor(`
       model A {
         type: "ay";


### PR DESCRIPTION
Fixed an issue with the discriminated union `mapping` output property not generating correctly when multiple visibilities are involved. Previously subsequently discovered visibilities would mutate previously created `mapping` properties, resulting in `oneOf` references and `mapping` not referencing the same models