### PR TITLE
[Hot Fix] Add typesVersions metadata for emitter framework to package.json

### DIFF
--- a/common/changes/@typespec/compiler/release-september-2023_2023-09-15-20-46.json
+++ b/common/changes/@typespec/compiler/release-september-2023_2023-09-15-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Add typesVersions metadata for the emitter framework to package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -40,6 +40,9 @@
       ],
       "module-resolver": [
         "./dist/src/core/module-resolver.d.ts"
+      ],
+      "emitter-framework": [
+        "./dist/src/emitter-framework/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Some consumers need this metadata to find types for the emitter framework.