### PR TITLE
[Hot Fix] Fix losing reference context for types nested under the referenced type

### DIFF
--- a/common/changes/@typespec/compiler/hotfix-emitter-framework-ref-context2_2023-09-15-22-28.json
+++ b/common/changes/@typespec/compiler/hotfix-emitter-framework-ref-context2_2023-09-15-22-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix emitter framework issue causing reference context to be lost in certain cases.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}


### PR DESCRIPTION
Previously, when calling emitTypeReference, a variable with the incoming reference context was set. When emitting a type, if reference context was found, the top of the context stack would have reference context added in and the incoming reference context was cleared. The result was that for types lexically contained within the referenced type (e.g. model properties of a referenced model) would not have reference context available.

Now, reference context is preserved until we have finished emitting the reference, and restored to its previous value afterwards. We also store the type that was referenced, so we know where in the context stack to apply references (if I reference `SomeNS.Foo` with reference context set, only when emitting `Foo` do I see the reference context, `SomeNS` does not see it).

Longer term, the context logic should be refactored to preserve context while emitting lexically contained types, only adding context as more context is added, rather than restoring context from scratch each time. The current logic should only be required when emitting a type that is not lexically contained in the current type. This will likely simplify a lot of logic, but is a substantial refactoring that I will leave for later.