### PR TITLE
Suppress new `unsupported-http-auth-scheme` from `typespec-autorest`

### DIFF
--- a/packages/samples/specs/authentication/main.tsp
+++ b/packages/samples/specs/authentication/main.tsp
@@ -2,6 +2,7 @@ import "@typespec/rest";
 
 using TypeSpec.Http;
 
+#suppress "@azure-tools/typespec-autorest/unsupported-http-auth-scheme" "BearerAuth is not supported by typespec-autorest"
 @service({
   title: "Authenticated service",
 })


### PR DESCRIPTION
This is a companion PR to https://github.com/Azure/typespec-azure/pull/3597 which changes one of the validation samples we use to suppress the new `unsupported-http-auth-scheme` from `@azure-tools/typespec-autorest` because `BearerAuth` is not supported by that emitter.