### PR TITLE
Fix: Formatting of comments between a directive or doc and its node

### DIFF
--- a/common/changes/@typespec/compiler/fix-formatting-doc-directive_2023-09-19-17-39.json
+++ b/common/changes/@typespec/compiler/fix-formatting-doc-directive_2023-09-19-17-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@typespec/compiler",
-      "comment": "Fix: Formatting of comments between a directive or doc and its node",
+      "comment": "Fix: Correct formatting of comments between a directive or doc and its node",
       "type": "none"
     }
   ],

--- a/common/changes/@typespec/compiler/fix-formatting-doc-directive_2023-09-19-17-39.json
+++ b/common/changes/@typespec/compiler/fix-formatting-doc-directive_2023-09-19-17-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: Formatting of comments between a directive or doc and its node",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/formatter/print/comment-handler.ts
+++ b/packages/compiler/src/formatter/print/comment-handler.ts
@@ -16,7 +16,7 @@ export const commentHandler: Printer<Node>["handleComments"] = {
     [
       addEmptyInterfaceComment,
       addEmptyModelComment,
-      addStatementDecoratorComment,
+      addCommentBetweenAnnotationsAndNode,
       handleOnlyComments,
     ].some((x) => x({ comment, text, options, ast: ast as TypeSpecScriptNode, isLastComment })),
 };
@@ -37,7 +37,7 @@ interface CommentContext {
  *   // My comment
  * }
  */
-function addEmptyInterfaceComment({ comment }: CommentContext) {
+function addEmptyInterfaceComment({ comment, ast }: CommentContext) {
   const { precedingNode, enclosingNode } = comment;
 
   if (
@@ -54,7 +54,7 @@ function addEmptyInterfaceComment({ comment }: CommentContext) {
 }
 
 /**
- * When a comment is in between decorators.
+ * When a comment is in between a node and its annotations(Decorator, directives, doc comments).
  *
  * @example
  *
@@ -64,12 +64,14 @@ function addEmptyInterfaceComment({ comment }: CommentContext) {
  * model Foo {
  * }
  */
-function addStatementDecoratorComment({ comment }: CommentContext) {
+function addCommentBetweenAnnotationsAndNode({ comment }: CommentContext) {
   const { enclosingNode, precedingNode } = comment;
 
   if (
     precedingNode &&
-    precedingNode.kind === SyntaxKind.DecoratorExpression &&
+    (precedingNode.kind === SyntaxKind.DecoratorExpression ||
+      precedingNode.kind === SyntaxKind.DirectiveExpression ||
+      precedingNode.kind === SyntaxKind.Doc) &&
     enclosingNode &&
     (enclosingNode.kind === SyntaxKind.NamespaceStatement ||
       enclosingNode.kind === SyntaxKind.ModelStatement ||

--- a/packages/compiler/src/formatter/print/printer.ts
+++ b/packages/compiler/src/formatter/print/printer.ts
@@ -421,7 +421,6 @@ export function canAttachComment(node: Node): boolean {
       kind !== SyntaxKind.LineComment &&
       kind !== SyntaxKind.BlockComment &&
       kind !== SyntaxKind.EmptyStatement &&
-      kind !== SyntaxKind.Doc &&
       kind !== SyntaxKind.DocParamTag &&
       kind !== SyntaxKind.DocReturnsTag &&
       kind !== SyntaxKind.DocTemplateTag &&

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -1015,6 +1015,50 @@ model Foo {
       });
     });
 
+    it("format single line comments after doc comment", async () => {
+      await assertFormat({
+        code: `
+model A {
+  /**
+   * block
+   */
+    // one line
+  s: string;
+}
+        
+`,
+        expected: `
+model A {
+  /**
+   * block
+   */
+  // one line
+  s: string;
+}
+`,
+      });
+    });
+
+    it("format single line comments after directive", async () => {
+      await assertFormat({
+        code: `
+model A {
+  #suppress "foo"
+    // one line
+  s: string;
+}
+        
+`,
+        expected: `
+model A {
+  #suppress "foo"
+  // one line
+  s: string;
+}
+`,
+      });
+    });
+
     it("format empty interface with comment inside", async () => {
       await assertFormat({
         code: `
@@ -1051,19 +1095,21 @@ interface Foo {
       });
     });
 
-    describe("format comment between decorator and statement", () => {
-      [
-        ["blockless namespace", "namespace Bar;"],
-        ["flattened blockless namespace", "namespace Foo.Bar;"],
-        ["block namespace", "namespace Bar {\n\n}"],
-        ["flattened block namespace", "namespace Foo.Bar {\n\n}"],
-        ["model", "model Bar {}"],
-        ["op", "op test(foo: string): void;"],
-        ["scalar", "scalar foo;"],
-        ["interface", "interface Foo {}"],
-        ["union", "union Foo {}"],
-        ["enum", "enum Foo {}"],
-      ].forEach(([name, code]) => {
+    const types = [
+      ["blockless namespace", "namespace Bar;"],
+      ["flattened blockless namespace", "namespace Foo.Bar;"],
+      ["block namespace", "namespace Bar {\n\n}"],
+      ["flattened block namespace", "namespace Foo.Bar {\n\n}"],
+      ["model", "model Bar {}"],
+      ["op", "op test(foo: string): void;"],
+      ["scalar", "scalar foo;"],
+      ["interface", "interface Foo {}"],
+      ["union", "union Foo {}"],
+      ["enum", "enum Foo {}"],
+    ];
+
+    describe("format comment between decorator and node", () => {
+      types.forEach(([name, code]) => {
         it(name, async () => {
           await assertFormat({
             code: `
@@ -1073,6 +1119,44 @@ ${code}
 `,
             expected: `
 @foo
+// comment
+${code}
+`,
+          });
+        });
+      });
+    });
+
+    describe("format comment between directive and node", () => {
+      types.forEach(([name, code]) => {
+        it(name, async () => {
+          await assertFormat({
+            code: `
+#suppress "foo"
+    // comment
+${code}
+`,
+            expected: `
+#suppress "foo"
+// comment
+${code}
+`,
+          });
+        });
+      });
+    });
+
+    describe("format comment between doc comment and node", () => {
+      types.forEach(([name, code]) => {
+        it(name, async () => {
+          await assertFormat({
+            code: `
+/** doc */
+    // comment
+${code}
+`,
+            expected: `
+/** doc */
 // comment
 ${code}
 `,


### PR DESCRIPTION
fix [#2361](https://github.com/microsoft/typespec/issues/2361)