### PR TITLE
`tsp format` should return non-zero exit code on failures

### DIFF
--- a/common/changes/@typespec/compiler/fix-format-exit-code_2023-09-20-15-44.json
+++ b/common/changes/@typespec/compiler/fix-format-exit-code_2023-09-20-15-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "`tsp format` now returns a non-zero exit code when it fails to format a file",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/cli/actions/format.ts
+++ b/packages/compiler/src/core/cli/actions/format.ts
@@ -1,4 +1,5 @@
 import { findUnformattedTypeSpecFiles, formatTypeSpecFiles } from "../../formatter-fs.js";
+import { logDiagnostics } from "../../index.js";
 import { CliCompilerHost } from "../types.js";
 
 export interface FormatArgs {
@@ -23,9 +24,13 @@ export async function formatAction(host: CliCompilerHost, args: FormatArgs) {
       process.exit(1);
     }
   } else {
-    await formatTypeSpecFiles(args["include"], {
+    const [_, diagnostics] = await formatTypeSpecFiles(args["include"], {
       exclude: args["exclude"],
       debug: args.debug,
     });
+    if (diagnostics.length > 0) {
+      logDiagnostics(diagnostics, host.logSink);
+      process.exit(1);
+    }
   }
 }

--- a/packages/compiler/src/core/formatter-fs.ts
+++ b/packages/compiler/src/core/formatter-fs.ts
@@ -3,6 +3,8 @@ import { globby } from "globby";
 import { resolveConfig } from "prettier";
 import { PrettierParserError } from "../formatter/parser.js";
 import { checkFormatTypeSpec, formatTypeSpec } from "./formatter.js";
+import { Diagnostic, NoTarget } from "./index.js";
+import { createDiagnostic } from "./messages.js";
 import { normalizePath } from "./path-utils.js";
 
 export interface TypeSpecFormatOptions {
@@ -10,28 +12,43 @@ export interface TypeSpecFormatOptions {
   debug?: boolean;
 }
 
+export interface TypeSpecFormatResult {
+  formattedFiles: string[];
+}
+
 /**
  * Format all the TypeSpec files.
  * @param patterns List of wildcard pattern searching for TypeSpec files.
+ * @returns list of files which failed to format.
  */
 export async function formatTypeSpecFiles(
   patterns: string[],
   { exclude, debug }: TypeSpecFormatOptions
-) {
+): Promise<[TypeSpecFormatResult, readonly Diagnostic[]]> {
   const files = await findFiles(patterns, exclude);
+  const diagnostics: Diagnostic[] = [];
+  const formattedFiles: string[] = [];
   for (const file of files) {
     try {
       await formatTypeSpecFile(file);
+      formattedFiles.push(file);
     } catch (e) {
       if (e instanceof PrettierParserError) {
         const details = debug ? e.message : "";
-        // eslint-disable-next-line no-console
-        console.error(`File '${file}' failed to format. ${details}`);
+        diagnostics.push(
+          createDiagnostic({
+            code: "format-failed",
+            format: { file, details },
+            target: NoTarget,
+          })
+        );
       } else {
         throw e;
       }
     }
   }
+
+  return [{ formattedFiles }, diagnostics];
 }
 
 /**

--- a/packages/compiler/src/core/formatter-fs.ts
+++ b/packages/compiler/src/core/formatter-fs.ts
@@ -13,6 +13,9 @@ export interface TypeSpecFormatOptions {
 }
 
 export interface TypeSpecFormatResult {
+  /**
+   * The list of files which were formatted successfully, the paths of which are either relative or absolute based on the original file path patterns.
+   */
   formattedFiles: string[];
 }
 

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -653,6 +653,16 @@ const diagnostics = {
   },
 
   /**
+   * Formatter
+   */
+  "format-failed": {
+    severity: "error",
+    messages: {
+      default: paramMessage`File '${"file"}' failed to format. ${"details"}`,
+    },
+  },
+
+  /**
    * Decorator
    */
   "decorator-wrong-target": {


### PR DESCRIPTION
This PR fixes #2323 by returning a non-zero exit code upon any failure when `tsp format` is executed at the command line.  I'm also changing the return type of `formatTypeSpecFiles` to return a list of file paths that failed, not sure whether that explicitly qualifies as a breaking change.  If needed, I can create a new function to expose and wrap it with the original function without changing its signature.