### PR TITLE
Don't emit `deprecated` for type reference in deprecated declaration

### DIFF
--- a/common/changes/@typespec/compiler/no-double-deprecation_2023-09-25-12-54.json
+++ b/common/changes/@typespec/compiler/no-double-deprecation_2023-09-25-12-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Skip emit of `deprecated` diagnostic for a type reference that is used in a deprecated declaration statement",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -903,6 +903,7 @@ export function createChecker(program: Program): Checker {
         return checkDeprecatedNode(node);
       case SyntaxKind.IntersectionExpression:
       case SyntaxKind.UnionExpression:
+      case SyntaxKind.ModelProperty:
       case SyntaxKind.OperationSignatureDeclaration:
       case SyntaxKind.OperationSignatureReference:
         return isTypeReferenceContextDeprecated(node.parent!);

--- a/packages/compiler/test/checker/deprecation.test.ts
+++ b/packages/compiler/test/checker/deprecation.test.ts
@@ -342,8 +342,14 @@ describe("compiler: checker: deprecation", () => {
             #deprecated "OldBlah is deprecated"
             model OldBlah extends OldFoo {}
 
+            #deprecated "OldFooReference is deprecated"
             model OldFooReference {
               foo: OldFoo.foo;
+            }
+
+            #deprecated "OldFooProperty is deprecated"
+            model OldFooProperty {
+              foo: OldFoo;
             }
 
             #deprecated "OldBaz is deprecated"

--- a/packages/compiler/test/checker/deprecation.test.ts
+++ b/packages/compiler/test/checker/deprecation.test.ts
@@ -323,6 +323,58 @@ describe("compiler: checker: deprecation", () => {
 
       expectDiagnosticEmpty(diagnostics);
     });
+
+    describe("skips type deprecation warning when referenced in a deprecated parent context", () => {
+      it("deprecated model used in deprecated types", async () => {
+        await expectDeprecations(
+          `
+            #deprecated "OldFoo is deprecated"
+            model OldFoo {
+              foo: string;
+            }
+
+            #deprecated "oldOp is deprecated"
+            op oldOp(): OldFoo;
+
+            #deprecated "OldBar is deprecated"
+            model OldBar is OldFoo {}
+
+            #deprecated "OldBlah is deprecated"
+            model OldBlah extends OldFoo {}
+
+            model OldFooReference {
+              foo: OldFoo.foo;
+            }
+
+            #deprecated "OldBaz is deprecated"
+            interface OldBaz {
+              op oldBaz(): OldFoo;
+              op oldBazTwo(): string | OldFoo;
+              op oldBazThree(): OldFoo & { bar: string };
+            }
+          `,
+          []
+        );
+      });
+
+      it("deprecated operation used in deprecated types", async () => {
+        await expectDeprecations(
+          `
+            #deprecated "oldFoo is deprecated"
+            op oldFoo(): string;
+
+            #deprecated "oldBar is deprecated"
+            op oldBar is oldFoo;
+
+            #deprecated "OldBaz is deprecated"
+            interface OldBaz {
+              op oldBaz is oldBar;
+            }
+          `,
+          []
+        );
+      });
+    });
   });
 
   describe("@deprecated decorator", () => {


### PR DESCRIPTION
This PR fixes #2368 by checking the location where a type reference of a deprecate type is used and skipping the emit of `deprecated` for that reference if the parent declaration is also deprecated.  This should make diagnostics for files with multiple deprecations less noisy.

Let me know if I'm missing any other cases!