### PR TITLE
Add retries to Node and Rush install tasks

### DIFF
--- a/eng/pipelines/jobs/pull-request-consistency.yml
+++ b/eng/pipelines/jobs/pull-request-consistency.yml
@@ -7,8 +7,10 @@ steps:
       versionSpec: "16.x"
     displayName: Install Node.js
 
-  - script: node common/scripts/install-run-rush.js install --max-install-attempts 3
+  # purge before install to ensure a clean state between retries
+  - script: node common/scripts/install-run-rush.js install --purge
     displayName: Install JavaScript Dependencies
+    retryCountOnTaskFailure: 3
 
   - script: node common/scripts/install-run-rush.js change -v
     condition: and(succeeded(), not(or(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), startsWith(variables['System.PullRequest.SourceBranch'], 'backmerge/'))))

--- a/eng/pipelines/jobs/pull-request-consistency.yml
+++ b/eng/pipelines/jobs/pull-request-consistency.yml
@@ -2,15 +2,9 @@ steps:
   - checkout: self
     submodules: true
 
-  - task: NodeTool@0
-    inputs:
-      versionSpec: "16.x"
-    displayName: Install Node.js
-
-  # purge before install to ensure a clean state between retries
-  - script: node common/scripts/install-run-rush.js install --purge
-    displayName: Install JavaScript Dependencies
-    retryCountOnTaskFailure: 3
+  - template: ../templates/install.yml
+    parameters:
+      nodeVersion: "16.x"
 
   - script: node common/scripts/install-run-rush.js change -v
     condition: and(succeeded(), not(or(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), startsWith(variables['System.PullRequest.SourceBranch'], 'backmerge/'))))

--- a/eng/pipelines/jobs/pull-request-consistency.yml
+++ b/eng/pipelines/jobs/pull-request-consistency.yml
@@ -3,8 +3,6 @@ steps:
     submodules: true
 
   - template: ../templates/install.yml
-    parameters:
-      nodeVersion: "16.x"
 
   - script: node common/scripts/install-run-rush.js change -v
     condition: and(succeeded(), not(or(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), startsWith(variables['System.PullRequest.SourceBranch'], 'backmerge/'))))

--- a/eng/pipelines/pr-tryit.yml
+++ b/eng/pipelines/pr-tryit.yml
@@ -15,15 +15,9 @@ jobs:
       - checkout: self
         persistCredentials: true
 
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 16.x
-        displayName: Install Node.js
-
-      # purge before install to ensure a clean state between retries
-      - script: node common/scripts/install-run-rush.js install --purge
-        displayName: Install JavaScript Dependencies
-        retryCountOnTaskFailure: 3
+      - template: ../templates/install.yml
+        parameters:
+          nodeVersion: "16.x"
 
       - template: ./templates/build.yml
 

--- a/eng/pipelines/pr-tryit.yml
+++ b/eng/pipelines/pr-tryit.yml
@@ -20,8 +20,10 @@ jobs:
           versionSpec: 16.x
         displayName: Install Node.js
 
-      - script: node common/scripts/install-run-rush.js install --max-install-attempts 3
+      # purge before install to ensure a clean state between retries
+      - script: node common/scripts/install-run-rush.js install --purge
         displayName: Install JavaScript Dependencies
+        retryCountOnTaskFailure: 3
 
       - template: ./templates/build.yml
 

--- a/eng/pipelines/pr-tryit.yml
+++ b/eng/pipelines/pr-tryit.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout: self
         persistCredentials: true
 
-      - template: ../templates/install.yml
+      - template: ./templates/install.yml
         parameters:
           nodeVersion: "16.x"
 

--- a/eng/pipelines/pr-tryit.yml
+++ b/eng/pipelines/pr-tryit.yml
@@ -16,8 +16,6 @@ jobs:
         persistCredentials: true
 
       - template: ./templates/install.yml
-        parameters:
-          nodeVersion: "16.x"
 
       - template: ./templates/build.yml
 

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -9,6 +9,7 @@ steps:
     inputs:
       versionSpec: ${{ parameters.nodeVersion }}
     displayName: Install Node.js
+    retryCountOnTaskFailure: 3
 
   - task: UseDotNet@2
     inputs:
@@ -23,8 +24,15 @@ steps:
       dotnet --version
     displayName: "Log tool versions used"
 
-  - script: node common/scripts/install-run-rush.js install --max-install-attempts 3
+  # TODO: Purge before install, to ensure a clean state between retries.
+  # Append "|| cd ." to "rush purge" to ignore errors (works on both Windows and Linux) as a workaround
+  # for microsoft/rushstack#4334.
+  # node common/scripts/install-run-rush.js purge || cd .
+
+  - script: |
+      node common/scripts/install-run-rush.js install
     displayName: Install JavaScript Dependencies
+    retryCountOnTaskFailure: 3
 
   - script: dotnet restore
     displayName: Restore .NET Dependencies

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -25,8 +25,7 @@ steps:
     displayName: "Log tool versions used"
 
   # purge before install to ensure a clean state between retries
-  - script: |
-      node common/scripts/install-run-rush.js install --purge
+  - script: node common/scripts/install-run-rush.js install --purge
     displayName: Install JavaScript Dependencies
     retryCountOnTaskFailure: 3
 

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -24,13 +24,9 @@ steps:
       dotnet --version
     displayName: "Log tool versions used"
 
-  # TODO: Purge before install, to ensure a clean state between retries.
-  # Append "|| cd ." to "rush purge" to ignore errors (works on both Windows and Linux) as a workaround
-  # for microsoft/rushstack#4334.
-  # node common/scripts/install-run-rush.js purge || cd .
-
+  # purge before install to ensure a clean state between retries
   - script: |
-      node common/scripts/install-run-rush.js install
+      node common/scripts/install-run-rush.js install --purge
     displayName: Install JavaScript Dependencies
     retryCountOnTaskFailure: 3
 


### PR DESCRIPTION
- Partially fixes Azure/typespec-azure#3630

Verification that `rush install --purge` with retries solves the problem with `prettier` install:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=3114195&view=logs&j=b4d1f14e-3dbb-5058-5996-5516c720cb93&t=8447d1d6-d904-5fcc-4271-269f1a9728f0&l=238