### PR TITLE
Fix bug with renamedFrom resulting in duplicate properties

### DIFF
--- a/common/changes/@typespec/versioning/versioning-RenamedFromBug_2023-09-27-22-20.json
+++ b/common/changes/@typespec/versioning/versioning-RenamedFromBug_2023-09-27-22-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "Ensure that use of `@renamedFrom` does not result in duplicate properties on a model.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -89,6 +89,12 @@ const libDef = {
         default: paramMessage`Property '${"name"}' marked with @madeOptional but is required. Should be '${"name"}?'`,
       },
     },
+    "renamed-duplicate-property": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Property '${"name"}' marked with '@renamedFrom' conflicts with existing property in version ${"version"}.`,
+      },
+    }
   },
 } as const;
 export const { reportDiagnostic, createStateSymbol } = createTypeSpecLibrary(libDef);

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -94,7 +94,7 @@ const libDef = {
       messages: {
         default: paramMessage`Property '${"name"}' marked with '@renamedFrom' conflicts with existing property in version ${"version"}.`,
       },
-    }
+    },
   },
 } as const;
 export const { reportDiagnostic, createStateSymbol } = createTypeSpecLibrary(libDef);

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -245,8 +245,6 @@ function getVersionedNameMap(
     case "UnionVariant":
       if (typeof source.name === "string") {
         lastName = source.name;
-      } else if (typeof source.name === "symbol") {
-        lastName = source.name.description;
       }
       break;
     case "EnumMember":

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -3,10 +3,13 @@ import {
   getService,
   getTypeName,
   isTemplateInstance,
+  Model,
+  ModelProperty,
   Namespace,
   navigateProgram,
   NoTarget,
   Program,
+  RekeyableMap,
   Type,
 } from "@typespec/compiler";
 import { reportDiagnostic } from "./lib.js";
@@ -16,6 +19,7 @@ import {
   findVersionedNamespace,
   getAvailabilityMap,
   getMadeOptionalOn,
+  getRenamedFrom,
   getReturnTypeChangedFrom,
   getTypeChangedFrom,
   getUseDependencies,
@@ -65,6 +69,7 @@ export function $onValidate(program: Program) {
           // Validate model property type is correct when madeOptional
           validateMadeOptional(program, prop);
         }
+        validateVersionedPropertyNames(program, model);
       },
       union: (union) => {
         // If this is an instantiated type we don't want to keep the mapping.
@@ -205,6 +210,65 @@ function validateMultiTypeReference(program: Program, source: Type) {
   }
 }
 
+
+/**
+ * Constructs a map of version to name for the the source.
+ */
+function getVersionedNameMap(
+  program: Program,
+  source: Type
+): Map<Version, string | undefined> | undefined {
+  const allVersions = getAllVersions(program, source);
+  if (allVersions === undefined) return undefined;
+
+  const map: Map<Version, string | undefined> = new Map(allVersions.map((v) => [v, undefined]));
+  const availMap = getAvailabilityMap(program, source);
+  const alwaysAvail = availMap === undefined;
+
+  // Populate the map with any RenamedFrom data, which may have holes.
+  // We will fill these holes in a later pass.
+  const renamedFrom = getRenamedFrom(program, source);
+  if (renamedFrom !== undefined) {
+    for (const rename of renamedFrom) {
+      const version = rename.version;
+      const oldName = rename.oldName;
+      const versionIndex = allVersions.indexOf(version);
+      if (versionIndex !== -1) {
+        map.set(allVersions[versionIndex - 1], oldName);
+      }
+    }
+  }
+  let lastName: string | undefined = undefined;
+  switch (source.kind) {
+    case "ModelProperty":
+      lastName = source.name;
+      break;
+    default:
+      throw new Error(`Not implemented '${source.kind}'.`);
+  }
+  for (const version of allVersions.reverse()) {
+    const isAvail =
+      alwaysAvail ||
+      [Availability.Added, Availability.Available].includes(availMap.get(version.name)!);
+
+    // If property is unavailable in this version, it can't have a type
+    if (!isAvail) {
+      map.set(version, undefined);
+      continue;
+    }
+
+    // Working backwards, we fill in any holes from the last type we encountered. Since we expect
+    // to encounter a hole at the start, we use the raw property type
+    const mapType = map.get(version);
+    if (mapType !== undefined) {
+      lastName = mapType;
+    } else {
+      map.set(version, lastName);
+    }
+  }
+  return map;
+}
+
 /**
  * Constructs a map of version to type for the the source.
  */
@@ -298,6 +362,48 @@ function validateVersionedNamespaceUsage(
             targetNs: getNamespaceFullName(target),
           },
           target: source ?? NoTarget,
+        });
+      }
+    }
+  }
+}
+
+function validateVersionedPropertyNames(program: Program, source: Model) {
+  const allVersions = getAllVersions(program, source);
+  if (allVersions === undefined) return;
+
+  const versionedNameMap = new Map<Version, string[]>(
+    allVersions.map((v) => [v, []])
+  );
+
+  for (const property of source.properties.values()) {
+    const nameMap = getVersionedNameMap(program, property);
+    if (nameMap === undefined) continue;
+    for (const [version, name] of nameMap) {
+      if (name === undefined) continue;
+      versionedNameMap.get(version)?.push(name);
+    }
+  }
+  
+  // for each version, ensure there are no duplicate property names
+  for (const [version, names] of versionedNameMap.entries()) {
+    // create a map with names to count of occurrences
+    const nameCounts = new Map<string, number>();
+    for (const name of names) {
+      const count = nameCounts.get(name) ?? 0;
+      nameCounts.set(name, count + 1);
+    }
+    // emit diagnostic for each duplicate name
+    for (const [name, count] of nameCounts.entries()) {
+      if (name === undefined) continue;
+      if (count > 1) {
+        reportDiagnostic(program, {
+          code: "renamed-duplicate-property",
+          format: {
+            name: name,
+            version: prettyVersion(version),
+          },
+          target: source,
         });
       }
     }

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -179,7 +179,10 @@ export function $madeOptional(context: DecoratorContext, t: ModelProperty, v: En
   program.stateMap(madeOptionalKey).set(t, version);
 }
 
-function getRenamedFrom(p: Program, t: Type): Array<RenamedFrom> | undefined {
+/**
+ * @returns the array of RenamedFrom metadata if applicable.
+ */
+export function getRenamedFrom(p: Program, t: Type): Array<RenamedFrom> | undefined {
   return p.stateMap(renamedFromKey).get(t) as Array<RenamedFrom>;
 }
 

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -11,7 +11,7 @@ import {
   Type,
   Union,
 } from "@typespec/compiler";
-import { BasicTestRunner, createTestWrapper } from "@typespec/compiler/testing";
+import { BasicTestRunner, createTestWrapper, expectDiagnostics } from "@typespec/compiler/testing";
 import { fail, ok, strictEqual } from "assert";
 import { Version } from "../src/types.js";
 import { VersioningTimeline } from "../src/versioning-timeline.js";
@@ -67,6 +67,36 @@ describe("versioning: logic", () => {
   });
 
   describe("models", () => {
+    it("@renamedFrom emits diagnostic for incorrect usage", async () => {
+      const code = `
+      model Test {
+        @key id: string;
+        weight: int32;
+        @renamedFrom(Versions.v3, "color") shade: string;
+        @added(Versions.v2)
+        color: string;
+      }
+      `;
+
+      const {
+        source,
+        projections: [v1, v2, v3],
+      } = await versionedModel(
+        ["v1", "v2", "v3"],
+        code
+      );
+      const prop1 = [...v1.properties.values()];
+      const prop2 = [...v2.properties.values()];
+      const prop3 = [...v3.properties.values()];
+      const test = "best";
+      // const diagnostics = await runner.diagnose(code);
+      // expectDiagnostics(diagnostics, {
+      //   code: "invalid-argument",
+      //   message:
+      //     "Argument '[[VersionedLib.Versions.l1, VersionedLib.Versions.l1]]' is not assignable to parameter of type 'EnumMember'",
+      // });
+    });
+
     it("can be renamed", async () => {
       const {
         source,

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -67,36 +67,6 @@ describe("versioning: logic", () => {
   });
 
   describe("models", () => {
-    it("@renamedFrom emits diagnostic when duplicate properties result", async () => {
-      const code = `
-      @versioned(Versions)
-      @service({
-        title: "Widget Service",
-      })
-      namespace DemoService;
-
-      enum Versions {
-        "v1",
-        "v2",
-        "v3",
-      }
-      
-      model Test {
-        @key id: string;
-        weight: int32;
-        @renamedFrom(Versions.v3, "color") shade: string;
-        @added(Versions.v2)
-        color: string;
-      }
-      `;
-      const diagnostics = await runner.diagnose(code);
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/versioning/renamed-duplicate-property",
-        message:
-          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v2.",
-      });
-    });
-
     it("can be renamed", async () => {
       const {
         source,
@@ -360,6 +330,36 @@ describe("versioning: logic", () => {
       );
     });
 
+    it("emits diagnostic when renaming causes duplicates", async () => {
+      const code = `
+      @versioned(Versions)
+      @service({
+        title: "Widget Service",
+      })
+      namespace DemoService;
+
+      enum Versions {
+        "v1",
+        "v2",
+        "v3",
+      }
+      
+      model Test {
+        @key id: string;
+        weight: int32;
+        @renamedFrom(Versions.v3, "color") shade: string;
+        @added(Versions.v2)
+        color: string;
+      }
+      `;
+      const diagnostics = await runner.diagnose(code);
+      expectDiagnostics(diagnostics, {
+        code: "@typespec/versioning/renamed-duplicate-property",
+        message:
+          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v2.",
+      });
+    });
+
     it("can be added/removed multiple times", async () => {
       const {
         source,
@@ -500,6 +500,7 @@ describe("versioning: logic", () => {
         source
       );
     });
+
     it("can be added", async () => {
       const {
         projections: [v1, v2],
@@ -695,6 +696,32 @@ describe("versioning: logic", () => {
       assertHasVariants(v3, ["c"]);
       assertHasVariants(v4, ["c"]);
       assertHasVariants(v5, ["d"]);
+    });
+
+    it("emits diagnostic when renaming causes duplicates", async () => {
+      const code = `
+      @versioned(Versions)
+      @service({
+        title: "Widget Service",
+      })
+      namespace DemoService;
+
+      enum Versions {
+        "v1",
+        "v2",
+      }
+
+      union BadUnion {
+        color: string,
+        @renamedFrom(Versions.v2, "color") shade: string;
+      }      
+      `;
+      const diagnostics = await runner.diagnose(code);
+      expectDiagnostics(diagnostics, {
+        code: "@typespec/versioning/renamed-duplicate-property",
+        message:
+          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v2.",
+      });
     });
 
     it("can be added/removed multiple times", async () => {
@@ -1625,6 +1652,32 @@ describe("versioning: logic", () => {
       assertHasMembers(v3, ["c"]);
       assertHasMembers(v4, ["c"]);
       assertHasMembers(v5, ["d"]);
+    });
+
+    it("emits diagnostic when renaming causes duplicates", async () => {
+      const code = `
+      @versioned(Versions)
+      @service({
+        title: "Widget Service",
+      })
+      namespace DemoService;
+
+      enum Versions {
+        "v1",
+        "v2",
+      }
+      
+      enum BadEnum {
+        color,
+        @renamedFrom(Versions.v2, "color") shade;
+      }
+      `;
+      const diagnostics = await runner.diagnose(code);
+      expectDiagnostics(diagnostics, {
+        code: "@typespec/versioning/renamed-duplicate-property",
+        message:
+          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v2.",
+      });
     });
 
     it("can be added/removed multiple times", async () => {

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -720,7 +720,7 @@ describe("versioning: logic", () => {
       expectDiagnostics(diagnostics, {
         code: "@typespec/versioning/renamed-duplicate-property",
         message:
-          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v2.",
+          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v1.",
       });
     });
 
@@ -1676,7 +1676,7 @@ describe("versioning: logic", () => {
       expectDiagnostics(diagnostics, {
         code: "@typespec/versioning/renamed-duplicate-property",
         message:
-          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v2.",
+          "Property 'color' marked with '@renamedFrom' conflicts with existing property in version v1.",
       });
     });
 


### PR DESCRIPTION
Fix #1244.

**TODO** 
- [x] Fix for Model Properties
- [x] Fix for union variants
- [x] Fix for enum members
- [x] <del>Evaluate if this is relevant for operations</del> already covered