### PR TITLE
Fix init config

### DIFF
--- a/common/changes/@typespec/compiler/fix-init-config_2023-09-28-18-02.json
+++ b/common/changes/@typespec/compiler/fix-init-config_2023-09-28-18-02.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: `tsp init` was not creating the `tspconfig.yaml` file for templates that specified it",
+      "type": "none"
+    },
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix: `tsp init` will create a placeholder `tspconfig.yaml` file for templates that don't specify an explicit one.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/init/init.ts
+++ b/packages/compiler/src/init/init.ts
@@ -111,6 +111,7 @@ export function makeScaffoldingConfig(config: Partial<ScaffoldingConfig>): Scaff
     skipCompilerPackage: config.skipCompilerPackage ?? false,
     folderName: config.folderName ?? "",
     parameters: config.parameters ?? {},
+    config: config.config,
     normalizeVersion: config.normalizeVersion ?? normalizeVersion,
     toLowerCase: config.toLowerCase ?? toLowerCase,
     normalizePackageName: config.normalizePackageName ?? normalizePackageName,
@@ -168,6 +169,7 @@ export async function initTypeSpecProject(
     toLowerCase,
     normalizePackageName,
   });
+
   await scaffoldNewProject(host, scaffoldingConfig);
 
   // eslint-disable-next-line no-console
@@ -223,7 +225,7 @@ const builtInTemplates: Record<string, InitTemplate> = {
     title: "Generic Rest API",
     description: "Create a project representing a generic Rest API",
     compilerVersion: MANIFEST.version,
-    libraries: ["@typespec/rest", "@typespec/openapi3"],
+    libraries: ["@typespec/http", "@typespec/rest", "@typespec/openapi3"],
     config: {
       emit: ["@typespec/openapi3"],
     },
@@ -422,14 +424,29 @@ async function writePackageJson(host: CompilerHost, config: ScaffoldingConfig) {
   );
 }
 
+const placeholderConfig = `
+# extends: ../tspconfig.yaml                    # Extend another config file
+# emit:                                         # Emitter name
+#   - "<emitter-name"
+# options:                                      # Emitter options
+#   <emitter-name>:
+#    "<option-name>": "<option-value>"
+# environment-variables:                        # Environment variables which can be used to interpolate emitter options
+#   <variable-name>:
+#     default: "<variable-default>"
+# parameters:                                   # Parameters which can be used to interpolate emitter options
+#   <param-name>:
+#     default: "<param-default>"
+# trace:                                        # Trace areas to enable tracing
+#  - "<trace-name>"
+# warn-as-error: true                           # Treat warnings as errors
+# output-dir: "{project-root}/_generated"       # Configure the base output directory for all emitters
+`.trim();
 async function writeConfig(host: CompilerHost, config: ScaffoldingConfig) {
   if (isFileSkipGeneration(TypeSpecConfigFilename, config.files ?? [])) {
     return;
   }
-  if (!config.config) {
-    return;
-  }
-  const content = stringify(config.config);
+  const content = config.config ? stringify(config.config) : placeholderConfig;
   return host.writeFile(joinPaths(config.directory, TypeSpecConfigFilename), content);
 }
 


### PR DESCRIPTION
fix #2357 

Fix template that provided a programatic config

If a template doesn't provide a config it will still create an empty one 

```
# extends: ../tspconfig.yaml                    # Extend another config file
# emit:                                         # Emitter name
#   - "<emitter-name"
# options:                                      # Emitter options
#   <emitter-name>:
#    "<option-name>": "<option-value>"
# environment-variables:                        # Environment variables which can be used to interpolate emitter options
#   <variable-name>:
#     default: "<variable-default>"
# parameters:                                   # Parameters which can be used to interpolate emitter options
#   <param-name>:
#     default: "<param-default>"
# trace:                                        # Trace areas to enable tracing
#  - "<trace-name>"
# warn-as-error: true                           # Treat warnings as errors
# output-dir: "{project-root}/_generated"       # Configure the base output directory for all emitters
```