### PR TITLE
Force upgrade dependency "node-fetch" from 3.2.8 to 3.3.2

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -90,7 +90,8 @@
    */
   "globalOverrides": {
     "trim@0.0.1": "0.0.3",
-    "update-notifier@^5.1.0": "^6.0.2"
+    "update-notifier@^5.1.0": "^6.0.2",
+    "node-fetch@3.2.8": "^3.3.2"
     // "example1": "^1.0.0",
     // "example2": "npm:@company/example2@^1.0.0"
   },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   trim@0.0.1: 0.0.3
   update-notifier@^5.1.0: ^6.0.2
+  node-fetch@3.2.8: ^3.3.2
 
 importers:
 
@@ -3081,7 +3082,7 @@ packages:
       js-yaml: 4.1.0
       mkdirp: 1.0.4
       mustache: 4.2.0
-      node-fetch: 3.2.8
+      node-fetch: 3.3.2
       node-watch: 0.7.4
       picocolors: 1.0.0
       prettier: 2.7.1
@@ -3103,7 +3104,7 @@ packages:
       js-yaml: 4.1.0
       mkdirp: 1.0.4
       mustache: 4.2.0
-      node-fetch: 3.2.8
+      node-fetch: 3.3.2
       node-watch: 0.7.4
       picocolors: 1.0.0
       prettier: 2.7.1
@@ -3125,7 +3126,7 @@ packages:
       js-yaml: 4.1.0
       mkdirp: 1.0.4
       mustache: 4.2.0
-      node-fetch: 3.2.8
+      node-fetch: 3.3.2
       node-watch: 0.7.4
       picocolors: 1.0.0
       prettier: 2.8.8
@@ -7386,7 +7387,7 @@ packages:
       js-yaml: 4.1.0
       mkdirp: 1.0.4
       mustache: 4.2.0
-      node-fetch: 3.2.8
+      node-fetch: 3.3.2
       node-watch: 0.7.4
       picocolors: 1.0.0
       prettier: 2.8.8
@@ -7408,7 +7409,7 @@ packages:
       js-yaml: 4.1.0
       mkdirp: 1.0.4
       mustache: 4.2.0
-      node-fetch: 3.2.8
+      node-fetch: 3.3.2
       node-watch: 0.7.4
       picocolors: 1.0.0
       prettier: 2.8.8
@@ -13119,8 +13120,8 @@ packages:
       whatwg-url: 5.0.0
     dev: false
 
-  /node-fetch@3.2.8:
-    resolution: {integrity: sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==}
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       data-uri-to-buffer: 4.0.1


### PR DESCRIPTION
- Used by @cadl-lang/compiler, which is used by packages/migrate
