### PR TITLE
Resolve property reference type when checking if assignable

### DIFF
--- a/common/changes/@typespec/compiler/fix-property-reference-comparison_2023-10-02-13-31.json
+++ b/common/changes/@typespec/compiler/fix-property-reference-comparison_2023-10-02-13-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Resolve property reference type when checking if assignable",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -5323,8 +5323,16 @@ export function createChecker(program: Program): Checker {
           );
         }
       } else {
+        // It is possible that the property type is a reference to another
+        // property so make sure we're comparing against the referenced
+        // property's type and not the ModelProperty itself
+        const sourcePropertyType =
+          sourceProperty.type.kind === "ModelProperty"
+            ? sourceProperty.type.type
+            : sourceProperty.type;
+
         const [related, propDiagnostics] = isTypeAssignableToInternal(
-          sourceProperty.type,
+          sourcePropertyType,
           prop.type,
           diagnosticTarget,
           relationCache

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -668,6 +668,14 @@ describe("compiler: checker: type relations", () => {
       });
     });
 
+    it("can assign object with property reference that is assignable", async () => {
+      await expectTypeAssignable({
+        source: "{ name: Foo.name }",
+        target: "{ name: string }",
+        commonCode: `model Foo { name: string; }`,
+      });
+    });
+
     it("emit diagnostic when required property is missing", async () => {
       await expectTypeNotAssignable(
         { source: `{foo: "abc"}`, target: `{foo: string, bar: string}` },
@@ -695,6 +703,20 @@ describe("compiler: checker: type relations", () => {
         {
           code: "unassignable",
           message: "Type 'string[] | int32[]' is not assignable to type '{}'",
+        }
+      );
+    });
+
+    it("emit diagnostic when property reference type is not assignable", async () => {
+      await expectTypeNotAssignable(
+        {
+          source: "{ name: Foo.name }",
+          target: "{ name: string }",
+          commonCode: `model Foo { name: int32; }`,
+        },
+        {
+          code: "unassignable",
+          message: "Type 'int32' is not assignable to type 'string'",
         }
       );
     });


### PR DESCRIPTION
This change fixes #2498 which reports that property references are not resolved when checking if two model types are assignable.  Here is the repro:

```
model Props {
  name: string;
}

model Foo<T extends Props> {
  ...T
}

alias UseFoo = Foo<{ name: Props.name; }>;
```

The template constraint check fails saying that `Foo.name` is not assignable to `string`.