### PR TITLE
Fix linter rule docs using `:` instead of `/` as separator

### DIFF
--- a/docs/extending-typespec/linters.md
+++ b/docs/extending-typespec/linters.md
@@ -109,10 +109,10 @@ export const $lib = createTypeSpecLibrary({
     ruleSets: {
       recommended: {
         // (optional) A ruleset takes a map of rules to explicitly enable
-        enable: { [`@typespec/my-linter:${requiredDocRule.name}`]: true },
+        enable: { [`@typespec/my-linter/${requiredDocRule.name}`]: true },
 
         // (optional) A rule set can extend another rule set
-        extends: ["@typespec/best-practices:recommended"],
+        extends: ["@typespec/best-practices/recommended"],
 
         // (optional) A rule set can disable a rule enabled in a ruleset it extended.
         disable: {

--- a/docs/extending-typespec/linters.md
+++ b/docs/extending-typespec/linters.md
@@ -116,7 +116,7 @@ export const $lib = createTypeSpecLibrary({
 
         // (optional) A rule set can disable a rule enabled in a ruleset it extended.
         disable: {
-          "`@typespec/best-practices:no-a": "This doesn't apply in this ruleset.",
+          "`@typespec/best-practices/no-a": "This doesn't apply in this ruleset.",
         },
       },
     },
@@ -124,7 +124,7 @@ export const $lib = createTypeSpecLibrary({
 });
 ```
 
-When referencing a rule or ruleset(in `enable`, `extends`, `disable`) the rule or rule set id must be used which in this format: `<libraryName>:<ruleName>`
+When referencing a rule or ruleset(in `enable`, `extends`, `disable`) the rule or rule set id must be used which in this format: `<libraryName>/<ruleName>`
 
 ## Testing a linter
 
@@ -147,7 +147,7 @@ describe("required-doc rule", () => {
 
   it("emit diagnostics when using model named foo", async () => {
     await ruleTester.expect(`model Foo {}`).toEmitDiagnostics({
-      code: "@typespec/my-linter:no-foo-model",
+      code: "@typespec/my-linter/no-foo-model",
       message: "Cannot name a model with 'Foo'",
     });
   });

--- a/docs/introduction/configuration/configuration.md
+++ b/docs/introduction/configuration/configuration.md
@@ -316,13 +316,13 @@ Configure which linter rules should be enabled in this repository. Referencing t
 ```yaml
 linter:
   extends: # Extend `recommended` ruleset from @typespec/best-practices library
-    - "@typespec/best-practices:recommended"
+    - "@typespec/best-practices/recommended"
 
   enable: # Explicitly enable some rules
-    "@typespec/best-practices:no-x": true
+    "@typespec/best-practices/no-x": true
 
   disable: # Disable some rules defined in one of the ruleset extended.
-    "@typespec/best-practices:no-y": "This rule cannot be applied in this project because X"
+    "@typespec/best-practices/no-y": "This rule cannot be applied in this project because X"
 ```
 
 ## Emitter control cli flags

--- a/packages/best-practices/src/lib.ts
+++ b/packages/best-practices/src/lib.ts
@@ -8,7 +8,7 @@ export const $lib = createTypeSpecLibrary({
     rules: [casingRule],
     ruleSets: {
       recommended: {
-        enable: { [`@typespec/best-practices:${casingRule.name}`]: true },
+        enable: { [`@typespec/best-practices/${casingRule.name}`]: true },
       },
     },
   },


### PR DESCRIPTION
fix #2520