### PR TITLE
Fix: `tsp init` ignoring files in templates

### DIFF
--- a/common/changes/@typespec/compiler/fix-issue-with-tsp-init_2023-10-10-20-42.json
+++ b/common/changes/@typespec/compiler/fix-issue-with-tsp-init_2023-10-10-20-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Fix `tsp init` was ignoring the `files` specified in an init template",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/init/init.ts
+++ b/packages/compiler/src/init/init.ts
@@ -112,6 +112,7 @@ export function makeScaffoldingConfig(config: Partial<ScaffoldingConfig>): Scaff
     folderName: config.folderName ?? "",
     parameters: config.parameters ?? {},
     config: config.config,
+    files: config.files,
     normalizeVersion: config.normalizeVersion ?? normalizeVersion,
     toLowerCase: config.toLowerCase ?? toLowerCase,
     normalizePackageName: config.normalizePackageName ?? normalizePackageName,

--- a/packages/compiler/test/init/init-template.test.ts
+++ b/packages/compiler/test/init/init-template.test.ts
@@ -24,13 +24,6 @@ describe("compiler: init: templates", () => {
         name: "test-template",
         folderName: "test-template",
         description: "This is only a test.",
-        files: [
-          {
-            path: "./main.tsp",
-            destination: "main.tsp",
-            skipGeneration: false,
-          },
-        ],
         ...config,
       })
     );


### PR DESCRIPTION
Not sure since when this has been broken but `files` entry were completely ignored.