### PR TITLE
Don't build website in ci

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -13,6 +13,10 @@ jobs:
     pool:
       name: azsdk-pool-mms-win-2022-general
       vmImage: windows-2022
+
+    variables:
+      TYPESPEC_SKIP_DOCUSAURUS_BUILD: true # Disable docusaurus build
+
     steps:
       - template: ./templates/install.yml
         parameters:
@@ -48,6 +52,10 @@ jobs:
     pool:
       name: azsdk-pool-mms-win-2022-general
       vmImage: windows-2022
+
+    variables:
+      TYPESPEC_SKIP_DOCUSAURUS_BUILD: true # Disable docusaurus build
+
     steps:
       - template: ./templates/install.yml
         parameters:


### PR DESCRIPTION
We don't need to build the website in the ci.yml, it just slows down the build a lot, we also build it twice (stable and dev)