### PR TITLE
Stop publishing `@typespec/lint`

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -106,7 +106,7 @@
       "packageName": "@typespec/lint",
       "projectFolder": "packages/lint",
       "reviewCategory": "production",
-      "versionPolicyName": "typespec"
+      "shouldPublish": false
     },
     {
       "packageName": "@typespec/migrate",


### PR DESCRIPTION
Also marked the package as deprecated on npm https://www.npmjs.com/package/@typespec/lint

We should probably move package to archive branch too