### PR TITLE
Update targets for Versioning decorators

### DIFF
--- a/common/changes/@typespec/versioning/versioning-narrowTargets_2023-10-17-21-22.json
+++ b/common/changes/@typespec/versioning/versioning-narrowTargets_2023-10-17-21-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "Update targets for `@added`, `@removed`, `@renamedFrom`, `@madeOptional` and `@typeChangedFrom` to more clearly communicate where they can be used.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/docs/standard-library/versioning/reference/decorators.md
+++ b/docs/standard-library/versioning/reference/decorators.md
@@ -18,7 +18,7 @@ Identifies when the target was added.
 
 #### Target
 
-`(intrinsic) unknown`
+`union Model | ModelProperty | Operation | Enum | EnumMember | Union | UnionVariant | Scalar | Interface`
 
 #### Parameters
 
@@ -53,7 +53,7 @@ Identifies when a target was made optional.
 
 #### Target
 
-`(intrinsic) unknown`
+`ModelProperty`
 
 #### Parameters
 
@@ -82,7 +82,7 @@ Identifies when the target was removed.
 
 #### Target
 
-`(intrinsic) unknown`
+`union Model | ModelProperty | Operation | Enum | EnumMember | Union | UnionVariant | Scalar | Interface`
 
 #### Parameters
 
@@ -117,7 +117,7 @@ Identifies when the target has been renamed.
 
 #### Target
 
-`(intrinsic) unknown`
+`union Model | ModelProperty | Operation | Enum | EnumMember | Union | UnionVariant | Scalar | Interface`
 
 #### Parameters
 
@@ -162,7 +162,7 @@ Identifies when the target type changed.
 
 #### Target
 
-`(intrinsic) unknown`
+`ModelProperty`
 
 #### Parameters
 

--- a/packages/versioning/README.md
+++ b/packages/versioning/README.md
@@ -67,7 +67,7 @@ Identifies when the target was added.
 
 ##### Target
 
-`(intrinsic) unknown`
+`union Model | ModelProperty | Operation | Enum | EnumMember | Union | UnionVariant | Scalar | Interface`
 
 ##### Parameters
 
@@ -102,7 +102,7 @@ Identifies when a target was made optional.
 
 ##### Target
 
-`(intrinsic) unknown`
+`ModelProperty`
 
 ##### Parameters
 
@@ -131,7 +131,7 @@ Identifies when the target was removed.
 
 ##### Target
 
-`(intrinsic) unknown`
+`union Model | ModelProperty | Operation | Enum | EnumMember | Union | UnionVariant | Scalar | Interface`
 
 ##### Parameters
 
@@ -166,7 +166,7 @@ Identifies when the target has been renamed.
 
 ##### Target
 
-`(intrinsic) unknown`
+`union Model | ModelProperty | Operation | Enum | EnumMember | Union | UnionVariant | Scalar | Interface`
 
 ##### Parameters
 
@@ -211,7 +211,7 @@ Identifies when the target type changed.
 
 ##### Target
 
-`(intrinsic) unknown`
+`ModelProperty`
 
 ##### Parameters
 

--- a/packages/versioning/lib/decorators.tsp
+++ b/packages/versioning/lib/decorators.tsp
@@ -71,7 +71,19 @@ namespace TypeSpec {
      * }
      * ```
      */
-    extern dec added(target: unknown, version: EnumMember);
+    extern dec added(
+      target:
+        | Model
+        | ModelProperty
+        | Operation
+        | Enum
+        | EnumMember
+        | Union
+        | UnionVariant
+        | Scalar
+        | Interface,
+      version: EnumMember
+    );
 
     /**
      * Identifies when the target was removed.
@@ -93,7 +105,19 @@ namespace TypeSpec {
      * }
      * ```
      */
-    extern dec removed(target: unknown, version: EnumMember);
+    extern dec removed(
+      target:
+        | Model
+        | ModelProperty
+        | Operation
+        | Enum
+        | EnumMember
+        | Union
+        | UnionVariant
+        | Scalar
+        | Interface,
+      version: EnumMember
+    );
 
     /**
      * Identifies when the target has been renamed.
@@ -106,7 +130,20 @@ namespace TypeSpec {
      * op newName(): void;
      * ```
      */
-    extern dec renamedFrom(target: unknown, version: EnumMember, oldName: valueof string);
+    extern dec renamedFrom(
+      target:
+        | Model
+        | ModelProperty
+        | Operation
+        | Enum
+        | EnumMember
+        | Union
+        | UnionVariant
+        | Scalar
+        | Interface,
+      version: EnumMember,
+      oldName: valueof string
+    );
 
     /**
      * Identifies when a target was made optional.
@@ -122,14 +159,14 @@ namespace TypeSpec {
      * }
      * ```
      */
-    extern dec madeOptional(target: unknown, version: EnumMember);
+    extern dec madeOptional(target: ModelProperty, version: EnumMember);
 
     /**
      * Identifies when the target type changed.
      * @param version The version that the target type changed in.
      * @param oldType The previous type of the target.
      */
-    extern dec typeChangedFrom(target: unknown, version: EnumMember, oldType: unknown);
+    extern dec typeChangedFrom(target: ModelProperty, version: EnumMember, oldType: unknown);
 
     /**
      * Identifies when the target type changed.


### PR DESCRIPTION
Fix #2497.

Clarifies which TypeSpec types these decorators can _actually_ be used on by-design. 

**BREAKING CHANGE** This is a breaking change because if unsupported elements were previously decorated with these (i.e. Namespaces) those will now throw an error. 