### PR TITLE
Error out if model spreads itself in its declaration

### DIFF
--- a/common/changes/@typespec/compiler/modelSpreadSelfError_2023-10-18-23-19.json
+++ b/common/changes/@typespec/compiler/modelSpreadSelfError_2023-10-18-23-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "Issue error if a model spreads itself within its declaration.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -2741,7 +2741,12 @@ export function createChecker(program: Program): Checker {
       function checkForSelfReference(node: ModelSpreadPropertyNode, parent: ModelStatementNode) {
         let targetName = "";
         let parentName = "";
-        if (node.target.target.kind === SyntaxKind.Identifier) {
+
+        let targetRef = resolveTypeReferenceSym(node.target, undefined);
+        if (targetRef && targetRef.flags & SymbolFlags.Alias) {
+          targetRef = resolveAliasedSymbol(targetRef);
+          targetName = targetRef?.name ?? "";
+        } else if (node.target.target.kind === SyntaxKind.Identifier) {
           targetName = node.target.target.sv;
         }
         if (parent.kind === SyntaxKind.ModelStatement) {

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -367,6 +367,7 @@ const diagnostics = {
     messages: {
       default: "Cannot spread properties of non-model type.",
       neverIndex: "Cannot spread type because it cannot hold properties.",
+      selfSpread: "Cannot spread type within its own declaration.",
     },
   },
   "unsupported-default": {

--- a/packages/compiler/test/checker/spread.test.ts
+++ b/packages/compiler/test/checker/spread.test.ts
@@ -79,6 +79,21 @@ describe("compiler: spread", () => {
     });
   });
 
+  it("emit diagnostic if model spreads itself through alias", async () => {
+    const diagnostics = await runner.diagnose(`
+      model Foo {
+        ...Bar,
+        name: string,
+      }
+      alias Bar = Foo;
+      `);
+
+    expectDiagnostics(diagnostics, {
+      code: "spread-model",
+      message: "Cannot spread type within its own declaration.",
+    });
+  });
+
   it("emit diagnostic if spreading scalar type", async () => {
     const diagnostics = await runner.diagnose(`
       model Foo {

--- a/packages/compiler/test/checker/spread.test.ts
+++ b/packages/compiler/test/checker/spread.test.ts
@@ -65,6 +65,20 @@ describe("compiler: spread", () => {
     });
   });
 
+  it("emit diagnostic if model spreads itself", async () => {
+    const diagnostics = await runner.diagnose(`
+      model Foo {
+        ...Foo,
+        name: string,
+      }
+      `);
+
+    expectDiagnostics(diagnostics, {
+      code: "spread-model",
+      message: "Cannot spread type within its own declaration.",
+    });
+  });
+
   it("emit diagnostic if spreading scalar type", async () => {
     const diagnostics = await runner.diagnose(`
       model Foo {


### PR DESCRIPTION
Fix #2543.

**BREAKING CHANGE** If a spec had something like this:
```
Model Foo {
  ...Foo
  name: string;
}
```

Previously that would have compiled. Now it will throw and error. 