### PR TITLE
Fix: Rekey in Rekeyable map shouldn't keep target item if rekeying to existing key

### DIFF
--- a/packages/compiler/src/core/util.ts
+++ b/packages/compiler/src/core/util.ts
@@ -585,6 +585,10 @@ class RekeyableMapImpl<K, V> implements RekeyableMap<K, V> {
       return false;
     }
     this.#keys.delete(existingKey);
+    const newKeyItem = this.#keys.get(newKey);
+    if (newKeyItem) {
+      this.#values.delete(newKeyItem);
+    }
     keyItem.key = newKey;
     this.#keys.set(newKey, keyItem);
     return true;

--- a/packages/compiler/test/util.test.ts
+++ b/packages/compiler/test/util.test.ts
@@ -72,5 +72,25 @@ describe("compiler: util", () => {
         ]
       );
     });
+
+    it("rekeying to existing key override the target", () => {
+      const map = createRekeyableMap([
+        ["a", "pos 1"],
+        ["b", "pos 2"],
+        ["c", "pos 3"],
+        ["d", "pos 4"],
+      ]);
+
+      map.rekey("c", "b");
+
+      deepStrictEqual(
+        [...map.entries()],
+        [
+          ["a", "pos 1"],
+          ["b", "pos 3"],
+          ["d", "pos 4"],
+        ]
+      );
+    });
   });
 });


### PR DESCRIPTION
fix [#2489](https://github.com/microsoft/typespec/issues/2489)