### PR TITLE
[OpenAPI3] Fix: Using `@body _: void` in operation parameters and treat it as no body.

### DIFF
--- a/common/changes/@typespec/openapi3/fix-void-request-body_2023-10-27-17-39.json
+++ b/common/changes/@typespec/openapi3/fix-void-request-body_2023-10-27-17-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Fix: Stops emitting an error when using `@body _: void` in operation parameters and treat it as no body.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -40,6 +40,7 @@ import {
   isRecordModelType,
   isSecret,
   isTemplateDeclaration,
+  isVoidType,
   listServices,
   Model,
   ModelProperty,
@@ -1129,7 +1130,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
   }
 
   function emitRequestBody(body: HttpOperationRequestBody | undefined, visibility: Visibility) {
-    if (body === undefined) {
+    if (body === undefined || isVoidType(body.type)) {
       return;
     }
 

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -301,7 +301,7 @@ describe("openapi3: parameters", () => {
   });
 
   it("omit request body if type is void", async () => {
-    const res = await openApiFor(`op test( @body foo: void ): void;`);
+    const res = await openApiFor(`op test(@body foo: void ): void;`);
     strictEqual(res.paths["/"].post.requestBody, undefined);
   });
 

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -300,6 +300,11 @@ describe("openapi3: parameters", () => {
     strictEqual(res.paths["/"].get.parameters[0].name, "top");
   });
 
+  it("omit request body if type is void", async () => {
+    const res = await openApiFor(`op test( @body foo: void ): void;`);
+    strictEqual(res.paths["/"].post.requestBody, undefined);
+  });
+
   describe("content type parameter", () => {
     it("header named with 'Content-Type' gets resolved as content type for operation.", async () => {
       const res = await openApiFor(


### PR DESCRIPTION
```
op test(@body _: void): string;
```
 Will not crash and be treated as no request body