### PR TITLE
Fix caching not complely accurate symbol

### DIFF
--- a/common/changes/@typespec/compiler/fix-caching-invalid_2023-10-30-22-27.json
+++ b/common/changes/@typespec/compiler/fix-caching-invalid_2023-10-30-22-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -2152,16 +2152,17 @@ export function createChecker(program: Program): Checker {
     mapper: TypeMapper | undefined,
     options?: Partial<SymbolResolutionOptions> | boolean
   ): Sym | undefined {
-    if (mapper === undefined && referenceSymCache.has(node)) {
-      return referenceSymCache.get(node);
-    }
-
     const resolvedOptions: SymbolResolutionOptions =
       typeof options === "boolean"
         ? { ...defaultSymbolResolutionOptions, resolveDecorators: options }
         : { ...defaultSymbolResolutionOptions, ...(options ?? {}) };
+    if (mapper === undefined && resolvedOptions.checkTemplateTypes && referenceSymCache.has(node)) {
+      return referenceSymCache.get(node);
+    }
     const sym = resolveTypeReferenceSymInternal(node, mapper, resolvedOptions);
-    referenceSymCache.set(node, sym);
+    if (resolvedOptions.checkTemplateTypes) {
+      referenceSymCache.set(node, sym);
+    }
     return sym;
   }
 


### PR DESCRIPTION
This PR https://github.com/microsoft/typespec/pull/2603 resolved an issue where resolving meta types would cause types to be checked too early but this broke some late bound symbol resolution.

It would return the declaration symbol when `checkTemplateTypes` is false but would cache it. So in some cases it would then resolve the wrong symbol later 