### PR TITLE
OpenAPI3: emit all properties for unreferenced schemas

### DIFF
--- a/common/changes/@typespec/openapi3/unreferencedVisibilityFix_2023-11-01-16-22.json
+++ b/common/changes/@typespec/openapi3/unreferencedVisibilityFix_2023-11-01-16-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Emitter will now emit all properties on unreferenced schemas.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1295,7 +1295,7 @@ function createOAPIEmitter(
           !paramModels.has(type) &&
           !shouldInline(program, type)
         ) {
-          callSchemaEmitter(type, Visibility.Read);
+          callSchemaEmitter(type, Visibility.All);
         }
       };
       const skipSubNamespaces = isGlobalNamespace(program, serviceNamespace);

--- a/packages/openapi3/src/visibility-usage.ts
+++ b/packages/openapi3/src/visibility-usage.ts
@@ -34,9 +34,10 @@ export function resolveVisibilityUsage(
   const reachableTypes = new Set<Type>(usages.keys());
 
   if (!omitUnreachableTypes) {
+    // Evaluate all unreferenced types and the types they reference with Visibility.All
     const trackType = (type: Type) => {
       if (!usages.has(type)) {
-        navigateReferencedTypes(type, Visibility.Read, (type, vis) =>
+        navigateReferencedTypes(type, Visibility.All, (type, vis) =>
           trackUsageExact(usages, type, vis)
         );
       }

--- a/packages/openapi3/test/metadata.test.ts
+++ b/packages/openapi3/test/metadata.test.ts
@@ -66,7 +66,7 @@ describe("openapi3: metadata", () => {
           },
         },
       },
-      SharedReadOrCreateOrUpdateOrDelete: {
+      SharedReadOrCreateOrUpdateOrDeleteOrQuery: {
         type: "object",
         required: ["password", "prop"],
         properties: {
@@ -83,7 +83,7 @@ describe("openapi3: metadata", () => {
         properties: {
           c: { type: "string" },
           r: { type: "string", readOnly: true },
-          shared: { $ref: "#/components/schemas/SharedReadOrCreateOrUpdateOrDelete" },
+          shared: { $ref: "#/components/schemas/SharedReadOrCreateOrUpdateOrDeleteOrQuery" },
         },
         required: ["r", "c", "shared"],
       },

--- a/packages/openapi3/test/metadata.test.ts
+++ b/packages/openapi3/test/metadata.test.ts
@@ -2,6 +2,30 @@ import { deepStrictEqual } from "assert";
 import { openApiFor } from "./test-host.js";
 
 describe("openapi3: metadata", () => {
+  it("will expose all properties on unreferenced models", async () => {
+    const res = await openApiFor(`
+      model M {
+        @visibility("read") r: string;
+        @visibility("create", "update") uc?: string;
+        @visibility("read", "create") rc?: string;
+        @visibility("read", "update", "create") ruc?: string;
+      }
+    `);
+
+    deepStrictEqual(res.components.schemas, {
+      M: {
+        type: "object",
+        properties: {
+          r: { type: "string", readOnly: true },
+          uc: { type: "string" },
+          rc: { type: "string" },
+          ruc: { type: "string" },
+        },
+        required: ["r"],
+      },
+    });
+  });
+
   it("will expose create visibility properties on PATCH model using @requestVisibility", async () => {
     const res = await openApiFor(`
       model M {

--- a/packages/samples/specs/visibility/visibility.tsp
+++ b/packages/samples/specs/visibility/visibility.tsp
@@ -72,6 +72,10 @@ namespace Hello {
   @post op create(@body person: WritablePerson): ReadablePerson;
   @put op update(@body person: WriteableOptionalPerson): ReadablePerson;
 
+  @route("/hello/optional")
+  @get
+  op getOptional(): OptionalPerson;
+
   @TypeSpec.Rest.listsResource(Person)
   op list(): ListResult<Person>;
 

--- a/packages/samples/specs/visibility/visibility.tsp
+++ b/packages/samples/specs/visibility/visibility.tsp
@@ -72,10 +72,6 @@ namespace Hello {
   @post op create(@body person: WritablePerson): ReadablePerson;
   @put op update(@body person: WriteableOptionalPerson): ReadablePerson;
 
-  @route("/hello/optional")
-  @get
-  op getOptional(): OptionalPerson;
-
   @TypeSpec.Rest.listsResource(Person)
   op list(): ListResult<Person>;
 

--- a/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
@@ -70,6 +70,17 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PersonUpdate'
+  /hello/hello/optional:
+    get:
+      operationId: Hello_getOptional
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptionalPerson'
   /hello/{id}:
     get:
       operationId: Hello_read
@@ -103,8 +114,6 @@ components:
         id:
           type: string
           readOnly: true
-        secret:
-          type: string
         name:
           type: string
         test:

--- a/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
@@ -103,6 +103,8 @@ components:
         id:
           type: string
           readOnly: true
+        secret:
+          type: string
         name:
           type: string
         test:
@@ -112,7 +114,7 @@ components:
         relatives:
           type: array
           items:
-            $ref: '#/components/schemas/PersonRelative'
+            $ref: '#/components/schemas/PersonRelativeReadOrCreateOrUpdateOrDeleteOrQueryItem'
     Person:
       type: object
       required:
@@ -174,6 +176,31 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PersonRelativeCreateOrUpdateItem'
+    PersonReadOrCreateOrUpdateOrDeleteOrQueryItem:
+      type: object
+      required:
+        - id
+        - secret
+        - name
+        - test
+        - other
+        - relatives
+      properties:
+        id:
+          type: string
+          readOnly: true
+        secret:
+          type: string
+        name:
+          type: string
+        test:
+          type: string
+        other:
+          type: string
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonRelativeReadOrCreateOrUpdateOrDeleteOrQueryItem'
     PersonRelative:
       type: object
       required:
@@ -202,6 +229,16 @@ components:
       properties:
         person:
           $ref: '#/components/schemas/PersonCreateOrUpdateItem'
+        relationship:
+          type: string
+    PersonRelativeReadOrCreateOrUpdateOrDeleteOrQueryItem:
+      type: object
+      required:
+        - person
+        - relationship
+      properties:
+        person:
+          $ref: '#/components/schemas/PersonReadOrCreateOrUpdateOrDeleteOrQueryItem'
         relationship:
           type: string
     PersonRelativeUpdateItem:

--- a/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
@@ -70,17 +70,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PersonUpdate'
-  /hello/hello/optional:
-    get:
-      operationId: Hello_getOptional
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OptionalPerson'
   /hello/{id}:
     get:
       operationId: Hello_read
@@ -114,6 +103,8 @@ components:
         id:
           type: string
           readOnly: true
+        secret:
+          type: string
         name:
           type: string
         test:


### PR DESCRIPTION
Fix #2571.

**BREAKING CHANGE**: Since the previous behavior was to emit unreferenced schemas with Read visibility, this change can produce a breaking change in Swagger if unreferenced schemas were previously emitted that had write visibility properties stripped. 