### PR TITLE
Fix: Default must be last

### DIFF
--- a/common/changes/@typespec/compiler/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/compiler/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/compiler"
+}

--- a/common/changes/@typespec/html-program-viewer/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/html-program-viewer/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/html-program-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/html-program-viewer"
+}

--- a/common/changes/@typespec/http/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/http/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/common/changes/@typespec/library-linter/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/library-linter/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/library-linter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/library-linter"
+}

--- a/common/changes/@typespec/openapi/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/openapi/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi"
+}

--- a/common/changes/@typespec/openapi3/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/openapi3/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/common/changes/@typespec/playground/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/playground/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/playground",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/playground"
+}

--- a/common/changes/@typespec/rest/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/rest/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/rest"
+}

--- a/common/changes/@typespec/versioning/fix-default-must-be-last_2023-11-06-22-32.json
+++ b/common/changes/@typespec/versioning/fix-default-must-be-last_2023-11-06-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/versioning"
+}

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -22,20 +22,20 @@
   "tspMain": "lib/main.tsp",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     },
     "./module-resolver": {
-      "default": "./dist/src/core/module-resolver.js",
-      "types": "./dist/src/core/module-resolver.d.ts"
+      "types": "./dist/src/core/module-resolver.d.ts",
+      "default": "./dist/src/core/module-resolver.js"
     },
     "./emitter-framework": {
-      "default": "./dist/src/emitter-framework/index.js",
-      "types": "./dist/src/emitter-framework/index.d.ts"
+      "types": "./dist/src/emitter-framework/index.d.ts",
+      "default": "./dist/src/emitter-framework/index.js"
     }
   },
   "browser": {

--- a/packages/html-program-viewer/package.json
+++ b/packages/html-program-viewer/package.json
@@ -20,12 +20,12 @@
   "main": "dist/src/index.js",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "tspMain": "dist/src/index.js",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -21,12 +21,12 @@
   "tspMain": "lib/http.tsp",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "engines": {

--- a/packages/library-linter/package.json
+++ b/packages/library-linter/package.json
@@ -20,12 +20,12 @@
   "main": "dist/src/index.js",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "tspMain": "dist/src/index.js",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -21,12 +21,12 @@
   "tspMain": "dist/src/index.js",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "engines": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -21,12 +21,12 @@
   "tspMain": "lib/main.tsp",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "engines": {

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -21,12 +21,12 @@
   "tspMain": "lib/main.tsp",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "engines": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -20,24 +20,24 @@
   "main": "dist/src/index.js",
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./vite": {
-      "default": "./dist/vite/index.js",
-      "types": "./dist/src/vite/index.d.ts"
+      "types": "./dist/src/vite/index.d.ts",
+      "default": "./dist/vite/index.js"
     },
     "./manifest": {
-      "default": "./dist/manifest.js",
-      "types": "./dist/src/manifest.d.ts"
+      "types": "./dist/src/manifest.d.ts",
+      "default": "./dist/manifest.js"
     },
     "./react": {
-      "default": "./dist/react/index.js",
-      "types": "./dist/src/react/index.d.ts"
+      "types": "./dist/src/react/index.d.ts",
+      "default": "./dist/react/index.js"
     },
     "./react/viewers": {
-      "default": "./dist/react/viewers.js",
-      "types": "./dist/src/react/viewers.d.ts"
+      "types": "./dist/src/react/viewers.d.ts",
+      "default": "./dist/react/viewers.js"
     },
     "./style.css": "./dist/index.css"
   },

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -21,12 +21,12 @@
   "tspMain": "lib/rest.tsp",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "engines": {

--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -21,8 +21,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     }
   },
   "engines": {

--- a/packages/tspd/package.json
+++ b/packages/tspd/package.json
@@ -23,16 +23,16 @@
   "main": "./dist/src/index.js",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./ref-doc": {
-      "default": "./dist/src/ref-doc/index.js",
-      "types": "./dist/src/ref-doc/index.d.ts"
+      "types": "./dist/src/ref-doc/index.d.ts",
+      "default": "./dist/src/ref-doc/index.js"
     },
     "./ref-doc/emitters/docusaurus": {
-      "default": "./dist/src/ref-doc/emitters/docusaurus.js",
-      "types": "./dist/src/ref-doc/emitters/docusaurus.d.ts"
+      "types": "./dist/src/ref-doc/emitters/docusaurus.d.ts",
+      "default": "./dist/src/ref-doc/emitters/docusaurus.js"
     }
   },
   "engines": {

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -21,12 +21,12 @@
   "tspMain": "lib/versioning.tsp",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "default": "./dist/src/testing/index.js",
-      "types": "./dist/src/testing/index.d.ts"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     }
   },
   "engines": {


### PR DESCRIPTION
`default` entry must be last in `exports`. Most tools do not care but it seems like webpack and docusaurus do. This is causing issue when trying to imoport the playground directly there.