### PR TITLE
Update casing of Bearer in basic TypeSpec

### DIFF
--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -71,7 +71,7 @@ export interface BasicAuth extends HttpAuthBase {
  */
 export interface BearerAuth extends HttpAuthBase {
   type: "http";
-  scheme: "bearer";
+  scheme: "Bearer";
 }
 
 type ApiKeyLocation = "header" | "query" | "cookie";


### PR DESCRIPTION
Like @johanste was saying, it shouldn't matter, but we got services that refused `bearer`, and worked only on `Bearer`, hence suggesting this change.

Codegen just take the scheme and put it straight into the prefix of the header value, so fixing it here makes it work everywhere, as a win-win for all parties.