### PR TITLE
Refactor symbol handling by introducing new name resolution phase

### DIFF
--- a/packages/compiler/lib/main.tsp
+++ b/packages/compiler/lib/main.tsp
@@ -2,3 +2,4 @@ import "./lib.tsp";
 import "./decorators.tsp";
 import "./reflection.tsp";
 import "./projected-names.tsp";
+import "./prototypes.tsp";

--- a/packages/compiler/lib/prototypes.tsp
+++ b/packages/compiler/lib/prototypes.tsp
@@ -1,0 +1,17 @@
+namespace TypeSpec.Prototypes;
+extern dec getter(target: Reflection.Operation);
+
+namespace Types {
+  interface ModelProperty {
+    @getter type(): unknown;
+  }
+
+  interface Operation {
+    @getter returnType(): unknown;
+    @getter parameters(): unknown;
+  }
+
+  interface Array<TElementType> {
+    @getter elementType(): TElementType;
+  }
+}

--- a/packages/compiler/src/core/binder.ts
+++ b/packages/compiler/src/core/binder.ts
@@ -60,7 +60,7 @@ const SymbolTable = class extends Map<string, Sym> implements SymbolTable {
    */
   include(source: SymbolTable) {
     for (const [key, value] of source) {
-      super.set(key, value);
+      super.set(key, { ...value });
     }
     for (const [key, value] of source.duplicates) {
       this.duplicates.set(key, new Set(value));

--- a/packages/compiler/src/core/inspector.ts
+++ b/packages/compiler/src/core/inspector.ts
@@ -1,0 +1,114 @@
+import pc from "picocolors";
+import { Node, Sym, SymbolFlags, SymbolLinks, SyntaxKind } from "./types.js";
+
+export function inspectSymbol(sym: Sym, links: SymbolLinks = {}) {
+  let output = `
+${pc.blue(pc.inverse(` sym `))} ${pc.white(sym.name)}
+${pc.dim("flags")} ${inspectSymbolFlags(sym.flags)}
+  `.trim();
+
+  if (sym.declarations && sym.declarations.length > 0) {
+    const decls = sym.declarations.map((d) => SyntaxKind[d.kind]).join("\n");
+    output += `\n${pc.dim("declarations")} ${decls}`;
+  }
+
+  if (sym.exports) {
+    output += `\n${pc.dim("exports")} ${[...sym.exports.keys()].join(", ")}`;
+  }
+
+  if (sym.id) {
+    output += `\n${pc.dim("id")} ${sym.id}`;
+  }
+
+  if (sym.members) {
+    output += `\n${pc.dim("members")} ${[...sym.members.keys()].join(", ")}`;
+  }
+
+  if (sym.metatypeMembers) {
+    output += `\n${pc.dim("metatypeMembers")} ${[...sym.metatypeMembers.keys()].join(", ")}`;
+  }
+
+  if (sym.parent) {
+    output += `\n${pc.dim("parent")} ${sym.parent.name}`;
+  }
+
+  if (sym.symbolSource) {
+    output += `\n${pc.dim("symbolSource")} ${sym.symbolSource.name}`;
+  }
+
+  if (sym.type) {
+    output += `\n${pc.dim("type")} ${
+      "name" in sym.type && sym.type.name ? String(sym.type.name) : sym.type.kind
+    }`;
+  }
+
+  if (sym.value) {
+    output += `\n${pc.dim("value")} present`;
+  }
+
+  if (Object.keys(links).length > 0) {
+    output += `\nlinks\n`;
+
+    if (links.declaredType) {
+      output += `\n${pc.dim("declaredType")} ${
+        "name" in links.declaredType && links.declaredType.name
+          ? String(links.declaredType.name)
+          : links.declaredType.kind
+      }`;
+    }
+
+    if (links.instantiations) {
+      output += `\n${pc.dim("instantiations")} initialized`;
+    }
+
+    if (links.type) {
+      output += `\n${pc.dim("type")} ${
+        "name" in links.type && links.type.name ? String(links.type.name) : links.type.kind
+      }`;
+    }
+  }
+
+  return output;
+}
+
+export function inspectSymbolFlags(symbolFlags: SymbolFlags) {
+  if (symbolFlags === SymbolFlags.None) {
+    return "None";
+  }
+  const flags = [];
+
+  symbolFlags & SymbolFlags.Alias && flags.push("Alias");
+  symbolFlags & SymbolFlags.Declaration && flags.push("Declaration");
+  symbolFlags & SymbolFlags.Decorator && flags.push("Decorator");
+  symbolFlags & SymbolFlags.DuplicateUsing && flags.push("DuplicateUsing");
+  symbolFlags & SymbolFlags.Enum && flags.push("Enum");
+  symbolFlags & SymbolFlags.ExportContainer && flags.push("ExportContainer");
+  symbolFlags & SymbolFlags.Function && flags.push("Function");
+  symbolFlags & SymbolFlags.FunctionParameter && flags.push("FunctionParameter");
+  symbolFlags & SymbolFlags.Implementation && flags.push("Implementation");
+  symbolFlags & SymbolFlags.Interface && flags.push("Interface");
+  symbolFlags & SymbolFlags.LateBound && flags.push("LateBound");
+  symbolFlags & SymbolFlags.Member && flags.push("Member");
+  symbolFlags & SymbolFlags.MemberContainer && flags.push("MemberContainer");
+  symbolFlags & SymbolFlags.Model && flags.push("Model");
+  symbolFlags & SymbolFlags.Namespace && flags.push("Namespace");
+  symbolFlags & SymbolFlags.Operation && flags.push("Operation");
+  symbolFlags & SymbolFlags.Projection && flags.push("Projection");
+  symbolFlags & SymbolFlags.ProjectionParameter && flags.push("ProjectionParameter");
+  symbolFlags & SymbolFlags.Scalar && flags.push("Scalar");
+  symbolFlags & SymbolFlags.SourceFile && flags.push("SourceFile");
+  symbolFlags & SymbolFlags.TemplateParameter && flags.push("TemplateParameter");
+  symbolFlags & SymbolFlags.Union && flags.push("Union");
+  symbolFlags & SymbolFlags.Using && flags.push("Using");
+
+  return flags.join(" ");
+}
+
+export function inspectSyntaxNode(node: Node) {
+  let output = `
+    ${pc.blue(pc.inverse(` node `))} ${pc.white(SyntaxKind[node.kind])}
+  `.trim();
+
+  //output += JSON.stringify(node);
+  return output;
+}

--- a/packages/compiler/src/core/links.ts
+++ b/packages/compiler/src/core/links.ts
@@ -1,0 +1,3 @@
+import { Node, NodeLinks, Sym, SymbolLinks } from "./types.js";
+import { mutate } from "./util.js";
+

--- a/packages/compiler/src/core/name-resolver.ts
+++ b/packages/compiler/src/core/name-resolver.ts
@@ -1,0 +1,670 @@
+/**
+ * The name resolver is responsible for resolving identifiers to symbols and
+ * creating symbols for types that become known during this process. After name
+ * resolution, we can do some limited analysis of the reference graph in order
+ * to support e.g. augment decorators.
+ *
+ * Name resolution does not alter any AST nodes or attached symbols in order to
+ * ensure AST nodes and attached symbols can be trivially reused between
+ * compilations. Instead, symbols created here are either stored in augmented
+ * symbol tables or as merged symbols. Any metadata about symbols and nodes are
+ * stored in symbol links and node links respectively. The resolver provides
+ * APIs for managing this metadata which is useful during later phases.
+ *
+ * While we resolve some identifiers to symbols during this phase, we often
+ * cannot say for sure that an identifier does not exist. Some symbols must be
+ * late-bound because the symbol does not become known until after the program
+ * has been checked. A common example is members of a model template which often
+ * cannot be known until the template is instantiated. Instead, we mark that the
+ * reference is unknown and will resolve the symbol (or report an error if it
+ * doesn't exist) in later phases. These unknown references cannot be used as
+ * the target of an augment decorator.
+ *
+ * There are some errors we can detect because we have complete symbol
+ * information, but we do not report them from here. For example, because we
+ * know all namespace bindings and all the declarations inside of them, we could
+ * in principle report an error when we attempt to `using` something that isn't
+ * a namespace. However, giving a good error message sometimes requires knowing
+ * what type was mistakenly referenced, so we merely mark that resolution has
+ * failed and move on. Even in cases where we could give a good error we chose
+ * not to in order to uniformly handle error reporting in the checker.
+ *
+ * Name resolution has three sub-phases:
+ *
+ * 1. Merge namespace symbols and decorator implementation/declaration symbols
+ * 2. Resolve using references to namespaces and create namespace-local bindings
+ *    for used symbols
+ * 3. Resolve type references and bind members
+ *
+ * The reference resolution and member binding phase implements a deferred
+ * resolution strategy. Often we cannot resolve a reference without binding
+ * members, but we often cannot bind members without resolving references. In
+ * such situations, we stop resolving or binding the current reference or type
+ * and attempt to resolve or bind the reference or type it depends on. Once we
+ * have done so, we return to the original reference or type and complete our
+ * work.
+ *
+ * This is accomplished by doing a depth-first traversal of the reference graph.
+ * On the way down, we discover any dependencies that need to be resolved or
+ * bound for the current node, and recurse into the AST nodes, so that on the
+ * way back up, all of our dependencies are bound and resolved and we can
+ * complete. So while we start with a depth-first traversal of the ASTs in order
+ * to discover work to do, most of the actual work is done while following the
+ * reference graph, binding and resolving along the way. Circular references are
+ * discovered during the reference graph walk and marked as such. Symbol and
+ * node links are used to ensure we never resolve the same reference twice. The
+ * checker implements a very similar algorithm to evaluate the types of the
+ * program.
+ **/
+
+import { createSymbol, createSymbolTable } from "./binder.js";
+import {
+  AliasStatementNode,
+  ModelExpressionNode,
+  ModelStatementNode,
+  ResolutionResult,
+  compilerAssert,
+  visitChildren,
+} from "./index.js";
+import { createDiagnostic } from "./messages.js";
+import { Program } from "./program.js";
+import {
+  IdentifierNode,
+  MemberExpressionNode,
+  NamespaceStatementNode,
+  Node,
+  NodeFlags,
+  NodeLinks,
+  ResolutionResultFlags,
+  Sym,
+  SymbolFlags,
+  SymbolLinks,
+  SymbolTable,
+  SyntaxKind,
+  TypeReferenceNode,
+  TypeSpecScriptNode,
+} from "./types.js";
+import { Mutable, mutate } from "./util.js";
+
+export function createResolver(program: Program) {
+  const mergedSymbols = new Map<Sym, Sym>();
+  const augmentedSymbolTables = new Map<SymbolTable, SymbolTable>();
+  const nodeLinks = new Map<number, NodeLinks>();
+  let currentNodeId = 0;
+  const symbolLinks = new Map<number, SymbolLinks>();
+  let currentSymbolId = 0;
+
+  const globalNamespaceNode = createGlobalNamespaceNode();
+  const globalNamespaceSym = createSymbol(globalNamespaceNode, "global", SymbolFlags.Namespace);
+  mutate(globalNamespaceNode).symbol = globalNamespaceSym;
+
+  return {
+    resolveProgram() {
+      // Merge namespace symbols and decorator implementation/declaration symbols
+      for (const file of program.jsSourceFiles.values()) {
+        mergeSymbolTable(file.symbol.exports!, mutate(globalNamespaceSym.exports!));
+      }
+
+      for (const file of program.sourceFiles.values()) {
+        mergeSymbolTable(file.symbol.exports!, mutate(globalNamespaceSym.exports!));
+      }
+
+      // Bind usings to namespaces, create namespace-local bindings for used symbols
+      for (const file of program.sourceFiles.values()) {
+        setUsingsForFile(file);
+      }
+
+      // Begin reference graph walk starting at each node to ensure we visit all possible
+      // references and types that need binding.
+      for (const file of program.sourceFiles.values()) {
+        bindAndResolveNode(file);
+      }
+    },
+
+    getMergedSymbol,
+    getAugmentedSymbolTable,
+    getNodeLinks,
+    getSymbolLinks,
+
+    getGlobalNamespaceSymbol() {
+      return globalNamespaceSym;
+    },
+  };
+
+  function getMergedSymbol(sym: Sym) {
+    if (!sym) return sym;
+    return mergedSymbols.get(sym) || sym;
+  }
+
+  /**
+   * @internal
+   */
+  function getNodeLinks(n: Node): NodeLinks {
+    const id = getNodeId(n);
+
+    if (nodeLinks.has(id)) {
+      return nodeLinks.get(id)!;
+    }
+
+    const links = {};
+    nodeLinks.set(id, links);
+
+    return links;
+  }
+
+  function getNodeId(n: Node) {
+    if (n._id === undefined) {
+      mutate(n)._id = currentNodeId++;
+    }
+    return n._id!;
+  }
+
+  /**
+   * @internal
+   */
+  function getSymbolLinks(s: Sym): SymbolLinks {
+    const id = getSymbolId(s);
+
+    if (symbolLinks.has(id)) {
+      return symbolLinks.get(id)!;
+    }
+
+    const links = {};
+    symbolLinks.set(id, links);
+
+    return links;
+  }
+
+  function getSymbolId(s: Sym) {
+    if (s.id === undefined) {
+      mutate(s).id = currentSymbolId++;
+    }
+    return s.id!;
+  }
+
+  function resolveTypeReference(
+    node: TypeReferenceNode | MemberExpressionNode | IdentifierNode
+  ): ResolutionResult {
+    const links = getNodeLinks(node);
+
+    if (links.resolutionResult) {
+      return [links.resolvedSymbol, links.resolutionResult];
+    }
+
+    let result = resolveTypeReferenceWorker(node);
+
+    // Unwrap aliases
+    while (result[1] & ResolutionResultFlags.Resolved && result[0]!.flags & SymbolFlags.Alias) {
+      const aliasNode = result[0]!.declarations[0] as AliasStatementNode;
+      if (
+        aliasNode.templateParameters.length === 0 &&
+        aliasNode.value.kind === SyntaxKind.TypeReference &&
+        aliasNode.value.arguments.length === 0
+      ) {
+        const [aliasRefSym, aliasRefResult] = resolveTypeReference(aliasNode.value);
+        if (aliasRefResult & ResolutionResultFlags.Resolved) {
+          result = [aliasRefSym!, ResolutionResultFlags.Resolved];
+          continue;
+        }
+      }
+      break;
+    }
+
+    if (result[0]) {
+      links.resolvedSymbol = result[0];
+    }
+    links.resolutionResult = result[1];
+    return result;
+  }
+
+  function resolveTypeReferenceWorker(
+    node: TypeReferenceNode | MemberExpressionNode | IdentifierNode
+  ): ResolutionResult {
+    if (node.kind === SyntaxKind.TypeReference) {
+      if (node.arguments.length > 0) {
+        return [undefined, ResolutionResultFlags.Unknown];
+      }
+      return resolveTypeReference(node.target);
+    } else if (node.kind === SyntaxKind.MemberExpression) {
+      return resolveMemberExpression(node);
+    } else if (node.kind === SyntaxKind.Identifier) {
+      return resolveIdentifier(node);
+    }
+
+    compilerAssert(false, "Unexpected node kind");
+  }
+
+  function resolveMemberExpression(node: MemberExpressionNode): ResolutionResult {
+    const [baseSym, baseResult] = resolveTypeReference(node.base);
+    if (baseResult & ResolutionResultFlags.ResolutionFailed) {
+      return [undefined, baseResult];
+    }
+    compilerAssert(baseSym, "Base symbol must be defined if resolution did not fail");
+
+    if (baseSym.flags & SymbolFlags.MemberContainer) {
+      return resolveMember(baseSym, node.id);
+    } else if (baseSym.flags & SymbolFlags.ExportContainer) {
+      return resolveExport(getMergedSymbol(baseSym), node.id);
+    }
+
+    throw new Error("NYI rme");
+  }
+
+  function resolveMember(baseSym: Sym, id: IdentifierNode): ResolutionResult {
+    const baseNode = baseSym.declarations[0];
+    compilerAssert(baseNode, "Base symbol must have a declaration");
+
+    bindMemberContainer(baseNode);
+
+    switch (baseNode.kind) {
+      case SyntaxKind.ModelStatement:
+      case SyntaxKind.ModelExpression:
+        return resolveModelMember(baseSym, baseNode, id);
+    }
+    throw new Error("NYI");
+  }
+
+  function resolveModelMember(
+    modelSym: Sym,
+    modelNode: ModelStatementNode | ModelExpressionNode,
+    id: IdentifierNode
+  ): ResolutionResult {
+    const modelSymLinks = getSymbolLinks(modelSym);
+
+    // step 1: check direct members
+    // spreads have already been bound
+    const memberSym = tableLookup(modelSym.members!, id);
+    if (memberSym) {
+      return [memberSym, ResolutionResultFlags.Resolved];
+    }
+
+    // step 2: check extends. Don't look up to extends references if we have
+    // unknown members, and resolve any property as unknown if we extend
+    // something unknown.
+    const extendsRef = modelNode.kind === SyntaxKind.ModelStatement ? modelNode.extends : undefined;
+    if (
+      extendsRef &&
+      extendsRef.kind === SyntaxKind.TypeReference &&
+      !modelSymLinks.hasUnknownMembers
+    ) {
+      const [extendsSym, extendsResult] = resolveTypeReference(extendsRef);
+      if (extendsResult & ResolutionResultFlags.Resolved) {
+        return resolveMember(extendsSym!, id);
+      }
+
+      if (extendsResult & ResolutionResultFlags.Unknown) {
+        modelSymLinks.hasUnknownMembers = true;
+        return [undefined, ResolutionResultFlags.Unknown];
+      }
+    }
+
+    // step 3: return either unknown or not found depending on whether we have
+    // unknown members
+    return [
+      undefined,
+      modelSymLinks.hasUnknownMembers
+        ? ResolutionResultFlags.Unknown
+        : ResolutionResultFlags.NotFound,
+    ];
+  }
+
+  function resolveExport(baseSym: Sym, id: IdentifierNode): ResolutionResult {
+    const node = baseSym.declarations[0];
+    compilerAssert(
+      node.kind === SyntaxKind.NamespaceStatement || node.kind === SyntaxKind.TypeSpecScript,
+      "Unexpected node kind"
+    );
+
+    const exportSym = tableLookup(baseSym.exports!, id);
+    if (!exportSym) {
+      return [undefined, ResolutionResultFlags.NotFound];
+    }
+
+    return [exportSym, ResolutionResultFlags.Resolved];
+  }
+
+  function tableLookup(table: SymbolTable, node: IdentifierNode, resolveDecorator = false) {
+    table = augmentedSymbolTables.get(table) ?? table;
+    let sym;
+    if (resolveDecorator) {
+      sym = table.get("@" + node.sv);
+    } else {
+      sym = table.get(node.sv);
+    }
+
+    if (!sym) return sym;
+
+    return getMergedSymbol(sym);
+  }
+
+  /**
+   * This method will take a member container and compute all the known member
+   * symbols. It will determine whether it has unknown members and set the
+   * symbol link value appropriately. This is used during resolution to know if
+   * member resolution should return `unknown` when a member isn't found.
+   * @param node
+   * @returns
+   */
+  function bindMemberContainer(node: Node) {
+    switch (node.kind) {
+      case SyntaxKind.ModelStatement:
+      case SyntaxKind.ModelExpression:
+        bindModelMembers(node);
+        return;
+    }
+  }
+
+  function bindModelMembers(node: ModelStatementNode | ModelExpressionNode) {
+    const modelSym = node.symbol!;
+    const modelSymLinks = getSymbolLinks(modelSym);
+
+    if (modelSymLinks.membersBound) {
+      return;
+    }
+
+    modelSymLinks.membersBound = true;
+
+    const targetTable = getAugmentedSymbolTable(modelSym.members!);
+
+    const isRef = node.kind === SyntaxKind.ModelStatement ? node.is : undefined;
+    if (isRef && isRef.kind === SyntaxKind.TypeReference) {
+      const [isSym, isResult] = resolveTypeReference(isRef);
+
+      if (isResult & ResolutionResultFlags.Unknown) {
+        modelSymLinks.hasUnknownMembers = true;
+      } else if (isResult & ResolutionResultFlags.Resolved && isSym!.flags & SymbolFlags.Model) {
+        const isSymLinks = getSymbolLinks(isSym!);
+        if (isSymLinks.hasUnknownMembers) {
+          modelSymLinks.hasUnknownMembers = true;
+        }
+        const sourceTable = getAugmentedSymbolTable(isSym!.members!);
+        targetTable.include(sourceTable);
+      }
+    }
+
+    // here we just need to check if we're extending something with unknown symbols
+    const extendsRef = node.kind === SyntaxKind.ModelStatement ? node.extends : undefined;
+    if (extendsRef && extendsRef.kind === SyntaxKind.TypeReference) {
+      const [extendsSym, extendsResult] = resolveTypeReference(extendsRef);
+      if (extendsResult & ResolutionResultFlags.Resolved) {
+        if (getSymbolLinks(extendsSym!).hasUnknownMembers) {
+          modelSymLinks.hasUnknownMembers = true;
+        }
+      } else if (extendsResult & ResolutionResultFlags.Unknown) {
+        modelSymLinks.hasUnknownMembers = true;
+      }
+    }
+
+    for (const propertyNode of node.properties) {
+      if (propertyNode.kind === SyntaxKind.ModelSpreadProperty) {
+        const [sourceSym, sourceResult] = resolveTypeReference(propertyNode.target);
+        if (~sourceResult & ResolutionResultFlags.Resolved) {
+          if (sourceResult & ResolutionResultFlags.Unknown) {
+            modelSymLinks.hasUnknownMembers = true;
+          }
+          continue;
+        }
+
+        compilerAssert(sourceSym, "Spread symbol must be defined if resolution succeeded");
+
+        if (!(sourceSym.flags & SymbolFlags.Model)) {
+          // will be a checker error
+          continue;
+        }
+
+        const sourceSymLinks = getSymbolLinks(sourceSym!);
+        if (sourceSymLinks.hasUnknownMembers) {
+          modelSymLinks.hasUnknownMembers = true;
+          continue;
+        }
+
+        const sourceTable = getAugmentedSymbolTable(sourceSym.members!);
+        targetTable.include(sourceTable);
+      }
+    }
+  }
+
+  function resolveIdentifier(node: IdentifierNode): ResolutionResult {
+    let scope: Node | undefined = node.parent;
+    let binding: Sym | undefined;
+
+    while (scope && scope.kind !== SyntaxKind.TypeSpecScript) {
+      if (scope.symbol && scope.symbol.flags & SymbolFlags.ExportContainer) {
+        const mergedSymbol = getMergedSymbol(scope.symbol);
+        binding = tableLookup(mergedSymbol.exports!, node);
+        if (binding) return [binding, ResolutionResultFlags.Resolved];
+      }
+
+      if ("locals" in scope && scope.locals !== undefined) {
+        binding = tableLookup(scope.locals, node);
+        if (binding) return [binding, ResolutionResultFlags.Resolved];
+      }
+
+      scope = scope.parent;
+    }
+
+    if (!binding && scope && scope.kind === SyntaxKind.TypeSpecScript) {
+      // check any blockless namespace decls
+      for (const ns of scope.inScopeNamespaces) {
+        const mergedSymbol = getMergedSymbol(ns.symbol);
+        binding = tableLookup(mergedSymbol.exports!, node);
+
+        if (binding) return [binding, ResolutionResultFlags.Resolved];
+      }
+
+      // check "global scope" declarations
+      const globalBinding = tableLookup(globalNamespaceNode.symbol.exports!, node);
+
+      // check using types
+      const usingBinding = tableLookup(scope.locals, node);
+
+      if (globalBinding && usingBinding) {
+        return [undefined, ResolutionResultFlags.Ambiguous];
+      } else if (globalBinding) {
+        return [globalBinding, ResolutionResultFlags.Resolved];
+      } else if (usingBinding) {
+        if (usingBinding.flags & SymbolFlags.DuplicateUsing) {
+          return [undefined, ResolutionResultFlags.ResolutionFailed];
+        }
+        return [usingBinding, ResolutionResultFlags.Resolved];
+      }
+    }
+
+    return [undefined, ResolutionResultFlags.Unknown];
+  }
+  /**
+   * We cannot inject symbols into the symbol tables hanging off syntax tree nodes as
+   * syntax tree nodes can be shared by other programs. This is called as a copy-on-write
+   * to inject using and late-bound symbols, and then we use the copy when resolving
+   * in the table.
+   */
+  function getAugmentedSymbolTable(table: SymbolTable): Mutable<SymbolTable> {
+    let augmented = augmentedSymbolTables.get(table);
+    if (!augmented) {
+      augmented = createSymbolTable(table);
+      augmentedSymbolTables.set(table, augmented);
+    }
+    return mutate(augmented);
+  }
+
+  function mergeSymbolTable(source: SymbolTable, target: Mutable<SymbolTable>) {
+    for (const [sym, duplicates] of source.duplicates) {
+      const targetSet = target.duplicates.get(sym);
+      if (targetSet === undefined) {
+        mutate(target.duplicates).set(sym, new Set([...duplicates]));
+      } else {
+        for (const duplicate of duplicates) {
+          mutate(targetSet).add(duplicate);
+        }
+      }
+    }
+
+    for (const [key, sourceBinding] of source) {
+      if (sourceBinding.flags & SymbolFlags.Namespace) {
+        let targetBinding = target.get(key);
+        if (!targetBinding) {
+          targetBinding = {
+            ...sourceBinding,
+            declarations: [],
+            exports: createSymbolTable(),
+          };
+          target.set(key, targetBinding);
+        }
+        if (targetBinding.flags & SymbolFlags.Namespace) {
+          mergedSymbols.set(sourceBinding, targetBinding);
+          mutate(targetBinding.declarations).push(...sourceBinding.declarations);
+          mergeSymbolTable(sourceBinding.exports!, mutate(targetBinding.exports!));
+        } else {
+          // this will set a duplicate error
+          target.set(key, sourceBinding);
+        }
+      } else if (
+        sourceBinding.flags & SymbolFlags.Declaration ||
+        sourceBinding.flags & SymbolFlags.Implementation
+      ) {
+        if (sourceBinding.flags & SymbolFlags.Decorator) {
+          mergeDeclarationOrImplementation(key, sourceBinding, target, SymbolFlags.Decorator);
+        } else if (sourceBinding.flags & SymbolFlags.Function) {
+          mergeDeclarationOrImplementation(key, sourceBinding, target, SymbolFlags.Function);
+        } else {
+          target.set(key, sourceBinding);
+        }
+      } else {
+        target.set(key, sourceBinding);
+      }
+    }
+  }
+
+  function mergeDeclarationOrImplementation(
+    key: string,
+    sourceBinding: Sym,
+    target: Mutable<SymbolTable>,
+    expectTargetFlags: SymbolFlags
+  ) {
+    const targetBinding = target.get(key);
+    if (!targetBinding || !(targetBinding.flags & expectTargetFlags)) {
+      target.set(key, sourceBinding);
+      return;
+    }
+    const isSourceDeclaration = sourceBinding.flags & SymbolFlags.Declaration;
+    const isSourceImplementation = sourceBinding.flags & SymbolFlags.Implementation;
+    const isTargetDeclaration = targetBinding.flags & SymbolFlags.Declaration;
+    const isTargetImplementation = targetBinding.flags & SymbolFlags.Implementation;
+    if (isTargetDeclaration && isTargetImplementation) {
+      // If the target already has both a declaration and implementation set the symbol which will mark it as duplicate
+      target.set(key, sourceBinding);
+    } else if (isTargetDeclaration && isSourceImplementation) {
+      mergedSymbols.set(sourceBinding, targetBinding);
+      mutate(targetBinding).value = sourceBinding.value;
+      mutate(targetBinding).flags |= sourceBinding.flags;
+      mutate(targetBinding.declarations).push(...sourceBinding.declarations);
+    } else if (isTargetImplementation && isSourceDeclaration) {
+      mergedSymbols.set(sourceBinding, targetBinding);
+      mutate(targetBinding).flags |= sourceBinding.flags;
+      mutate(targetBinding.declarations).unshift(...sourceBinding.declarations);
+    } else {
+      // this will set a duplicate error
+      target.set(key, sourceBinding);
+    }
+  }
+
+  function setUsingsForFile(file: TypeSpecScriptNode) {
+    const usedUsing = new Set<Sym>();
+    for (const using of file.usings) {
+      const parentNs = using.parent!;
+      const [usedSym, usedSymResult] = resolveTypeReference(using.name);
+      if (~usedSymResult & ResolutionResultFlags.Resolved) {
+        continue;
+      }
+      compilerAssert(usedSym, "Used symbol must be defined if resolution succeeded");
+      if (~usedSym.flags & SymbolFlags.Namespace) {
+        reportCheckerDiagnostic(createDiagnostic({ code: "using-invalid-ref", target: using }));
+        continue;
+      }
+
+      const namespaceSym = getMergedSymbol(usedSym)!;
+
+      if (usedUsing.has(namespaceSym)) {
+        reportCheckerDiagnostic(
+          createDiagnostic({
+            code: "duplicate-using",
+            format: { usingName: memberExpressionToString(using.name) },
+            target: using,
+          })
+        );
+        continue;
+      }
+      usedUsing.add(namespaceSym);
+
+      addUsingSymbols(namespaceSym.exports!, parentNs.locals!);
+    }
+  }
+
+  function addUsingSymbols(source: SymbolTable, destination: SymbolTable): void {
+    const augmented = getAugmentedSymbolTable(destination);
+    for (const symbolSource of source.values()) {
+      const sym: Sym = {
+        flags: SymbolFlags.Using,
+        declarations: [],
+        name: symbolSource.name,
+        symbolSource: symbolSource,
+        node: undefined as any,
+      };
+      augmented.set(sym.name, sym);
+    }
+  }
+
+  function memberExpressionToString(expr: IdentifierNode | MemberExpressionNode) {
+    let current = expr;
+    const parts = [];
+
+    while (current.kind === SyntaxKind.MemberExpression) {
+      parts.push(current.id.sv);
+      current = current.base;
+    }
+
+    parts.push(current.sv);
+
+    return parts.reverse().join(".");
+  }
+
+  function createGlobalNamespaceNode() {
+    const nsId: IdentifierNode = {
+      kind: SyntaxKind.Identifier,
+      pos: 0,
+      end: 0,
+      sv: "global",
+      symbol: undefined!,
+      flags: NodeFlags.Synthetic,
+    };
+
+    const nsNode: NamespaceStatementNode = {
+      kind: SyntaxKind.NamespaceStatement,
+      decorators: [],
+      pos: 0,
+      end: 0,
+      id: nsId,
+      symbol: undefined!,
+      locals: createSymbolTable(),
+      flags: NodeFlags.Synthetic,
+    };
+
+    return nsNode;
+  }
+
+  function bindAndResolveNode(node: Node) {
+    switch (node.kind) {
+      case SyntaxKind.TypeReference:
+        resolveTypeReference(node);
+        break;
+      case SyntaxKind.ModelStatement:
+      case SyntaxKind.ModelExpression:
+        bindMemberContainer(node);
+    }
+
+    visitChildren(node, bindAndResolveNode);
+  }
+}
+function reportCheckerDiagnostic(arg0: any) {
+  throw new Error("Function not implemented.");
+}

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -661,20 +661,43 @@ export interface SymbolLinks {
   /**
    * The symbol aliased by an alias symbol. When present, guaranteed to be a
    * non-alias symbol. Will not be present when the name resolver could not
-   * determine a symbol for the alias, e.g. when it is a template.
+   * determine a symbol for the alias, e.g. when it is a computed type.
    */
   aliasedSymbol?: Sym;
+
+  /**
+   * The result of resolving the aliased reference. When resolved, aliasedSymbol
+   * will contain the resolved symbol. Otherwise, aliasedSymbol may be present
+   * if the alias is a type literal with a symbol, otherwise it will be
+   * undefined.
+   */
+  aliasResolutionResult?: ResolutionResultFlags;
+
+  /**
+   * The symbol for the constraint of a type parameter. Will not be present when
+   * the name resolver could not determine a symbol for the constraint, e.g.
+   * when it is a computed type.
+   */
+  constraintSymbol?: Sym;
+
+  /**
+   * The result of resolving the type parameter constraint. When resolved,
+   * constraintSymbol will contain the resolved symbol. Otherwise,
+   * constraintSymbol may be present if the constraint is a type literal with a
+   * symbol, otherwise it will be undefined.
+   */
+  constraintResolutionResult?: ResolutionResultFlags;
 }
 
 export interface NodeLinks {
   /** the result of type checking this node */
   resolvedType?: Type;
 
-  /** the result of resolving this node */
+  /** the result of resolving this reference node */
   resolvedSymbol?: Sym;
 
   /**
-   * The result of resolution of this node.
+   * The result of resolution of this reference node.
    *
    * When the the result is `Resolved`, `resolvedSymbol` contains the result.
    **/
@@ -689,7 +712,6 @@ export enum ResolutionResultFlags {
   NotFound = 1 << 4,
 
   ResolutionFailed = Unknown | Ambiguous | NotFound,
-  ResolutionFatal = Ambiguous | NotFound,
 }
 
 export type ResolutionResult = [sym: Sym | undefined, result: ResolutionResultFlags];

--- a/packages/compiler/src/core/util.ts
+++ b/packages/compiler/src/core/util.ts
@@ -414,7 +414,7 @@ export class Queue<T> {
  */
 //prettier-ignore
 export type Mutable<T> =
-  T extends SymbolTable ? T & { set(key: string, value: Sym): void } :
+  T extends SymbolTable ? T & { set(key: string, value: Sym): void, include(source: SymbolTable): void } :
   T extends ReadonlyMap<infer K, infer V> ? Map<K, V> :
   T extends ReadonlySet<infer T> ? Set<T> :
   T extends readonly (infer V)[] ? V[] :

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -245,6 +245,16 @@ export function getIndexer(program: Program, target: Type): ModelIndexer | undef
   return program.stateMap(indexTypeKey).get(target);
 }
 
+const prototypeGetterKey = createStateSymbol("prototypes.getter");
+export function $getter(context: DecoratorContext, target: Type) {
+  context.program.stateMap(prototypeGetterKey).set(target, true);
+}
+$getter.namespace = "Prototypes";
+
+export function isPrototypeGetter(program: Program, target: Type): ModelIndexer | undefined {
+  return program.stateMap(prototypeGetterKey).get(target) ?? false;
+}
+
 export function isStringType(program: Program | ProjectedProgram, target: Type): target is Scalar {
   const coreType = program.checker.getStdType("string");
   const stringType = target.projector ? target.projector.projectType(coreType) : coreType;

--- a/packages/compiler/test/checker/alias.test.ts
+++ b/packages/compiler/test/checker/alias.test.ts
@@ -75,7 +75,7 @@ describe("compiler: aliases", () => {
     testHost.addTypeSpecFile(
       "main.tsp",
       `
-      alias Foo<T> = int32 | T;
+      alias Foo<TEST> = int32 | TEST;
       
       @test model A {
         prop: Foo<"hi">

--- a/packages/compiler/test/checker/resolve-type-reference.test.ts
+++ b/packages/compiler/test/checker/resolve-type-reference.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from "assert";
+import { ok, strictEqual } from "assert";
 import {
   BasicTestRunner,
   createTestHost,
@@ -20,7 +20,7 @@ describe("compiler: resolveTypeReference", () => {
     }
     const [resolved, diagnostics] = runner.program.resolveTypeReference(reference);
     expectDiagnosticEmpty(diagnostics);
-    strictEqual(resolved, target);
+    ok(resolved === target, `Exected to resolve ${reference} to same type as ${code}`);
   }
 
   async function diagnoseResolution(reference: string, code: string) {
@@ -90,6 +90,16 @@ describe("compiler: resolveTypeReference", () => {
     );
   });
 
+  it("resolve model property from base class", async () => {
+    await expectResolve(
+      "Pet.name",
+      `
+      model Animal { @test("target") name: string}
+      model Pet extends Animal { }
+    `
+    );
+  });
+
   it("resolve metatype", async () => {
     await expectResolve(
       "Pet.home::type.street",
@@ -109,6 +119,16 @@ describe("compiler: resolveTypeReference", () => {
       "Direction.up",
       `
       enum Direction { @test("target") up}
+    `
+    );
+  });
+
+  it("resolve enum member with spread", async () => {
+    await expectResolve(
+      "Direction.up",
+      `
+      enum Foo { @test("target") up }
+      enum Direction { ... Foo }
     `
     );
   });

--- a/packages/compiler/test/name-resolver.test.ts
+++ b/packages/compiler/test/name-resolver.test.ts
@@ -1,0 +1,628 @@
+import { NodeFlags, SymbolLinks, SyntaxKind } from "@typespec/compiler";
+import { ok, strictEqual } from "assert";
+import { Binder, createBinder } from "../src/core/binder.js";
+import { inspectSymbolFlags } from "../src/core/inspector.js";
+import { createLogger } from "../src/core/logger/logger.js";
+import { createTracer } from "../src/core/logger/tracer.js";
+import { createResolver } from "../src/core/name-resolver.js";
+import { getNodeAtPosition, parse } from "../src/core/parser.js";
+import {
+  Node,
+  ResolutionResult,
+  ResolutionResultFlags,
+  SymbolFlags,
+  TypeReferenceNode,
+} from "../src/core/types.js";
+import { Program, Sym } from "../src/index.js";
+
+describe.only("compiler: nameResolver", () => {
+  let binder: Binder;
+  let resolver: ReturnType<typeof createResolver>;
+  let program: Program;
+
+  beforeEach(() => {
+    program = createProgramShim();
+    binder = createBinder(program);
+    resolver = createResolver(program);
+  });
+
+  describe("models", () => {
+    describe("binding", () => {
+      it("binds is members", () => {
+        const sym = getGlobalSymbol([
+          `
+          model M1 {
+            x: "x";
+          }
+  
+          model M2 is M1 {
+            y: "y";
+          }
+          `,
+        ]);
+
+        assertSymbol(sym, {
+          exports: {
+            M1: {
+              members: {
+                x: {
+                  flags: SymbolFlags.Member,
+                },
+              },
+            },
+            M2: {
+              members: {
+                x: {
+                  flags: SymbolFlags.Member,
+                },
+                y: {
+                  flags: SymbolFlags.Member,
+                },
+              },
+            },
+          },
+        });
+      });
+
+      it("binds spread members", () => {
+        const sym = getGlobalSymbol([
+          `
+          model M1 {
+            x: "x";
+          }
+  
+          model M2 {
+            ... M1,
+            y: "y";
+          }
+          `,
+        ]);
+
+        assertSymbol(sym, {
+          exports: {
+            M1: {
+              members: {
+                x: {
+                  flags: SymbolFlags.Member,
+                },
+              },
+            },
+            M2: {
+              members: {
+                x: {
+                  flags: SymbolFlags.Member,
+                },
+                y: {
+                  flags: SymbolFlags.Member,
+                },
+              },
+            },
+          },
+        });
+      });
+
+      it("sets containsUnknownMembers flag with spread/extends of instantiations", () => {
+        const sym = getGlobalSymbol([
+          `
+          model Template<T> { ... T };
+  
+          model M1 extends Template<{}> {}
+
+          model M2 {
+            ... Template<{}>;
+          }
+
+          model M3 extends M1 {}
+          model M4 {
+            ... M1;
+          }
+          `,
+        ]);
+
+        const hasUnknownMembers = { links: { hasUnknownMembers: true } };
+        assertSymbol(sym, {
+          exports: {
+            M1: hasUnknownMembers,
+            M2: hasUnknownMembers,
+            M3: hasUnknownMembers,
+            M4: hasUnknownMembers,
+          },
+        });
+      });
+
+      it("binds members of templates", () => {
+        const sym = getGlobalSymbol([
+          `
+          model Template<T> {
+            x: "x";
+          }
+          `,
+        ]);
+
+        assertSymbol(sym, {
+          exports: {
+            Template: {
+              members: {
+                x: {
+                  flags: SymbolFlags.Member,
+                },
+              },
+            },
+          },
+        });
+      });
+    });
+
+    describe("resolution", () => {
+      it("resolves model members", () => {
+        const { "Foo.prop": prop } = getResolutions(
+          [
+            `
+            model Foo {
+              prop: "prop";
+            }
+            ┆
+            `,
+          ],
+          "Foo.prop"
+        );
+        assertSymbol(prop, { name: "prop", flags: SymbolFlags.Member });
+      });
+
+      it("resolves model members from spread", () => {
+        const { "Foo.prop": prop } = getResolutions(
+          [
+            `
+            model Bar {
+              prop: "prop";
+            }
+  
+            model Foo {
+              ... Bar;
+            }
+            ┆
+            `,
+          ],
+          "Foo.prop"
+        );
+        assertSymbol(prop, { name: "prop", flags: SymbolFlags.Member });
+      });
+
+      it("resolves model members from extends", () => {
+        const { "Foo.prop": prop, Bar } = getResolutions(
+          [
+            `
+            model Bar {
+              prop: "prop";
+            }
+  
+            model Foo extends Bar {}
+            ┆
+            `,
+          ],
+          "Foo.prop",
+          "Bar"
+        );
+        assertSymbol(prop, { name: "prop", flags: SymbolFlags.Member });
+        ok(prop[0].parent === Bar[0]);
+      });
+
+      it("resolves model members from extends with unknown spreads to unknown not inherited member", () => {
+        const { "Foo.prop": prop } = getResolutions(
+          [
+            `
+            model Bar {
+              prop: "prop";
+            }
+  
+            model Foo extends Bar {
+              ... Baz<{}>;
+            }
+  
+            model Baz<T> {
+              ... T;
+            }
+  
+            ┆
+            `,
+          ],
+          "Foo.prop"
+        );
+        ok(prop[1] & ResolutionResultFlags.Unknown);
+      });
+
+      it("model members should be unknown with an unknown spread", () => {
+        const { "Foo.prop": prop } = getResolutions(
+          [
+            `
+            model Foo {
+              ... Baz<{}>;
+            }
+  
+            model Baz<T> {
+              ... T;
+            }
+  
+            ┆
+            `,
+          ],
+          "Foo.prop"
+        );
+        ok(prop[1] & ResolutionResultFlags.Unknown);
+      });
+
+      it("model members should be unknown with an unknown base class", () => {
+        const { "Foo.prop": prop } = getResolutions(
+          [
+            `
+            model Foo extends Baz<{}> {
+            }
+  
+            model Baz<T> {
+              ... T;
+            }
+  
+            ┆
+            `,
+          ],
+          "Foo.prop"
+        );
+        ok(prop[1] & ResolutionResultFlags.Unknown);
+      });
+    });
+  });
+
+  describe("namespaces", () => {
+    describe("binding", () => {
+      it("merges across the same file", () => {
+        const sym = getGlobalSymbol([
+          `namespace Foo {
+            model M { }  
+          }
+          namespace Foo {
+            model N { }
+          }`,
+        ]);
+
+        assertSymbol(sym, {
+          exports: {
+            Foo: {
+              flags: SymbolFlags.Namespace,
+              exports: {
+                M: {
+                  flags: SymbolFlags.Model,
+                },
+                N: {
+                  flags: SymbolFlags.Model,
+                },
+              },
+            },
+          },
+        });
+      });
+
+      it("merges across files", () => {
+        const sym = getGlobalSymbol([
+          `namespace Foo {
+            model M { }  
+          }`,
+          `namespace Foo {
+            model N { }
+          }`,
+        ]);
+
+        assertSymbol(sym, {
+          exports: {
+            Foo: {
+              flags: SymbolFlags.Namespace,
+              exports: {
+                M: {
+                  flags: SymbolFlags.Model,
+                },
+                N: {
+                  flags: SymbolFlags.Model,
+                },
+              },
+            },
+          },
+        });
+      });
+    });
+
+    describe("resolution", () => {
+      it("resolves namespace members", () => {
+        const { "Foo.Bar.M": M, "Foo.N": N } = getResolutions(
+          [
+            `namespace Foo {
+              namespace Bar {
+                model M {}
+              }
+              model N { }
+            }
+            ┆
+            `,
+          ],
+          "Foo.Bar.M",
+          "Foo.N"
+        );
+        assertSymbol(M, { name: "M" });
+        assertSymbol(N, { name: "N" });
+      });
+    });
+  });
+
+  describe("aliases", () => {
+    describe("binding", () => {
+      it("binds aliases to symbols", () => {
+        // this is just handled by the binder, but verifying here.
+        const sym = getGlobalSymbol([
+          `namespace Foo {
+            model M { }  
+          }
+          namespace Bar {
+            alias M = Foo.M;
+          }`,
+        ]);
+
+        assertSymbol(sym, {
+          exports: {
+            Foo: {
+              flags: SymbolFlags.Namespace,
+              exports: {
+                M: {
+                  flags: SymbolFlags.Model,
+                },
+              },
+            },
+            Bar: {
+              flags: SymbolFlags.Namespace,
+              exports: {
+                M: {
+                  flags: SymbolFlags.Alias,
+                },
+              },
+            },
+          },
+        });
+      });
+    });
+
+    describe("resolution", () => {
+      it.only("resolves aliases", () => {
+        const { "Foo.Bar.M": M, "Baz.AliasM": AliasM } = getResolutions(
+          [
+            `namespace Foo {
+                namespace Bar {
+                  model M {}
+                }
+              }
+              namespace Baz {
+                alias AliasM = Foo.Bar.M;
+              }
+              ┆
+              `,
+          ],
+          "Foo.Bar.M",
+          "Baz.AliasM"
+        );
+        assertSymbol(M, { name: "M", flags: SymbolFlags.Model });
+        assertSymbol(AliasM, { name: "M", flags: SymbolFlags.Model });
+      });
+    });
+  });
+
+  describe("usings", () => {
+    describe("binding", () => {
+      it("binds usings to locals", () => {
+        const sym = getGlobalSymbol(["namespace Foo { model M { }} namespace Bar { using Foo; }"]);
+        assertSymbol(sym, {
+          exports: {
+            Foo: {
+              flags: SymbolFlags.Namespace,
+            },
+            Bar: {
+              flags: SymbolFlags.Namespace,
+              locals: {
+                M: {
+                  flags: SymbolFlags.Model | SymbolFlags.Using,
+                },
+              },
+            },
+          },
+        });
+      });
+    });
+
+    describe("resolution", () => {
+      it("resolves usings", () => {
+        const sources = [
+          `
+          namespace Foo {
+            model M { }
+          }
+          
+          namespace Bar {
+            using Foo;
+            ┆
+          }
+        `,
+        ];
+
+        const { M } = getResolutions(sources, "M");
+        assertSymbol(M[0], { name: "M", flags: SymbolFlags.Using });
+      });
+    });
+  });
+
+  type StringTuplesToSymbolRecord<T extends string[]> = {
+    [K in T[number]]: ResolutionResult;
+  };
+
+  function getResolutions<T extends string[]>(
+    sources: string[],
+    ...names: T
+  ): StringTuplesToSymbolRecord<T> {
+    let index = 0;
+    const symbols = {} as any;
+    const referenceNodes: TypeReferenceNode[] = [];
+
+    for (let source of sources) {
+      const cursorPos = source.indexOf("┆");
+      if (cursorPos >= 0) {
+        const aliasCodes = names.map((name) => `alias test${name.replace(/\./g, "")} = ${name};`);
+        const aliasOffsets: number[] = [];
+        let prevOffset = 0;
+        for (let i = 0; i < names.length; i++) {
+          aliasOffsets.push(prevOffset + aliasCodes[i].length - 1);
+          prevOffset += aliasCodes[i].length;
+        }
+        source = source.slice(0, cursorPos) + aliasCodes.join("") + source.slice(cursorPos + 1);
+        const sf = parse(source);
+        program.sourceFiles.set(String(index++), sf);
+        binder.bindSourceFile(sf);
+
+        for (let i = 0; i < names.length; i++) {
+          const node = getNodeAtPosition(sf, cursorPos + aliasOffsets[i]);
+          referenceNodes.push(getParentTypeRef(node));
+        }
+      }
+    }
+
+    resolver.resolveProgram();
+    for (let i = 0; i < names.length; i++) {
+      const nodeLinks = resolver.getNodeLinks(referenceNodes[i]);
+      if (!nodeLinks.resolutionResult) {
+        throw new Error(`Reference ${names[i]} hasn't been resolved`);
+      }
+
+      symbols[names[i]] = [nodeLinks.resolvedSymbol, nodeLinks.resolutionResult];
+    }
+    return symbols;
+  }
+
+  function getParentTypeRef(node: Node | undefined) {
+    if (!node) {
+      throw new Error("Can't find parent of undefined node.");
+    }
+    if (node.kind !== SyntaxKind.MemberExpression && node.kind !== SyntaxKind.Identifier) {
+      throw new Error("Can't find parent of non-reference node.");
+    }
+
+    if (!node.parent) {
+      throw new Error("can't find parent.");
+    }
+
+    if (node.parent.kind === SyntaxKind.TypeReference) {
+      return node.parent;
+    }
+
+    return getParentTypeRef(node.parent);
+  }
+
+  function getGlobalSymbol(typespecSources: string[]): Sym {
+    let index = 0;
+    for (const source of typespecSources) {
+      const sf = parse(source);
+      program.sourceFiles.set(String(index++), sf);
+      binder.bindSourceFile(sf);
+    }
+
+    resolver.resolveProgram();
+    return resolver.getGlobalNamespaceSymbol();
+  }
+
+  function assertSymbol(
+    sym: ResolutionResult | Sym | undefined,
+    record: SymbolDescriptor = {}
+  ): asserts sym is [Sym, ResolutionResultFlags] | Sym {
+    if (Array.isArray(sym)) {
+      sym = sym[0];
+    }
+    if (!sym) {
+      throw new Error(`Symbol not found.`);
+    }
+    if (record.flags) {
+      ok(
+        sym.flags & record.flags,
+        `Expected symbol ${sym.name} to have flags ${inspectSymbolFlags(
+          record.flags
+        )} but got ${inspectSymbolFlags(sym.flags)}`
+      );
+    }
+
+    if (record.nodeFlags) {
+      ok(
+        sym.declarations[0].flags & record.nodeFlags,
+        `Expected symbol ${sym.name} to have node flags ${record.nodeFlags} but got ${sym.declarations[0].flags}`
+      );
+    }
+
+    if (record.name) {
+      strictEqual(sym.name, record.name);
+    }
+
+    if (record.exports) {
+      ok(sym.exports, `Expected symbol ${sym.name} to have exports`);
+      const exports = resolver.getAugmentedSymbolTable(sym.exports);
+
+      for (const [name, descriptor] of Object.entries(record.exports)) {
+        const exportSym = exports.get(name);
+        ok(exportSym, `Expected symbol ${sym.name} to have export ${name}`);
+        assertSymbol(exportSym, descriptor);
+      }
+    }
+
+    if (record.locals) {
+      const node = sym.declarations[0] as any;
+      ok(node.locals, `Expected symbol ${sym.name} to have locals`);
+      const locals = resolver.getAugmentedSymbolTable(node.locals);
+
+      for (const [name, descriptor] of Object.entries(record.locals)) {
+        const localSym = locals.get(name);
+        ok(localSym, `Expected symbol ${sym.name} to have local ${name}`);
+        assertSymbol(localSym, descriptor);
+      }
+    }
+
+    if (record.members) {
+      ok(sym.members, `Expected symbol ${sym.name} to have exports`);
+      const members = resolver.getAugmentedSymbolTable(sym.members);
+
+      for (const [name, descriptor] of Object.entries(record.members)) {
+        const exportSym = members.get(name);
+        ok(exportSym, `Expected symbol ${sym.name} to have member ${name}`);
+        assertSymbol(exportSym, descriptor);
+      }
+    }
+
+    if (record.links) {
+      const links = resolver.getSymbolLinks(sym);
+      for (const [key, value] of Object.entries(record.links) as [keyof SymbolLinks, any][]) {
+        if (value) {
+          ok(links[key], `Expected symbol ${sym.name} to have link ${key}`);
+          strictEqual(links[key], value);
+        }
+      }
+    }
+  }
+});
+
+interface SymbolDescriptor {
+  name?: string;
+  flags?: SymbolFlags;
+  nodeFlags?: NodeFlags;
+  locals?: Record<string, SymbolDescriptor>;
+  exports?: Record<string, SymbolDescriptor>;
+  members?: Record<string, SymbolDescriptor>;
+  links?: SymbolLinks;
+}
+
+function createProgramShim(): Program {
+  return {
+    tracer: createTracer(createLogger({ sink: { log: () => {} } })),
+    reportDuplicateSymbols() {},
+    onValidate() {},
+    sourceFiles: new Map(),
+    jsSourceFiles: new Map(),
+  } as any;
+}


### PR DESCRIPTION
fix #4764 
This is nowhere near ready, but putting up in draft PR to share progress.

The goals of this change:

1. Increase performance by doing work early and once and allocating far fewer symbols.
2. Reduce complexity around binding and resolution by centralizing the logic and cleanly separating symbol resolution from type checking to the extent possible
3. Fix meta-properties across all use cases we know about
4. Enable augment decoration of many new things (basically everything we'd want except things involving templates)

Details about the approach can be found in the comment at the top of `name-resolver.ts`.