### PR TITLE
JsonSchema: Fix `@maxValueExclusive` setting `minimumExclusive` instead of `maximumExclusive`

### DIFF
--- a/common/changes/@typespec/json-schema/fix-json-schema-exclusive-max_2023-11-09-17-10.json
+++ b/common/changes/@typespec/json-schema/fix-json-schema-exclusive-max_2023-11-09-17-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "JsonSchema: Fix `@maxValueExclusive` setting `minimumExclusive` instead of `maximumExclusive`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -451,7 +451,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
     applyConstraint(getMinValue, "minimum");
     applyConstraint(getMinValueExclusive, "exclusiveMinimum");
     applyConstraint(getMaxValue, "maximum");
-    applyConstraint(getMaxValueExclusive, "exclusiveMinimum");
+    applyConstraint(getMaxValueExclusive, "exclusiveMaximum");
     applyConstraint(getPattern, "pattern");
     applyConstraint(getMinItems, "minItems");
     applyConstraint(getMaxItems, "maxItems");

--- a/packages/json-schema/test/scalar-constraints.test.ts
+++ b/packages/json-schema/test/scalar-constraints.test.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert, { strictEqual } from "assert";
 import { emitSchema } from "./utils.js";
 
 describe("jsonschema: scalar constraints", () => {
@@ -51,6 +51,36 @@ describe("jsonschema: scalar constraints", () => {
     `);
         assertNumericConstraints(schemas["Test.json"]);
       });
+    });
+
+    describe("@minValueExclusive/@maxValueExclusive", () => {
+      for (const numType of scalarNumberTypes) {
+        it(numType, async () => {
+          const schemas = await emitSchema(
+            `
+            @minValueExclusive(1)
+            @maxValueExclusive(2)
+            scalar Test extends ${numType};
+          `
+          );
+
+          strictEqual(schemas["Test.json"].exclusiveMinimum, 1);
+          strictEqual(schemas["Test.json"].exclusiveMaximum, 2);
+        });
+
+        it("can be applied on a union", async () => {
+          const schemas = await emitSchema(
+            `
+            @minValueExclusive(1)
+            @maxValueExclusive(2)
+            union Test {int32, string, null};
+          `
+          );
+
+          strictEqual(schemas["Test.json"].exclusiveMinimum, 1);
+          strictEqual(schemas["Test.json"].exclusiveMaximum, 2);
+        });
+      }
     });
 
     describe("on property", () => {


### PR DESCRIPTION
fix [#2531](https://github.com/microsoft/typespec/issues/2531)