### PR TITLE
Json Schema Fix: `0` value in an enum would cause the enum type to be `string` and `number`

### DIFF
--- a/common/changes/@typespec/json-schema/fix-enum-0-string_2023-11-09-18-36.json
+++ b/common/changes/@typespec/json-schema/fix-enum-0-string_2023-11-09-18-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/json-schema",
+      "comment": "Fix: Enum with a value of `0` would have resulting in `type` of `string` and `number`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/json-schema"
+}

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -189,7 +189,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
     const enumValues = new Set<string | number>();
     for (const member of en.members.values()) {
       // ???: why do we let emitters decide what the default type of an enum is
-      enumTypes.add(member.value ? typeof member.value : "string");
+      enumTypes.add(typeof member.value === "number" ? "number" : "string");
       enumValues.add(member.value ?? member.name);
     }
 

--- a/packages/json-schema/test/enums.test.ts
+++ b/packages/json-schema/test/enums.test.ts
@@ -15,14 +15,15 @@ describe("emitting enums", () => {
   it("handles numbers", async () => {
     const schemas = await emitSchema(`
       enum Foo {
-        a: 1;
-        b: 2;
+        a: 0;
+        b: 1;
+        c: 2;
       }
     `);
     const Foo = schemas["Foo.json"];
 
     assert.deepEqual(Foo.type, "number");
-    assert.deepStrictEqual(Foo.enum, [1, 2]);
+    assert.deepStrictEqual(Foo.enum, [0, 1, 2]);
   });
 
   it("handles strings", async () => {


### PR DESCRIPTION
fix [#2538](https://github.com/microsoft/typespec/issues/2538)