### PR TITLE
Improve logic of no-routes rule

### DIFF
--- a/common/changes/@typespec/http/http-FixNoRoutes_2023-11-16-16-49.json
+++ b/common/changes/@typespec/http/http-FixNoRoutes_2023-11-16-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "Add diagnostic when a namespace exists with routes, but no namespace is marked with `@service`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/common/changes/@typespec/openapi3/http-FixNoRoutes_2023-11-16-16-49.json
+++ b/common/changes/@typespec/openapi3/http-FixNoRoutes_2023-11-16-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/http/src/lib.ts
+++ b/packages/http/src/lib.ts
@@ -88,11 +88,10 @@ export const $lib = createTypeSpecLibrary({
         default: "`Content-Type` header ignored because there is no body.",
       },
     },
-    "no-routes": {
+    "no-service-found": {
       severity: "warning",
       messages: {
-        default:
-          "Current spec is not exposing any routes. This could be to not having the service namespace marked with @service.",
+        default: paramMessage`No namespace with '@service' was found.`,
       },
     },
     "invalid-type-for-auth": {

--- a/packages/http/src/lib.ts
+++ b/packages/http/src/lib.ts
@@ -91,7 +91,7 @@ export const $lib = createTypeSpecLibrary({
     "no-service-found": {
       severity: "warning",
       messages: {
-        default: paramMessage`No namespace with '@service' was found.`,
+        default: paramMessage`No namespace with '@service' was found, but Namespace '${"namespace"}' contains routes. Did you mean to annotate this with '@service'?`,
       },
     },
     "invalid-type-for-auth": {

--- a/packages/http/src/operations.ts
+++ b/packages/http/src/operations.ts
@@ -119,8 +119,12 @@ export function getAllRoutes(
 
 export function reportIfNoRoutes(program: Program, routes: HttpOperation[]) {
   if (routes.length === 0) {
+    // FIXME: Fix this.
     reportDiagnostic(program, {
-      code: "no-routes",
+      code: "no-service-found",
+      format: {
+        namespace: "Blah",
+      },
       target: program.getGlobalNamespaceType(),
     });
   }

--- a/packages/http/src/operations.ts
+++ b/packages/http/src/operations.ts
@@ -119,14 +119,24 @@ export function getAllRoutes(
 
 export function reportIfNoRoutes(program: Program, routes: HttpOperation[]) {
   if (routes.length === 0) {
-    // FIXME: Fix this.
-    reportDiagnostic(program, {
-      code: "no-service-found",
-      format: {
-        namespace: "Blah",
+    const namespaceCounts = new Map<Namespace, number>();
+    navigateProgram(program, {
+      namespace: (namespace) => {
+        namespaceCounts.set(namespace, namespace.operations.size);
       },
-      target: program.getGlobalNamespaceType(),
     });
+    // if there is any namespace with namespaceCounts > 0, then report the diagnostic
+    for (const [namespace, count] of namespaceCounts) {
+      if (count > 0) {
+        reportDiagnostic(program, {
+          code: "no-service-found",
+          format: {
+            namespace: namespace.name,
+          },
+          target: namespace,
+        });
+      }
+    }
   }
 }
 

--- a/packages/http/src/operations.ts
+++ b/packages/http/src/operations.ts
@@ -119,24 +119,19 @@ export function getAllRoutes(
 
 export function reportIfNoRoutes(program: Program, routes: HttpOperation[]) {
   if (routes.length === 0) {
-    const namespaceCounts = new Map<Namespace, number>();
     navigateProgram(program, {
       namespace: (namespace) => {
-        namespaceCounts.set(namespace, namespace.operations.size);
+        if (namespace.operations.size > 0) {
+          reportDiagnostic(program, {
+            code: "no-service-found",
+            format: {
+              namespace: namespace.name,
+            },
+            target: namespace,
+          });
+        }
       },
     });
-    // if there is any namespace with namespaceCounts > 0, then report the diagnostic
-    for (const [namespace, count] of namespaceCounts) {
-      if (count > 0) {
-        reportDiagnostic(program, {
-          code: "no-service-found",
-          format: {
-            namespace: namespace.name,
-          },
-          target: namespace,
-        });
-      }
-    }
   }
 }
 

--- a/packages/openapi3/test/decorators.test.ts
+++ b/packages/openapi3/test/decorators.test.ts
@@ -59,9 +59,7 @@ describe("openapi3: decorators", () => {
         model Foo {}
       `);
 
-      expectDiagnosticEmpty(
-        diagnostics.filter((d) => d.code !== "@typespec/http/no-service-found")
-      );
+      expectDiagnosticEmpty(diagnostics);
 
       strictEqual(getRef(runner.program, Foo), "../common.json#/definitions/Foo");
     });

--- a/packages/openapi3/test/decorators.test.ts
+++ b/packages/openapi3/test/decorators.test.ts
@@ -59,7 +59,9 @@ describe("openapi3: decorators", () => {
         model Foo {}
       `);
 
-      expectDiagnosticEmpty(diagnostics.filter((d) => d.code !== "@typespec/http/no-routes"));
+      expectDiagnosticEmpty(
+        diagnostics.filter((d) => d.code !== "@typespec/http/no-service-found")
+      );
 
       strictEqual(getRef(runner.program, Foo), "../common.json#/definitions/Foo");
     });

--- a/packages/openapi3/test/no-service-found.test.ts
+++ b/packages/openapi3/test/no-service-found.test.ts
@@ -1,0 +1,45 @@
+import { expectDiagnosticEmpty, expectDiagnostics } from "@typespec/compiler/testing";
+import { diagnoseOpenApiFor } from "./test-host.js";
+
+describe("openapi3: no-service-found diagnostic", () => {
+  it("does not emit warning if a non-service namespace has no routes", async () => {
+    const diagnostics = await diagnoseOpenApiFor(
+      `
+    namespace Test {
+      model Foo {};
+    }
+    `
+    );
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("emit a warning if a non-service namespace has routes", async () => {
+    const diagnostics = await diagnoseOpenApiFor(
+      `
+    namespace Test {
+      model Foo {};
+
+      @route("/foo")
+      op get(): Foo;
+    }
+    `
+    );
+    expectDiagnostics(diagnostics, [
+      {
+        code: "no-service-found",
+      },
+    ]);
+  });
+
+  it("does not emit a warning if a service namespace has no routes", async () => {
+    const diagnostics = await diagnoseOpenApiFor(
+      `
+    @service
+    namespace Test {
+      model Foo {};
+    }
+    `
+    );
+    expectDiagnosticEmpty(diagnostics);
+  });
+});

--- a/packages/openapi3/test/no-service-found.test.ts
+++ b/packages/openapi3/test/no-service-found.test.ts
@@ -26,7 +26,7 @@ describe("openapi3: no-service-found diagnostic", () => {
     );
     expectDiagnostics(diagnostics, [
       {
-        code: "no-service-found",
+        code: "@typespec/http/no-service-found",
       },
     ]);
   });
@@ -37,6 +37,21 @@ describe("openapi3: no-service-found diagnostic", () => {
     @service
     namespace Test {
       model Foo {};
+    }
+    `
+    );
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("does not emit a warning if a service namespace has routes", async () => {
+    const diagnostics = await diagnoseOpenApiFor(
+      `
+    @service
+    namespace Test {
+      model Foo {};
+
+      @route("/foo")
+      op get(): Foo;
     }
     `
     );

--- a/packages/openapi3/test/no-service-found.test.ts
+++ b/packages/openapi3/test/no-service-found.test.ts
@@ -53,6 +53,10 @@ describe("openapi3: no-service-found diagnostic", () => {
       @route("/foo")
       op get(): Foo;
     }
+
+    namespace Library {
+      op ping(): void;
+    }
     `
     );
     expectDiagnosticEmpty(diagnostics);

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -19,7 +19,7 @@ async function openapiWithOptions(
     options: { "@typespec/openapi3": { ...options, "output-file": outPath } },
   });
 
-  expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found"));
+  expectDiagnosticEmpty(diagnostics);
 
   const content = runner.fs.get(outPath)!;
   return JSON.parse(content);

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -19,7 +19,7 @@ async function openapiWithOptions(
     options: { "@typespec/openapi3": { ...options, "output-file": outPath } },
   });
 
-  expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-routes"));
+  expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found"));
 
   const content = runner.fs.get(outPath)!;
   return JSON.parse(content);

--- a/packages/openapi3/test/output-file.test.ts
+++ b/packages/openapi3/test/output-file.test.ts
@@ -46,7 +46,7 @@ describe("openapi3: output file", () => {
       options: { "@typespec/openapi3": { ...options, "emitter-output-dir": outputDir } },
     });
 
-    expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found"));
+    expectDiagnosticEmpty(diagnostics);
   }
 
   function expectOutput(

--- a/packages/openapi3/test/output-file.test.ts
+++ b/packages/openapi3/test/output-file.test.ts
@@ -46,7 +46,7 @@ describe("openapi3: output file", () => {
       options: { "@typespec/openapi3": { ...options, "emitter-output-dir": outputDir } },
     });
 
-    expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-routes"));
+    expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found"));
   }
 
   function expectOutput(

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -53,7 +53,7 @@ export async function diagnoseOpenApiFor(code: string, options: OpenAPI3EmitterO
     emit: ["@typespec/openapi3"],
     options: { "@typespec/openapi3": options as any },
   });
-  return diagnostics.filter((x) => x.code !== "@typespec/http/no-routes");
+  return diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found");
 }
 
 export async function openApiFor(
@@ -74,7 +74,7 @@ export async function openApiFor(
     emit: ["@typespec/openapi3"],
     options: { "@typespec/openapi3": { ...options, "output-file": outPath } },
   });
-  expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-routes"));
+  expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found"));
 
   if (!versions) {
     return JSON.parse(host.fs.get(resolveVirtualPath("openapi.json"))!);

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -53,7 +53,7 @@ export async function diagnoseOpenApiFor(code: string, options: OpenAPI3EmitterO
     emit: ["@typespec/openapi3"],
     options: { "@typespec/openapi3": options as any },
   });
-  return diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found");
+  return diagnostics;
 }
 
 export async function openApiFor(
@@ -74,7 +74,7 @@ export async function openApiFor(
     emit: ["@typespec/openapi3"],
     options: { "@typespec/openapi3": { ...options, "output-file": outPath } },
   });
-  expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@typespec/http/no-service-found"));
+  expectDiagnosticEmpty(diagnostics);
 
   if (!versions) {
     return JSON.parse(host.fs.get(resolveVirtualPath("openapi.json"))!);


### PR DESCRIPTION
Fix #2573.

[Playground](https://cadlplayground.z22.web.core.windows.net/prs/2673/?c=aW1wb3J0ICJAdHlwZXNwZWMvaHR0cCI7DQoNCnVzaW5nIFR5cGVTcGVjLkh0dHDFGG5hbWVzcGFjZSBUZXN0IHvEFG1vZGVsIFdpZGdldCB7fcUoQMQMb3AgZ2V0KCk6xx3FGn3OR0Zvb8RGICDGRlRoxHjFRc8pQmFyxinKLU5vb2RsZchzICDPdcYfOyANCn0%3D&e=%40typespec%2Fopenapi3&options=%7B%7D) shows that:
- the warning now appears on any namespace that has operations if none have `@service`
- does not appear when there are operations in the global namespace
- disappears from all namespaces when `@service` is placed on any namespace that has operations