### PR TITLE
Disable CodeQL by default

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -7,6 +7,9 @@ trigger:
 
 pr: none
 
+variables:
+  - template: templates/variables/globals.yml
+
 jobs:
   - job: npm_stable
     displayName: Npm publish

--- a/eng/pipelines/pr-tryit.yml
+++ b/eng/pipelines/pr-tryit.yml
@@ -3,6 +3,9 @@ pr:
   - main
   - release/*
 
+variables:
+  - template: templates/variables/globals.yml
+
 jobs:
   - job: publish_playground
     displayName: Publish playground

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -4,6 +4,9 @@ pr:
   - main
   - release/*
 
+variables:
+  - template: templates/variables/globals.yml
+
 jobs:
   - job: Build_And_Test
     displayName: Build And Test

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,0 +1,3 @@
+variables:
+  # Disable CodeQL by default to prevent build timeouts
+  Codeql.SkipTaskAutoInjection: true


### PR DESCRIPTION
- CodeQL is causing frequent build timeouts (with no logs)