### PR TITLE
Update the link to initialize a library in emitters-basics.md

### DIFF
--- a/docs/extending-typespec/emitters-basics.md
+++ b/docs/extending-typespec/emitters-basics.md
@@ -9,7 +9,7 @@ TypeSpec emitters are libraries that use various TypeSpec compiler APIs to refle
 
 ## Getting started
 
-TypeSpec emitters are a special kind of TypeSpec library and so have the same getting started instructions. Follow [these steps](#todo) to initialize a typespec library.
+TypeSpec emitters are a special kind of TypeSpec library and so have the same getting started instructions. Follow [these steps](./basics.md) to initialize a typespec library.
 
 ## $onEmit
 


### PR DESCRIPTION
I am following the document to create an emitter and found this link of steps to initialize a typespec library is not working. So I create this PR to update the md to point the link to basics.md file, which is for creating a TypeSpec library. 