### PR TITLE
Emitter framework: Allow reference context to be passed to `emitTypeReference`

### DIFF
--- a/packages/compiler/src/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/src/emitter-framework/asset-emitter.ts
@@ -205,107 +205,122 @@ export function createAssetEmitter<T, TOptions extends object>(
       return sourceFile;
     },
 
-    emitTypeReference(target): EmitEntity<T> {
-      if (target.kind === "ModelProperty") {
-        return invokeTypeEmitter("modelPropertyReference", target);
-      } else if (target.kind === "EnumMember") {
-        return invokeTypeEmitter("enumMemberReference", target);
-      }
+    emitTypeReference(target, contextPatch?: Partial<ContextState>): EmitEntity<T> {
+      return withPatchedReferenceContext(contextPatch ?? {}, () => {
+        const oldIncomingReferenceContext = incomingReferenceContext;
+        const oldIncomingReferenceContextTarget = incomingReferenceContextTarget;
 
-      const oldIncomingReferenceContext = incomingReferenceContext;
-      const oldIncomingReferenceContextTarget = incomingReferenceContextTarget;
+        incomingReferenceContext = context.referenceContext ?? null;
+        incomingReferenceContextTarget = incomingReferenceContext ? target : null;
 
-      incomingReferenceContext = context.referenceContext ?? null;
-      incomingReferenceContextTarget = incomingReferenceContext ? target : null;
-
-      const entity = this.emitType(target);
-
-      incomingReferenceContext = oldIncomingReferenceContext;
-      incomingReferenceContextTarget = oldIncomingReferenceContextTarget;
-
-      let placeholder: Placeholder<T> | null = null;
-
-      if (entity.kind === "circular") {
-        let waiting = waitingCircularRefs.get(entity.emitEntityKey);
-        if (!waiting) {
-          waiting = [];
-          waitingCircularRefs.set(entity.emitEntityKey, waiting);
+        let result;
+        if (target.kind === "ModelProperty") {
+          result = invokeTypeEmitter("modelPropertyReference", target);
+        } else if (target.kind === "EnumMember") {
+          result = invokeTypeEmitter("enumMemberReference", target);
         }
 
-        const typeChainSnapshot = referenceTypeChain;
-        waiting.push({
-          state: {
-            lexicalTypeStack,
-            context,
-          },
-          cb: (resolvedEntity) =>
-            invokeReference(
-              this,
-              resolvedEntity,
-              true,
-              resolveReferenceCycle(typeChainSnapshot, entity, typeToEmitEntity as any)
-            ),
-        });
+        if (result) {
+          incomingReferenceContext = oldIncomingReferenceContext;
+          incomingReferenceContextTarget = oldIncomingReferenceContextTarget;
+          return result;
+        }
 
-        placeholder = new Placeholder();
-        return this.result.rawCode(placeholder);
-      } else {
-        return invokeReference(this, entity, false);
-      }
+        const entity = this.emitType(target);
 
-      function invokeReference(
-        assetEmitter: AssetEmitter<T, TOptions>,
-        entity: EmitEntity<T>,
-        circular: boolean,
-        cycle?: ReferenceCycle
-      ): EmitEntity<T> {
-        let ref;
-        const scope = currentScope();
+        incomingReferenceContext = oldIncomingReferenceContext;
+        incomingReferenceContextTarget = oldIncomingReferenceContextTarget;
 
-        if (circular) {
-          ref = typeEmitter.circularReference(entity, scope, cycle!);
+        let placeholder: Placeholder<T> | null = null;
+
+        if (entity.kind === "circular") {
+          let waiting = waitingCircularRefs.get(entity.emitEntityKey);
+          if (!waiting) {
+            waiting = [];
+            waitingCircularRefs.set(entity.emitEntityKey, waiting);
+          }
+
+          const typeChainSnapshot = referenceTypeChain;
+          waiting.push({
+            state: {
+              lexicalTypeStack,
+              context,
+            },
+            cb: (resolvedEntity) =>
+              invokeReference(
+                this,
+                resolvedEntity,
+                true,
+                resolveReferenceCycle(typeChainSnapshot, entity, typeToEmitEntity as any)
+              ),
+          });
+
+          placeholder = new Placeholder();
+          return this.result.rawCode(placeholder);
         } else {
-          if (entity.kind !== "declaration") {
-            return entity;
+          return invokeReference(this, entity, false);
+        }
+
+        function invokeReference(
+          assetEmitter: AssetEmitter<T, TOptions>,
+          entity: EmitEntity<T>,
+          circular: boolean,
+          cycle?: ReferenceCycle
+        ): EmitEntity<T> {
+          let ref;
+          const scope = currentScope();
+
+          if (circular) {
+            ref = typeEmitter.circularReference(entity, scope, cycle!);
+          } else {
+            if (entity.kind !== "declaration") {
+              return entity;
+            }
+            compilerAssert(
+              scope,
+              "Emit context must have a scope set in order to create references to declarations."
+            );
+            const { pathUp, pathDown, commonScope } = resolveDeclarationReferenceScope(
+              entity,
+              scope
+            );
+            ref = typeEmitter.reference(entity, pathUp, pathDown, commonScope);
           }
-          compilerAssert(
-            scope,
-            "Emit context must have a scope set in order to create references to declarations."
-          );
-          const { pathUp, pathDown, commonScope } = resolveDeclarationReferenceScope(entity, scope);
-          ref = typeEmitter.reference(entity, pathUp, pathDown, commonScope);
-        }
 
-        if (!(ref instanceof EmitterResult)) {
-          ref = assetEmitter.result.rawCode(ref) as RawCode<T>;
-        }
-
-        if (placeholder) {
-          // this should never happen as this function shouldn't be called until
-          // the target declaration is finished being emitted.
-          compilerAssert(ref.kind !== "circular", "TypeEmitter `reference` returned circular emit");
-
-          // this could presumably be allowed if we want.
-          compilerAssert(
-            ref.kind === "none" || !(ref.value instanceof Placeholder),
-            "TypeEmitter's `reference` method cannot return a placeholder."
-          );
-
-          switch (ref.kind) {
-            case "code":
-            case "declaration":
-              placeholder.setValue(ref.value as T);
-              break;
-            case "none":
-              // this cast is incorrect, think about what should happen
-              // if reference returns noEmit...
-              placeholder.setValue("" as T);
-              break;
+          if (!(ref instanceof EmitterResult)) {
+            ref = assetEmitter.result.rawCode(ref) as RawCode<T>;
           }
-        }
 
-        return ref;
-      }
+          if (placeholder) {
+            // this should never happen as this function shouldn't be called until
+            // the target declaration is finished being emitted.
+            compilerAssert(
+              ref.kind !== "circular",
+              "TypeEmitter `reference` returned circular emit"
+            );
+
+            // this could presumably be allowed if we want.
+            compilerAssert(
+              ref.kind === "none" || !(ref.value instanceof Placeholder),
+              "TypeEmitter's `reference` method cannot return a placeholder."
+            );
+
+            switch (ref.kind) {
+              case "code":
+              case "declaration":
+                placeholder.setValue(ref.value as T);
+                break;
+              case "none":
+                // this cast is incorrect, think about what should happen
+                // if reference returns noEmit...
+                placeholder.setValue("" as T);
+                break;
+            }
+          }
+
+          return ref;
+        }
+      });
     },
 
     emitDeclarationName(type): string | undefined {
@@ -569,6 +584,8 @@ export function createAssetEmitter<T, TOptions extends object>(
     method: TMethod,
     args: Parameters<TypeEmitter<T, TOptions>[TMethod]>
   ) {
+    console.log("Set context for type", method, context.referenceContext);
+
     const type = args[0];
     let newTypeStack: LexicalTypeStackEntry[];
 
@@ -614,6 +631,7 @@ export function createAssetEmitter<T, TOptions extends object>(
             ...incomingReferenceContext,
           }),
         });
+        console.log("Changed context", context.referenceContext);
       }
 
       const seenContext = knownContexts.get([entry, context]);
@@ -694,6 +712,27 @@ export function createAssetEmitter<T, TOptions extends object>(
     context = oldContext;
     lexicalTypeStack = oldTypeStack;
     referenceTypeChain = oldRefTypeStack;
+  }
+
+  function withPatchedReferenceContext<T>(contextPatch: Partial<ContextState>, cb: () => T): T {
+    if (contextPatch.referenceContext !== undefined) {
+      const oldContext = context;
+
+      context = stateInterner.intern({
+        lexicalContext: context.lexicalContext,
+        referenceContext: stateInterner.intern({
+          ...context.referenceContext,
+          ...contextPatch.referenceContext,
+        }),
+      });
+
+      console.log("Context", context.referenceContext);
+      const result = cb();
+      context = oldContext;
+      return result;
+    } else {
+      return cb();
+    }
   }
 
   /**

--- a/packages/compiler/src/emitter-framework/types.ts
+++ b/packages/compiler/src/emitter-framework/types.ts
@@ -28,7 +28,7 @@ export interface AssetEmitter<T, TOptions extends object = Record<string, unknow
   getContext(): Context;
   getOptions(): AssetEmitterOptions<TOptions>;
   getProgram(): Program;
-  emitTypeReference(type: Type): EmitEntity<T>;
+  emitTypeReference(type: Type, context?: Partial<ContextState>): EmitEntity<T>;
   emitDeclarationName(type: TypeSpecDeclaration): string | undefined;
   emitType(type: Type, context?: Partial<ContextState>): EmitEntity<T>;
   emitProgram(options?: { emitGlobalNamespace?: boolean; emitTypeSpecNamespace?: boolean }): void;


### PR DESCRIPTION
Current way of setting reference context is flawed in that you cannot have a different context to different reference. It is also run before the element itself instead of before emitting the reference so this mean the context would apply to the referrer as well.

This allows the `emitTypeReference` to take a parameter to patch the reference context