### PR TITLE
HotFix: OpenAPI3 creating conflicting type declaration when type was used in multipart implicit body and json body.

### DIFF
--- a/common/changes/@typespec/openapi3/hotfix-openapi3-multipart-conflict_2023-12-13-16-39.json
+++ b/common/changes/@typespec/openapi3/hotfix-openapi3-multipart-conflict_2023-12-13-16-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/openapi3",
+      "comment": "Fix: OpenAPI3 creating conflicting type declaration when type was used in multipart implicit body and json body",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/openapi3"
+}

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -125,7 +125,7 @@ export class OpenAPI3SchemaEmitter extends TypeEmitter<
     const contentType = this.#getContentType();
 
     if (contentType === "application/json") {
-      delete patch.contentType;
+      patch.contentType = undefined;
     }
 
     return patch;

--- a/packages/openapi3/test/multipart.test.ts
+++ b/packages/openapi3/test/multipart.test.ts
@@ -107,8 +107,8 @@ describe("typespec-autorest: multipart", () => {
     const res = await openApiFor(
       `
       enum FilePurpose {
-        fineTune,
-        fineTuneResults,
+        one,
+        two,
       }
       
       interface Files {
@@ -117,6 +117,6 @@ describe("typespec-autorest: multipart", () => {
       }
       `
     );
-    deepStrictEqual(res.components.schemas.FilePurpose, {});
+    deepStrictEqual(res.components.schemas.FilePurpose, { type: "string", enum: ["one", "two"] });
   });
 });

--- a/packages/openapi3/test/multipart.test.ts
+++ b/packages/openapi3/test/multipart.test.ts
@@ -102,4 +102,21 @@ describe("typespec-autorest: multipart", () => {
       }
     );
   });
+
+  it("enum used in both a json payload and multipart part shouldn't create 2 models", async () => {
+    const res = await openApiFor(
+      `
+      enum FilePurpose {
+        fineTune,
+        fineTuneResults,
+      }
+      
+      interface Files {
+        @get listFiles(purpose: FilePurpose): string;
+        @post uploadFile(@header contentType: "multipart/form-data", purpose: FilePurpose): string;
+      }
+      `
+    );
+    deepStrictEqual(res.components.schemas.FilePurpose, {});
+  });
 });


### PR DESCRIPTION
fix #2751

Problem was when we reduce the context it is a patch not a replace so if we delete the contentType to have the default handling then it would keep the previous value instead of actually removing it.