### PR TITLE
Stop warning user when `tsp init` a template without `compilerVersion` specified

### DIFF
--- a/docs/extending-typespec/writing-scaffolding-template.md
+++ b/docs/extending-typespec/writing-scaffolding-template.md
@@ -10,6 +10,17 @@ typespec provides scaffolding functionality via the `tsp init` command.
 tsp init <templateUrl>
 ```
 
+## Specifying a minimum typespec version
+If your template needs a functionality that was only added in a newer version of TypeSpec you might want to specify that in the template. This will warn the user that the template might not work as expected and prompt them to confirm that they want to continue.
+
+To do so you can set `compilerVersion` in the each template configuration. The value is the minimum semver version required. 
+
+```json
+{
+  "compilerVersion": "0.51.0" 
+}
+```
+
 ## Basic
 
 A scaffolding template is a `json` document that can be hosted locally or online.

--- a/packages/compiler/src/init/init.ts
+++ b/packages/compiler/src/init/init.ts
@@ -196,7 +196,10 @@ async function validateTemplate(template: any, loaded: LoadedTemplate): Promise<
   const currentCompilerVersion = MANIFEST.version;
   let validationResult: ValidationResult;
   // 1. If current version > compilerVersion, proceed with strict validation
-  if (template.compilerVersion && semver.gte(currentCompilerVersion, template.compilerVersion)) {
+  if (
+    template.compilerVersion === undefined ||
+    semver.gte(currentCompilerVersion, template.compilerVersion)
+  ) {
     validationResult = validateTemplateDefinitions(template, loaded.file, true);
 
     // 1.1 If strict validation fails, try relaxed validation
@@ -205,9 +208,7 @@ async function validateTemplate(template: any, loaded: LoadedTemplate): Promise<
     }
   } else {
     // 2. if version mis-match or none specified, warn and prompt user to continue or not
-    const confirmationMessage = template.compilerVersion
-      ? `The template you selected is designed for tsp version ${template.compilerVersion}. You are currently using tsp version ${currentCompilerVersion}.`
-      : `The template you selected did not specify minimum support compiler version. You are currently using tsp version ${currentCompilerVersion}.`;
+    const confirmationMessage = `The template you selected is designed for tsp version ${template.compilerVersion}. You are currently using tsp version ${currentCompilerVersion}.`;
     if (
       await confirm(
         `${confirmationMessage} The project created may not be correct. Do you want to continue?`


### PR DESCRIPTION
fix #2741 Add doc for `compilerVersion`
fix #2742 Stop warning 