### PR TITLE
Fix: `@route` with non alphanumeric path parameter

### DIFF
--- a/common/changes/@typespec/http/fix-wrong-route-with-dash-param_2024-01-12-17-18.json
+++ b/common/changes/@typespec/http/fix-wrong-route-with-dash-param_2024-01-12-17-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@typespec/http",
+      "comment": "Fix: Wrong route generated when path parameter is not alpha numeric(Either with a different name provided in `@path` or if the property name is not an identifier)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@typespec/http"
+}

--- a/packages/http/src/route.ts
+++ b/packages/http/src/route.ts
@@ -163,6 +163,7 @@ export function DefaultRouteProducer(
       ? overloadBase.pathSegments
       : [...parentSegments, ...(routePath ? [routePath] : [])];
   const routeParams = segments.flatMap(extractParamsFromPath);
+  console.log("Segments2", segments, routeParams);
 
   const parameters: HttpOperationParameters = diagnostics.pipe(
     getOperationParameters(program, operation, overloadBase, routeParams, options.paramOptions)

--- a/packages/http/src/route.ts
+++ b/packages/http/src/route.ts
@@ -163,7 +163,6 @@ export function DefaultRouteProducer(
       ? overloadBase.pathSegments
       : [...parentSegments, ...(routePath ? [routePath] : [])];
   const routeParams = segments.flatMap(extractParamsFromPath);
-  console.log("Segments2", segments, routeParams);
 
   const parameters: HttpOperationParameters = diagnostics.pipe(
     getOperationParameters(program, operation, overloadBase, routeParams, options.paramOptions)

--- a/packages/http/src/utils.ts
+++ b/packages/http/src/utils.ts
@@ -5,5 +5,5 @@
  * @example "foo/{name}/bar" -> ["name"]
  */
 export function extractParamsFromPath(path: string): string[] {
-  return path.match(/\{.+\}/g)?.map((s) => s.slice(1, -1)) ?? [];
+  return path.match(/\{[^/]+\}/g)?.map((s) => s.slice(1, -1)) ?? [];
 }

--- a/packages/http/src/utils.ts
+++ b/packages/http/src/utils.ts
@@ -5,5 +5,5 @@
  * @example "foo/{name}/bar" -> ["name"]
  */
 export function extractParamsFromPath(path: string): string[] {
-  return path.match(/\{[^/]+\}/g)?.map((s) => s.slice(1, -1)) ?? [];
+  return path.match(/\{[^/.]+\}/g)?.map((s) => s.slice(1, -1)) ?? [];
 }

--- a/packages/http/src/utils.ts
+++ b/packages/http/src/utils.ts
@@ -5,5 +5,5 @@
  * @example "foo/{name}/bar" -> ["name"]
  */
 export function extractParamsFromPath(path: string): string[] {
-  return path.match(/\{\w+\}/g)?.map((s) => s.slice(1, -1)) ?? [];
+  return path.match(/\{.+\}/g)?.map((s) => s.slice(1, -1)) ?? [];
 }

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -156,10 +156,21 @@ describe("http: routes", () => {
 
       deepStrictEqual(routes, [{ verb: "get", path: "/{myParam}", params: ["myParam"] }]);
     });
+
     it("respect the name provided by @path argument", async () => {
       const routes = await getRoutesFor(`op test(@path("custom-name") myParam: string): void;`);
 
       deepStrictEqual(routes, [{ verb: "get", path: "/{custom-name}", params: ["custom-name"] }]);
+    });
+
+    it("respect the name provided by @path argument when being explicit in the route", async () => {
+      const routes = await getRoutesFor(
+        `@route("/foo/{custom-name}") op test(@path("custom-name") myParam: string): void;`
+      );
+
+      deepStrictEqual(routes, [
+        { verb: "get", path: "/foo/{custom-name}", params: ["custom-name"] },
+      ]);
     });
   });
 


### PR DESCRIPTION
If a route had a path parameter that wasn't alpha numeric([a-zA-Z0-9]) it wouldn't extract them and produce the wrong url

```
@route("foo/{custom-name}") op test(@path `custom-name`: string): void
```
would make `foo/{custom-name}/{custom-name}` instead of  `foo/{custom-name}` 