### PR TITLE
Fix website docs slug for /docs

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -1,6 +1,7 @@
 ---
 id: installation
 title: Installation
+slug: /
 ---
 
 # Installation

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -212,7 +212,7 @@ const config: Config = {
           },
           {
             label: "Getting started",
-            to: "/docs/introduction/installation",
+            to: "/docs",
           },
           {
             type: "docsVersionDropdown",

--- a/packages/website/versioned_docs/version-latest/introduction/installation.md
+++ b/packages/website/versioned_docs/version-latest/introduction/installation.md
@@ -1,6 +1,7 @@
 ---
 id: installation
 title: Installation
+slug: /
 ---
 
 # Installation


### PR DESCRIPTION
Issue was we didn't have a doc at `/docs` anymore because the docs entrypoint was `/docs/introduction/installation`
