### PR TITLE
Fix Markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can compile it to OpenAPI 3.0 by using the following command:
 tsp compile sample.tsp --emit @typespec/openapi3
 ```
 
-Once it compiles, you can find the emitted OpenAPI document in `./tsp-output/openapi.json.
+Once it compiles, you can find the emitted OpenAPI document in `./tsp-output/openapi.json`.
 
 You can also pass in a directory instead of a file to `tsp compile`. That's
 equivalent to passing `main.tsp` in that directory.


### PR DESCRIPTION
Add a missing backtick.

Please consider using https://github.com/DavidAnson/markdownlint-cli2 to keep your Markdown healthy.
