### PR TITLE
Allow using default values for union property types & description being dropped

### DIFF
--- a/.changeset/hotfix-unions-handling-2024-1-8-1-20-37.md
+++ b/.changeset/hotfix-unions-handling-2024-1-8-1-20-37.md
@@ -1,0 +1,7 @@
+---
+"@typespec/compiler": patch
+"@typespec/json-schema": patch
+"@typespec/openapi3": patch
+---
+
+Allow using default values for union property types

--- a/.changeset/hotfix-unions-handling-2024-1-8-1-20-38.md
+++ b/.changeset/hotfix-unions-handling-2024-1-8-1-20-38.md
@@ -1,0 +1,5 @@
+---
+"@typespec/openapi3": patch
+---
+
+Fix: union of primitive types that gets emitted as an `enum` keeps the description

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3470,6 +3470,9 @@ export function createChecker(program: Program): Checker {
       const [valid] = isStringTemplateSerializable(type);
       return valid;
     }
+    if (type.kind === "UnionVariant") {
+      return isValueType(type.type);
+    }
     const valueTypes = new Set(["String", "Number", "Boolean", "EnumMember", "Tuple"]);
     return valueTypes.has(type.kind);
   }

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -217,6 +217,8 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
             });
       case "EnumMember":
         return defaultType.value ?? defaultType.name;
+      case "UnionVariant":
+        return this.#getDefaultValue(type, defaultType.type);
       default:
         reportDiagnostic(program, {
           code: "invalid-default",

--- a/packages/json-schema/test/models.test.ts
+++ b/packages/json-schema/test/models.test.ts
@@ -323,5 +323,25 @@ describe("emitting models", () => {
         default: true,
       });
     });
+
+    it("specify default value on union with variant", async () => {
+      const res = await emitSchema(
+        `
+        model Foo {
+          optionalUnion?: MyUnion = MyUnion.a;
+        };
+        
+        union MyUnion {
+          a: "a-value",
+          b: "b-value",
+        }
+        `
+      );
+
+      deepStrictEqual(res["Foo.json"].properties.optionalUnion, {
+        $ref: "MyUnion.json",
+        default: "a-value",
+      });
+    });
   });
 });

--- a/packages/json-schema/test/unions.test.ts
+++ b/packages/json-schema/test/unions.test.ts
@@ -17,6 +17,18 @@ describe("emitting unions", () => {
     assert.deepStrictEqual(Foo.anyOf, [{ type: "string" }, { type: "boolean" }]);
   });
 
+  it("union description carries over", async () => {
+    const schemas = await emitSchema(`
+      /** Foo doc */
+      union Foo {
+        x: string;
+        y: boolean;
+      }
+    `);
+
+    assert.strictEqual(schemas["Foo.json"].description, "Foo doc");
+  });
+
   it("works with declarations with anonymous variants", async () => {
     const schemas = await emitSchema(`
       union Foo {

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -491,7 +491,6 @@ export class OpenAPI3SchemaEmitter extends TypeEmitter<
       }
     }
 
-    console.log("literalVariantEnumByType", literalVariantEnumByType, schemaMembers);
     if (schemaMembers.length === 0) {
       if (nullable) {
         // This union is equivalent to just `null` but OA3 has no way to specify

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -491,6 +491,7 @@ export class OpenAPI3SchemaEmitter extends TypeEmitter<
       }
     }
 
+    console.log("literalVariantEnumByType", literalVariantEnumByType, schemaMembers);
     if (schemaMembers.length === 0) {
       if (nullable) {
         // This union is equivalent to just `null` but OA3 has no way to specify
@@ -507,6 +508,7 @@ export class OpenAPI3SchemaEmitter extends TypeEmitter<
       // we can just return the single schema member after applying nullable
       let schema = schemaMembers[0].schema;
       const type = schemaMembers[0].type;
+      const additionalProps: Partial<OpenAPI3Schema> = this.#applyConstraints(union, {});
 
       if (nullable) {
         if (schema instanceof Placeholder || "$ref" in schema) {
@@ -528,10 +530,17 @@ export class OpenAPI3SchemaEmitter extends TypeEmitter<
         }
       }
 
-      return schema;
+      if (Object.keys(additionalProps).length === 0) {
+        return schema;
+      } else {
+        return new ObjectBuilder({
+          allOf: [schema],
+          ...additionalProps,
+        });
+      }
     }
 
-    const schema: any = {
+    const schema: OpenAPI3Schema = {
       [ofType]: schemaMembers.map((m) => m.schema),
     };
 

--- a/packages/openapi3/test/models.test.ts
+++ b/packages/openapi3/test/models.test.ts
@@ -204,6 +204,33 @@ describe("openapi3: models", () => {
       },
     });
   });
+
+  it("specify default value on union with variant", async () => {
+    const res = await oapiForModel(
+      "Foo",
+      `
+      model Foo {
+        optionalUnion?: MyUnion = MyUnion.a;
+      };
+      
+      union MyUnion {
+        a: "a-value",
+        b: "b-value",
+      }
+      `
+    );
+
+    deepStrictEqual(res.schemas.Foo, {
+      type: "object",
+      properties: {
+        optionalUnion: {
+          allOf: [{ $ref: "#/components/schemas/MyUnion" }],
+          default: "a-value",
+        },
+      },
+    });
+  });
+
   it("specify default value on nullable property", async () => {
     const res = await oapiForModel(
       "Foo",

--- a/packages/openapi3/test/union-schema.test.ts
+++ b/packages/openapi3/test/union-schema.test.ts
@@ -338,6 +338,21 @@ describe("openapi3: union type", () => {
     });
   });
 
+  it("supports description on unions that reduce to enums", async () => {
+    const res = await oapiForModel(
+      "Foo",
+      `
+      @doc("FooUnion")
+      union Foo {
+        "a";
+        "b";
+      }
+
+      `
+    );
+    strictEqual(res.schemas.Foo.description, "FooUnion");
+  });
+
   it("supports summary on unions and union variants", async () => {
     const res = await oapiForModel(
       "Foo",


### PR DESCRIPTION
fix #2894 Cannot use union variant as default value
fix #2895 Description lost on union of primitive types