### PR TITLE
Fix: Required array not respecting encodedName

### DIFF
--- a/.changeset/wicked-brooms-march.md
+++ b/.changeset/wicked-brooms-march.md
@@ -1,0 +1,5 @@
+---
+"@typespec/openapi3": patch
+---
+
+Fix: `required` array on schema wasn't using the value provided by `@encodedName("application/json"`

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -268,7 +268,13 @@ export class OpenAPI3SchemaEmitter extends TypeEmitter<
       }
 
       if (!this.#metadataInfo.isOptional(prop, visibility)) {
-        requiredProps.push(prop.name);
+        const encodedName = resolveEncodedName(
+          this.emitter.getProgram(),
+          prop,
+          this.#getContentType()
+        );
+
+        requiredProps.push(encodedName);
       }
     }
 

--- a/packages/openapi3/test/models.test.ts
+++ b/packages/openapi3/test/models.test.ts
@@ -32,6 +32,7 @@ describe("openapi3: models", () => {
     );
 
     expect(res.schemas.Foo).toMatchObject({
+      required: ["xJson"],
       properties: {
         xJson: { type: "integer", format: "int32" },
       },
@@ -48,6 +49,7 @@ describe("openapi3: models", () => {
     );
 
     expect(res.schemas.Foo).toMatchObject({
+      required: ["xJson"],
       properties: {
         xJson: { type: "integer", format: "int32" },
       },
@@ -65,6 +67,7 @@ describe("openapi3: models", () => {
     );
 
     expect(res.schemas.Foo).toMatchObject({
+      required: ["xJson"],
       properties: {
         xJson: { type: "integer", format: "int32" },
       },

--- a/packages/samples/test/output/encoded-names/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/encoded-names/@typespec/openapi3/openapi.yaml
@@ -23,8 +23,8 @@ components:
     WithEncodedNames:
       type: object
       required:
-        - notBefore
-        - expires
+        - nbf
+        - exp
         - created
         - updated
       properties:


### PR DESCRIPTION
The required array didn't make use the encoded name creating invalid spec where there would be a mismatch of names