### PR TITLE
Fix pr artifacts deps versions

### DIFF
--- a/.chronus/changes/fix-pr-build-dep-versions-2024-1-13-23-26-47.md
+++ b/.chronus/changes/fix-pr-build-dep-versions-2024-1-13-23-26-47.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: patch
+packages:
+  - "@typespec/internal-build-utils"
+---
+
+Bumping PR version will also update the dependencies to be an open range

--- a/.chronus/changes/fix-pr-build-dep-versions-2024-1-13-23-26-47.md
+++ b/.chronus/changes/fix-pr-build-dep-versions-2024-1-13-23-26-47.md
@@ -1,6 +1,6 @@
 ---
 # Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: patch
+changeKind: fix
 packages:
   - "@typespec/internal-build-utils"
 ---


### PR DESCRIPTION
Since we moved to `workspace:~` instead of `workspace:~x.y.z` for dependency when building pr artifact it is repalced with the actual version which in pr case is `x.y.z-pr.{prnumber}.{buildid}` and this cause installation conflict