### PR TITLE
Improvement to the import auto complete

### DIFF
--- a/.chronus/changes/ide-completion-improvments-2024-1-17-3-52-31.md
+++ b/.chronus/changes/ide-completion-improvments-2024-1-17-3-52-31.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+[IDE] Autocompleting file or folder with non alpha numeric charachter completes correctly

--- a/.chronus/changes/ide-completion-improvments-2024-1-17-3-53-42.md
+++ b/.chronus/changes/ide-completion-improvments-2024-1-17-3-53-42.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+[IDE] Fix crashing when trying to autocomplete an invalid folder

--- a/.chronus/changes/ide-completion-improvments-2024-1-17-4-14-46.md
+++ b/.chronus/changes/ide-completion-improvments-2024-1-17-4-14-46.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/playground"
+---
+
+Autocomplete installed libraries in `import` statements

--- a/packages/compiler/src/server/completion.ts
+++ b/packages/compiler/src/server/completion.ts
@@ -54,6 +54,7 @@ export async function resolveCompletion(
         addKeywordCompletion("namespace", completions);
         break;
       case SyntaxKind.Identifier:
+        addDirectiveCompletion(context, node);
         addIdentifierCompletion(context, node);
         break;
       case SyntaxKind.StringLiteral:
@@ -274,6 +275,19 @@ function addIdentifierCompletion(
 
   if (node.parent?.kind === SyntaxKind.TypeReference) {
     addKeywordCompletion("identifier", completions);
+  }
+}
+
+const directiveNames = ["suppress", "deprecated"];
+function addDirectiveCompletion({ completions }: CompletionContext, node: IdentifierNode) {
+  if (!(node.parent?.kind === SyntaxKind.DirectiveExpression && node.parent.target === node)) {
+    return;
+  }
+  for (const directive of directiveNames) {
+    completions.items.push({
+      label: directive,
+      kind: CompletionItemKind.Keyword,
+    });
   }
 }
 

--- a/packages/compiler/test/server/completion.test.ts
+++ b/packages/compiler/test/server/completion.test.ts
@@ -129,25 +129,35 @@ describe("compiler: server: completion", () => {
       const completions = await complete(` import "./┆ `, undefined, {
         "test/bar.tsp": "",
         "test/foo.tsp": "",
-        "test/foo/test.tsp": "",
+        "test/dir/test.tsp": "",
       });
+      const range = { start: { line: 0, character: 11 }, end: { line: 0, character: 11 } };
       check(
         completions,
         [
           {
             label: "bar.tsp",
-            commitCharacters: [],
             kind: CompletionItemKind.File,
+            textEdit: {
+              newText: "bar.tsp",
+              range,
+            },
           },
           {
             label: "foo.tsp",
-            commitCharacters: [],
             kind: CompletionItemKind.File,
+            textEdit: {
+              newText: "foo.tsp",
+              range,
+            },
           },
           {
-            label: "foo",
-            commitCharacters: [],
+            label: "dir",
             kind: CompletionItemKind.Folder,
+            textEdit: {
+              newText: "dir",
+              range,
+            },
           },
         ],
         {
@@ -166,9 +176,12 @@ describe("compiler: server: completion", () => {
         completions,
         [
           {
-            commitCharacters: [],
             kind: 19,
             label: "main",
+            textEdit: {
+              newText: "main",
+              range: { start: { line: 0, character: 11 }, end: { line: 0, character: 11 } },
+            },
           },
         ],
         {
@@ -185,9 +198,12 @@ describe("compiler: server: completion", () => {
         completions,
         [
           {
-            commitCharacters: [],
             kind: 17,
             label: "foo.tsp",
+            textEdit: {
+              newText: "foo.tsp",
+              range: { start: { line: 0, character: 24 }, end: { line: 0, character: 24 } },
+            },
           },
         ],
         {
@@ -204,9 +220,12 @@ describe("compiler: server: completion", () => {
         completions,
         [
           {
-            commitCharacters: [],
             kind: 17,
             label: "foo.tsp",
+            textEdit: {
+              newText: "foo.tsp",
+              range: { start: { line: 0, character: 15 }, end: { line: 0, character: 15 } },
+            },
           },
         ],
         {

--- a/packages/compiler/test/server/completion.test.ts
+++ b/packages/compiler/test/server/completion.test.ts
@@ -981,6 +981,39 @@ describe("compiler: server: completion", () => {
     ]);
   });
 
+  describe("directives", () => {
+    it("complete directives when starting with `#`", async () => {
+      const completions = await complete(
+        `
+        #┆
+        model Bar {}
+        `
+      );
+
+      check(completions, [
+        {
+          label: "suppress",
+          kind: CompletionItemKind.Keyword,
+        },
+        {
+          label: "deprecated",
+          kind: CompletionItemKind.Keyword,
+        },
+      ]);
+    });
+
+    it("doesn't complete when in the argument section", async () => {
+      const completions = await complete(
+        `
+        #suppress s┆
+        model Bar {}
+        `
+      );
+
+      check(completions, []);
+    });
+  });
+
   function check(
     list: CompletionList,
     expectedItems: CompletionItem[],

--- a/packages/playground/src/browser-host.ts
+++ b/packages/playground/src/browser-host.ts
@@ -38,6 +38,15 @@ export async function createBrowserHost(
     for (const [key, value] of Object.entries<any>(_TypeSpecLibrary_.jsSourceFiles)) {
       addJsImport(`/test/node_modules/${libName}/${key}`, value);
     }
+    virtualFs.set(
+      `/test/package.json`,
+      JSON.stringify({
+        name: "playground-pkg",
+        dependencies: Object.fromEntries(
+          Object.values(libraries).map((x) => [x.name, x.packageJson.version])
+        ),
+      })
+    );
   }
 
   function addJsImport(path: string, value: any) {

--- a/packages/playground/src/services.ts
+++ b/packages/playground/src/services.ts
@@ -287,12 +287,18 @@ export async function registerMonacoLanguage(host: BrowserHost) {
 
       const suggestions: monaco.languages.CompletionItem[] = [];
       for (const item of result.items) {
+        let itemRange = range;
+        let insertText = item.insertText!;
+        if (item.textEdit && "range" in item.textEdit) {
+          itemRange = monacoRange(item.textEdit.range);
+          insertText = item.textEdit.newText;
+        }
         suggestions.push({
           label: item.label,
           kind: item.kind as any,
           documentation: item.documentation,
-          insertText: item.insertText!,
-          range,
+          insertText,
+          range: itemRange,
           commitCharacters:
             item.commitCharacters ?? lsConfig.capabilities.completionProvider!.allCommitCharacters,
           tags: item.tags,


### PR DESCRIPTION
- fix #2481 Autocomplete directive names
- Stop crashing when completing invalid dir
- Autocompleting dir with non letter char (e.g. `-`) will autocomplete correctly
- Playground autocomplete imports
<img width="579" alt="image" src="https://github.com/microsoft/typespec/assets/1031227/08e9e516-6472-4ab2-b3a5-30b4a8ce722d">
