### PR TITLE
Validate `@useAuth` is unique on node

### DIFF
--- a/.chronus/changes/validate-useauth-unique-2024-1-27-17-26-52.md
+++ b/.chronus/changes/validate-useauth-unique-2024-1-27-17-26-52.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/http"
+---
+
+Validate `@useAuth` is unique on node

--- a/.chronus/changes/validate-useauth-unique-2024-1-27-17-26-52.md
+++ b/.chronus/changes/validate-useauth-unique-2024-1-27-17-26-52.md
@@ -5,4 +5,4 @@ packages:
   - "@typespec/http"
 ---
 
-Validate `@useAuth` is unique on node
+Validate that only one `@useAuth` decorator is applied to a type.

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -436,6 +436,7 @@ export function $useAuth(
   entity: Namespace | Interface | Operation,
   authConfig: Model | Union | Tuple
 ) {
+  validateDecoratorUniqueOnNode(context, entity, $useAuth);
   const [auth, diagnostics] = extractAuthentication(context.program, authConfig);
   if (diagnostics.length > 0) context.program.reportDiagnostics(diagnostics);
   if (auth !== undefined) {


### PR DESCRIPTION
fix #2787 

having multiple has no effect, the latest value will override the previous ones so there is no reason to use `@useAuth` twice on the same node