### PR TITLE
Do not run decorators that have missing args

### DIFF
--- a/.chronus/changes/fix-dont-run-decorator-missing-args-2024-1-27-18-6-41.md
+++ b/.chronus/changes/fix-dont-run-decorator-missing-args-2024-1-27-18-6-41.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Decorators that have missing arguments will not run. This is inline with passing invalid argument to a decorator that would prevent it from running.

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3605,8 +3605,13 @@ export function createChecker(program: Program): Checker {
       : declaration.parameters.length;
 
     if (args.length < minArgs || (maxArgs !== undefined && args.length > maxArgs)) {
+      // In the case we have too little args then this decorator is not applicable.
+      // If there is too many args then we can still run the decorator as long as the args are valid.
+      if (args.length < minArgs) {
+        hasError = true;
+      }
+
       if (maxArgs === undefined) {
-        hasError = true; // In the case we have too little args then this decorator is not applicable.
         reportCheckerDiagnostic(
           createDiagnostic({
             code: "invalid-argument-count",
@@ -3616,7 +3621,6 @@ export function createChecker(program: Program): Checker {
           })
         );
       } else {
-        // If there is too many args then we can still run the decorator as long as the args are valid.
         const expected = minArgs === maxArgs ? minArgs.toString() : `${minArgs}-${maxArgs}`;
         reportCheckerDiagnostic(
           createDiagnostic({

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3606,6 +3606,7 @@ export function createChecker(program: Program): Checker {
 
     if (args.length < minArgs || (maxArgs !== undefined && args.length > maxArgs)) {
       if (maxArgs === undefined) {
+        hasError = true; // In the case we have too little args then this decorator is not applicable.
         reportCheckerDiagnostic(
           createDiagnostic({
             code: "invalid-argument-count",
@@ -3615,6 +3616,7 @@ export function createChecker(program: Program): Checker {
           })
         );
       } else {
+        // If there is too many args then we can still run the decorator as long as the args are valid.
         const expected = minArgs === maxArgs ? minArgs.toString() : `${minArgs}-${maxArgs}`;
         reportCheckerDiagnostic(
           createDiagnostic({

--- a/packages/compiler/test/checker/decorators.test.ts
+++ b/packages/compiler/test/checker/decorators.test.ts
@@ -1,5 +1,5 @@
 import { ok, strictEqual } from "assert";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { setTypeSpecNamespace } from "../../src/core/index.js";
 import {
   BasicTestRunner,
@@ -103,8 +103,9 @@ describe("compiler: checker: decorators", () => {
 
   describe("usage", () => {
     let runner: BasicTestRunner;
-    let calledArgs: any[];
+    let calledArgs: any[] | undefined;
     beforeEach(() => {
+      calledArgs = undefined;
       testHost.addJsFile("test.js", {
         $testDec: (...args: any[]) => (calledArgs = args),
       });
@@ -115,12 +116,17 @@ describe("compiler: checker: decorators", () => {
     });
 
     function expectDecoratorCalledWith(target: unknown, ...args: unknown[]) {
+      ok(calledArgs, "Decorator was not called.");
       strictEqual(calledArgs.length, 2 + args.length);
       strictEqual(calledArgs[0].program, runner.program);
       strictEqual(calledArgs[1], target);
       for (const [index, arg] of args.entries()) {
         strictEqual(calledArgs[2 + index], arg);
       }
+    }
+
+    function expectDecoratorNotCalled() {
+      strictEqual(calledArgs, undefined);
     }
 
     it("calls a decorator with no argument", async () => {
@@ -183,22 +189,22 @@ describe("compiler: checker: decorators", () => {
         code: "invalid-argument-count",
         message: "Expected 2 arguments, but got 1.",
       });
-      expect(calledArgs).toBeUndefined();
+      expectDecoratorNotCalled();
     });
 
     it("errors if not calling with too many arguments", async () => {
-      const diagnostics = await runner.diagnose(`
-        extern dec testDec(target: unknown, arg1: string, arg2?: string);
+      const [{ Foo }, diagnostics] = await runner.compileAndDiagnose(`
+        extern dec testDec(target: unknown, arg1: valueof string, arg2?: valueof string);
 
         @testDec("one", "two", "three")
-        model Foo {}
+        @test model Foo {}
       `);
 
       expectDiagnostics(diagnostics, {
         code: "invalid-argument-count",
         message: "Expected 1-2 arguments, but got 3.",
       });
-      expect(calledArgs).toEqual(["one", "two"]);
+      expectDecoratorCalledWith(Foo, "one", "two");
     });
 
     it("errors if not calling with argument and decorator expect none", async () => {
@@ -213,7 +219,6 @@ describe("compiler: checker: decorators", () => {
         code: "invalid-argument-count",
         message: "Expected 0 arguments, but got 1.",
       });
-      expect(calledArgs).toBeUndefined();
     });
 
     it("errors if not calling with too few arguments with rest", async () => {
@@ -228,6 +233,7 @@ describe("compiler: checker: decorators", () => {
         code: "invalid-argument-count",
         message: "Expected at least 1 arguments, but got 0.",
       });
+      expectDecoratorNotCalled();
     });
 
     it("errors if target type is incorrect", async () => {
@@ -242,6 +248,7 @@ describe("compiler: checker: decorators", () => {
         code: "decorator-wrong-target",
         message: "Cannot apply @testDec decorator to Foo since it is not assignable to Union",
       });
+      expectDecoratorNotCalled();
     });
 
     it("errors if argument is not assignable to parameter type", async () => {
@@ -256,6 +263,7 @@ describe("compiler: checker: decorators", () => {
         code: "invalid-argument",
         message: "Argument '123' is not assignable to parameter of type 'string'",
       });
+      expectDecoratorNotCalled();
     });
 
     it("errors if argument is not assignable to rest parameter type", async () => {
@@ -276,6 +284,7 @@ describe("compiler: checker: decorators", () => {
           message: "Argument '456' is not assignable to parameter of type 'string'",
         },
       ]);
+      expectDecoratorNotCalled();
     });
 
     describe("value marshalling", () => {
@@ -287,7 +296,7 @@ describe("compiler: checker: decorators", () => {
           @test
           model Foo {}
         `);
-        return calledArgs[2];
+        return calledArgs![2];
       }
 
       describe("passing a string literal", () => {

--- a/packages/compiler/test/checker/decorators.test.ts
+++ b/packages/compiler/test/checker/decorators.test.ts
@@ -1,5 +1,5 @@
 import { ok, strictEqual } from "assert";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { setTypeSpecNamespace } from "../../src/core/index.js";
 import {
   BasicTestRunner,
@@ -183,6 +183,7 @@ describe("compiler: checker: decorators", () => {
         code: "invalid-argument-count",
         message: "Expected 2 arguments, but got 1.",
       });
+      expect(calledArgs).toBeUndefined();
     });
 
     it("errors if not calling with too many arguments", async () => {
@@ -197,6 +198,7 @@ describe("compiler: checker: decorators", () => {
         code: "invalid-argument-count",
         message: "Expected 1-2 arguments, but got 3.",
       });
+      expect(calledArgs).toEqual(["one", "two"]);
     });
 
     it("errors if not calling with argument and decorator expect none", async () => {
@@ -211,6 +213,7 @@ describe("compiler: checker: decorators", () => {
         code: "invalid-argument-count",
         message: "Expected 0 arguments, but got 1.",
       });
+      expect(calledArgs).toBeUndefined();
     });
 
     it("errors if not calling with too few arguments with rest", async () => {


### PR DESCRIPTION
fix [#3940](https://github.com/Azure/typespec-azure-pr/issues/3940)