### PR TITLE
Fix duplicate docs in hover or completion details

### DIFF
--- a/.chronus/changes/fix-dup-doc-2024-2-1-20-28-15.md
+++ b/.chronus/changes/fix-dup-doc-2024-2-1-20-28-15.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+[IDE] Fix type documentation shown twice when hovering symbols or in completion details.

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -91,7 +91,7 @@ export interface DocData {
 
   /**
    * How was the doc set.
-   * - `@doc` means the `@doc` decorator was used
+   * - `decorator` means the `@doc` decorator was used
    * - `comment` means it was set from a `/** comment * /`
    */
   source: "decorator" | "comment";

--- a/packages/compiler/src/server/type-details.ts
+++ b/packages/compiler/src/server/type-details.ts
@@ -64,8 +64,8 @@ function getSymbolDocumentation(program: Program, symbol: Sym) {
   // Add @doc(...) API docs
   const type = symbol.type ?? program.checker.getTypeForNode(symbol.declarations[0]);
   const apiDocs = getDocData(program, type);
-  // The doc comment is already included above we don't want to duplicate
-  if (apiDocs && apiDocs.source === "comment") {
+  // The doc comment is already included above we don't want to duplicate. Only include if it was specificed via `@doc`
+  if (apiDocs && apiDocs.source === "decorator") {
     docs.push(apiDocs.value);
   }
 


### PR DESCRIPTION
Before
<img width="465" alt="image" src="https://github.com/microsoft/typespec/assets/1031227/b620cac2-b70a-4a99-a784-bf03d55bd28b">

Now
<img width="413" alt="image" src="https://github.com/microsoft/typespec/assets/1031227/d2a0b293-7924-44e7-9e1c-036ff40f1b6d">
