### PR TITLE
Fix non portable export

### DIFF
--- a/packages/tspd/test/test-utils.ts
+++ b/packages/tspd/test/test-utils.ts
@@ -1,8 +1,12 @@
+import { Diagnostic } from "@typespec/compiler";
 import { createTestHost, expectDiagnosticEmpty } from "@typespec/compiler/testing";
 import { MarkdownRenderer } from "../src/ref-doc/emitters/markdown.js";
 import { extractRefDocs } from "../src/ref-doc/extractor.js";
+import { TypeSpecRefDocBase } from "../src/ref-doc/types.js";
 
-export async function extractTestRefDoc(code: string) {
+export async function extractTestRefDoc(
+  code: string
+): Promise<[TypeSpecRefDocBase, readonly Diagnostic[]]> {
   const host = await createTestHost();
   host.addTypeSpecFile("main.tsp", code);
   await host.compile("main.tsp");


### PR DESCRIPTION
Not sure why only catching that in the typespec-azure repo build but it complains that the return type of this function wasn't portable, Probably good anyway to be more explicit here.