### PR TITLE
More reliable codefix application

### DIFF
--- a/.chronus/changes/more-reliable-codefix-application-2024-2-22-17-23-9.md
+++ b/.chronus/changes/more-reliable-codefix-application-2024-2-22-17-23-9.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Improve relability of application of codefixes in IDE, often it would not do anything


### PR DESCRIPTION
Current approach was getting in all kind of conflict because it was calling getCodeActions too much and we were clearing the cached id 