### PR TITLE
Fix codefixes docs

### DIFF
--- a/docs/extending-typespec/linters.md
+++ b/docs/extending-typespec/linters.md
@@ -78,8 +78,8 @@ context.reportDiagnostic({
   codefixes: [
     defineCodeFix({
       id: "add-model-suffix",
-      description: "Add 'Model' suffix to model name",
-      apply: (program) => {
+      label: "Add 'Model' suffix to model name",
+      fix: (program) => {
         program.update(model, {
           name: `${model.name}Model`,
         });

--- a/packages/website/sidebars.ts
+++ b/packages/website/sidebars.ts
@@ -150,6 +150,7 @@ const sidebars: SidebarsConfig = {
         "extending-typespec/diagnostics",
         "extending-typespec/create-decorators",
         "extending-typespec/linters",
+        "extending-typespec/codefixes",
         "extending-typespec/emitters",
         "extending-typespec/emitter-framework",
         "extending-typespec/emitter-metadata-handling",


### PR DESCRIPTION
Codefixes doc was not included in the sidebar and linter codefix section was showing wrong properties