### PR TITLE
Union template declaration were being finished in projector

### DIFF
--- a/.chronus/changes/fix-union-template-2024-2-26-16-22-2.md
+++ b/.chronus/changes/fix-union-template-2024-2-26-16-22-2.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix: Union template declaration were incorrectly being finished in projection

--- a/packages/compiler/src/core/type-utils.ts
+++ b/packages/compiler/src/core/type-utils.ts
@@ -50,6 +50,7 @@ export function getParentTemplateNode(node: Node): (Node & TemplateDeclarationNo
     case SyntaxKind.ModelStatement:
     case SyntaxKind.ScalarStatement:
     case SyntaxKind.OperationStatement:
+    case SyntaxKind.UnionStatement:
     case SyntaxKind.InterfaceStatement:
       return node.templateParameters.length > 0 ? node : undefined;
     case SyntaxKind.OperationSignatureDeclaration:


### PR DESCRIPTION
fix [#2946](https://github.com/microsoft/typespec/issues/2946)

Problem was that in the projector were were calling to this helper to see if that was a type that we should finish but it was missing the union case causing union template declaration from being finished in the projector and then being shown as finished type in the semantic navigator and crashing openapi3 emitter.