### PR TITLE
Improve TM language for enums, unions and escaped identifiers

### DIFF
--- a/.chronus/changes/tmlanguage-escpaed-identifiers-2024-2-27-16-22-28.md
+++ b/.chronus/changes/tmlanguage-escpaed-identifiers-2024-2-27-16-22-28.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+TmLanguage: Fix tokenization of escaped identifiers, enums and unions

--- a/grammars/typespec.json
+++ b/grammars/typespec.json
@@ -85,7 +85,7 @@
     },
     "decorator-declaration-statement": {
       "name": "meta.decorator-declaration-statement.typespec",
-      "begin": "(?:(extern)\\s+)?\\b(dec)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)",
+      "begin": "(?:(extern)\\s+)?\\b(dec)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.tsp"
@@ -160,7 +160,7 @@
     },
     "doc-comment-param": {
       "name": "comment.block.tsp",
-      "match": "(?x)((@)(?:param|template))\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)\\b",
+      "match": "(?x)((@)(?:param|template))\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)\\b",
       "captures": {
         "1": {
           "name": "keyword.tag.tspdoc"
@@ -187,7 +187,7 @@
     },
     "doc-comment-unknown-tag": {
       "name": "comment.block.tsp",
-      "match": "(?x)((@)(?:\\b[_$[:alpha:]][_$[:alnum:]]*\\b))\\b",
+      "match": "(?x)((@)(?:\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`))\\b",
       "captures": {
         "1": {
           "name": "entity.name.tag.tsp"
@@ -236,12 +236,65 @@
         }
       ]
     },
+    "enum-body": {
+      "name": "meta.enum-body.typespec",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.open.tsp"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.close.tsp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#enum-member"
+        },
+        {
+          "include": "#token"
+        },
+        {
+          "include": "#directive"
+        },
+        {
+          "include": "#decorator"
+        },
+        {
+          "include": "#punctuation-comma"
+        }
+      ]
+    },
+    "enum-member": {
+      "name": "meta.enum-member.typespec",
+      "begin": "(?:(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`))",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.name.tsp"
+        }
+      },
+      "end": "(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
+      "patterns": [
+        {
+          "include": "#token"
+        },
+        {
+          "include": "#type-annotation"
+        }
+      ]
+    },
     "enum-statement": {
       "name": "meta.enum-statement.typespec",
-      "begin": "\\b(enum)\\b",
+      "begin": "\\b(enum)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.tsp"
+        },
+        "2": {
+          "name": "entity.name.type.tsp"
         }
       },
       "end": "(?<=\\})|(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
@@ -250,7 +303,7 @@
           "include": "#token"
         },
         {
-          "include": "#expression"
+          "include": "#enum-body"
         }
       ]
     },
@@ -288,7 +341,7 @@
     },
     "function-call": {
       "name": "meta.function-call.typespec",
-      "begin": "(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)\\s*(\\()",
+      "begin": "(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)\\s*(\\()",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.tsp"
@@ -311,7 +364,7 @@
     },
     "function-declaration-statement": {
       "name": "meta.function-declaration-statement.typespec",
-      "begin": "(?:(extern)\\s+)?\\b(fn)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)",
+      "begin": "(?:(extern)\\s+)?\\b(fn)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.tsp"
@@ -338,7 +391,7 @@
     },
     "identifier-expression": {
       "name": "entity.name.type.tsp",
-      "match": "\\b[_$[:alpha:]][_$[:alnum:]]*\\b"
+      "match": "\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`"
     },
     "if-expression": {
       "name": "meta.if-expression.typespec",
@@ -425,7 +478,7 @@
     },
     "interface-member": {
       "name": "meta.interface-member.typespec",
-      "begin": "(?:\\b(op)\\b\\s+)?(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)",
+      "begin": "(?:\\b(op)\\b\\s+)?(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.tsp"
@@ -503,7 +556,7 @@
           "include": "#decorator"
         },
         {
-          "include": "#model-spread-property"
+          "include": "#spread-operator"
         },
         {
           "include": "#punctuation-semicolon"
@@ -530,7 +583,7 @@
     },
     "model-property": {
       "name": "meta.model-property.typespec",
-      "begin": "(?:(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)|(\\\"(?:[^\\\"\\\\]|\\\\.)*\\\"))",
+      "begin": "(?:(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)|(\\\"(?:[^\\\"\\\\]|\\\\.)*\\\"))",
       "beginCaptures": {
         "1": {
           "name": "variable.name.tsp"
@@ -550,21 +603,6 @@
         {
           "include": "#operator-assignment"
         },
-        {
-          "include": "#expression"
-        }
-      ]
-    },
-    "model-spread-property": {
-      "name": "meta.model-spread-property.typespec",
-      "begin": "\\.\\.\\.",
-      "beginCaptures": {
-        "0": {
-          "name": "keyword.operator.spread.tsp"
-        }
-      },
-      "end": "(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
-      "patterns": [
         {
           "include": "#expression"
         }
@@ -692,7 +730,7 @@
           "include": "#model-property"
         },
         {
-          "include": "#model-spread-property"
+          "include": "#spread-operator"
         },
         {
           "include": "#punctuation-comma"
@@ -717,7 +755,7 @@
     },
     "operation-statement": {
       "name": "meta.operation-statement.typespec",
-      "begin": "\\b(op)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)",
+      "begin": "\\b(op)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.tsp"
@@ -822,7 +860,7 @@
     },
     "projection-parameter": {
       "name": "meta.projection-parameter.typespec",
-      "begin": "(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)",
+      "begin": "(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "variable.name.tsp"
@@ -856,7 +894,7 @@
     },
     "projection-statement": {
       "name": "meta.projection-statement.typespec",
-      "begin": "\\b(projection)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)(#)(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)",
+      "begin": "\\b(projection)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)(#)(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.tsp"
@@ -947,6 +985,21 @@
         {
           "include": "#scalar-extends"
         },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "spread-operator": {
+      "name": "meta.spread-operator.typespec",
+      "begin": "\\.\\.\\.",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.spread.tsp"
+        }
+      },
+      "end": "(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
+      "patterns": [
         {
           "include": "#expression"
         }
@@ -1150,7 +1203,7 @@
     },
     "type-parameter": {
       "name": "meta.type-parameter.typespec",
-      "begin": "(\\b[_$[:alpha:]][_$[:alnum:]]*\\b)",
+      "begin": "(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.type.tsp"

--- a/grammars/typespec.json
+++ b/grammars/typespec.json
@@ -270,10 +270,13 @@
     },
     "enum-member": {
       "name": "meta.enum-member.typespec",
-      "begin": "(?:(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`))",
+      "begin": "(?:(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)\\s*(:?))",
       "beginCaptures": {
         "1": {
           "name": "variable.name.tsp"
+        },
+        "2": {
+          "name": "keyword.operator.type.annotation.tsp"
         }
       },
       "end": "(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
@@ -1346,9 +1349,6 @@
       "patterns": [
         {
           "include": "#token"
-        },
-        {
-          "include": "#type-annotation"
         },
         {
           "include": "#expression"

--- a/grammars/typespec.json
+++ b/grammars/typespec.json
@@ -1275,12 +1275,50 @@
         }
       ]
     },
+    "union-body": {
+      "name": "meta.union-body.typespec",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.open.tsp"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.close.tsp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#union-variant"
+        },
+        {
+          "include": "#token"
+        },
+        {
+          "include": "#directive"
+        },
+        {
+          "include": "#decorator"
+        },
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "#punctuation-comma"
+        }
+      ]
+    },
     "union-statement": {
       "name": "meta.union-statement.typespec",
-      "begin": "\\b(union)\\b",
+      "begin": "\\b(union)\\b\\s+(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.tsp"
+        },
+        "2": {
+          "name": "entity.name.type.tsp"
         }
       },
       "end": "(?<=\\})|(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
@@ -1289,7 +1327,28 @@
           "include": "#token"
         },
         {
-          "include": "#type-parameters"
+          "include": "#union-body"
+        }
+      ]
+    },
+    "union-variant": {
+      "name": "meta.union-variant.typespec",
+      "begin": "(?:(\\b[_$[:alpha:]][_$[:alnum:]]*\\b|`(?:[^`\\\\]|\\\\.)*`)\\s*(:))",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.name.tsp"
+        },
+        "2": {
+          "name": "keyword.operator.type.annotation.tsp"
+        }
+      },
+      "end": "(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
+      "patterns": [
+        {
+          "include": "#token"
+        },
+        {
+          "include": "#type-annotation"
         },
         {
           "include": "#expression"

--- a/grammars/typespec.json
+++ b/grammars/typespec.json
@@ -3,7 +3,7 @@
   "name": "TypeSpec",
   "scopeName": "source.tsp",
   "fileTypes": [
-    ".tsp"
+    "tsp"
   ],
   "patterns": [
     {

--- a/packages/compiler/src/server/classify.ts
+++ b/packages/compiler/src/server/classify.ts
@@ -218,6 +218,9 @@ export function getSemanticTokens(ast: TypeSpecScriptNode): SemanticToken[] {
       case SyntaxKind.EnumStatement:
         classify(node.id, SemanticTokenKind.Enum);
         break;
+      case SyntaxKind.UnionStatement:
+        classify(node.id, SemanticTokenKind.Enum);
+        break;
       case SyntaxKind.EnumMember:
         classify(node.id, SemanticTokenKind.EnumMember);
         break;

--- a/packages/compiler/src/server/tmlanguage.ts
+++ b/packages/compiler/src/server/tmlanguage.ts
@@ -508,9 +508,10 @@ const scalarStatement: BeginEndRule = {
 const enumMember: BeginEndRule = {
   key: "enum-member",
   scope: meta,
-  begin: `(?:(${identifier}))`,
+  begin: `(?:(${identifier})\\s*(:?))`,
   beginCaptures: {
     "1": { scope: "variable.name.tsp" },
+    "2": { scope: "keyword.operator.type.annotation.tsp" },
   },
   end: universalEnd,
   patterns: [token, typeAnnotation],
@@ -551,7 +552,7 @@ const namedUnionVariant: BeginEndRule = {
     "2": { scope: "keyword.operator.type.annotation.tsp" },
   },
   end: universalEnd,
-  patterns: [token, typeAnnotation, expression],
+  patterns: [token, expression],
 };
 
 const unionBody: BeginEndRule = {

--- a/packages/compiler/src/server/tmlanguage.ts
+++ b/packages/compiler/src/server/tmlanguage.ts
@@ -542,15 +542,42 @@ const enumStatement: BeginEndRule = {
   patterns: [token, enumBody],
 };
 
+const namedUnionVariant: BeginEndRule = {
+  key: "union-variant",
+  scope: meta,
+  begin: `(?:(${identifier})\\s*(:))`,
+  beginCaptures: {
+    "1": { scope: "variable.name.tsp" },
+    "2": { scope: "keyword.operator.type.annotation.tsp" },
+  },
+  end: universalEnd,
+  patterns: [token, typeAnnotation, expression],
+};
+
+const unionBody: BeginEndRule = {
+  key: "union-body",
+  scope: meta,
+  begin: "\\{",
+  beginCaptures: {
+    "0": { scope: "punctuation.curlybrace.open.tsp" },
+  },
+  end: "\\}",
+  endCaptures: {
+    "0": { scope: "punctuation.curlybrace.close.tsp" },
+  },
+  patterns: [namedUnionVariant, token, directive, decorator, expression, punctuationComma],
+};
+
 const unionStatement: BeginEndRule = {
   key: "union-statement",
   scope: meta,
-  begin: "\\b(union)\\b",
+  begin: `\\b(union)\\b\\s+(${identifier})`,
   beginCaptures: {
     "1": { scope: "keyword.other.tsp" },
+    "2": { scope: "entity.name.type.tsp" },
   },
   end: `(?<=\\})|${universalEnd}`,
-  patterns: [token, typeParameters, expression],
+  patterns: [token, unionBody],
 };
 
 const aliasStatement: BeginEndRule = {

--- a/packages/compiler/src/server/tmlanguage.ts
+++ b/packages/compiler/src/server/tmlanguage.ts
@@ -952,7 +952,7 @@ const grammar: Grammar = {
   $schema: tm.schema,
   name: "TypeSpec",
   scopeName: "source.tsp",
-  fileTypes: [".tsp"],
+  fileTypes: ["tsp"],
   patterns: [statement],
 };
 

--- a/packages/compiler/test/server/colorization.test.ts
+++ b/packages/compiler/test/server/colorization.test.ts
@@ -34,6 +34,7 @@ const Token = {
     model: createToken("model", "keyword.other.tsp"),
     scalar: createToken("scalar", "keyword.other.tsp"),
     enum: createToken("enum", "keyword.other.tsp"),
+    union: createToken("union", "keyword.other.tsp"),
     operation: createToken("op", "keyword.other.tsp"),
     namespace: createToken("namespace", "keyword.other.tsp"),
     interface: createToken("interface", "keyword.other.tsp"),
@@ -819,6 +820,69 @@ function testColorization(description: string, tokenize: Tokenize) {
           Token.identifiers.variable("down"),
           Token.operators.typeAnnotation,
           Token.literals.stringQuoted("Down"),
+          Token.punctuation.closeBrace,
+        ]);
+      });
+    });
+
+    describe("union statements", () => {
+      it("simple union", async () => {
+        const tokens = await tokenize("union Foo {}");
+        deepStrictEqual(tokens, [
+          Token.keywords.union,
+          Token.identifiers.type("Foo"),
+          Token.punctuation.openBrace,
+          Token.punctuation.closeBrace,
+        ]);
+      });
+
+      it("union with unamed variants", async () => {
+        const tokens = await tokenize(`union Direction { "up", string, 123 }`);
+        deepStrictEqual(tokens, [
+          Token.keywords.union,
+          Token.identifiers.type("Direction"),
+          Token.punctuation.openBrace,
+          Token.literals.stringQuoted("up"),
+          Token.punctuation.comma,
+          Token.identifiers.type("string"),
+          Token.punctuation.comma,
+          Token.literals.numeric("123"),
+          Token.punctuation.closeBrace,
+        ]);
+      });
+
+      it("union with named variants", async () => {
+        const tokens = await tokenize(`union Direction { up: "Up", down: "Down" }`);
+        deepStrictEqual(tokens, [
+          Token.keywords.union,
+          Token.identifiers.type("Direction"),
+          Token.punctuation.openBrace,
+          Token.identifiers.variable("up"),
+          Token.operators.typeAnnotation,
+          Token.literals.stringQuoted("Up"),
+          Token.punctuation.comma,
+          Token.identifiers.variable("down"),
+          Token.operators.typeAnnotation,
+          Token.literals.stringQuoted("Down"),
+          Token.punctuation.closeBrace,
+        ]);
+      });
+
+      it("union with named variants with escaped identifier", async () => {
+        const tokens = await tokenize(
+          `union Direction { \`north east\`: "North East", \`north west\`: "North West" }`
+        );
+        deepStrictEqual(tokens, [
+          Token.keywords.union,
+          Token.identifiers.type("Direction"),
+          Token.punctuation.openBrace,
+          Token.identifiers.variable("`north east`"),
+          Token.operators.typeAnnotation,
+          Token.literals.stringQuoted("North East"),
+          Token.punctuation.comma,
+          Token.identifiers.variable("`north west`"),
+          Token.operators.typeAnnotation,
+          Token.literals.stringQuoted("North West"),
           Token.punctuation.closeBrace,
         ]);
       });

--- a/packages/compiler/test/server/colorization.test.ts
+++ b/packages/compiler/test/server/colorization.test.ts
@@ -33,6 +33,7 @@ const Token = {
   keywords: {
     model: createToken("model", "keyword.other.tsp"),
     scalar: createToken("scalar", "keyword.other.tsp"),
+    enum: createToken("enum", "keyword.other.tsp"),
     operation: createToken("op", "keyword.other.tsp"),
     namespace: createToken("namespace", "keyword.other.tsp"),
     interface: createToken("interface", "keyword.other.tsp"),
@@ -766,6 +767,61 @@ function testColorization(description: string, tokenize: Tokenize) {
         Token.punctuation.typeParameters.end,
         Token.punctuation.semicolon,
       ]);
+    });
+
+    describe("enums", () => {
+      it("simple enum", async () => {
+        const tokens = await tokenize("enum Foo {}");
+        deepStrictEqual(tokens, [
+          Token.keywords.enum,
+          Token.identifiers.type("Foo"),
+          Token.punctuation.openBrace,
+          Token.punctuation.closeBrace,
+        ]);
+      });
+
+      it("enum with simple members", async () => {
+        const tokens = await tokenize("enum Direction { up, down}");
+        deepStrictEqual(tokens, [
+          Token.keywords.enum,
+          Token.identifiers.type("Direction"),
+          Token.punctuation.openBrace,
+          Token.identifiers.variable("up"),
+          Token.punctuation.comma,
+          Token.identifiers.variable("down"),
+          Token.punctuation.closeBrace,
+        ]);
+      });
+
+      it("enum with escaped identifiers", async () => {
+        const tokens = await tokenize("enum Direction { `North West`, `North West`}");
+        deepStrictEqual(tokens, [
+          Token.keywords.enum,
+          Token.identifiers.type("Direction"),
+          Token.punctuation.openBrace,
+          Token.identifiers.variable("`North West`"),
+          Token.punctuation.comma,
+          Token.identifiers.variable("`North West`"),
+          Token.punctuation.closeBrace,
+        ]);
+      });
+
+      it("enum with string values", async () => {
+        const tokens = await tokenize(`enum Direction { up: "Up", down: "Down"}`);
+        deepStrictEqual(tokens, [
+          Token.keywords.enum,
+          Token.identifiers.type("Direction"),
+          Token.punctuation.openBrace,
+          Token.identifiers.variable("up"),
+          Token.operators.typeAnnotation,
+          Token.literals.stringQuoted("Up"),
+          Token.punctuation.comma,
+          Token.identifiers.variable("down"),
+          Token.operators.typeAnnotation,
+          Token.literals.stringQuoted("Down"),
+          Token.punctuation.closeBrace,
+        ]);
+      });
     });
 
     describe("namespaces", () => {


### PR DESCRIPTION
resolves https://github.com/microsoft/typespec/issues/3070
The tm language wasn't correctly defining the syntax for escaped identifiers 

```
`North West`
```


Enums and unions syntax was also not very accurate and didn't tokenize everything correctly


## Example of issue before

![image](https://github.com/microsoft/typespec/assets/1031227/ee60f4fe-5eef-4f86-baa5-1cc96b665526)

## After
![image](https://github.com/microsoft/typespec/assets/1031227/38405f18-0fa4-44ba-82f6-594bcd4fcebf)

