### PR TITLE
Update inconsistent docs

### DIFF
--- a/docs/getting-started/typespec-for-openapi-dev.md
+++ b/docs/getting-started/typespec-for-openapi-dev.md
@@ -228,7 +228,7 @@ The fields in an OpenAPI operation object are specified with the following TypeS
 | `callbacks`               |                                            | Not currently supported.                             |
 | `deprecated`              | `@deprecated` decorator                    |                                                      |
 | `security`                |                                            | Not currently supported.                             |
-| `servers`                 |                                            | Not currently supported.                             |
+| `servers`                 | `@server` decorator                        | Can be specified multiple times.                     |
 
 ### Tags
 

--- a/packages/website/versioned_docs/version-latest/getting-started/typespec-for-openapi-dev.md
+++ b/packages/website/versioned_docs/version-latest/getting-started/typespec-for-openapi-dev.md
@@ -228,7 +228,7 @@ The fields in an OpenAPI operation object are specified with the following TypeS
 | `callbacks`               |                                            | Not currently supported.                             |
 | `deprecated`              | `@deprecated` decorator                    |                                                      |
 | `security`                |                                            | Not currently supported.                             |
-| `servers`                 |                                            | Not currently supported.                             |
+| `servers`                 | `@server` decorator                        | Can be specified multiple times.                     |
 
 ### Tags
 


### PR DESCRIPTION
@server works to provide values for the `servers` object, as is documented elsewhere in the same files. This PR updates the table to reflect that. Closes #3071.