### PR TITLE
Do not crash if hitting a unsupported intrinsic type

### DIFF
--- a/.chronus/changes/fix-dont-crash-unsupported-intrinsic-2024-2-28-19-23-35.md
+++ b/.chronus/changes/fix-dont-crash-unsupported-intrinsic-2024-2-28-19-23-35.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Do not crash if using an unsupported intrinsic type

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -925,7 +925,12 @@ export class OpenAPI3SchemaEmitter extends TypeEmitter<
         return { nullable: true };
     }
 
-    throw new Error("Unknown intrinsic type " + name);
+    reportDiagnostic(this.emitter.getProgram(), {
+      code: "invalid-schema",
+      format: { type: name },
+      target: intrinsic,
+    });
+    return {};
   }
 
   programContext(program: Program): Context {


### PR DESCRIPTION
fix #3073

This still doesn't provide an optimal experience as the error shows up on the void type instead of where it is referenced but solving that is that long standing issue about tracing back where an error should be