### PR TITLE
Allow reload of js files in vitest

### DIFF
--- a/.chronus/changes/vitest-allow-reload-js-2024-3-1-10-34-31.md
+++ b/.chronus/changes/vitest-allow-reload-js-2024-3-1-10-34-31.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/openapi"
+---
+

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -39,6 +39,7 @@
     "gen-extern-signature": "tspd --enable-experimental gen-extern-signature .",
     "lint-typespec-library": "tsp compile . --warn-as-error --import @typespec/library-linter --no-emit",
     "test": "vitest run",
+    "test:watch": "vitest -w",
     "test:ui": "vitest --ui",
     "test-official": "vitest run --coverage --reporter=junit --reporter=default --no-file-parallelism",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -66,7 +66,7 @@ export const $extension: ExtensionDecorator = (
   if (diagnostics.length > 0) {
     context.program.reportDiagnostics(diagnostics);
   }
-  // setExtension(context.program, entity, extensionName as ExtensionKey, data);
+  setExtension(context.program, entity, extensionName as ExtensionKey, data);
 };
 
 export function setExtension(

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -66,7 +66,7 @@ export const $extension: ExtensionDecorator = (
   if (diagnostics.length > 0) {
     context.program.reportDiagnostics(diagnostics);
   }
-  setExtension(context.program, entity, extensionName as ExtensionKey, data);
+  // setExtension(context.program, entity, extensionName as ExtensionKey, data);
 };
 
 export function setExtension(

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -15,4 +15,7 @@ export const defaultTypeSpecVitestConfig = {
     },
     watchExclude: [],
   },
+  build: {
+    outDir: "dummy", // Workaround for bug https://github.com/vitest-dev/vitest/issues/5429
+  },
 };


### PR DESCRIPTION
Setup a workaround for the fact that vitest(vite underneath) doesn't ever want to reload files in the outDir https://github.com/vitest-dev/vitest/issues/5429

as the outDir isn't actually used in vitest(as far as I understand) this is just an ok workaround.