### PR TITLE
Fix swagger ui build

### DIFF
--- a/.chronus/changes/fix-swagger-ui-build-2024-3-1-18-48-1.md
+++ b/.chronus/changes/fix-swagger-ui-build-2024-3-1-18-48-1.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/playground"
+---
+

--- a/packages/playground/rollup.config.ts
+++ b/packages/playground/rollup.config.ts
@@ -12,6 +12,7 @@ const packageJson = JSON.parse(readFileSync(resolve(__dirname, "package.json")).
 const dependencies = Object.keys(packageJson.dependencies);
 const external = [
   ...dependencies,
+  "swagger-ui-dist/swagger-ui-es-bundle.js",
   "swagger-ui-dist/swagger-ui.css",
   "@typespec/bundler/vite",
   "react-dom/client",

--- a/packages/playground/src/react/viewers/react-wrapper.tsx
+++ b/packages/playground/src/react/viewers/react-wrapper.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from "react";
-import { SwaggerUIBundle } from "swagger-ui-dist";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import SwaggerUIBundle from "swagger-ui-dist/swagger-ui-es-bundle.js";
 
 export default (props: { spec: string }) => {
   const uiRef = useRef(null);

--- a/packages/playground/src/react/viewers/react-wrapper.tsx
+++ b/packages/playground/src/react/viewers/react-wrapper.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+// File exists but not describe in the @types package
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import SwaggerUIBundle from "swagger-ui-dist/swagger-ui-es-bundle.js";


### PR DESCRIPTION
Missed that when doing the PR, the default import tries to load the `path` library, recommendation is just to import the right bundle directly.