### PR TITLE
Fix directive parsing on namespaces

### DIFF
--- a/.chronus/changes/fixDirectiveParsing-2024-3-16-17-9-37.md
+++ b/.chronus/changes/fixDirectiveParsing-2024-3-16-17-9-37.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix issue where directives were not parsed to the leaf node in multi-segment Namespace segments. 

--- a/packages/compiler/src/core/parser.ts
+++ b/packages/compiler/src/core/parser.ts
@@ -420,7 +420,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
           item = parseScalarStatement(pos, decorators);
           break;
         case Token.NamespaceKeyword:
-          item = parseNamespaceStatement(pos, decorators, docs);
+          item = parseNamespaceStatement(pos, decorators, docs, directives);
           break;
         case Token.InterfaceKeyword:
           item = parseInterfaceStatement(pos, decorators);
@@ -461,8 +461,8 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
           break;
       }
 
-      mutate(item).directives = directives;
       if (tok !== Token.NamespaceKeyword) {
+        mutate(item).directives = directives;
         mutate(item).docs = docs;
       }
 
@@ -515,7 +515,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
           item = parseScalarStatement(pos, decorators);
           break;
         case Token.NamespaceKeyword:
-          const ns = parseNamespaceStatement(pos, decorators, docs);
+          const ns = parseNamespaceStatement(pos, decorators, docs, directives);
 
           if (!Array.isArray(ns.statements)) {
             error({ code: "blockless-namespace-first", messageId: "topLevel", target: ns });
@@ -595,7 +595,8 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
   function parseNamespaceStatement(
     pos: number,
     decorators: DecoratorExpressionNode[],
-    docs: DocNode[]
+    docs: DocNode[],
+    directives: DirectiveExpressionNode[]
   ): NamespaceStatementNode {
     parseExpected(Token.NamespaceKeyword);
     let currentName = parseIdentifierOrMemberExpression();
@@ -621,7 +622,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
       id: nsSegments[0],
       locals: undefined!,
       statements,
-
+      directives: directives,
       ...finishNode(pos),
     };
 
@@ -629,6 +630,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
       outerNs = {
         kind: SyntaxKind.NamespaceStatement,
         decorators: [],
+        directives: [],
         id: nsSegments[i],
         statements: outerNs,
         locals: undefined!,

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -5,7 +5,6 @@ import { formatDiagnostic, logVerboseTestOutput } from "../src/core/diagnostics.
 import { hasParseError, parse, visitChildren } from "../src/core/parser.js";
 import {
   IdentifierNode,
-  NamespaceStatementNode,
   Node,
   ParseOptions,
   SourceFile,

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -721,15 +721,15 @@ describe("compiler: parser", () => {
           `@doc("foo")\n#suppress "foo"\nnamespace Foo.Bar {}`,
           (node) => {
             const fooNs = node.statements[0];
-            assert(fooNs.kind === SyntaxKind.NamespaceStatement);
+            strictEqual(fooNs.kind, SyntaxKind.NamespaceStatement);
             const barNs = (fooNs as any).statements;
-            assert(barNs.kind === SyntaxKind.NamespaceStatement);
-            assert(fooNs.id.sv === "Foo");
-            assert(barNs.id.sv === "Bar");
-            assert(fooNs.directives?.length === 0);
-            assert(fooNs.decorators.length === 0);
-            assert(barNs.directives?.length === 1);
-            assert(barNs.decorators.length === 1);
+            strictEqual(barNs.kind, SyntaxKind.NamespaceStatement);
+            strictEqual(fooNs.id.sv, "Foo");
+            strictEqual(barNs.id.sv, "Bar");
+            strictEqual(fooNs.directives?.length, 0);
+            strictEqual(fooNs.decorators.length, 0);
+            strictEqual(barNs.directives?.length, 1);
+            strictEqual(barNs.decorators.length, 1);
           },
         ],
       ]);

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -720,9 +720,9 @@ describe("compiler: parser", () => {
         [
           `@doc("foo")\n#suppress "foo"\nnamespace Foo.Bar {}`,
           (node) => {
-            const fooNs = node.statements[0] as NamespaceStatementNode;
+            const fooNs = node.statements[0];
             assert(fooNs.kind === SyntaxKind.NamespaceStatement);
-            const barNs = (fooNs as any).statements as NamespaceStatementNode;
+            const barNs = (fooNs as any).statements;
             assert(barNs.kind === SyntaxKind.NamespaceStatement);
             assert(fooNs.id.sv === "Foo");
             assert(barNs.id.sv === "Bar");


### PR DESCRIPTION
Fixes #3165.

Ensures that decorators and directives are attached the leaf node on Namespace chains.