### PR TITLE
Fix tsp init hanging when done due to unclosed connection

### DIFF
--- a/.chronus/changes/fix-init-never-ending-2024-3-17-20-24-14.md
+++ b/.chronus/changes/fix-init-never-ending-2024-3-17-20-24-14.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix tsp init hanging when done due to unclosed connection

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -85,6 +85,7 @@
     "@babel/code-frame": "~7.24.2",
     "ajv": "~8.12.0",
     "change-case": "~5.4.4",
+    "follow-redirects": "^1.15.6",
     "globby": "~14.0.1",
     "mustache": "~4.2.0",
     "picocolors": "~1.0.0",
@@ -98,6 +99,7 @@
   },
   "devDependencies": {
     "@types/babel__code-frame": "~7.0.6",
+    "@types/follow-redirects": "^1.14.4",
     "@types/mustache": "~4.2.5",
     "@types/node": "~18.11.19",
     "@types/prompts": "~2.4.9",

--- a/packages/compiler/src/core/fetch.ts
+++ b/packages/compiler/src/core/fetch.ts
@@ -25,6 +25,7 @@ export function fetch(uri: string): Promise<FetchResponse> {
     protocol
       .get(url, (res) => {
         if ((res.statusCode === 301 || res.statusCode === 302) && res.headers.location) {
+          res.destroy(); // destroy the response otherwise it gets stuck waiting for data.
           return request(res.headers.location, resolve, reject);
         }
         let data = "";

--- a/packages/compiler/src/core/fetch.ts
+++ b/packages/compiler/src/core/fetch.ts
@@ -1,4 +1,4 @@
-import { http, https } from "follow-redirects";
+import followRedirects from "follow-redirects";
 import { compilerAssert } from "./diagnostics.js";
 
 export interface FetchResponse {
@@ -18,7 +18,11 @@ export function fetch(uri: string): Promise<FetchResponse> {
   function request(uri: string, resolve: (arg: FetchResponse) => void, reject: (arg: any) => void) {
     const url = new URL(uri);
     const protocol =
-      url.protocol === "https:" ? https : url.protocol === "http:" ? http : undefined;
+      url.protocol === "https:"
+        ? followRedirects.https
+        : url.protocol === "http:"
+          ? followRedirects.http
+          : undefined;
     compilerAssert(protocol, `Protocol '${url.protocol}' is not supported`);
 
     protocol

--- a/packages/compiler/src/core/fetch.ts
+++ b/packages/compiler/src/core/fetch.ts
@@ -1,5 +1,4 @@
-import http from "http";
-import https from "https";
+import { http, https } from "follow-redirects";
 import { compilerAssert } from "./diagnostics.js";
 
 export interface FetchResponse {
@@ -24,10 +23,6 @@ export function fetch(uri: string): Promise<FetchResponse> {
 
     protocol
       .get(url, (res) => {
-        if ((res.statusCode === 301 || res.statusCode === 302) && res.headers.location) {
-          res.destroy(); // destroy the response otherwise it gets stuck waiting for data.
-          return request(res.headers.location, resolve, reject);
-        }
         let data = "";
 
         res.on("data", (chunk) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       change-case:
         specifier: ~5.4.4
         version: 5.4.4
+      follow-redirects:
+        specifier: ^1.15.6
+        version: 1.15.6
       globby:
         specifier: ~14.0.1
         version: 14.0.1
@@ -259,6 +262,9 @@ importers:
       '@types/babel__code-frame':
         specifier: ~7.0.6
         version: 7.0.6
+      '@types/follow-redirects':
+        specifier: ^1.14.4
+        version: 1.14.4
       '@types/mustache':
         specifier: ~4.2.5
         version: 4.2.5
@@ -7715,6 +7721,12 @@ packages:
       '@types/qs': 6.9.14
       '@types/serve-static': 1.15.5
     dev: false
+
+  /@types/follow-redirects@1.14.4:
+    resolution: {integrity: sha512-GWXfsD0Jc1RWiFmMuMFCpXMzi9L7oPDVwxUnZdg89kDNnqsRfUKXEtUYtA98A6lig1WXH/CYY/fvPW9HuN5fTA==}
+    dependencies:
+      '@types/node': 18.11.19
+    dev: true
 
   /@types/gtag.js@0.0.12:
     resolution: {integrity: sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==}


### PR DESCRIPTION
fix [#3102](https://github.com/microsoft/typespec/issues/3102)

Problem was that when following redirect we need to explicitly close the response watch otherwise we always await on it

However I switched to using `follow-redirects` library that will more safely handle redirect for us.(e.g. max redirects)
With node 22 the fetch api should not be experimental anymore so we could potentially migrate to it next year when node 20 is out of support