### PR TITLE
docs: fix incorrect example code in namespaces.md

### DIFF
--- a/docs/language-basics/namespaces.md
+++ b/docs/language-basics/namespaces.md
@@ -93,6 +93,6 @@ namespace Two {
   alias B = A; // This is valid
 }
 
-alias C = One.A; // This is not valid
+alias C = Two.A; // This is not valid
 alias C = Two.B; // This is valid
 ```


### PR DESCRIPTION
## Backgrounds

I first reported this on discussion: #3194

## Issue description

There is a code sample [here](https://typespec.io/docs/language-basics/namespaces#using-namespaces) describing the scope of an item introduced by `using`.

```ts
namespace One {
  model A {}
}

namespace Two {
  using One;
  alias B = A; // This is valid
}

alias C = One.A; // This is not valid
alias C = Two.B; // This is valid
```

## Expected result

The code should failed to compile because of `One.A`.

## Actual result

It compiles without any warning.

## How to fix

It appears that the original intent was to show that accessing an item introduced with `using` outside the scope of `using` is not possible. In this code, the 'invalid accessing' is `Two.A`.

## Changes

- change `One.A` to `Two.A`