### PR TITLE
Fix: augmenting template property didn't resolve declaration

### DIFF
--- a/.chronus/changes/fix-augment-decorator-template-decl-2024-3-23-15-44-27.md
+++ b/.chronus/changes/fix-augment-decorator-template-decl-2024-3-23-15-44-27.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix: augmenting template model property could result in sending invalid argument to decorator

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -1981,7 +1981,6 @@ export function createChecker(program: Program): Checker {
 
   function getSymbolLinks(s: Sym): SymbolLinks {
     const id = getSymbolId(s);
-
     if (symbolLinks.has(id)) {
       return symbolLinks.get(id)!;
     }
@@ -3675,7 +3674,7 @@ export function createChecker(program: Program): Checker {
             x.kind === SyntaxKind.DecoratorDeclarationStatement
         );
       if (decoratorDeclNode) {
-        checkDecoratorDeclaration(decoratorDeclNode, mapper);
+        checkDecoratorDeclaration(decoratorDeclNode, undefined);
       }
     }
     if (symbolLinks.declaredType) {

--- a/packages/compiler/test/checker/decorators.test.ts
+++ b/packages/compiler/test/checker/decorators.test.ts
@@ -287,6 +287,21 @@ describe("compiler: checker: decorators", () => {
       expectDecoratorNotCalled();
     });
 
+    // Regresssion test for https://github.com/microsoft/typespec/issues/3211
+    it("augmenting a template model property before a decorator declaration resolve the declaration correctly", async () => {
+      await runner.compile(`
+        model Foo<T> {
+          prop: T;
+        }
+        model Test {foo: Foo<string>}
+
+        @@testDec(Foo.prop, "abc");
+        extern dec testDec(target: unknown, arg1: valueof string);
+
+      `);
+      strictEqual(calledArgs![2], "abc");
+    });
+
     describe("value marshalling", () => {
       async function testCallDecorator(type: string, value: string): Promise<any> {
         await runner.compile(`


### PR DESCRIPTION
fix #3211
Problem was we were checking the decorator declaration passing the `mapper` this mean the checker was thinking we were defining this decorator declaration in a template instance(which is not possible)
This resulted in the argument marshaling to not happen as it will only happen when there is a valueof constraint