### PR TITLE
Update extensions.json for Vitest Explorer.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "ZixuanChen.vitest-explorer"
+    "vitest.explorer"
   ]
 }


### PR DESCRIPTION
This was done for TypeSpec Azure but not regular TypeSpec. VSCode keeps asking me to install a deprecated extension.