### PR TITLE
Ignore already escaped `|` when building markdown table

### DIFF
--- a/packages/tspd/src/ref-doc/utils/markdown.ts
+++ b/packages/tspd/src/ref-doc/utils/markdown.ts
@@ -27,8 +27,9 @@ export function link(text: string, url: string) {
 }
 
 function escapeMarkdownTable(text: string) {
-  // revert test
-  return text.replace(/(\|)/g, "\\$1").replace(/\n/g, "<br />");
+  return text
+    .replace(/(\|)/g, "\\$1") // revert test
+    .replace(/\n/g, "<br />");
 }
 
 export function table([header, ...rows]: string[][]) {

--- a/packages/tspd/src/ref-doc/utils/markdown.ts
+++ b/packages/tspd/src/ref-doc/utils/markdown.ts
@@ -27,7 +27,8 @@ export function link(text: string, url: string) {
 }
 
 function escapeMarkdownTable(text: string) {
-  return text.replace(/([^\\]\|)/g, "\\$1").replace(/\n/g, "<br />");
+  // revert test
+  return text.replace(/(\|)/g, "\\$1").replace(/\n/g, "<br />");
 }
 
 export function table([header, ...rows]: string[][]) {

--- a/packages/tspd/src/ref-doc/utils/markdown.ts
+++ b/packages/tspd/src/ref-doc/utils/markdown.ts
@@ -27,7 +27,7 @@ export function link(text: string, url: string) {
 }
 
 function escapeMarkdownTable(text: string) {
-  return text.replace(/(\|)/g, "\\$1").replace(/\n/g, "<br />");
+  return text.replace(/([^\\]\|)/g, "\\$1").replace(/\n/g, "<br />");
 }
 
 export function table([header, ...rows]: string[][]) {

--- a/packages/tspd/src/ref-doc/utils/markdown.ts
+++ b/packages/tspd/src/ref-doc/utils/markdown.ts
@@ -27,9 +27,7 @@ export function link(text: string, url: string) {
 }
 
 function escapeMarkdownTable(text: string) {
-  return text
-    .replace(/(\|)/g, "\\$1") // revert test
-    .replace(/\n/g, "<br />");
+  return text.replace(/([^\\])(\|)/g, "$1\\$2").replace(/\n/g, "<br />");
 }
 
 export function table([header, ...rows]: string[][]) {


### PR DESCRIPTION
Fix CodeQL issue https://github.com/microsoft/typespec/security/code-scanning/13