### PR TITLE
Templated interface extending another templated interface shouldn't run decorator on their operations

### DIFF
--- a/.chronus/changes/fix-no-finish-cloned-unfinished-2024-4-6-20-0-24.md
+++ b/.chronus/changes/fix-no-finish-cloned-unfinished-2024-4-6-20-0-24.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Templated interface extending another templated interface shouldn't run decorator on their operations

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -4724,7 +4724,9 @@ export function createChecker(program: Program): Checker {
         clone.decorators.push(dec);
       }
     }
-    clone = finishType(clone);
+    if (type.isFinished) {
+      clone = finishType(clone);
+    }
     compilerAssert(clone.kind === type.kind, "cloneType must not change type kind");
     return clone;
   }

--- a/packages/compiler/test/checker/interface.test.ts
+++ b/packages/compiler/test/checker/interface.test.ts
@@ -429,6 +429,25 @@ describe("compiler: interfaces", () => {
       expect($track).not.toHaveBeenCalled();
     });
 
+    it("templated interface extending another templated interface doesn't run decorator on extended interface operations", async () => {
+      const $track = vi.fn();
+      testHost.addJsFile("dec.js", { $track });
+      testHost.addTypeSpecFile(
+        "main.tsp",
+        `
+        import "./dec.js";
+         
+        interface Base<T> {
+          @track bar(): T;
+        }
+
+        interface Foo<T> extends Base<T> {}
+        `
+      );
+      await testHost.compile("./");
+      expect($track).not.toHaveBeenCalled();
+    });
+
     it("emit warning if shadowing parent templated type", async () => {
       const diagnostics = await runner.diagnose(`
       interface Base<A> {


### PR DESCRIPTION
fix #3286