### PR TITLE
Simplify inactivity flow

### DIFF
--- a/.github/policies/issues.inactivity.yml
+++ b/.github/policies/issues.inactivity.yml
@@ -53,6 +53,8 @@ configuration:
               label: needs-author-feedback
           - isOpen
         then:
+          - assignTo:
+              users: []
           - addLabel:
               label: needs-triage
           - removeLabel:

--- a/.github/policies/issues.inactivity.yml
+++ b/.github/policies/issues.inactivity.yml
@@ -8,23 +8,6 @@ where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-      - description: Mark issue with no-recent-activity label if it has been stale for 7 days and needs author feedback.
-        frequencies:
-          - hourly:
-              hour: 6
-        filters:
-          - isIssue
-          - isOpen
-          - isNotLabeledWith:
-              label: no-recent-activity
-          - hasLabel:
-              label: needs-author-feedback
-          - noActivitySince:
-              days: 7
-        actions:
-          - addLabel:
-              label: no-recent-activity
-
       - description: Close issues needing author feedback that have been stale for 14 days
         frequencies:
           - hourly:
@@ -37,7 +20,7 @@ configuration:
           - hasLabel:
               label: needs-author-feedback
           - noActivitySince:
-              days: 7
+              days: 14
         actions:
           - closeIssue
           - addReply:
@@ -59,23 +42,6 @@ configuration:
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
 
-      - description: >-
-          When the label "no-recent-activity" is added to an issue
-          * Add the issue specific reply notifying the issue author of pending closure
-        if:
-          - payloadType: Issues
-          - labelAdded:
-              label: no-recent-activity
-        then:
-          - addReply:
-              reply: >-
-                Hello @${issueAuthor},
-
-                This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
-
-        # The policy service should trigger even when the label was added by the policy service
-        triggerOnOwnActions: true
-
       - description: Remove needs-author-feedback label when author comments on issue
         if:
           - payloadType: Issue_Comment
@@ -88,7 +54,7 @@ configuration:
           - isOpen
         then:
           - addLabel:
-              label: needs-team-attention
+              label: needs-triage
           - removeLabel:
               label: needs-author-feedback
 onFailure:

--- a/.github/policies/issues.needs-info.yml
+++ b/.github/policies/issues.needs-info.yml
@@ -1,6 +1,6 @@
 id: issues.inactivity
 name: GitOps.PullRequestIssueManagement
-description: Manage issues that need author response and are stale
+description: Manage issues that need author response
 owner:
 resource: repository
 disabled: false
@@ -18,7 +18,7 @@ configuration:
           - hasLabel:
               label: No-Recent-Activity
           - hasLabel:
-              label: needs-author-feedback
+              label: needs-info
           - noActivitySince:
               days: 14
         actions:
@@ -30,11 +30,11 @@ configuration:
                 Please feel free to reopen if you have any further questions or concerns.
 
     eventResponderTasks:
-      - description: When the label "needs-author-feedback" is added to an issue assign back to the author
+      - description: When the label "needs-info" is added to an issue assign back to the author
         if:
           - payloadType: Issues
           - labelAdded:
-              label: needs-author-feedback
+              label: needs-info
           - isOpen
         then:
           - assignTo:
@@ -42,7 +42,7 @@ configuration:
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
 
-      - description: Remove needs-author-feedback label when author comments on issue
+      - description: Remove needs-info label when author comments on issue
         if:
           - payloadType: Issue_Comment
           - isAction:
@@ -50,7 +50,7 @@ configuration:
           - isActivitySender:
               issueAuthor: True
           - hasLabel:
-              label: needs-author-feedback
+              label: needs-info
           - isOpen
         then:
           - assignTo:
@@ -58,6 +58,6 @@ configuration:
           - addLabel:
               label: needs-triage
           - removeLabel:
-              label: needs-author-feedback
+              label: needs-info
 onFailure:
 onSuccess:


### PR DESCRIPTION
Simplfy flow from discussion in #3265 

- Add `needs-author-feedback` manually -> this assign issue back to user
- 14 days without reply close the issue
- User reply remove `needs-author-feedback` and unassign user