### PR TITLE
feat(http-client-csharp): bump tcgc to 0.41.5

### DIFF
--- a/packages/http-client-csharp/emitter/src/lib/model.ts
+++ b/packages/http-client-csharp/emitter/src/lib/model.ts
@@ -1016,7 +1016,7 @@ export function navigateModels(
     {
       model: (m) => {
         const realModel = getRealType(m);
-        return realModel.kind === "Model" && realModel.name != "" && computeType(realModel);
+        return realModel.kind === "Model" && realModel.name !== "" && computeType(realModel);
       },
       enum: (e) => {
         const realEnum = getRealType(e);

--- a/packages/http-client-csharp/emitter/src/lib/model.ts
+++ b/packages/http-client-csharp/emitter/src/lib/model.ts
@@ -21,6 +21,7 @@ import {
   NeverType,
   Operation,
   Program,
+  ProjectedProgram,
   Scalar,
   Type,
   Union,
@@ -1007,15 +1008,30 @@ export function navigateModels(
   models: Map<string, InputModelType>,
   enums: Map<string, InputEnumType>
 ) {
-  const computeModel = (x: Type) =>
+  const computeType = (x: Type) =>
     getInputType(context, getFormattedType(context.program, x), models, enums) as any;
   const skipSubNamespaces = isGlobalNamespace(context.program, namespace);
   navigateTypesInNamespace(
     namespace,
     {
-      model: (x) => x.name !== "" && x.kind === "Model" && computeModel(x),
-      enum: computeModel,
+      model: (m) => {
+        const realModel = getRealType(m);
+        return realModel.kind === "Model" && realModel.name != "" && computeType(realModel);
+      },
+      enum: (e) => {
+        const realEnum = getRealType(e);
+        return realEnum.kind === "Enum" && computeType(realEnum);
+      },
     },
     { skipSubNamespaces }
   );
+
+  // TODO: we should try to remove this when we adopt getModels
+  // we should avoid handling raw type definitions because they could be not correctly projected
+  // in the given api version
+  function getRealType(type: Type): Type {
+    if ("projector" in context.program)
+      return (context.program as ProjectedProgram).projector.projectedTypes.get(type) ?? type;
+    return type;
+  }
 }

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -4,6 +4,7 @@ import { tspOutputFileName } from "./constants.js";
 import { LoggerLevel } from "./lib/logger.js";
 
 export type NetEmitterOptions = {
+  "api-version"?: string;
   outputFile?: string;
   logFile?: string;
   namespace: string;
@@ -35,6 +36,7 @@ export const NetEmitterOptionsSchema: JSONSchemaType<NetEmitterOptions> = {
   type: "object",
   additionalProperties: false,
   properties: {
+    "api-version": { type: "string", nullable: true },
     outputFile: { type: "string", nullable: true },
     logFile: { type: "string", nullable: true },
     namespace: { type: "string" },
@@ -110,6 +112,7 @@ export const NetEmitterOptionsSchema: JSONSchemaType<NetEmitterOptions> = {
 };
 
 const defaultOptions = {
+  "api-version": "latest",
   outputFile: tspOutputFileName,
   logFile: "log.json",
   skipSDKGeneration: false,

--- a/packages/http-client-csharp/package-lock.json
+++ b/packages/http-client-csharp/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@azure-tools/typespec-azure-core": "0.41.0",
-        "@azure-tools/typespec-client-generator-core": "0.41.3",
+        "@azure-tools/typespec-client-generator-core": "0.41.5",
         "@microsoft/api-extractor": "^7.40.3",
         "@types/node": "~18.13.0",
         "@typespec/compiler": "0.55.0",
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.41.3.tgz",
-      "integrity": "sha512-f5H6gz7GCi0kUd7/8LoyJaMq68E0fNldZKQPxUIxqwlQHTFUI/7K37kCkOMNVk8gqmLgLKCShBLhE7zONKe8MA==",
+      "version": "0.41.5",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.41.5.tgz",
+      "integrity": "sha512-qY2dnyKIJm68+yv45lXu46QxHK5wepNbVXVBfdpF2thx1505ltjsq6fOwJhSwiHdC4wjiUtDUxYsB9bmG2+g2g==",
       "dev": true,
       "dependencies": {
         "change-case": "~5.4.4",

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@azure-tools/typespec-azure-core": "0.41.0",
-    "@azure-tools/typespec-client-generator-core": "0.41.3",
+    "@azure-tools/typespec-client-generator-core": "0.41.5",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "~18.13.0",
     "@typespec/compiler": "0.55.0",


### PR DESCRIPTION
- bump tcgc to 0.41.5
- add `api-version` option property

this is a backport of https://github.com/Azure/autorest.csharp/pull/4629