### PR TITLE
Rename the `GetExpressionTypeProviderWriter` to simple `GetWriter`

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ClientModelPlugin.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ClientModelPlugin.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Generator.CSharp.ClientModel
         private OutputLibrary? _scmOutputLibrary;
         public override OutputLibrary OutputLibrary => _scmOutputLibrary ??= new();
 
-        public override ExpressionTypeProviderWriter GetExpressionTypeProviderWriter(CodeWriter writer, TypeProvider provider) => new(writer, provider);
+        public override TypeProviderWriter GetWriter(CodeWriter writer, TypeProvider provider) => new(writer, provider);
 
         public override TypeFactory TypeFactory { get; }
 

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Generator.CSharp
             foreach (var model in output.Models)
             {
                 CodeWriter writer = new CodeWriter();
-                ExpressionTypeProviderWriter modelWriter = CodeModelPlugin.Instance.GetExpressionTypeProviderWriter(writer, model);
+                TypeProviderWriter modelWriter = CodeModelPlugin.Instance.GetWriter(writer, model);
                 modelWriter.Write();
                 generateFilesTasks.Add(workspace.AddGeneratedFile(Path.Combine("src", "Generated", "Models", $"{model.Name}.cs"), writer.ToString()));
             }
@@ -40,7 +40,7 @@ namespace Microsoft.Generator.CSharp
             foreach (var client in output.Clients)
             {
                 CodeWriter writer = new CodeWriter();
-                ExpressionTypeProviderWriter clientWriter = CodeModelPlugin.Instance.GetExpressionTypeProviderWriter(writer, client);
+                TypeProviderWriter clientWriter = CodeModelPlugin.Instance.GetWriter(writer, client);
                 clientWriter.Write();
                 generateFilesTasks.Add(workspace.AddGeneratedFile(Path.Combine("src", "Generated", $"{client.Name}.cs"), writer.ToString()));
             }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
@@ -32,16 +32,14 @@ namespace Microsoft.Generator.CSharp
             foreach (var model in output.Models)
             {
                 CodeWriter writer = new CodeWriter();
-                TypeProviderWriter modelWriter = CodeModelPlugin.Instance.GetWriter(writer, model);
-                modelWriter.Write();
+                CodeModelPlugin.Instance.GetWriter(writer, model).Write();
                 generateFilesTasks.Add(workspace.AddGeneratedFile(Path.Combine("src", "Generated", "Models", $"{model.Name}.cs"), writer.ToString()));
             }
 
             foreach (var client in output.Clients)
             {
                 CodeWriter writer = new CodeWriter();
-                TypeProviderWriter clientWriter = CodeModelPlugin.Instance.GetWriter(writer, client);
-                clientWriter.Write();
+                CodeModelPlugin.Instance.GetWriter(writer, client).Write();
                 generateFilesTasks.Add(workspace.AddGeneratedFile(Path.Combine("src", "Generated", $"{client.Name}.cs"), writer.ToString()));
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CodeModelPlugin.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CodeModelPlugin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -35,6 +35,6 @@ namespace Microsoft.Generator.CSharp
         public abstract ExtensibleSnippets ExtensibleSnippets { get; }
         public abstract OutputLibrary OutputLibrary { get; }
         public InputLibrary InputLibrary { get; }
-        public virtual ExpressionTypeProviderWriter GetExpressionTypeProviderWriter(CodeWriter writer, TypeProvider provider) => new(writer, provider);
+        public virtual TypeProviderWriter GetWriter(CodeWriter writer, TypeProvider provider) => new(writer, provider);
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Writers/TypeProviderWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Writers/TypeProviderWriter.cs
@@ -1,16 +1,16 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Linq;
 
 namespace Microsoft.Generator.CSharp.Writers
 {
-    public class ExpressionTypeProviderWriter
+    public class TypeProviderWriter
     {
         protected readonly TypeProvider _provider;
         protected readonly CodeWriter _writer;
 
-        public ExpressionTypeProviderWriter(CodeWriter writer, TypeProvider provider)
+        public TypeProviderWriter(CodeWriter writer, TypeProvider provider)
         {
             _provider = provider;
             _writer = writer;
@@ -145,7 +145,7 @@ namespace Microsoft.Generator.CSharp.Writers
         {
             foreach (var nested in _provider.NestedTypes)
             {
-                var nestedWriter = new ExpressionTypeProviderWriter(_writer, nested);
+                var nestedWriter = new TypeProviderWriter(_writer, nested);
                 nestedWriter.Write();
                 _writer.WriteLine();
             }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Writers/ExpressionTypeProviderWriterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Writers/ExpressionTypeProviderWriterTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Generator.CSharp.Tests
     internal class ExpressionTypeProviderWriterTests
     {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private ExpressionTypeProviderWriter _expressionTypeProviderWriter;
+        private TypeProviderWriter _expressionTypeProviderWriter;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [SetUp]
@@ -29,7 +29,7 @@ namespace Microsoft.Generator.CSharp.Tests
             Assert.That(_expressionTypeProviderWriter.Write, Throws.Exception.TypeOf<NotImplementedException>());
         }
 
-        internal class MockExpressionTypeProviderWriter : ExpressionTypeProviderWriter
+        internal class MockExpressionTypeProviderWriter : TypeProviderWriter
         {
             public MockExpressionTypeProviderWriter(CodeWriter writer, TypeProvider provider) : base(writer, provider) { }
 


### PR DESCRIPTION
I think  the method name `GetExpressionTypeProviderWriter` is too verbose, considering
1. we no longer have a type of `ExpressionTypeProvider` here, only `TypeProvider`
2. We should not have another writer
I simplified the name of this method, and the name of the writer `ExpressionTypeProviderWriter` to `TypeProviderWriter`.