### PR TITLE
Fix vitest not reloading JS files

### DIFF
--- a/.chronus/changes/fix-vitest-2024-4-17-21-35-16.md
+++ b/.chronus/changes/fix-vitest-2024-4-17-21-35-16.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/openapi3"
+---
+
+Fix vitest not reloading JS files

--- a/packages/openapi3/vitest.config.ts
+++ b/packages/openapi3/vitest.config.ts
@@ -6,7 +6,6 @@ export default mergeConfig(
   defineConfig({
     test: {
       testTimeout: 10000,
-      watchExclude: ["dist/**"],
     },
   })
 );

--- a/packages/samples/src/sample-snapshot-testing.ts
+++ b/packages/samples/src/sample-snapshot-testing.ts
@@ -50,7 +50,7 @@ export function defineSampleSnaphotTests(config: SampleSnapshotTestOptions) {
   });
 
   afterAll(async function (context: Readonly<Suite | File>) {
-    if (context.tasks.length !== samples.length) {
+    if (context.tasks.some((x) => x.mode === "skip")) {
       return; // Not running the full test suite, so don't bother checking snapshots.
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import { defaultTypeSpecVitestConfig } from "./vitest.workspace.js";
+
+export default mergeConfig(defaultTypeSpecVitestConfig, defineConfig({}));


### PR DESCRIPTION
Seems like we also need a `vitest.config.ts` at the root of the workspace to override the `watchExclude` setting otherwise `dist` and `node_modules` are still excluded and everytime require a refresh of the vitest UI or restarting the watch. Only thing that was working is if you modified the test files or modified imported files directly from the test