### PR TITLE
change the array to `IReadOnlyList` since it is a public API

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ClientModelPlugin.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ClientModelPlugin.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.Generator.CSharp.ClientModel.Expressions;
 using Microsoft.Generator.CSharp.Expressions;
-using Microsoft.Generator.CSharp.Input;
 using Microsoft.Generator.CSharp.Writers;
 
 namespace Microsoft.Generator.CSharp.ClientModel
@@ -30,10 +30,10 @@ namespace Microsoft.Generator.CSharp.ClientModel
         /// Returns the serialization type providers for the given model type provider.
         /// </summary>
         /// <param name="provider">The model type provider.</param>
-        public override TypeProvider[] GetSerializationTypeProviders(ModelTypeProvider provider)
+        public override IReadOnlyList<TypeProvider> GetSerializationTypeProviders(ModelTypeProvider provider)
         {
             // Add JSON serialization type provider
-            return new TypeProvider[] { new MrwSerializationTypeProvider(provider) };
+            return [new MrwSerializationTypeProvider(provider)];
         }
 
         [ImportingConstructor]

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CodeModelPlugin.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CodeModelPlugin.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.Generator.CSharp.Expressions;
 using Microsoft.Generator.CSharp.Input;
@@ -43,6 +44,6 @@ namespace Microsoft.Generator.CSharp
         /// Returns a serialization type provider for the given model type provider.
         /// </summary>
         /// <param name="provider">The model type provider.</param>
-        public abstract TypeProvider[] GetSerializationTypeProviders(ModelTypeProvider provider);
+        public abstract IReadOnlyList<TypeProvider> GetSerializationTypeProviders(ModelTypeProvider provider);
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputTypes/ModelTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputTypes/ModelTypeProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Generator.CSharp
         /// <summary>
         /// The serializations providers for the model provider.
         /// </summary>
-        public TypeProvider[] SerializationProviders { get; } = Array.Empty<TypeProvider>();
+        public IReadOnlyList<TypeProvider> SerializationProviders { get; } = Array.Empty<TypeProvider>();
 
         public ModelTypeProvider(InputModelType inputModel, SourceInputModel? sourceInputModel)
             : base(sourceInputModel)


### PR DESCRIPTION
Since the `GetSerializationTypeProviders` is a public API and we never except the consumer of this method to modify the returned values, we should return it in a `IReadOnlyList<>`