### PR TITLE
Circular reference fixes

### DIFF
--- a/.chronus/changes/json-schema-fixes-2024-4-25-0-58-10.md
+++ b/.chronus/changes/json-schema-fixes-2024-4-25-0-58-10.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Emitter framework: fix losing context when referencing circular types

--- a/.chronus/changes/json-schema-fixes-2024-4-25-0-58-28.md
+++ b/.chronus/changes/json-schema-fixes-2024-4-25-0-58-28.md
@@ -1,5 +1,5 @@
 ---
-changeKind: fix
+changeKind: internal
 packages:
   - "@typespec/json-schema"
 ---

--- a/.chronus/changes/json-schema-fixes-2024-4-25-0-58-28.md
+++ b/.chronus/changes/json-schema-fixes-2024-4-25-0-58-28.md
@@ -1,0 +1,6 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/json-schema"
+---
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,6 +61,7 @@
         "compile",
         "../samples/scratch",
         "--output-dir=temp/scratch-output",
+        "--emit=@typespec/openapi3"
       ],
       "smartStep": true,
       "sourceMaps": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,6 @@
         "compile",
         "../samples/scratch",
         "--output-dir=temp/scratch-output",
-        "--emit=@typespec/openapi3"
       ],
       "smartStep": true,
       "sourceMaps": true,

--- a/packages/compiler/src/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/src/emitter-framework/asset-emitter.ts
@@ -733,8 +733,8 @@ export function createAssetEmitter<T, TOptions extends object>(
    * Invoke the callback with the given context.
    */
   function withContext(newContext: EmitterState, cb: () => void) {
-    const oldContext = newContext.context;
-    const oldTypeStack = newContext.lexicalTypeStack;
+    const oldContext = context;
+    const oldTypeStack = lexicalTypeStack;
     context = newContext.context;
     lexicalTypeStack = newContext.lexicalTypeStack;
 

--- a/packages/json-schema/test/references.test.ts
+++ b/packages/json-schema/test/references.test.ts
@@ -196,4 +196,28 @@ describe("referencing non-JSON Schema types", () => {
     assert(amSchemas["B.json"] !== undefined);
     assert(Object.keys(amSchemas).length === 2);
   });
+
+  it("handles circular refs among non-json schema types", async () => {
+    const schemas = await emitSchema(
+      `
+      @jsonSchema
+      model R {
+        test: A;
+      }
+      
+      model A {
+        a: B;
+      }
+      
+      model B {
+        a: A;
+      }
+    `,
+      {},
+      { emitNamespace: false, emitTypes: ["R"] }
+    );
+    assert(schemas["R.json"] !== undefined);
+    assert(Object.keys(schemas).length === 1);
+    assert(Object.keys(schemas["R.json"].$defs).length === 2);
+  });
 });


### PR DESCRIPTION
fix #3447 
Fixed a few issues with circular references in the JSON Schema emitter and emitter framework:

* The emitter framework wouldn't restore context correctly when directly emitting a type reference to a type with a circular reference.
* The JSON Schema emitter did not handle circular references involving non-JSON Schema types.
* The JSON Schema emitter would create an infinite loop when circular references needed to be put into $defs.