### PR TITLE
feat(http-client-csharp): support `@flattenProperty`

### DIFF
--- a/packages/http-client-csharp/emitter/src/type/input-model-property.ts
+++ b/packages/http-client-csharp/emitter/src/type/input-model-property.ts
@@ -11,4 +11,5 @@ export interface InputModelProperty {
   IsRequired: boolean;
   IsReadOnly: boolean;
   IsDiscriminator?: boolean;
+  FlattenedNames?: string[];
 }

--- a/packages/http-client-csharp/emitter/test/Unit/model-type.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/model-type.test.ts
@@ -78,6 +78,7 @@ op test(@body input: Pet): Pet;
         IsReadOnly: false,
         IsDiscriminator: true,
         Description: "Discriminator",
+        FlattenedNames: undefined,
       } as InputModelProperty,
       discriminatorProperty
     );
@@ -188,6 +189,7 @@ op test(@body input: Pet): Pet;
         IsRequired: true,
         IsReadOnly: false,
         IsDiscriminator: true,
+        FlattenedNames: undefined,
       } as InputModelProperty,
       discriminatorProperty
     );
@@ -312,6 +314,7 @@ op test(@body input: Pet): Pet;
         IsRequired: true,
         IsReadOnly: false,
         IsDiscriminator: true,
+        FlattenedNames: undefined,
       } as InputModelProperty,
       discriminatorProperty
     );

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputModelProperty.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputModelProperty.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Generator.CSharp.Input
 {
     public class InputModelProperty
     {
-        public InputModelProperty(string name, string serializedName, string description, InputType type, bool isRequired, bool isReadOnly, bool isDiscriminator)
+        public InputModelProperty(string name, string serializedName, string description, InputType type, bool isRequired, bool isReadOnly, bool isDiscriminator, IReadOnlyList<string>? flattenedNames = null)
         {
             Name = name;
             SerializedName = serializedName;
@@ -14,6 +16,7 @@ namespace Microsoft.Generator.CSharp.Input
             IsRequired = isRequired;
             IsReadOnly = isReadOnly;
             IsDiscriminator = isDiscriminator;
+            FlattenedNames = flattenedNames;
         }
 
         public string Name { get; }
@@ -23,5 +26,6 @@ namespace Microsoft.Generator.CSharp.Input
         public bool IsRequired { get; }
         public bool IsReadOnly { get; }
         public bool IsDiscriminator { get; }
+        public IReadOnlyList<string>? FlattenedNames { get; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputModelPropertyConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputModelPropertyConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -31,6 +32,7 @@ namespace Microsoft.Generator.CSharp.Input
             bool isReadOnly = false;
             bool isRequired = false;
             bool isDiscriminator = false;
+            IReadOnlyList<string>? flattenedNames = null;
 
             while (reader.TokenType != JsonTokenType.EndObject)
             {
@@ -41,7 +43,8 @@ namespace Microsoft.Generator.CSharp.Input
                     || reader.TryReadWithConverter(nameof(InputModelProperty.Type), options, ref propertyType)
                     || reader.TryReadBoolean(nameof(InputModelProperty.IsReadOnly), ref isReadOnly)
                     || reader.TryReadBoolean(nameof(InputModelProperty.IsRequired), ref isRequired)
-                    || reader.TryReadBoolean(nameof(InputModelProperty.IsDiscriminator), ref isDiscriminator);
+                    || reader.TryReadBoolean(nameof(InputModelProperty.IsDiscriminator), ref isDiscriminator)
+                    || reader.TryReadStringArray(nameof(InputModelProperty.FlattenedNames), ref flattenedNames);
 
                 if (!isKnownProperty)
                 {
@@ -55,7 +58,7 @@ namespace Microsoft.Generator.CSharp.Input
             // description = BuilderHelpers.EscapeXmlDocDescription(description);
             propertyType = propertyType ?? throw new JsonException($"{nameof(InputModelProperty)} must have a property type.");
 
-            var property = new InputModelProperty(name, serializedName ?? name, description, propertyType, isRequired, isReadOnly, isDiscriminator);
+            var property = new InputModelProperty(name, serializedName ?? name, description, propertyType, isRequired, isReadOnly, isDiscriminator, flattenedNames);
             if (id != null)
             {
                 resolver.AddReference(id, property);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/Utf8JsonReaderExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/Utf8JsonReaderExtensions.cs
@@ -232,6 +232,37 @@ namespace Microsoft.Generator.CSharp.Input
             return result;
         }
 
+        public static bool TryReadStringArray(this ref Utf8JsonReader reader, string propertyName, ref IReadOnlyList<string>? value)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException();
+            }
+
+            if (reader.GetString() != propertyName)
+            {
+                return false;
+            }
+
+            reader.Read();
+
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException();
+            }
+            reader.Read();
+
+            var result = new List<string>();
+            while (reader.TokenType != JsonTokenType.EndArray)
+            {
+                result.Add(reader.GetString() ?? throw new JsonException());
+                reader.Read();
+            }
+            reader.Read();
+            value = result;
+            return true;
+        }
+
         public static void SkipProperty(this ref Utf8JsonReader reader)
         {
             if (reader.TokenType != JsonTokenType.PropertyName)


### PR DESCRIPTION
this is a port of https://github.com/Azure/autorest.csharp/pull/4688 with some additional changes due to different code base:
- add `FlattenedNames` to `InputModelProperty`
- add `TryReadStringArray` to `Utf8JsonReaderExtensions`