### PR TITLE
fix(website): OpenAPI home illustration

### DIFF
--- a/packages/website/static/tsp-samples/openapi3/hero/main.tsp
+++ b/packages/website/static/tsp-samples/openapi3/hero/main.tsp
@@ -27,5 +27,5 @@ interface Pets {
 @route("/stores")
 interface Stores {
   list(@query filter: string): Store[];
-  read(@path id: Store): Store;
+  read(@path id: string): Store;
 }

--- a/packages/website/static/tsp-samples/openapi3/hero/out/openapi.yaml
+++ b/packages/website/static/tsp-samples/openapi3/hero/out/openapi.yaml
@@ -80,7 +80,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Store'
+            type: string
       responses:
         '200':
           description: The request has succeeded.


### PR DESCRIPTION
## Why?
Because it does not make sense to me to be able to pass something else than a `string` in a path.
![Capture d’écran 2024-05-31 à 17 39 02](https://github.com/microsoft/typespec/assets/2571084/9005c45f-e59c-483b-a1e4-108c51e8722d)

