### PR TITLE
Inverse order in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Catch all
+*                                            @bterlson @markcowl @allenjzhang @timotheeguerin
+
 ######################
 # CSharp
 ######################
@@ -9,5 +12,3 @@
 ######################
 /eng/emitters/                               @m-nash
 
-# Catch all
-*                                            @bterlson @markcowl @allenjzhang @timotheeguerin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,6 @@
 # CSharp
 ######################
 /packages/http-client-csharp/                @m-nash
-/packages/http-client-csharp-generator/      @m-nash
 
 ######################
 # Emiter Shared


### PR DESCRIPTION
From the doc this seems to be the way to define catch all. Currently we are getting added to all csharp emitter PRs

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Particularly this part
```

# These owners will be the default owners for everything in
# the repo. Unless a later match takes precedence,
# @global-owner1 and @global-owner2 will be requested for
# review when someone opens a pull request.
*       @global-owner1 @global-owner2

```