### PR TITLE
Revert "support Arm processor for vs extension"

### DIFF
--- a/.chronus/changes/vs-extension-arm-2024-4-27-15-58-16.md
+++ b/.chronus/changes/vs-extension-arm-2024-4-27-15-58-16.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - typespec-vs
----
-
-Support Arm64

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -35,7 +35,8 @@ jobs:
         if: |
           !startsWith(github.head_ref, 'publish/') &&
           !startsWith(github.head_ref, 'dependabot/') &&
-          !startsWith(github.head_ref, 'backmerge/')
+          !startsWith(github.head_ref, 'backmerge/') &&
+          !startsWith(github.head_ref, 'revert-')
 
   # Validate spell check
   spellcheck:

--- a/packages/typespec-vs/src/Microsoft.TypeSpec.VS.csproj
+++ b/packages/typespec-vs/src/Microsoft.TypeSpec.VS.csproj
@@ -41,19 +41,17 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Use 17.0.x or latest 16.x if no 17.0.x for compatible API-->
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.10.40171" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203"
+      ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="16.3.43"
       ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.3.43"
       ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.9.3184">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <!-- Use latest 17.x for build tools-->
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093" PrivateAssets="All" />
     <!-- Align with VS 17.0 version here:
     https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/-->
-    <PackageReference Include="NewtonSoft.JSON" Version="13.0.3" ExcludeAssets="Runtime" />
+    <PackageReference Include="NewtonSoft.JSON" Version="13.0.2" ExcludeAssets="Runtime" />
   </ItemGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets"

--- a/packages/typespec-vs/src/source.extension.vsixmanifest
+++ b/packages/typespec-vs/src/source.extension.vsixmanifest
@@ -13,9 +13,6 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
-      <ProductArchitecture>arm64</ProductArchitecture>
-    </InstallationTarget>
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />


### PR DESCRIPTION
Reverts microsoft/typespec#3461

Breaking when using dotnet 6 or 7. Only works with dotnet 8