### PR TITLE
include cjs files so that we can add breakpoint of vscode extension during debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -108,6 +108,10 @@
       "type": "extensionHost",
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/typespec-vscode"],
+      "outFiles": [
+        "${workspaceFolder}/packages/*/dist/**/*.cjs",
+        "${workspaceFolder}/packages/*/dist-dev/**/*.cjs"
+      ],
       "env": {
         // Log elapsed time for each call to server.
         //"TYPESPEC_SERVER_LOG_TIMING": "true",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -109,8 +109,7 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/typespec-vscode"],
       "outFiles": [
-        "${workspaceFolder}/packages/*/dist/**/*.cjs",
-        "${workspaceFolder}/packages/*/dist-dev/**/*.cjs"
+        "${workspaceFolder}/packages/typespec-vscode/dist/**/*.cjs",
       ],
       "env": {
         // Log elapsed time for each call to server.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -109,7 +109,7 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/typespec-vscode"],
       "outFiles": [
-        "${workspaceFolder}/packages/typespec-vscode/dist/**/*.cjs",
+        "${workspaceFolder}/packages/typespec-vscode/dist/**/*.cjs"
       ],
       "env": {
         // Log elapsed time for each call to server.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -108,9 +108,7 @@
       "type": "extensionHost",
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/typespec-vscode"],
-      "outFiles": [
-        "${workspaceFolder}/packages/typespec-vscode/dist/**/*.cjs"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/typespec-vscode/dist/**/*.cjs"],
       "env": {
         // Log elapsed time for each call to server.
         //"TYPESPEC_SERVER_LOG_TIMING": "true",


### PR DESCRIPTION
Add cjs files so that vscode extension's outputs can be involved and breakpoints can be added during debug.