### PR TITLE
Deprecate getAssetEmitter and recommend calling `createAssetEmitter` directly

### DIFF
--- a/.chronus/changes/deprecate-get-asset-emitter-2024-5-4-16-18-29.md
+++ b/.chronus/changes/deprecate-get-asset-emitter-2024-5-4-16-18-29.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Deprecate getAssetEmitter and recommend calling `createAssetEmitter` directly

--- a/.chronus/changes/deprecate-get-asset-emitter-2024-5-4-16-38-47.md
+++ b/.chronus/changes/deprecate-get-asset-emitter-2024-5-4-16-38-47.md
@@ -1,0 +1,9 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/json-schema"
+  - "@typespec/openapi3"
+---
+
+Fix issue that could result in invalid document generation when runnning `tsp compile` from another directory

--- a/.chronus/changes/deprecate-get-asset-emitter-2024-5-4-16-38-47.md
+++ b/.chronus/changes/deprecate-get-asset-emitter-2024-5-4-16-38-47.md
@@ -6,4 +6,4 @@ packages:
   - "@typespec/openapi3"
 ---
 
-Fix issue that could result in invalid document generation when runnning `tsp compile` from another directory
+Fix issue that could result in invalid document generation when running `tsp compile` from another directory

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2602,6 +2602,8 @@ export interface EmitContext<TOptions extends object = Record<string, never>> {
   /**
    * Get an asset emitter to write emitted output to disk using a TypeEmitter
    *
+   * @deprecated call {@link createAssetEmitter} directly instead.
+   *
    * @param TypeEmitterClass The TypeEmitter to construct your emitted output
    */
   getAssetEmitter<T>(TypeEmitterClass: typeof TypeEmitter<T, TOptions>): AssetEmitter<T, TOptions>;

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -14,6 +14,7 @@ import {
   setTypeSpecNamespace,
   typespecTypeToJson,
 } from "@typespec/compiler";
+import { createAssetEmitter } from "@typespec/compiler/emitter-framework";
 import { ValidatesRawJsonDecorator } from "../generated-defs/TypeSpec.JsonSchema.Private.js";
 import {
   BaseUriDecorator,
@@ -44,7 +45,7 @@ export type JsonSchemaDeclaration = Model | Union | Enum | Scalar;
 const jsonSchemaKey = createStateSymbol("JsonSchema");
 
 export async function $onEmit(context: EmitContext<JSONSchemaEmitterOptions>) {
-  const emitter = context.getAssetEmitter(JsonSchemaEmitter);
+  const emitter = createAssetEmitter(context.program, JsonSchemaEmitter as any, context);
 
   if (emitter.getOptions().emitAllModels) {
     emitter.emitProgram({ emitTypeSpecNamespace: false });

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -301,12 +301,14 @@ function createOAPIEmitter(
       service.type,
       options.omitUnreachableTypes
     );
-    schemaEmitter = context.getAssetEmitter(
+    schemaEmitter = createAssetEmitter(
+      program,
       class extends OpenAPI3SchemaEmitter {
         constructor(emitter: AssetEmitter<Record<string, any>, OpenAPI3EmitterOptions>) {
           super(emitter, metadataInfo, visibilityUsage, options);
         }
-      } as any
+      } as any,
+      context
     );
 
     const securitySchemes = getOpenAPISecuritySchemes(allHttpAuthentications);


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/3397

Problem with calling `getAssetEmitter` is it create an asset emitter with the instance of the compiler used in the compilation and not the instance of the compiler defined in the type emitter necessarly. This cause issue with `instanceof` checks which are then not the exact same class as its loaded form different instance of the compiler
Calling `createAssetEmitter` solve the issue because it is imported in teh context of the emitter package and will use the emitter package version