### PR TITLE
Do not create all rulesets if there is no rules in linter config

### DIFF
--- a/.chronus/changes/fix-no-all-no-rules-2024-5-5-16-21-56.md
+++ b/.chronus/changes/fix-no-all-no-rules-2024-5-5-16-21-56.md
@@ -5,4 +5,4 @@ packages:
   - "@typespec/compiler"
 ---
 
-Do not create all rulesets if there is no rules in linter config
+Do not create all rulesets if there are no rules in linter config

--- a/.chronus/changes/fix-no-all-no-rules-2024-5-5-16-21-56.md
+++ b/.chronus/changes/fix-no-all-no-rules-2024-5-5-16-21-56.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+
+Do not create all rulesets if there is no rules in linter config

--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -33,10 +33,10 @@ export function resolveLinterDefinition(
   const rules: LinterRule<string, any>[] = linter.rules.map((rule) => {
     return { ...rule, id: `${libName}/${rule.name}` };
   });
-  if (linter.ruleSets && "all" in linter.ruleSets) {
+  if (linter.rules.length === 0 || (linter.ruleSets && "all" in linter.ruleSets)) {
     return {
       rules,
-      ruleSets: linter.ruleSets as any,
+      ruleSets: linter.ruleSets ?? {},
     };
   } else {
     return {

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2440,7 +2440,6 @@ export interface LinterDefinition {
 export interface LinterResolvedDefinition {
   readonly rules: LinterRule<string, DiagnosticMessages>[];
   readonly ruleSets: {
-    all: LinterRuleSet;
     [name: string]: LinterRuleSet;
   };
 }


### PR DESCRIPTION
This cover the case where you have a package only used to create ruleset but doesn't have any rules.