### PR TITLE
Fix playground crashing

### DIFF
--- a/.chronus/changes/fix-playground-regression-2024-5-5-16-53-46.md
+++ b/.chronus/changes/fix-playground-regression-2024-5-5-16-53-46.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/playground"
+---
+

--- a/packages/playground-website/e2e/ui.e2e.ts
+++ b/packages/playground-website/e2e/ui.e2e.ts
@@ -14,6 +14,15 @@ test.describe("playground UI tests", () => {
     await expect(outputContainer).toContainText(`title: Widget Service`);
   });
 
+  test("report compilation errors", async ({ page }) => {
+    await page.goto(host);
+    const typespecEditorContainer = page.locator("_react=TypeSpecEditor");
+    await typespecEditorContainer.click();
+    await typespecEditorContainer.pressSequentially("invalid");
+    const outputContainer = page.locator("_react=OutputView");
+    await expect(outputContainer).toContainText(`No files emitted.`);
+  });
+
   test("shared link works", async ({ page }) => {
     // Pass code "op sharedCode(): string;"
     // cspell:disable-next-line

--- a/packages/playground/src/react/output-view/file-viewer.tsx
+++ b/packages/playground/src/react/output-view/file-viewer.tsx
@@ -9,9 +9,6 @@ import style from "./output-view.module.css";
 const FileViewerComponent = ({ program, outputFiles }: OutputViewerProps) => {
   const [filename, setFilename] = useState<string>("");
   const [content, setContent] = useState<string>("");
-  if (outputFiles.length === 0) {
-    return <>No files emitted.</>;
-  }
 
   useEffect(() => {
     if (outputFiles.length > 0) {
@@ -36,6 +33,10 @@ const FileViewerComponent = ({ program, outputFiles }: OutputViewerProps) => {
     },
     [setFilename]
   );
+
+  if (outputFiles.length === 0) {
+    return <>No files emitted.</>;
+  }
 
   return (
     <div className={style["file-viewer"]}>


### PR DESCRIPTION
Issue is that we were returning before the hook declarations when there was no output files which cause react to crash due to number of hook running changing