### PR TITLE
Fixed broken links

### DIFF
--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -12,22 +12,22 @@ npm install @typespec/rest
 
 ### TypeSpec.Rest
 
-- [`@action`](#@action)
-- [`@actionSeparator`](#@actionseparator)
-- [`@autoRoute`](#@autoroute)
-- [`@collectionAction`](#@collectionaction)
-- [`@copyResourceKeyParameters`](#@copyresourcekeyparameters)
-- [`@createsOrReplacesResource`](#@createsorreplacesresource)
-- [`@createsOrUpdatesResource`](#@createsorupdatesresource)
-- [`@createsResource`](#@createsresource)
-- [`@deletesResource`](#@deletesresource)
-- [`@listsResource`](#@listsresource)
-- [`@parentResource`](#@parentresource)
-- [`@readsResource`](#@readsresource)
-- [`@resource`](#@resource)
-- [`@segment`](#@segment)
-- [`@segmentOf`](#@segmentof)
-- [`@updatesResource`](#@updatesresource)
+- [`@action`](#action)
+- [`@actionSeparator`](#actionseparator)
+- [`@autoRoute`](#autoroute)
+- [`@collectionAction`](#collectionaction)
+- [`@copyResourceKeyParameters`](#copyresourcekeyparameters)
+- [`@createsOrReplacesResource`](#createsorreplacesresource)
+- [`@createsOrUpdatesResource`](#createsorupdatesresource)
+- [`@createsResource`](#createsresource)
+- [`@deletesResource`](#deletesresource)
+- [`@listsResource`](#listsresource)
+- [`@parentResource`](#parentresource)
+- [`@readsResource`](#readsresource)
+- [`@resource`](#resource)
+- [`@segment`](#segment)
+- [`@segmentOf`](#segmentof)
+- [`@updatesResource`](#updatesresource)
 
 #### `@action`
 


### PR DESCRIPTION
the id and generated link on the headers do not include the `@` character, so removing the character on the links.