### PR TITLE
Do not run decorators on cloned type if the original type wasn't finished

### DIFF
--- a/.chronus/changes/fix-clone-type-donot-finish-unfinished-2024-5-11-21-54-41.md
+++ b/.chronus/changes/fix-clone-type-donot-finish-unfinished-2024-5-11-21-54-41.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+[API] Do not run decorators on cloned type if the original type wasn't finished

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -6512,7 +6512,10 @@ export function createChecker(program: Program): Checker {
    * recursively by the caller.
    */
   function cloneType<T extends Type>(type: T, additionalProps: Partial<T> = {}): T {
-    const clone = finishType(initializeClone(type, additionalProps));
+    let clone = initializeClone(type, additionalProps);
+    if (type.isFinished) {
+      clone = finishType(clone);
+    }
     const projection = projectionsByType.get(type);
     if (projection) {
       projectionsByType.set(clone, projection);


### PR DESCRIPTION
In the same way we have this logic for `cloneTypeForSymbol`