### PR TITLE
fix the nullable value type

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputTypes/CSharpType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputTypes/CSharpType.cs
@@ -70,28 +70,6 @@ namespace Microsoft.Generator.CSharp
             isNullable)
         { }
 
-        private static Type GetRealType(Type type)
-        {
-            return Nullable.GetUnderlyingType(type) ?? type;
-        }
-
-        private static IReadOnlyList<CSharpType> GetRealArguments(Type type)
-        {
-            var underlyingType = Nullable.GetUnderlyingType(type);
-            if (underlyingType != null)
-            {
-                // if we are a System.Nullable<T> type, we put nothing in the arguments because we have promoted the first argument to the position of type
-                return Array.Empty<CSharpType>();
-            }
-
-            return type.IsGenericType ? type.GetGenericArguments().Select(p => new CSharpType(p)).ToArray() : Array.Empty<CSharpType>();
-        }
-
-        private static bool GetRealIsNullable(Type type, bool isNullable)
-        {
-            return Nullable.GetUnderlyingType(type) != null ? true : isNullable;
-        }
-
         /// <summary>
         /// Constructs a non-nullable <see cref="CSharpType"/> from a <see cref="Type"/> with arguments
         /// </summary>

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using System;
-using NUnit.Framework;
-using System.Linq;
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using Moq;
 using System.IO;
+using System.Linq;
 using System.Text;
-using System.Net;
+using Moq;
+using NUnit.Framework;
 
 namespace Microsoft.Generator.CSharp.Tests
 {

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
@@ -401,11 +401,15 @@ namespace Microsoft.Generator.CSharp.Tests
         [TestCase(typeof(Uri), false)]
         [TestCase(typeof(Guid), false)]
         [TestCase(typeof(Guid?), true)]
+        [TestCase(typeof(TestStruct<int>), false)]
+        [TestCase(typeof(TestStruct<int>?), true)]
         public void ValidateNullableTypes(Type type, bool expectedIsNullable)
         {
             var csharpType = new CSharpType(type);
 
             Assert.AreEqual(expectedIsNullable, csharpType.IsNullable);
         }
+
+        internal struct TestStruct<T> where T : struct { }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using Moq;
 using System.IO;
 using System.Text;
+using System.Net;
 
 namespace Microsoft.Generator.CSharp.Tests
 {
@@ -393,6 +394,18 @@ namespace Microsoft.Generator.CSharp.Tests
                 .ToString();
 
             Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(int?), true)]
+        [TestCase(typeof(Uri), false)]
+        [TestCase(typeof(Guid), false)]
+        [TestCase(typeof(Guid?), true)]
+        public void ValidateNullableTypes(Type type, bool expectedIsNullable)
+        {
+            var csharpType = new CSharpType(type);
+
+            Assert.AreEqual(expectedIsNullable, csharpType.IsNullable);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
@@ -396,20 +396,70 @@ namespace Microsoft.Generator.CSharp.Tests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestCase(typeof(int), false)]
-        [TestCase(typeof(int?), true)]
-        [TestCase(typeof(Uri), false)]
-        [TestCase(typeof(Guid), false)]
-        [TestCase(typeof(Guid?), true)]
-        [TestCase(typeof(TestStruct<int>), false)]
-        [TestCase(typeof(TestStruct<int>?), true)]
-        public void ValidateNullableTypes(Type type, bool expectedIsNullable)
+        [TestCaseSource(nameof(ValidateNullableTypesData))]
+        public void ValidateNullableTypes(Type type, IReadOnlyList<CSharpType> expectedArguments, bool expectedIsNullable)
         {
             var csharpType = new CSharpType(type);
 
+            CollectionAssert.AreEqual(expectedArguments, csharpType.Arguments);
             Assert.AreEqual(expectedIsNullable, csharpType.IsNullable);
         }
 
-        internal struct TestStruct<T> where T : struct { }
+        private static object[] ValidateNullableTypesData = [
+            new object[]
+            {
+                typeof(int), Array.Empty<CSharpType>(), false
+            },
+            new object[]
+            {
+                typeof(int?), Array.Empty<CSharpType>(), true
+            },
+            new object[]
+            {
+                typeof(Uri), Array.Empty<CSharpType>(), false
+            },
+            new object[]
+            {
+                typeof(Guid), Array.Empty<CSharpType>(), false
+            },
+            new object[]
+            {
+                typeof(Guid?), Array.Empty<CSharpType>(), true
+            },
+            new object[]
+            {
+                typeof(TestStruct<int>), new CSharpType[] { typeof(int) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<int>?), new CSharpType[] { typeof(int) }, true
+            },
+            new object[]
+            {
+                typeof(TestStruct<int?>), new CSharpType[] { typeof(int?) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<int?>?), new CSharpType[] { typeof(int?) }, true
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>>), new CSharpType[] { typeof(TestStruct<int>) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>>?), new CSharpType[] { typeof(TestStruct<int>) }, true
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>?>), new CSharpType[] { typeof(TestStruct<int>?) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>?>?), new CSharpType[] { typeof(TestStruct<int>?) }, true
+            },
+        ];
+
+        internal struct TestStruct<T> { }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/4678

We are only checking if the input type is a generic type, and then get its generic argument if it is.
We are not checking if it is this special generic type `System.Nullable<T>` which appears to be a generic type but we actually want it to be non-generic but nullable.

This PR changes the final constructor that would be invoke for all cases that a ctor of CSharpType from a `System.Type` to add a check if it is `System.Nullable<T>`, we will use `T` as `_type`, and the arguments of `T` as the real arguments.
