### PR TITLE
Fix: Using a scalar constructor defined in a parent scalar doesn't reference the right scalar

### DIFF
--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -1127,7 +1127,8 @@ export type MemberContainerNode =
   | ModelExpressionNode
   | InterfaceStatementNode
   | EnumStatementNode
-  | UnionStatementNode;
+  | UnionStatementNode
+  | ScalarStatementNode;
 
 export type MemberNode =
   | ModelPropertyNode
@@ -1141,7 +1142,7 @@ export type MemberContainerType = Model | Enum | Interface | Union | Scalar;
 /**
  * Type that can be used as members of a container type.
  */
-export type MemberType = ModelProperty | EnumMember | Operation | UnionVariant;
+export type MemberType = ModelProperty | EnumMember | Operation | UnionVariant | ScalarConstructor;
 
 export type Comment = LineComment | BlockComment;
 

--- a/packages/compiler/test/checker/values/scalar-values.test.ts
+++ b/packages/compiler/test/checker/values/scalar-values.test.ts
@@ -62,8 +62,6 @@ describe("instantiate with named constructor", () => {
     strictEqual(value.type.name, "b");
     strictEqual(value.scalar?.name, "b");
     strictEqual(value.value.name, "fromString");
-    expect(value.value.args).toHaveLength(1);
-    strictEqual(value.value.args[0], "a");
   });
 
   it("instantiate from another scalar", async () => {

--- a/packages/compiler/test/checker/values/scalar-values.test.ts
+++ b/packages/compiler/test/checker/values/scalar-values.test.ts
@@ -49,6 +49,23 @@ describe("instantiate with named constructor", () => {
     ]);
   });
 
+  it("instantiate using constructor from parent scalar", async () => {
+    const value = await compileValue(
+      `b.fromString("a")`,
+      `
+      scalar a { init fromString(val: string);}
+      scalar b extends a { }
+    `
+    );
+    strictEqual(value.valueKind, "ScalarValue");
+    strictEqual(value.type.kind, "Scalar");
+    strictEqual(value.type.name, "b");
+    strictEqual(value.scalar?.name, "b");
+    strictEqual(value.value.name, "fromString");
+    expect(value.value.args).toHaveLength(1);
+    strictEqual(value.value.args[0], "a");
+  });
+
   it("instantiate from another scalar", async () => {
     const value = await compileValue(
       `b.fromA(a.fromString("a"))`,

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpTypeTests.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using System;
-using NUnit.Framework;
-using System.Linq;
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using Moq;
 using System.IO;
+using System.Linq;
 using System.Text;
+using Moq;
+using NUnit.Framework;
 
 namespace Microsoft.Generator.CSharp.Tests
 {
@@ -394,5 +394,71 @@ namespace Microsoft.Generator.CSharp.Tests
 
             Assert.AreEqual(expected, actual);
         }
+
+        [TestCaseSource(nameof(ValidateNullableTypesData))]
+        public void ValidateNullableTypes(Type type, IReadOnlyList<CSharpType> expectedArguments, bool expectedIsNullable)
+        {
+            var csharpType = new CSharpType(type);
+
+            CollectionAssert.AreEqual(expectedArguments, csharpType.Arguments);
+            Assert.AreEqual(expectedIsNullable, csharpType.IsNullable);
+        }
+
+        private static object[] ValidateNullableTypesData = [
+            new object[]
+            {
+                typeof(int), Array.Empty<CSharpType>(), false
+            },
+            new object[]
+            {
+                typeof(int?), Array.Empty<CSharpType>(), true
+            },
+            new object[]
+            {
+                typeof(Uri), Array.Empty<CSharpType>(), false
+            },
+            new object[]
+            {
+                typeof(Guid), Array.Empty<CSharpType>(), false
+            },
+            new object[]
+            {
+                typeof(Guid?), Array.Empty<CSharpType>(), true
+            },
+            new object[]
+            {
+                typeof(TestStruct<int>), new CSharpType[] { typeof(int) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<int>?), new CSharpType[] { typeof(int) }, true
+            },
+            new object[]
+            {
+                typeof(TestStruct<int?>), new CSharpType[] { typeof(int?) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<int?>?), new CSharpType[] { typeof(int?) }, true
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>>), new CSharpType[] { typeof(TestStruct<int>) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>>?), new CSharpType[] { typeof(TestStruct<int>) }, true
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>?>), new CSharpType[] { typeof(TestStruct<int>?) }, false
+            },
+            new object[]
+            {
+                typeof(TestStruct<TestStruct<int>?>?), new CSharpType[] { typeof(TestStruct<int>?) }, true
+            },
+        ];
+
+        internal struct TestStruct<T> { }
     }
 }


### PR DESCRIPTION
```
const a = unixTimestamp.fromISO("...");
```

a would have the scalar utcDateTime not unixTimestamp