### PR TITLE
Clear output path by default

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Generator.CSharp.Providers;
 
 namespace Microsoft.Generator.CSharp
 {
@@ -14,6 +13,7 @@ namespace Microsoft.Generator.CSharp
     {
         private const string ConfigurationFileName = "Configuration.json";
         private const string CodeModelFileName = "tspCodeModel.json";
+        private const string GeneratedFolderName = "Generated";
 
         private static readonly string[] _filesToKeep = [ConfigurationFileName, CodeModelFileName];
 
@@ -24,12 +24,12 @@ namespace Microsoft.Generator.CSharp
         {
             GeneratedCodeWorkspace.Initialize();
             var outputPath = CodeModelPlugin.Instance.Configuration.OutputDirectory;
-            var generatedTestOutputPath = Path.Combine(outputPath, "..", "..", "tests", "Generated");
+            var generatedTestOutputPath = Path.Combine(outputPath, "..", "..", "tests", GeneratedFolderName);
 
             GeneratedCodeWorkspace workspace = await GeneratedCodeWorkspace.Create();
 
             var output = CodeModelPlugin.Instance.OutputLibrary;
-            Directory.CreateDirectory(Path.Combine(outputPath, "src", "Generated", "Models"));
+            Directory.CreateDirectory(Path.Combine(outputPath, "src", GeneratedFolderName, "Models"));
             List<Task> generateFilesTasks = new();
 
             foreach (var model in output.Models)
@@ -57,7 +57,7 @@ namespace Microsoft.Generator.CSharp
                 generateFilesTasks.Add(workspace.AddGeneratedFile(CodeModelPlugin.Instance.GetWriter(client).Write()));
             }
 
-            Directory.CreateDirectory(Path.Combine(outputPath, "src", "Generated", "Internal"));
+            Directory.CreateDirectory(Path.Combine(outputPath, "src", GeneratedFolderName, "Internal"));
             foreach (var type in output.Types)
             {
                 generateFilesTasks.Add(workspace.AddGeneratedFile(CodeModelPlugin.Instance.GetWriter(type).Write()));
@@ -68,7 +68,7 @@ namespace Microsoft.Generator.CSharp
 
             if (CodeModelPlugin.Instance.Configuration.ClearOutputFolder)
             {
-                DeleteDirectory(outputPath, _filesToKeep);
+                DeleteDirectory(ParseOutputPath(outputPath), _filesToKeep);
                 DeleteDirectory(generatedTestOutputPath, _filesToKeep);
             }
 
@@ -97,6 +97,8 @@ namespace Microsoft.Generator.CSharp
             {
                 outputPath = Path.Combine(outputPath, "src");
             }
+
+            outputPath = Path.Combine(outputPath, GeneratedFolderName);
 
             return outputPath;
         }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CSharpGen.cs
@@ -24,12 +24,13 @@ namespace Microsoft.Generator.CSharp
         {
             GeneratedCodeWorkspace.Initialize();
             var outputPath = CodeModelPlugin.Instance.Configuration.OutputDirectory;
+            var generatedSourceOutputPath = ParseGeneratedSourceOutputPath(outputPath);
             var generatedTestOutputPath = Path.Combine(outputPath, "..", "..", "tests", GeneratedFolderName);
 
             GeneratedCodeWorkspace workspace = await GeneratedCodeWorkspace.Create();
 
             var output = CodeModelPlugin.Instance.OutputLibrary;
-            Directory.CreateDirectory(Path.Combine(outputPath, "src", GeneratedFolderName, "Models"));
+            Directory.CreateDirectory(Path.Combine(generatedSourceOutputPath, "Models"));
             List<Task> generateFilesTasks = new();
 
             foreach (var model in output.Models)
@@ -57,7 +58,7 @@ namespace Microsoft.Generator.CSharp
                 generateFilesTasks.Add(workspace.AddGeneratedFile(CodeModelPlugin.Instance.GetWriter(client).Write()));
             }
 
-            Directory.CreateDirectory(Path.Combine(outputPath, "src", GeneratedFolderName, "Internal"));
+            Directory.CreateDirectory(Path.Combine(generatedSourceOutputPath, "Internal"));
             foreach (var type in output.Types)
             {
                 generateFilesTasks.Add(workspace.AddGeneratedFile(CodeModelPlugin.Instance.GetWriter(type).Write()));
@@ -68,7 +69,7 @@ namespace Microsoft.Generator.CSharp
 
             if (CodeModelPlugin.Instance.Configuration.ClearOutputFolder)
             {
-                DeleteDirectory(ParseOutputPath(outputPath), _filesToKeep);
+                DeleteDirectory(generatedSourceOutputPath, _filesToKeep);
                 DeleteDirectory(generatedTestOutputPath, _filesToKeep);
             }
 
@@ -91,7 +92,7 @@ namespace Microsoft.Generator.CSharp
         /// </summary>
         /// <param name="outputPath">The output path.</param>
         /// <returns>The parsed output path string.</returns>
-        internal static string ParseOutputPath(string outputPath)
+        internal static string ParseGeneratedSourceOutputPath(string outputPath)
         {
             if (!outputPath.EndsWith("src", StringComparison.Ordinal) && !outputPath.EndsWith("src/", StringComparison.Ordinal))
             {

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Configuration.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Configuration.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Generator.CSharp
             { Options.UseModelNamespace, true },
             { Options.GenerateModelFactory, true },
             { Options.GenerateSampleProject, true },
-            { Options.ClearOutputFolder, false },
+            { Options.ClearOutputFolder, true },
             { Options.GenerateTestProject, false }
         };
 

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpGenTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpGenTests.cs
@@ -15,13 +15,14 @@ namespace Microsoft.Generator.CSharp.Tests
     public class CSharpGenTests
     {
         private readonly string _mocksFolder = "./Mocks";
+
         // Validates that the output path is parsed correctly when provided
         [Test]
         public void TestGetOutputPath_OutputPathProvided()
         {
             var outputPath = "./outputDir";
-            var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath).Replace("\\", "/");
-            var expectedPath = $"{outputPath}/src";
+            var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath);
+            var expectedPath = Path.Combine(outputPath, "src", "Generated");
             var areEqual = string.Equals(expectedPath, parsedOutputPath, StringComparison.OrdinalIgnoreCase);
 
             Assert.IsTrue(areEqual);
@@ -35,8 +36,8 @@ namespace Microsoft.Generator.CSharp.Tests
         public void TestGetConfigurationInputFilePath_DefaultPath()
         {
             var outputPath = "";
-            var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath).Replace("\\", "/");
-            var expectedPath = $"src";
+            var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath);
+            var expectedPath = Path.Combine("src", "Generated");
             var areEqual = string.Equals(expectedPath, parsedOutputPath, StringComparison.OrdinalIgnoreCase);
 
             Assert.IsTrue(areEqual);
@@ -84,15 +85,14 @@ namespace Microsoft.Generator.CSharp.Tests
 
         private void TestOutputPathAppended(string outputPath, string expectedPath)
         {
-            var srcPath = "/src";
+            var srcPath = "src";
 
-            outputPath += srcPath;
+            outputPath = Path.Combine(outputPath, srcPath);
 
 
             var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath);
-            var cleanedOutputPath = parsedOutputPath.Replace("\\", "/");
 
-            var areEqual = string.Equals(expectedPath, cleanedOutputPath, StringComparison.OrdinalIgnoreCase);
+            var areEqual = string.Equals(expectedPath, parsedOutputPath, StringComparison.OrdinalIgnoreCase);
 
             Assert.IsTrue(areEqual);
         }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpGenTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpGenTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Generator.CSharp.Tests
         public void TestGetOutputPath_OutputPathProvided()
         {
             var outputPath = "./outputDir";
-            var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath);
+            var parsedOutputPath = CSharpGen.ParseGeneratedSourceOutputPath(outputPath);
             var expectedPath = Path.Combine(outputPath, "src", "Generated");
             var areEqual = string.Equals(expectedPath, parsedOutputPath, StringComparison.OrdinalIgnoreCase);
 
@@ -36,7 +36,7 @@ namespace Microsoft.Generator.CSharp.Tests
         public void TestGetConfigurationInputFilePath_DefaultPath()
         {
             var outputPath = "";
-            var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath);
+            var parsedOutputPath = CSharpGen.ParseGeneratedSourceOutputPath(outputPath);
             var expectedPath = Path.Combine("src", "Generated");
             var areEqual = string.Equals(expectedPath, parsedOutputPath, StringComparison.OrdinalIgnoreCase);
 
@@ -90,7 +90,7 @@ namespace Microsoft.Generator.CSharp.Tests
             outputPath = Path.Combine(outputPath, srcPath);
 
 
-            var parsedOutputPath = CSharpGen.ParseOutputPath(outputPath);
+            var parsedOutputPath = CSharpGen.ParseGeneratedSourceOutputPath(outputPath);
 
             var areEqual = string.Equals(expectedPath, parsedOutputPath, StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Updates the generator to clear the generated output folder by default.

fixes: https://github.com/microsoft/typespec/issues/3469