### PR TITLE
Remove groupedBy from InputParameter

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputParameter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputParameter.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Generator.CSharp.Input
             InputType type,
             RequestLocation location,
             InputConstant? defaultValue,
-            InputParameter? groupedBy,
             InputOperationParameterKind kind,
             bool isRequired,
             bool isApiVersion,
@@ -30,7 +29,6 @@ namespace Microsoft.Generator.CSharp.Input
             Type = type;
             Location = location;
             DefaultValue = defaultValue;
-            GroupedBy = groupedBy;
             Kind = kind;
             IsRequired = isRequired;
             IsApiVersion = isApiVersion;
@@ -49,7 +47,6 @@ namespace Microsoft.Generator.CSharp.Input
         public InputType Type { get; }
         public RequestLocation Location { get; }
         public InputConstant? DefaultValue { get; }
-        public InputParameter? GroupedBy { get; }
         public InputOperationParameterKind Kind { get; }
         public bool IsRequired { get; }
         public bool IsApiVersion { get; }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputParameterConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputParameterConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -33,7 +33,6 @@ namespace Microsoft.Generator.CSharp.Input
             InputType? parameterType = null;
             string? location = null;
             InputConstant? defaultValue = null;
-            InputParameter? groupBy = null;
             string? kind = null;
             bool isRequired = false;
             bool isApiVersion = false;
@@ -53,7 +52,6 @@ namespace Microsoft.Generator.CSharp.Input
                     || reader.TryReadWithConverter(nameof(InputParameter.Type), options, ref parameterType)
                     || reader.TryReadString(nameof(InputParameter.Location), ref location)
                     || reader.TryReadWithConverter(nameof(InputParameter.DefaultValue), options, ref defaultValue)
-                    || reader.TryReadWithConverter(nameof(InputParameter.GroupedBy), options, ref groupBy)
                     || reader.TryReadString(nameof(InputParameter.Kind), ref kind)
                     || reader.TryReadBoolean(nameof(InputParameter.IsRequired), ref isRequired)
                     || reader.TryReadBoolean(nameof(InputParameter.IsApiVersion), ref isApiVersion)
@@ -94,7 +92,6 @@ namespace Microsoft.Generator.CSharp.Input
                 type: parameterType,
                 location: requestLocation,
                 defaultValue: defaultValue,
-                groupedBy: groupBy,
                 kind: parameterKind,
                 isRequired: isRequired,
                 isApiVersion: isApiVersion,

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpMethodCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/CSharpMethodCollectionTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Generator.CSharp.Tests
                     description: string.Empty,
                     accessibility: null,
                     parameters: [
-                        new InputParameter("message", "message", "The message to create.", new InputPrimitiveType(InputPrimitiveTypeKind.Boolean), RequestLocation.Body, null, null, InputOperationParameterKind.Method, true, false, false, false, false, false, false, null, null)
+                        new InputParameter("message", "message", "The message to create.", new InputPrimitiveType(InputPrimitiveTypeKind.Boolean), RequestLocation.Body, null, InputOperationParameterKind.Method, true, false, false, false, false, false, false, null, null)
                         ],
                     responses: Array.Empty<OperationResponse>(),
                     httpMethod: "GET",


### PR DESCRIPTION
Removes the `groupedBy` parameter from `InputParameter` as it's not supported by TSP yet.

fixes : https://github.com/Azure/autorest.csharp/issues/4779