### PR TITLE
Handle errors in tracing for environments that don't support Error.captureStackTrace (i.e. firefox)

### DIFF
--- a/.chronus/changes/avoid-break-from-stacktrace-2024-5-20-11-21-0.md
+++ b/.chronus/changes/avoid-break-from-stacktrace-2024-5-20-11-21-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Handle errors from trace to avoid it breaking normal functionality

--- a/.chronus/changes/avoid-break-from-stacktrace-2024-5-20-11-21-0.md
+++ b/.chronus/changes/avoid-break-from-stacktrace-2024-5-20-11-21-0.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/compiler"
 ---
 
-Handle errors from trace to avoid it breaking normal functionality
+Fix crash of language server on firefox 

--- a/packages/compiler/src/server/file-system-cache.ts
+++ b/packages/compiler/src/server/file-system-cache.ts
@@ -48,9 +48,17 @@ export function createFileSystemCache({
       changes = [];
       const r = cache.get(path);
       if (!r) {
-        const target: any = {};
-        Error.captureStackTrace(target);
-        const callstack = target.stack.substring("Error\n".length);
+        let callstack: string | undefined;
+        try {
+          const target: any = {};
+          if (typeof Error.captureStackTrace === "function") {
+            Error.captureStackTrace(target);
+            callstack = target.stack.substring("Error\n".length);
+          }
+        } catch {
+          // some browser doesn't support Error.captureStackTrace (i.e. Firefox)
+          // just ignore the stacktrace if the function doesn't exist
+        }
         log({ level: "trace", message: `FileSystemCache miss for ${path}`, detail: callstack });
       }
       return r;

--- a/packages/compiler/src/server/file-system-cache.ts
+++ b/packages/compiler/src/server/file-system-cache.ts
@@ -51,13 +51,13 @@ export function createFileSystemCache({
         let callstack: string | undefined;
         try {
           const target: any = {};
+          // some browser doesn't support Error.captureStackTrace (i.e. Firefox)
           if (typeof Error.captureStackTrace === "function") {
             Error.captureStackTrace(target);
             callstack = target.stack.substring("Error\n".length);
           }
         } catch {
-          // some browser doesn't support Error.captureStackTrace (i.e. Firefox)
-          // just ignore the stacktrace if the function doesn't exist
+          // just ignore the error, we don't want tracing error to impact normal functionality
         }
         log({ level: "trace", message: `FileSystemCache miss for ${path}`, detail: callstack });
       }


### PR DESCRIPTION
Error.captureStackTrace is used to get stacktrace for tracing details, but it's not supported in some browser like firefox, so add handling for it. thanks.