### PR TITLE
Add support to generate a model as struct

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/MrwSerializationTypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/MrwSerializationTypeProviderTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         public void TestBuildImplements()
         {
             // mock the model type provider
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var mockModelTypeProvider = new ModelProvider(inputModel);
             var jsonMrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
             var interfaces = jsonMrwSerializationTypeProvider.Implements;
@@ -67,7 +67,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         [Test]
         public void TestBuildJsonModelWriteMethod()
         {
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var mockModelTypeProvider = new ModelProvider(inputModel);
             var jsonMrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
             var method = jsonMrwSerializationTypeProvider.BuildJsonModelWriteMethod();
@@ -87,7 +87,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         [Test]
         public void TestBuildJsonModelCreateMethod()
         {
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var mockModelTypeProvider = new ModelProvider(inputModel);
             var jsonMrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
             var method = jsonMrwSerializationTypeProvider.BuildJsonModelCreateMethod();
@@ -108,7 +108,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         [Test]
         public void TestBuildIModelWriteMethodMethod()
         {
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var mockModelTypeProvider = new ModelProvider(inputModel);
             var jsonMrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
             var method = jsonMrwSerializationTypeProvider.BuildIModelWriteMethod();
@@ -129,7 +129,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         [Test]
         public void TestBuildIModelDeserializationMethod()
         {
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var mockModelTypeProvider = new ModelProvider(inputModel);
             var jsonMrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
             var method = jsonMrwSerializationTypeProvider.BuildIModelCreateMethod();
@@ -150,7 +150,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         [Test]
         public void TestBuildIModelGetFormatMethod()
         {
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var mockModelTypeProvider = new ModelProvider(inputModel);
             var jsonMrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
             var method = jsonMrwSerializationTypeProvider.BuildIModelGetFormatFromOptionsMethod();
@@ -173,7 +173,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         [Test]
         public void TestBuildSerializationConstructor()
         {
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var mockModelTypeProvider = new ModelProvider(inputModel);
             var MrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
             var constructor = MrwSerializationTypeProvider.BuildSerializationConstructor();
@@ -191,7 +191,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
         [Test]
         public void TestBuildFields()
         {
-            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, null, false, false);
             var model = new ModelProvider(inputModel);
             var typeProvider = new MrwSerializationTypeProvider(model, inputModel);
             var fields = typeProvider.Fields;
@@ -215,7 +215,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
                     new InputModelProperty("requiredDictionary", "requiredDictionary", "", new InputDictionaryType("Dictionary", new InputPrimitiveType(InputPrimitiveTypeKind.String, false), new InputPrimitiveType(InputPrimitiveTypeKind.String, false), false), true, false, false),
              };
 
-            var inputModel = new InputModelType("TestModel", "TestModel", "public", null, "Test model.", InputModelTypeUsage.RoundTrip, properties, null, Array.Empty<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("TestModel", "TestModel", "public", null, "Test model.", InputModelTypeUsage.RoundTrip, properties, null, Array.Empty<InputModelType>(), null, null, null, false, false);
 
             var ModelProvider = new ModelProvider(inputModel);
             var serializationModelTypeProvider = new MrwSerializationTypeProvider(ModelProvider, inputModel);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputModelType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputModelType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Generator.CSharp.Input
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public class InputModelType : InputType
     {
-        public InputModelType(string name, string? modelNamespace, string? accessibility, string? deprecated, string? description, InputModelTypeUsage usage, IReadOnlyList<InputModelProperty> properties, InputModelType? baseModel, IReadOnlyList<InputModelType> derivedModels, string? discriminatorValue, string? discriminatorPropertyName, InputDictionaryType? inheritedDictionaryType, bool isNullable)
+        public InputModelType(string name, string? modelNamespace, string? accessibility, string? deprecated, string? description, InputModelTypeUsage usage, IReadOnlyList<InputModelProperty> properties, InputModelType? baseModel, IReadOnlyList<InputModelType> derivedModels, string? discriminatorValue, string? discriminatorPropertyName, InputDictionaryType? inheritedDictionaryType, bool isNullable, bool modelAsStruct)
             : base(name, isNullable)
         {
             Namespace = modelNamespace;
@@ -25,6 +25,7 @@ namespace Microsoft.Generator.CSharp.Input
             InheritedDictionaryType = inheritedDictionaryType;
             IsUnknownDiscriminatorModel = false;
             IsPropertyBag = false;
+            ModelAsStruct = modelAsStruct;
         }
 
         public string? Namespace { get; internal set; }
@@ -33,6 +34,7 @@ namespace Microsoft.Generator.CSharp.Input
         public string? Description { get; internal set; }
         public InputModelTypeUsage Usage { get; internal set; }
         public IReadOnlyList<InputModelProperty> Properties { get; internal set; }
+        public bool ModelAsStruct { get; internal set; }
         public InputModelType? BaseModel { get; internal set; }
         public IReadOnlyList<InputModelType> DerivedModels { get; internal set; }
         public string? DiscriminatorValue { get; internal set; }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputModelTypeConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputModelTypeConverter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Generator.CSharp.Input
             id = id ?? throw new JsonException();
 
             // create an empty model to resolve circular references
-            var model = new InputModelType(name!, null, null, null, null, InputModelTypeUsage.None, null!, null, new List<InputModelType>(), null, null, null, false);
+            var model = new InputModelType(name!, null, null, null, null, InputModelTypeUsage.None, null!, null, new List<InputModelType>(), null, null, null, false, false);
             resolver.AddReference(id, model);
 
             bool isNullable = false;
@@ -47,6 +47,7 @@ namespace Microsoft.Generator.CSharp.Input
             InputDictionaryType? inheritedDictionaryType = null;
             InputModelType? baseModel = null;
             IReadOnlyList<InputModelProperty>? properties = null;
+            bool modelAsStruct = false;
 
             // read all possible properties and throw away the unknown properties
             while (reader.TokenType != JsonTokenType.EndObject)
@@ -62,7 +63,8 @@ namespace Microsoft.Generator.CSharp.Input
                     || reader.TryReadString(nameof(InputModelType.DiscriminatorValue), ref discriminatorValue)
                     || reader.TryReadWithConverter(nameof(InputModelType.InheritedDictionaryType), options, ref inheritedDictionaryType)
                     || reader.TryReadWithConverter(nameof(InputModelType.BaseModel), options, ref baseModel)
-                    || reader.TryReadWithConverter(nameof(InputModelType.Properties), options, ref properties);
+                    || reader.TryReadWithConverter(nameof(InputModelType.Properties), options, ref properties)
+                    || reader.TryReadBoolean(nameof(InputModelType.ModelAsStruct), ref modelAsStruct);
 
                 if (!isKnownProperty)
                 {
@@ -85,6 +87,7 @@ namespace Microsoft.Generator.CSharp.Input
             model.IsNullable = isNullable;
             model.BaseModel = baseModel;
             model.Properties = properties ?? Array.Empty<InputModelProperty>();
+            model.ModelAsStruct = modelAsStruct;
 
             return model;
         }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/perf/CodeWriterBenchmark.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/perf/CodeWriterBenchmark.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Generator.CSharp.Perf
             {
                 new InputModelProperty("MyProperty", "myProperty", "The property of mine", new InputPrimitiveType(InputPrimitiveTypeKind.Int32, false), true, false, false)
             };
-            var inputModel = new InputModelType("MyModel", null, null, null, "Test model", InputModelTypeUsage.RoundTrip, properties, null, Array.Empty<InputModelType>(), null, null, null, false);
+            var inputModel = new InputModelType("MyModel", null, null, null, "Test model", InputModelTypeUsage.RoundTrip, properties, null, Array.Empty<InputModelType>(), null, null, null, false, false);
             var modelProvider = new ModelProvider(inputModel);
             _writer = new TypeProviderWriter(modelProvider);
         }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Generator.CSharp.Providers
             Name = inputModel.Name.ToCleanName();
             Namespace = GetDefaultModelNamespace(CodeModelPlugin.Instance.Configuration.Namespace);
             Description = inputModel.Description != null ? FormattableStringHelpers.FromString(inputModel.Description) : $"The {Name}.";
-            // TODO -- support generating models as structs. Tracking issue: https://github.com/microsoft/typespec/issues/3453
-            _declarationModifiers = TypeSignatureModifiers.Partial | TypeSignatureModifiers.Class;
+            _declarationModifiers = TypeSignatureModifiers.Partial |
+                (inputModel.ModelAsStruct ? TypeSignatureModifiers.ReadOnly | TypeSignatureModifiers.Struct : TypeSignatureModifiers.Class);
             if (inputModel.Accessibility == "internal")
             {
                 _declarationModifiers |= TypeSignatureModifiers.Internal;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/typespec/issues/3453

This PR adds support to generate a model as struct based on `ModelAsStruct` decorator. 

We will add `@@modelAsStruct` decorator to the C# emitter.  [Here’s](https://github.com/microsoft/typespec/issues/3619) the tracking issue to add the decorator in the emitter.