### PR TITLE
Unable to override HTTP method from operation template - issue #3636

### DIFF
--- a/.chronus/changes/overridehttpverb-2024-5-20-22-53-48.md
+++ b/.chronus/changes/overridehttpverb-2024-5-20-22-53-48.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/http"
+---
+
+Unable to override HTTP method from operation template - issue #3636

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -362,17 +362,21 @@ function rangeDescription(start: number, end: number) {
   return undefined;
 }
 
-function setOperationVerb(program: Program, entity: Type, verb: HttpVerb): void {
+export function setOperationVerb(
+  program: Program,
+  entity: Type,
+  verb: HttpVerb,
+  warnOnOverride: boolean = true
+): void {
   if (entity.kind === "Operation") {
-    if (!program.stateMap(HttpStateKeys.verbs).has(entity)) {
-      program.stateMap(HttpStateKeys.verbs).set(entity, verb);
-    } else {
+    if (program.stateMap(HttpStateKeys.verbs).has(entity) && warnOnOverride) {
       reportDiagnostic(program, {
         code: "http-verb-duplicate",
         format: { entityName: entity.name },
         target: entity,
       });
     }
+    program.stateMap(HttpStateKeys.verbs).set(entity, verb);
   } else {
     reportDiagnostic(program, {
       code: "http-verb-wrong-type",

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -362,14 +362,9 @@ function rangeDescription(start: number, end: number) {
   return undefined;
 }
 
-export function setOperationVerb(
-  program: Program,
-  entity: Type,
-  verb: HttpVerb,
-  warnOnOverride: boolean = true
-): void {
+export function setOperationVerb(program: Program, entity: Type, verb: HttpVerb): void {
   if (entity.kind === "Operation") {
-    if (program.stateMap(HttpStateKeys.verbs).has(entity) && warnOnOverride) {
+    if (program.stateMap(HttpStateKeys.verbs).has(entity)) {
       reportDiagnostic(program, {
         code: "http-verb-duplicate",
         format: { entityName: entity.name },

--- a/packages/http/src/lib.ts
+++ b/packages/http/src/lib.ts
@@ -4,7 +4,7 @@ export const $lib = createTypeSpecLibrary({
   name: "@typespec/http",
   diagnostics: {
     "http-verb-duplicate": {
-      severity: "error",
+      severity: "warning",
       messages: {
         default: paramMessage`HTTP verb already applied to ${"entityName"}`,
       },

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -154,6 +154,23 @@ describe("http: decorators", () => {
       ]);
     });
 
+    describe("overrideHttpMethod", () => {
+      it("emit diagnostics when @post is added to operation with preexisting http method ", async () => {
+        const diagnostics = await runner.diagnose(`
+            @get op test<T>(): T;
+  
+            @post op test2 is test<string>;
+          `);
+
+        expectDiagnostics(diagnostics, [
+          {
+            code: "@typespec/http/http-verb-duplicate",
+            message: "HTTP verb already applied to test2",
+          },
+        ]);
+      });
+    });
+
     it("emit diagnostics when query name is not a string or of type QueryOptions", async () => {
       const diagnostics = await runner.diagnose(`
           op test(@query(123) MyQuery: string): string;

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -293,6 +293,31 @@ describe("http: routes", () => {
     deepStrictEqual(routes, [{ verb: "get", path: "/", params: [] }]);
   });
 
+  it("produces the right http method", async () => {
+    const routes = await getRoutesFor(
+      `
+      #suppress "@typespec/http/http-verb-duplicate" "For testing"
+      @get @post op get(): {};
+      #suppress "@typespec/http/http-verb-duplicate" "For testing"
+      @post @get op post(): {};
+      #suppress "@typespec/http/http-verb-duplicate" "For testing"
+      @put @put @get op put(): {};
+      #suppress "@typespec/http/http-verb-duplicate" "For testing"
+      @patch @delete op patch(): {};
+      #suppress "@typespec/http/http-verb-duplicate" "For testing"
+      @delete @get @post op delete(): {};
+      `
+    );
+
+    deepStrictEqual(routes, [
+      { verb: "get", path: "/", params: [] },
+      { verb: "post", path: "/", params: [] },
+      { verb: "put", path: "/", params: [] },
+      { verb: "patch", path: "/", params: [] },
+      { verb: "delete", path: "/", params: [] },
+    ]);
+  });
+
   it("always produces a route starting with /", async () => {
     const routes = await getRoutesFor(
       `


### PR DESCRIPTION
* Makes overriding of existing HTTP method into a warning rather than an error

Fixes #3636 