### PR TITLE
Move @typespec/compiler from dependencies to peerDependencies

### DIFF
--- a/.chronus/changes/Issue3632-2024-6-12-17-16-46.md
+++ b/.chronus/changes/Issue3632-2024-6-12-17-16-46.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Moved compiler dependencies to peer and dev for scaffolded projects.

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @typespec/compiler
 
+## 0.58.0
+
+### Bump dependencies
+
+- [#3699](https://github.com/microsoft/typespec/pull/3699) Updated dependencies to peer and dev.
+
+
 ## 0.57.0
 
 

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Change Log - @typespec/compiler
 
-## 0.58.0
-
-### Bump dependencies
-
-- [#3699](https://github.com/microsoft/typespec/pull/3699) Updated dependencies to peer and dev.
-
-
 ## 0.57.0
 
 

--- a/packages/compiler/src/init/scaffold.ts
+++ b/packages/compiler/src/init/scaffold.ts
@@ -104,21 +104,25 @@ async function writePackageJson(host: CompilerHost, config: ScaffoldingConfig) {
   if (isFileSkipGeneration("package.json", config.template.files ?? [])) {
     return;
   }
-  const dependencies: Record<string, string> = {};
+  const peerDependencies: Record<string, string> = {};
+  const devDependencies: Record<string, string> = {};
 
   if (!config.template.skipCompilerPackage) {
-    dependencies["@typespec/compiler"] = "latest";
+    peerDependencies["@typespec/compiler"] = "latest";
+    devDependencies["@typespec/compiler"] = "latest";
   }
 
   for (const library of config.libraries) {
-    dependencies[library.name] = await getLibraryVersion(library);
+    peerDependencies[library.name] = await getLibraryVersion(library);
+    devDependencies[library.name] = await getLibraryVersion(library);
   }
 
   const packageJson: NodePackage = {
     name: config.name,
     version: "0.1.0",
     type: "module",
-    dependencies,
+    peerDependencies,
+    devDependencies,
     private: true,
   };
 

--- a/packages/compiler/test/init/init-template.test.ts
+++ b/packages/compiler/test/init/init-template.test.ts
@@ -2,11 +2,11 @@ import { deepStrictEqual, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
 import { InitTemplate } from "../../src/init/init-template.js";
 import {
-  makeScaffoldingConfig,
   ScaffoldingConfig,
+  makeScaffoldingConfig,
   scaffoldNewProject,
 } from "../../src/init/scaffold.js";
-import { createTestHost, resolveVirtualPath, TestHost } from "../../src/testing/index.js";
+import { TestHost, createTestHost, resolveVirtualPath } from "../../src/testing/index.js";
 
 describe("compiler: init: templates", () => {
   let testHost: TestHost;
@@ -44,7 +44,13 @@ describe("compiler: init: templates", () => {
         libraries: [{ name: "foo", version: "~1.2.3" }, { name: "bar" }],
       });
 
-      deepStrictEqual(JSON.parse(getOutputFile("package.json")!).dependencies, {
+      deepStrictEqual(JSON.parse(getOutputFile("package.json")!).peerDependencies, {
+        "@typespec/compiler": "latest",
+        foo: "~1.2.3",
+        bar: "latest",
+      });
+
+      deepStrictEqual(JSON.parse(getOutputFile("package.json")!).devDependencies, {
         "@typespec/compiler": "latest",
         foo: "~1.2.3",
         bar: "latest",


### PR DESCRIPTION
Per the requirement in Issue: https://github.com/microsoft/typespec/issues/3632, the dependency of `@typespec/compiler` has to be moved from `dependencies` to `peerDependencies`. This PR moves the dependency.