### PR TITLE
Fix the ordering of `CrossLanguageDefinitionId` in `tspCodeModel.json`

### DIFF
--- a/packages/http-client-csharp/emitter/src/lib/converter.ts
+++ b/packages/http-client-csharp/emitter/src/lib/converter.ts
@@ -201,9 +201,9 @@ export function fromSdkEnumType(
     const newInputEnumType: InputEnumType = {
       Kind: "enum",
       Name: enumName,
+      CrossLanguageDefinitionId: enumType.crossLanguageDefinitionId,
       ValueType: fromSdkBuiltInType(enumType.valueType),
       Values: enumType.values.map((v) => fromSdkEnumValueType(v)),
-      CrossLanguageDefinitionId: enumType.crossLanguageDefinitionId,
       Accessibility: getAccessOverride(
         context,
         enumType.__raw as any

--- a/packages/http-client-csharp/emitter/src/type/input-type.ts
+++ b/packages/http-client-csharp/emitter/src/type/input-type.ts
@@ -91,9 +91,9 @@ export function isInputModelType(type: InputType): type is InputModelType {
 export interface InputEnumType extends InputTypeBase {
   Kind: "enum";
   Name: string;
+  CrossLanguageDefinitionId: string;
   ValueType: InputPrimitiveType;
   Values: InputEnumTypeValue[];
-  CrossLanguageDefinitionId: string;
   Accessibility?: string;
   Deprecated?: string;
   IsExtensible: boolean;

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/tspCodeModel.json
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/tspCodeModel.json
@@ -133,6 +133,7 @@
    "$id": "20",
    "Kind": "enum",
    "Name": "StringFixedEnum",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.StringFixedEnum",
    "ValueType": {
     "$id": "21",
     "Kind": "string"
@@ -154,7 +155,6 @@
      "Value": "4"
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.StringFixedEnum",
    "Description": "Simple enum",
    "IsExtensible": false,
    "Usage": "RoundTrip"
@@ -163,6 +163,7 @@
    "$id": "25",
    "Kind": "enum",
    "Name": "StringExtensibleEnum",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.StringExtensibleEnum",
    "ValueType": {
     "$id": "26",
     "Kind": "string"
@@ -184,7 +185,6 @@
      "Value": "4"
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.StringExtensibleEnum",
    "Description": "Extensible enum",
    "IsExtensible": true,
    "Usage": "RoundTrip"
@@ -193,6 +193,7 @@
    "$id": "30",
    "Kind": "enum",
    "Name": "IntExtensibleEnum",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.IntExtensibleEnum",
    "ValueType": {
     "$id": "31",
     "Kind": "int32"
@@ -214,7 +215,6 @@
      "Value": 4
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.IntExtensibleEnum",
    "Description": "Int based extensible enum",
    "IsExtensible": true,
    "Usage": "RoundTrip"
@@ -223,6 +223,7 @@
    "$id": "35",
    "Kind": "enum",
    "Name": "FloatExtensibleEnum",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatExtensibleEnum",
    "ValueType": {
     "$id": "36",
     "Kind": "float32"
@@ -244,7 +245,6 @@
      "Value": 4.4
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatExtensibleEnum",
    "Description": "Float based extensible enum",
    "IsExtensible": true,
    "Usage": "RoundTrip"
@@ -253,6 +253,7 @@
    "$id": "40",
    "Kind": "enum",
    "Name": "FloatExtensibleEnumWithIntValue",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatExtensibleEnumWithIntValue",
    "ValueType": {
     "$id": "41",
     "Kind": "float32"
@@ -274,7 +275,6 @@
      "Value": 4
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatExtensibleEnumWithIntValue",
    "Description": "float fixed enum",
    "IsExtensible": true,
    "Usage": "RoundTrip"
@@ -283,6 +283,7 @@
    "$id": "45",
    "Kind": "enum",
    "Name": "FloatFixedEnum",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatFixedEnum",
    "ValueType": {
     "$id": "46",
     "Kind": "float32"
@@ -304,7 +305,6 @@
      "Value": 4.4
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatFixedEnum",
    "Description": "float fixed enum",
    "IsExtensible": false,
    "Usage": "RoundTrip"
@@ -313,6 +313,7 @@
    "$id": "50",
    "Kind": "enum",
    "Name": "FloatFixedEnumWithIntValue",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatFixedEnumWithIntValue",
    "ValueType": {
     "$id": "51",
     "Kind": "int32"
@@ -334,7 +335,6 @@
      "Value": 4
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.FloatFixedEnumWithIntValue",
    "Description": "float fixed enum",
    "IsExtensible": false,
    "Usage": "RoundTrip"
@@ -343,6 +343,7 @@
    "$id": "55",
    "Kind": "enum",
    "Name": "IntFixedEnum",
+   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.IntFixedEnum",
    "ValueType": {
     "$id": "56",
     "Kind": "int32"
@@ -364,7 +365,6 @@
      "Value": 4
     }
    ],
-   "CrossLanguageDefinitionId": "UnbrandedTypeSpec.IntFixedEnum",
    "Description": "int fixed enum",
    "IsExtensible": false,
    "Usage": "RoundTrip"


### PR DESCRIPTION
- revert back the ordering change for `CrossLanguageDefinitionId` 