### PR TITLE
Generate GetFormatFromOptions struct override

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeProvider.cs
@@ -173,6 +173,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             {
                 methods.Add(BuildJsonModelWriteMethodObjectDeclaration());
                 methods.Add(BuildPersistableModelWriteMethodObjectDeclaration());
+                methods.Add(BuildPersistableModelGetFormatFromOptionsObjectDeclaration());
             }
 
             return [.. methods];
@@ -356,11 +357,28 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         internal MethodProvider BuildPersistableModelGetFormatFromOptionsMethod()
         {
             ValueExpression jsonWireFormat = SystemSnippet.JsonFormatSerialization;
-            // ModelReaderWriterFormat IPersistableModel<T>.GetFormatFromOptions(ModelReaderWriterOptions options)
+            // string IPersistableModel<T>.GetFormatFromOptions(ModelReaderWriterOptions options)
             return new MethodProvider
             (
-                new MethodSignature(nameof(IPersistableModel<object>.GetFormatFromOptions), null, MethodSignatureModifiers.None, typeof(string), null, new[] { _serializationOptionsParameter }, ExplicitInterface: _persistableModelTInterface),
+                new MethodSignature(nameof(IPersistableModel<object>.GetFormatFromOptions), null, MethodSignatureModifiers.None, typeof(string), null, [_serializationOptionsParameter], ExplicitInterface: _persistableModelTInterface),
                 jsonWireFormat,
+                this
+            );
+        }
+
+        /// <summary>
+        /// Builds the <see cref="IPersistableModel{object}"/> GetFormatFromOptions method for the model object.
+        /// </summary>
+        internal MethodProvider BuildPersistableModelGetFormatFromOptionsObjectDeclaration()
+        {
+            ValueExpression jsonWireFormat = SystemSnippet.JsonFormatSerialization;
+            var castToT = This.CastTo(_persistableModelTInterface);
+
+            // string IPersistableModel<object>.GetFormatFromOptions(ModelReaderWriterOptions options) => ((IPersistableModel<T>)this).GetFormatFromOptions(options);
+            return new MethodProvider
+            (
+                new MethodSignature(nameof(IPersistableModel<object>.GetFormatFromOptions), null, MethodSignatureModifiers.None, typeof(string), null, [_serializationOptionsParameter], ExplicitInterface: _persistableModelObjectInterface),
+                castToT.Invoke(nameof(IPersistableModel<object>.GetFormatFromOptions), [_serializationOptionsParameter]),
                 this
             );
         }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeProviderTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers
 
         // This test validates the json model serialization write method object declaration is built correctly
         [Test]
-        public void BuildJsonModelWriteMethodObjectDeclaration()
+        public void TestBuildJsonModelWriteMethodObjectDeclaration()
         {
             var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, new Dictionary<string, InputModelType>(), null, true);
             var mockModelTypeProvider = new ModelProvider(inputModel);
@@ -217,7 +217,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers
 
         // This test validates the PersistableModel serialization write method object declaration is built correctly
         [Test]
-        public void BuildPersistableModelWriteMethodObjectDeclaration()
+        public void TestBuildPersistableModelWriteMethodObjectDeclaration()
         {
             var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, new Dictionary<string, InputModelType>(), null, true);
             var mockModelTypeProvider = new ModelProvider(inputModel);
@@ -271,7 +271,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers
             Assert.AreEqual(expectedReturnType, methodSignature?.ReturnType);
         }
 
-        // This test validates the I model get format method is built correctly
+        // This test validates the persistable model get format method is built correctly
         [Test]
         public void TestBuildPersistableModelGetFormatMethod()
         {
@@ -293,6 +293,41 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers
 
             var methodBody = method?.BodyExpression;
             Assert.IsNotNull(methodBody);
+        }
+
+        // This test validates the persistable model get format method object declaration is built correctly
+        [Test]
+        public void TestBuildPersistableModelGetFormatMethodObjectDeclaration()
+        {
+            var inputModel = new InputModelType("mockInputModel", "mockNamespace", "public", null, null, InputModelTypeUsage.RoundTrip, Array.Empty<InputModelProperty>(), null, new List<InputModelType>(), null, null, new Dictionary<string, InputModelType>(), null, true);
+            var mockModelTypeProvider = new ModelProvider(inputModel);
+            var jsonMrwSerializationTypeProvider = new MrwSerializationTypeProvider(mockModelTypeProvider, inputModel);
+            var method = jsonMrwSerializationTypeProvider.BuildPersistableModelGetFormatFromOptionsObjectDeclaration();
+
+            Assert.IsNotNull(method);
+
+            var expectedInterface = new CSharpType(typeof(IPersistableModel<object>));
+            var methodSignature = method?.Signature as MethodSignature;
+            Assert.IsNotNull(methodSignature);
+            Assert.AreEqual("GetFormatFromOptions", methodSignature?.Name);
+            Assert.AreEqual(expectedInterface, methodSignature?.ExplicitInterface);
+            Assert.AreEqual(1, methodSignature?.Parameters.Count);
+            var expectedReturnType = new CSharpType(typeof(string));
+            Assert.AreEqual(expectedReturnType, methodSignature?.ReturnType);
+
+            // Check method modifiers
+            var expectedModifiers = MethodSignatureModifiers.None;
+            Assert.AreEqual(expectedModifiers, methodSignature?.Modifiers, "Method modifiers do not match the expected value.");
+
+
+            // Validate body
+            var methodBody = method?.BodyStatements;
+            Assert.IsNull(methodBody);
+            var bodyExpression = method?.BodyExpression as InvokeInstanceMethodExpression;
+            Assert.IsNotNull(bodyExpression);
+            Assert.AreEqual("GetFormatFromOptions", bodyExpression?.MethodName);
+            Assert.IsNotNull(bodyExpression?.InstanceReference);
+            Assert.AreEqual(1, bodyExpression?.Arguments.Count);
         }
 
         [Test]


### PR DESCRIPTION
This PR adds support for generating the `GetFormatFromOptions` method for models that are structs.

Supports https://github.com/microsoft/typespec/issues/3330.