### PR TITLE
Allow overriding base operation verb

### DIFF
--- a/.chronus/changes/allow-override-verb-2024-6-1-19-54-42.md
+++ b/.chronus/changes/allow-override-verb-2024-6-1-19-54-42.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/http"
+---
+
+Allow overriding base operation verb

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -9,6 +9,7 @@ import {
   Operation,
   Program,
   StringLiteral,
+  SyntaxKind,
   Tuple,
   Type,
   Union,
@@ -362,53 +363,48 @@ function rangeDescription(start: number, end: number) {
   return undefined;
 }
 
-function setOperationVerb(program: Program, entity: Type, verb: HttpVerb): void {
-  if (entity.kind === "Operation") {
-    if (!program.stateMap(HttpStateKeys.verbs).has(entity)) {
-      program.stateMap(HttpStateKeys.verbs).set(entity, verb);
-    } else {
-      reportDiagnostic(program, {
-        code: "http-verb-duplicate",
-        format: { entityName: entity.name },
-        target: entity,
-      });
-    }
-  } else {
-    reportDiagnostic(program, {
-      code: "http-verb-wrong-type",
-      format: { verb, entityKind: entity.kind },
-      target: entity,
+function setOperationVerb(context: DecoratorContext, entity: Operation, verb: HttpVerb): void {
+  validateVerbUniqueOnNode(context, entity);
+  context.program.stateMap(HttpStateKeys.verbs).set(entity, verb);
+}
+
+function validateVerbUniqueOnNode(context: DecoratorContext, type: Operation) {
+  const verbDecorators = type.decorators.filter(
+    (x) =>
+      VERB_DECORATORS.includes(x.decorator) &&
+      x.node?.kind === SyntaxKind.DecoratorExpression &&
+      x.node?.parent === type.node
+  );
+
+  if (verbDecorators.length > 1) {
+    reportDiagnostic(context.program, {
+      code: "http-verb-duplicate",
+      format: { entityName: type.name },
+      target: context.decoratorTarget,
     });
+    return false;
   }
+  return true;
 }
 
 export function getOperationVerb(program: Program, entity: Type): HttpVerb | undefined {
   return program.stateMap(HttpStateKeys.verbs).get(entity);
 }
 
-export const $get: GetDecorator = (context: DecoratorContext, entity: Operation) => {
-  setOperationVerb(context.program, entity, "get");
-};
+function createVerbDecorator(verb: HttpVerb) {
+  return (context: DecoratorContext, entity: Operation) => {
+    setOperationVerb(context, entity, verb);
+  };
+}
 
-export const $put: PutDecorator = (context: DecoratorContext, entity: Operation) => {
-  setOperationVerb(context.program, entity, "put");
-};
+export const $get: GetDecorator = createVerbDecorator("get");
+export const $put: PutDecorator = createVerbDecorator("put");
+export const $post: PostDecorator = createVerbDecorator("post");
+export const $patch: PatchDecorator = createVerbDecorator("patch");
+export const $delete: DeleteDecorator = createVerbDecorator("delete");
+export const $head: HeadDecorator = createVerbDecorator("head");
 
-export const $post: PostDecorator = (context: DecoratorContext, entity: Operation) => {
-  setOperationVerb(context.program, entity, "post");
-};
-
-export const $patch: PatchDecorator = (context: DecoratorContext, entity: Operation) => {
-  setOperationVerb(context.program, entity, "patch");
-};
-
-export const $delete: DeleteDecorator = (context: DecoratorContext, entity: Operation) => {
-  setOperationVerb(context.program, entity, "delete");
-};
-
-export const $head: HeadDecorator = (context: DecoratorContext, entity: Operation) => {
-  setOperationVerb(context.program, entity, "head");
-};
+const VERB_DECORATORS = [$get, $head, $post, $put, $patch, $delete];
 
 export interface HttpServer {
   url: string;

--- a/packages/http/src/lib.ts
+++ b/packages/http/src/lib.ts
@@ -9,12 +9,6 @@ export const $lib = createTypeSpecLibrary({
         default: paramMessage`HTTP verb already applied to ${"entityName"}`,
       },
     },
-    "http-verb-wrong-type": {
-      severity: "error",
-      messages: {
-        default: paramMessage`Cannot use @${"verb"} on a ${"entityKind"}`,
-      },
-    },
     "missing-path-param": {
       severity: "error",
       messages: {

--- a/packages/http/test/verbs.test.ts
+++ b/packages/http/test/verbs.test.ts
@@ -1,0 +1,40 @@
+import { expectDiagnostics } from "@typespec/compiler/testing";
+import { describe, expect, it } from "vitest";
+import { diagnoseOperations, getRoutesFor } from "./test-host.js";
+
+describe("specify verb with each decorator", () => {
+  it.each([
+    ["@get", "get"],
+    ["@post", "post"],
+    ["@put", "put"],
+    ["@patch", "patch"],
+    ["@delete", "delete"],
+    ["@head", "head"],
+  ])("%s set verb to %s", async (dec, expected) => {
+    const routes = await getRoutesFor(`${dec} op test(): string;`);
+    expect(routes[0].verb).toBe(expected);
+  });
+});
+
+describe("emit error when using 2 verb decorator together on the same node", () => {
+  it.each([
+    ["@get", "@post"],
+    ["@post", "@put"],
+  ])("%s", async (...decs) => {
+    const diagnostics = await diagnoseOperations(`${decs.join(" ")} op test(): string;`);
+    const diag = {
+      code: "@typespec/http/http-verb-duplicate",
+      message: "HTTP verb already applied to test",
+    };
+    expectDiagnostics(diagnostics, new Array(decs.length).fill(diag));
+  });
+});
+
+it("allow overriding the verb specified in a base operation", async () => {
+  const routes = await getRoutesFor(`
+    @get op test<T>(): T;
+    @head op ping is test<void>;  
+    
+  `);
+  expect(routes[0].verb).toBe("head");
+});


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/3636

[Playground example](https://cadlplayground.z22.web.core.windows.net/prs/3717/?c=aW1wb3J0ICJAdHlwZXNwZWMvaHR0cCI7Cgp1c2luZyBUeXBlU3BlYy5IdHRwOwpAc2VydmljZQpuYW1lc3BhY2UgRGVtb1PGFjsKCi8vIFRoaXMgc2hvdWxkIGJlIGFuIGVycm9yCkByb3V0ZSgiMSIpCkBnZXTGBW9wIG9wMSgpOiB2b2lk30LHQjLJQnBvc8dDMstDxBwgb3AgQmFzZTxUPsQaVMZaTm8gd2FybuQA2mhlcmXJUjQiKSDFTcQ3b3ZlcnJpZGUgaXPGQ3N0cmluZz47Cg%3D%3D&e=%40typespec%2Fopenapi3&options=%7B%22linterRuleSet%22%3A%7B%22extends%22%3A%5B%22%40typespec%2Fhttp%2Fall%22%5D%7D%7D)