### PR TITLE
Add serialization functional tests

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             // BinaryData PersistableModelWriteCore(ModelReaderWriterOptions options)
             return new MethodProvider
             (
-              new MethodSignature(PersistableModelWriteCoreMethodName, null, modifiers, returnType, null, [ _serializationOptionsParameter]),
+              new MethodSignature(PersistableModelWriteCoreMethodName, null, modifiers, returnType, null, [_serializationOptionsParameter]),
               BuildPersistableModelWriteCoreMethodBody(),
               this
             );

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Microsoft.Generator.CSharp.ClientModel.Tests.csproj
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Microsoft.Generator.CSharp.ClientModel.Tests.csproj
@@ -1,12 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <ProjectReference Include="..\..\TestProjects\ProjFiles\TestProjects.Local.Tests.csproj" />
     <ProjectReference Include="..\src\Microsoft.Generator.CSharp.ClientModel.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="../../TestProjects/Local/Unbranded-TypeSpec/src/Generated/Internal/**/*.cs" Link="Generated/Helpers/%(RecursiveDir)/%(Filename)%(Extension)" />
     <None Update="Mocks\Configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ModelReaderWriterValidation\TestProjects\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/ModelJsonTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/ModelJsonTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ClientModel.Primitives;
+using NUnit.Framework;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal abstract class ModelJsonTests<T> : ModelTests<T> where T : IJsonModel<T>
+    {
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithJsonInterfaceOfT(string format)
+            => RoundTripTest(format, new JsonInterfaceStrategy<T>());
+
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithJsonInterfaceNonGeneric(string format)
+              => RoundTripTest(format, new JsonInterfaceAsObjectStrategy<T>());
+
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithJsonInterfaceUtf8Reader(string format)
+            => RoundTripTest(format, new JsonInterfaceUtf8ReaderStrategy<T>());
+
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithJsonInterfaceUtf8ReaderNonGeneric(string format)
+            => RoundTripTest(format, new JsonInterfaceUtf8ReaderAsObjectStrategy<T>());
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/ModelTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/ModelTests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    public abstract class ModelTests<T> where T : IPersistableModel<T>
+    {
+        private static readonly ModelReaderWriterOptions _wireOptions = new ModelReaderWriterOptions("W");
+
+        private T? _modelInstance;
+        private T ModelInstance => _modelInstance ??= GetModelInstance();
+
+        private bool IsXmlWireFormat => WirePayload.StartsWith("<", StringComparison.Ordinal);
+
+        protected virtual T GetModelInstance()
+        {
+            var modelInstance = Activator.CreateInstance(typeof(T), true);
+            if (modelInstance is null)
+                throw new Exception($"Unable to create a model instance of {typeof(T).Name}");
+            return (T)modelInstance;
+        }
+
+        protected virtual string GetExpectedResult(string format)
+        {
+            if (format == "J")
+            {
+                return JsonPayload;
+            }
+
+            return WirePayload;
+        }
+        protected abstract void VerifyModel(T model, string format);
+        protected abstract void CompareModels(T model, T model2, string format);
+        protected abstract string JsonPayload { get; }
+        protected abstract string WirePayload { get; }
+
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithModelReaderWriter(string format)
+            => RoundTripTest(format, new ModelReaderWriterStrategy<T>());
+
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithModelReaderWriterNonGeneric(string format)
+            => RoundTripTest(format, new ModelReaderWriterNonGenericStrategy<T>());
+
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithModelInterface(string format)
+            => RoundTripTest(format, new ModelInterfaceStrategy<T>());
+
+        [TestCase("J")]
+        [TestCase("W")]
+        public void RoundTripWithModelInterfaceNonGeneric(string format)
+            => RoundTripTest(format, new ModelInterfaceAsObjectStrategy<T>());
+
+        protected void RoundTripTest(string format, RoundTripStrategy<T> strategy)
+        {
+            string serviceResponse = format == "J" ? JsonPayload : WirePayload;
+
+            ModelReaderWriterOptions options = new ModelReaderWriterOptions(format);
+
+            var expectedSerializedString = GetExpectedResult(format);
+
+            if (AssertFailures(strategy, format, serviceResponse, options))
+                return;
+
+            T model = (T)strategy.Read(serviceResponse, ModelInstance, options);
+
+            VerifyModel(model, format);
+            var data = strategy.Write(model, options);
+            string roundTrip = data.ToString();
+
+            // we validate those are equivalent element, representing the same json object (ignoring the spaces and orders, etc)
+            AssertJsonEquivalency(expectedSerializedString, roundTrip);
+
+            T model2 = (T)strategy.Read(roundTrip, ModelInstance, options);
+            CompareModels(model, model2, format);
+        }
+
+        private void AssertJsonEquivalency(string expected, string result)
+        {
+            using var expectedDoc = JsonDocument.Parse(expected);
+            using var resultDoc = JsonDocument.Parse(result);
+
+            AssertJsonEquivalency(expectedDoc.RootElement, resultDoc.RootElement);
+        }
+
+        private void AssertJsonEquivalency(JsonElement expected, JsonElement result)
+        {
+            string expectedKind = expected.ValueKind.ToString();
+            string resultKind = result.ValueKind.ToString();
+            if (!expectedKind.Equals(resultKind))
+            {
+                Assert.Fail($"kind does not match between {expected} and {result}");
+            }
+
+            switch (result.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    AssertJsonObjectEquivalency(expected, result);
+                    break;
+                case JsonValueKind.Array:
+                    AssertJsonArrayEquivalency(expected, result);
+                    break;
+                default:
+                    Assert.AreEqual(expected.ToString(), result.ToString());
+                    break;
+            }
+        }
+
+        private void AssertJsonObjectEquivalency(JsonElement expected, JsonElement result)
+        {
+            // check result should have all properties in expected
+            foreach (var expectedProperty in expected.EnumerateObject())
+            {
+                if (!result.TryGetProperty(expectedProperty.Name, out var resultPropertyValue))
+                {
+                    Assert.Fail($"expected property {expectedProperty} not found in {result}. Expected: {expected}");
+                }
+                AssertJsonEquivalency(expectedProperty.Value, resultPropertyValue);
+            }
+
+            foreach (var resultProperty in result.EnumerateObject())
+            {
+                if (!expected.TryGetProperty(resultProperty.Name, out var expectedPropertyValue))
+                {
+                    Assert.Fail($"result property {resultProperty} not found in {expected}.");
+                }
+                AssertJsonEquivalency(resultProperty.Value, expectedPropertyValue);
+            }
+        }
+
+        private void AssertJsonArrayEquivalency(JsonElement expected, JsonElement result)
+        {
+            var expectedArray = expected.EnumerateArray().ToArray();
+            var resultArray = result.EnumerateArray().ToArray();
+
+            if (expectedArray.Length != resultArray.Length)
+            {
+                Assert.Fail($"expected array {expected} but got {result}");
+            }
+
+            for (int i = 0; i < expectedArray.Length; i++)
+            {
+                var ee = expectedArray[i];
+                var re = resultArray[i];
+                AssertJsonEquivalency(ee, re);
+            }
+        }
+
+        private bool AssertFailures(RoundTripStrategy<T> strategy, string format, string serviceResponse, ModelReaderWriterOptions options)
+        {
+            bool result = false;
+            if (IsXmlWireFormat && (strategy.IsExplicitJsonRead || strategy.IsExplicitJsonWrite) && format == "W")
+            {
+                if (strategy.IsExplicitJsonRead)
+                {
+                    if (strategy.GetType().Name.StartsWith("ModelJsonConverterStrategy"))
+                    {
+                        //we never get to the interface implementation because JsonSerializer errors before that
+                        Assert.Throws<JsonException>(() => { T model = (T)strategy.Read(serviceResponse, ModelInstance, options); });
+                        result = true;
+                    }
+                    else
+                    {
+                        Assert.Throws<InvalidOperationException>(() => { T model = (T)strategy.Read(serviceResponse, ModelInstance, options); });
+                        result = true;
+                    }
+                }
+
+                if (strategy.IsExplicitJsonWrite)
+                {
+                    Assert.Throws<InvalidOperationException>(() => { var data = strategy.Write(ModelInstance, options); });
+                    result = true;
+                }
+            }
+            else if (ModelInstance is not IJsonModel<T> && format == "J")
+            {
+                Assert.Throws<FormatException>(() => { T model = (T)strategy.Read(serviceResponse, ModelInstance, options); });
+                Assert.Throws<FormatException>(() => { var data = strategy.Write(ModelInstance, options); });
+                result = true;
+            }
+            return result;
+        }
+
+        internal static IDictionary<string, BinaryData> GetRawData(object model)
+        {
+            Type modelType = model.GetType();
+            while (modelType.BaseType != typeof(object) && modelType.BaseType != typeof(ValueType))
+            {
+                modelType = modelType.BaseType!;
+            }
+            var propertyInfo = modelType.GetField("_serializedAdditionalRawData", BindingFlags.Instance | BindingFlags.NonPublic);
+            return propertyInfo?.GetValue(model) as IDictionary<string, BinaryData> ?? throw new InvalidOperationException($"unable to get raw data from {model.GetType().Name}");
+        }
+
+        [Test]
+        public void ThrowsIfUnknownFormat()
+        {
+            ModelReaderWriterOptions options = new ModelReaderWriterOptions("x");
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Write(ModelInstance, options));
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Read<T>(new BinaryData("x"), options));
+
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Write((IPersistableModel<object>)ModelInstance, options));
+            Assert.Throws<FormatException>(() => ModelReaderWriter.Read(new BinaryData("x"), typeof(T), options));
+            if (ModelInstance is IJsonModel<T> jsonModel)
+            {
+                Assert.Throws<FormatException>(() => jsonModel.Write(new Utf8JsonWriter(new MemoryStream()), options));
+                Assert.Throws<FormatException>(() => ((IJsonModel<object>)jsonModel).Write(new Utf8JsonWriter(new MemoryStream()), options));
+                bool gotException = false;
+                try
+                {
+                    Utf8JsonReader reader = default;
+                    jsonModel.Create(ref reader, options);
+                }
+                catch (FormatException)
+                {
+                    gotException = true;
+                }
+                finally
+                {
+                    Assert.IsTrue(gotException);
+                }
+
+                gotException = false;
+                try
+                {
+                    Utf8JsonReader reader = default;
+                    ((IJsonModel<object>)jsonModel).Create(ref reader, options);
+                }
+                catch (FormatException)
+                {
+                    gotException = true;
+                }
+                finally
+                {
+                    Assert.IsTrue(gotException);
+                }
+            }
+        }
+
+        [Test]
+        public void ThrowsIfWireIsNotJson()
+        {
+            if (ModelInstance is IJsonModel<T> jsonModel && IsXmlWireFormat)
+            {
+                Assert.Throws<FormatException>(() => jsonModel.Write(new Utf8JsonWriter(new MemoryStream()), _wireOptions));
+                Utf8JsonReader reader = new Utf8JsonReader(new byte[] { });
+                bool exceptionCaught = false;
+                try
+                {
+                    jsonModel.Create(ref reader, _wireOptions);
+                }
+                catch (FormatException)
+                {
+                    exceptionCaught = true;
+                }
+                Assert.IsTrue(exceptionCaught, "Expected FormatException to be thrown when deserializing wire format as json");
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/RoundTripStrategy.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/RoundTripStrategy.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    public abstract class RoundTripStrategy<T>
+    {
+        public abstract object Read(string payload, object model, ModelReaderWriterOptions options);
+        public abstract BinaryData Write(T model, ModelReaderWriterOptions options);
+        public abstract bool IsExplicitJsonWrite { get; }
+        public abstract bool IsExplicitJsonRead { get; }
+
+        protected BinaryData WriteWithJsonInterface<U>(IJsonModel<U> model, ModelReaderWriterOptions options)
+        {
+            using MemoryStream stream = new MemoryStream();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
+            model.Write(writer, options);
+            writer.Flush();
+            if (stream.Position > int.MaxValue)
+            {
+                return BinaryData.FromStream(stream);
+            }
+            else
+            {
+                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+            }
+        }
+    }
+
+    public class ModelReaderWriterStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Write(model, options);
+        }
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Read<T>(new BinaryData(Encoding.UTF8.GetBytes(payload)), options) ?? throw new InvalidOperationException($"Reading model of type {model.GetType().Name} resulted in null");
+        }
+    }
+
+    public class ModelReaderWriterNonGenericStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Write((object)model, options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ModelReaderWriter.Read(new BinaryData(Encoding.UTF8.GetBytes(payload)), typeof(T), options) ?? throw new InvalidOperationException($"Reading model of type {model.GetType().Name} resulted in null");
+        }
+    }
+
+    public class ModelInterfaceStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return model.Write(options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IPersistableModel<T>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class ModelInterfaceAsObjectStrategy<T> : RoundTripStrategy<T> where T : IPersistableModel<T>
+    {
+        public override bool IsExplicitJsonWrite => false;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return ((IPersistableModel<object>)model).Write(options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IPersistableModel<object>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class JsonInterfaceStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface(model, options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IJsonModel<T>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class JsonInterfaceAsObjectStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => false;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface((IJsonModel<object>)model, options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            return ((IJsonModel<object>)model).Create(new BinaryData(Encoding.UTF8.GetBytes(payload)), options);
+        }
+    }
+
+    public class JsonInterfaceUtf8ReaderStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => true;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface(model, options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            var reader = new Utf8JsonReader(new BinaryData(Encoding.UTF8.GetBytes(payload)));
+            return ((IJsonModel<T>)model).Create(ref reader, options);
+        }
+    }
+
+    public class JsonInterfaceUtf8ReaderAsObjectStrategy<T> : RoundTripStrategy<T> where T : IJsonModel<T>
+    {
+        public override bool IsExplicitJsonWrite => true;
+        public override bool IsExplicitJsonRead => true;
+
+        public override BinaryData Write(T model, ModelReaderWriterOptions options)
+        {
+            return WriteWithJsonInterface((IJsonModel<object>)model, options);
+        }
+
+        public override object Read(string payload, object model, ModelReaderWriterOptions options)
+        {
+            var reader = new Utf8JsonReader(new BinaryData(Encoding.UTF8.GetBytes(payload)));
+            return ((IJsonModel<object>)model).Create(ref reader, options);
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestData.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestData.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal static class TestData
+    {
+        public static string GetLocation(string filePath)
+        {
+            string testsLocation = Directory.GetParent(typeof(TestData).Assembly.Location)!.FullName;
+            StringBuilder builder = new StringBuilder();
+            int indexAfter = testsLocation.IndexOf(".Tests") + 6;
+            builder.Append(testsLocation.Substring(0, indexAfter));
+            if (testsLocation[indexAfter] == Path.DirectorySeparatorChar)
+            {
+                builder.Append(testsLocation.Substring(indexAfter));
+            }
+            else
+            {
+                int dirSeparatorIndex = testsLocation.IndexOf(Path.DirectorySeparatorChar, indexAfter);
+                builder.Append(testsLocation.Substring(dirSeparatorIndex));
+            }
+            return Path.Combine(builder.ToString(), "ModelReaderWriterValidation", "TestProjects", filePath);
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/FriendTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/FriendTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using NUnit.Framework;
+using UnbrandedTypeSpec.Models;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal class FriendTests : ModelJsonTests<Friend>
+    {
+        protected override string JsonPayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/Friend/Friend.json"));
+        protected override string WirePayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/Friend/FriendWireFormat.json"));
+
+        protected override void CompareModels(Friend model, Friend model2, string format)
+        {
+            Assert.AreEqual(model.Name, model2.Name);
+
+            if (format == "J")
+            {
+                var rawData = GetRawData(model);
+                var rawData2 = GetRawData(model2);
+                Assert.IsNotNull(rawData);
+                Assert.IsNotNull(rawData2);
+                Assert.AreEqual(rawData.Count, rawData2.Count);
+                Assert.AreEqual(rawData["extra"].ToObjectFromJson<string>(), rawData2["extra"].ToObjectFromJson<string>());
+            }
+        }
+
+        protected override void VerifyModel(Friend model, string format)
+        {
+            Assert.AreEqual("friendModel", model.Name);
+
+            var rawData = GetRawData(model);
+            Assert.IsNotNull(rawData);
+            if (format == "J")
+            {
+                Assert.AreEqual("stuff", rawData["extra"].ToObjectFromJson<string>());
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ModelWithRequiredNullablePropertiesTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ModelWithRequiredNullablePropertiesTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Text.Json;
+using NUnit.Framework;
+using UnbrandedTypeSpec.Models;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal class ModelWithRequiredNullablePropertiesTests : ModelJsonTests<ModelWithRequiredNullableProperties>
+    {
+        protected override string JsonPayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/ModelWithRequiredNullable/Model.json"));
+        protected override string WirePayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/ModelWithRequiredNullable/ModelWireFormat.json"));
+
+        protected override void CompareModels(ModelWithRequiredNullableProperties model, ModelWithRequiredNullableProperties model2, string format)
+        {
+            Assert.AreEqual(model.RequiredNullablePrimitive, model2.RequiredNullablePrimitive);
+            Assert.AreEqual(model.RequiredExtensibleEnum.ToString(), model2.RequiredExtensibleEnum.ToString());
+            Assert.AreEqual(model.RequiredFixedEnum.ToString(), model2.RequiredFixedEnum.ToString());
+
+            if (format == "J")
+            {
+                var rawData = GetRawData(model);
+                var rawData2 = GetRawData(model2);
+                Assert.IsNotNull(rawData);
+                Assert.IsNotNull(rawData2);
+                Assert.AreEqual(rawData.Count, rawData2.Count);
+                Assert.AreEqual(rawData["extra"].ToObjectFromJson<string>(), rawData2["extra"].ToObjectFromJson<string>());
+            }
+        }
+
+        protected override void VerifyModel(ModelWithRequiredNullableProperties model, string format)
+        {
+            var parsedWireJson = JsonDocument.Parse(WirePayload).RootElement;
+            Assert.IsNotNull(parsedWireJson);
+            Assert.AreEqual(parsedWireJson.GetProperty("requiredNullablePrimitive").GetInt32(), model.RequiredNullablePrimitive);
+            var requiredExtensibleEnumValue = parsedWireJson.GetProperty("requiredExtensibleEnum").GetString();
+            Assert.AreEqual(new StringExtensibleEnum(requiredExtensibleEnumValue), model.RequiredExtensibleEnum);
+            Assert.AreEqual(StringFixedEnum.One, model.RequiredFixedEnum);
+
+            var rawData = GetRawData(model);
+            Assert.IsNotNull(rawData);
+            if (format == "J")
+            {
+                var parsedJson = JsonDocument.Parse(JsonPayload).RootElement;
+                Assert.AreEqual(parsedJson.GetProperty("extra").GetString(), rawData["extra"].ToObjectFromJson<string>());
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ProjectedModelTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ProjectedModelTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using NUnit.Framework;
+using UnbrandedTypeSpec.Models;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal class ProjectedModelTests : ModelJsonTests<ProjectedModel>
+    {
+        protected override string JsonPayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/ProjectedModel/ProjectedModel.json"));
+        protected override string WirePayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/ProjectedModel/ProjectedModelWireFormat.json"));
+
+        protected override void CompareModels(ProjectedModel model, ProjectedModel model2, string format)
+        {
+            Assert.AreEqual(model.Name, model2.Name);
+
+            if (format == "J")
+            {
+                var rawData = GetRawData(model);
+                var rawData2 = GetRawData(model2);
+                Assert.IsNotNull(rawData);
+                Assert.IsNotNull(rawData2);
+                Assert.AreEqual(rawData.Count, rawData2.Count);
+                Assert.AreEqual(rawData["extra"].ToObjectFromJson<string>(), rawData2["extra"].ToObjectFromJson<string>());
+            }
+        }
+
+        protected override void VerifyModel(ProjectedModel model, string format)
+        {
+            Assert.AreEqual("projectedModel", model.Name);
+
+            var rawData = GetRawData(model);
+            Assert.IsNotNull(rawData);
+            if (format == "J")
+            {
+                Assert.AreEqual("stuff", rawData["extra"].ToObjectFromJson<string>());
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ReturnsAnonymousModelResponseTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ReturnsAnonymousModelResponseTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using NUnit.Framework;
+using UnbrandedTypeSpec.Models;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal class ReturnsAnonymousModelResponseTests : ModelJsonTests<ReturnsAnonymousModelResponse>
+    {
+        protected override string JsonPayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/ReturnsAnonymousModelResp/Model.json"));
+        protected override string WirePayload => "{}";
+
+        protected override void CompareModels(ReturnsAnonymousModelResponse model, ReturnsAnonymousModelResponse model2, string format)
+        {
+            if (format == "J")
+            {
+                var rawData = GetRawData(model);
+                var rawData2 = GetRawData(model2);
+                Assert.IsNotNull(rawData);
+                Assert.IsNotNull(rawData2);
+                Assert.AreEqual(rawData.Count, rawData2.Count);
+                Assert.AreEqual(rawData["extra"].ToObjectFromJson<string>(), rawData2["extra"].ToObjectFromJson<string>());
+            }
+        }
+
+        protected override void VerifyModel(ReturnsAnonymousModelResponse model, string format)
+        {
+            var rawData = GetRawData(model);
+            Assert.IsNotNull(rawData);
+            if (format == "J")
+            {
+                Assert.AreEqual("stuff", rawData["extra"].ToObjectFromJson<string>());
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/RoundTripModelTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/RoundTripModelTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Text.Json;
+using NUnit.Framework;
+using UnbrandedTypeSpec.Models;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal class RoundTripModelTests : ModelJsonTests<RoundTripModel>
+    {
+        protected override string JsonPayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/RoundTripModel/RoundTripModel.json"));
+        protected override string WirePayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/RoundTripModel/RoundTripModelWireFormat.json"));
+
+        protected override void CompareModels(RoundTripModel model, RoundTripModel model2, string format)
+        {
+            Assert.AreEqual(model.RequiredString, model2.RequiredString);
+            Assert.AreEqual(model.RequiredCollection, model2.RequiredCollection);
+            Assert.AreEqual(model.RequiredDictionary, model2.RequiredDictionary);
+            Assert.AreEqual(model.RequiredInt, model2.RequiredInt);
+            // compare the RequiredModel
+            var m1RequiredModel = model.RequiredModel;
+            var m2RequiredModel = model2.RequiredModel;
+            Assert.AreEqual(m1RequiredModel.Name, m2RequiredModel.Name);
+            Assert.AreEqual(m1RequiredModel.RequiredUnion.ToString(), m2RequiredModel.RequiredUnion.ToString());
+            Assert.AreEqual(m1RequiredModel.RequiredBadDescription, m2RequiredModel.RequiredBadDescription);
+            Assert.AreEqual(m1RequiredModel.RequiredNullableList, m2RequiredModel.RequiredNullableList);
+
+            Assert.AreEqual(model.IntExtensibleEnum, model2.IntExtensibleEnum);
+            Assert.AreEqual(model.IntExtensibleEnumCollection, model2.IntExtensibleEnumCollection);
+            Assert.AreEqual(model.FloatExtensibleEnum, model2.FloatExtensibleEnum);
+            Assert.AreEqual(model.FloatExtensibleEnumCollection, model2.FloatExtensibleEnumCollection);
+            Assert.AreEqual(model.FloatExtensibleEnumWithIntValue, model2.FloatExtensibleEnumWithIntValue);
+            Assert.AreEqual(model.FloatFixedEnum, model2.FloatFixedEnum);
+            Assert.AreEqual(model.FloatFixedEnumCollection, model2.FloatFixedEnumCollection);
+            Assert.AreEqual(model.FloatFixedEnumWithIntValue, model2.FloatFixedEnumWithIntValue);
+            Assert.AreEqual(model.IntFixedEnum, model2.IntFixedEnum);
+            Assert.AreEqual(model.IntFixedEnumCollection, model2.IntFixedEnumCollection);
+            Assert.AreEqual(model.StringFixedEnum, model2.StringFixedEnum);
+            Assert.AreEqual(model.RequiredUnknown.ToString(), model2.RequiredUnknown.ToString());
+            Assert.AreEqual(model.OptionalUnknown, model2.OptionalUnknown);
+            // compare the RequiredRecord
+            var m1RequiredRecord = model.RequiredRecordUnknown;
+            var m2RequiredRecord = model2.RequiredRecordUnknown;
+
+            foreach (var key in m1RequiredRecord.Keys)
+            {
+                Assert.IsTrue(m2RequiredRecord.ContainsKey(key));
+                Assert.AreEqual(m1RequiredRecord[key].ToString(), m2RequiredRecord[key].ToString());
+            }
+
+            // compare the OptionalRecord
+            var m1OptionalRecord = model.OptionalRecordUnknown;
+            var m2OptionalRecord = model2.OptionalRecordUnknown;
+
+            foreach (var key in m1OptionalRecord.Keys)
+            {
+                Assert.IsTrue(m2OptionalRecord.ContainsKey(key));
+                Assert.AreEqual(m1OptionalRecord[key].ToString(), m2OptionalRecord[key].ToString());
+            }
+
+            // compare the ModelWithRequiredNullableProperties
+            var m1ModelWithRequiredNullableProperties = model.ModelWithRequiredNullable;
+            var m2ModelWithRequiredNullableProperties = model2.ModelWithRequiredNullable;
+            Assert.AreEqual(m1ModelWithRequiredNullableProperties.RequiredNullablePrimitive, m2ModelWithRequiredNullableProperties.RequiredNullablePrimitive);
+            Assert.AreEqual(m1ModelWithRequiredNullableProperties.RequiredExtensibleEnum.ToString(), m2ModelWithRequiredNullableProperties.RequiredExtensibleEnum.ToString());
+            Assert.AreEqual(m1ModelWithRequiredNullableProperties.RequiredFixedEnum.ToString(), m2ModelWithRequiredNullableProperties.RequiredFixedEnum.ToString());
+
+            Assert.AreEqual(model.RequiredBytes.ToString(), model2.RequiredBytes.ToString());
+
+
+            if (format == "J")
+            {
+                // compare the ReadOnlyRequiredRecord
+                var m1ReadOnlyRequiredRecord = model.ReadOnlyRequiredRecordUnknown;
+                var m2ReadOnlyRequiredRecord = model2.ReadOnlyRequiredRecordUnknown;
+
+                foreach (var key in m1ReadOnlyRequiredRecord.Keys)
+                {
+                    Assert.IsTrue(m2ReadOnlyRequiredRecord.ContainsKey(key));
+                    Assert.AreEqual(m1ReadOnlyRequiredRecord[key].ToString(), m2ReadOnlyRequiredRecord[key].ToString());
+                }
+
+                var rawData = GetRawData(model);
+                var rawData2 = GetRawData(model2);
+                Assert.IsNotNull(rawData);
+                Assert.IsNotNull(rawData2);
+                Assert.AreEqual(rawData.Count, rawData2.Count);
+                Assert.AreEqual(rawData["extra"].ToObjectFromJson<string>(), rawData2["extra"].ToObjectFromJson<string>());
+            }
+        }
+
+        protected override void VerifyModel(RoundTripModel model, string format)
+        {
+            var parsedWireJson = JsonDocument.Parse(WirePayload).RootElement;
+            Assert.IsNotNull(parsedWireJson);
+
+            Assert.AreEqual(parsedWireJson.GetProperty("requiredString").GetString(), model.RequiredString);
+            Assert.AreEqual(parsedWireJson.GetProperty("requiredInt").GetInt32(), model.RequiredInt);
+            Assert.AreEqual(1, model.RequiredCollection.Count);
+            Assert.AreEqual(new IntExtensibleEnum(1), model.IntExtensibleEnum);
+            Assert.AreEqual(2, model.IntExtensibleEnumCollection.Count);
+            Assert.AreEqual(new FloatExtensibleEnum(1.1F), model.FloatExtensibleEnum);
+            Assert.AreEqual(new FloatExtensibleEnumWithIntValue(1), model.FloatExtensibleEnumWithIntValue);
+            Assert.AreEqual(2, model.FloatExtensibleEnumCollection.Count);
+            Assert.AreEqual(2, model.FloatFixedEnumCollection.Count);
+            Assert.AreEqual(FloatFixedEnum.OneDotOne, model.FloatFixedEnum);
+            Assert.AreEqual(FloatFixedEnumWithIntValue.One, model.FloatFixedEnumWithIntValue);
+            Assert.AreEqual(IntFixedEnum.One, model.IntFixedEnum);
+            Assert.AreEqual(2, model.IntFixedEnumCollection.Count);
+            Assert.AreEqual(StringFixedEnum.One, model.StringFixedEnum);
+            Assert.AreEqual("\"foo\"", model.RequiredUnknown.ToString());
+
+            var requiredRecord = model.RequiredRecordUnknown;
+            Assert.AreEqual(2, requiredRecord.Count);
+            Assert.AreEqual("\"foo\"", requiredRecord["recordKey1"].ToString());
+            Assert.AreEqual("\"bar\"", requiredRecord["recordKey2"].ToString());
+
+            var optionalRecord = model.OptionalRecordUnknown;
+            Assert.AreEqual(2, optionalRecord.Count);
+            Assert.AreEqual("\"foo\"", optionalRecord["recordKey1"].ToString());
+            Assert.AreEqual("\"bar\"", optionalRecord["recordKey2"].ToString());
+
+            var modelWithRequiredNullable = model.ModelWithRequiredNullable;
+            Assert.IsNull(modelWithRequiredNullable.RequiredNullablePrimitive);
+            Assert.AreEqual(new StringExtensibleEnum("Non-null value"), modelWithRequiredNullable.RequiredExtensibleEnum);
+            Assert.AreEqual(StringFixedEnum.One, modelWithRequiredNullable.RequiredFixedEnum);
+
+            Assert.AreEqual(new StringExtensibleEnum("EnumValue1"), model.RequiredDictionary["key1"]);
+            Assert.AreEqual(new StringExtensibleEnum("EnumValue2"), model.RequiredDictionary["key2"]);
+            var requiredModel = model.RequiredModel;
+            Assert.AreEqual("Example Thing", requiredModel.Name);
+            Assert.AreEqual("\"mockUnion\"", requiredModel.RequiredUnion.ToString());
+            Assert.AreEqual("This is a description with potentially problematic characters like < or >.", requiredModel.RequiredBadDescription);
+            Assert.AreEqual(3, requiredModel.RequiredNullableList.Count);
+
+            var rawData = GetRawData(model);
+            Assert.IsNotNull(rawData);
+            if (format == "J")
+            {
+                var parsedJson = JsonDocument.Parse(JsonPayload).RootElement;
+                Assert.AreEqual(parsedJson.GetProperty("extra").GetString(), rawData["extra"].ToObjectFromJson<string>());
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Friend/Friend.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Friend/Friend.json
@@ -1,0 +1,4 @@
+{
+  "name": "friendModel",
+  "extra": "stuff"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Friend/FriendWireFormat.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Friend/FriendWireFormat.json
@@ -1,0 +1,3 @@
+{
+  "name": "friendModel"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ModelWithRequiredNullable/Model.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ModelWithRequiredNullable/Model.json
@@ -1,0 +1,6 @@
+{
+  "requiredNullablePrimitive": 1,
+  "requiredExtensibleEnum": "Five",
+  "requiredFixedEnum": "1",
+  "extra": "stuff"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ModelWithRequiredNullable/ModelWireFormat.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ModelWithRequiredNullable/ModelWireFormat.json
@@ -1,0 +1,5 @@
+{
+  "requiredNullablePrimitive": 1,
+  "requiredExtensibleEnum": "Five",
+  "requiredFixedEnum": "1"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ProjectedModel/ProjectedModel.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ProjectedModel/ProjectedModel.json
@@ -1,0 +1,4 @@
+{
+  "name": "projectedModel",
+  "extra": "stuff"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ProjectedModel/ProjectedModelWireFormat.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ProjectedModel/ProjectedModelWireFormat.json
@@ -1,0 +1,3 @@
+{
+  "name": "projectedModel"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ReturnsAnonymousModelResp/Model.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/ReturnsAnonymousModelResp/Model.json
@@ -1,0 +1,3 @@
+{
+  "extra": "stuff"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/RoundTripModel/RoundTripModel.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/RoundTripModel/RoundTripModel.json
@@ -1,0 +1,59 @@
+﻿{
+  "requiredString": "Example String",
+  "requiredInt": 42,
+  "requiredCollection": ["1"],
+  "requiredDictionary": {
+    "key1": "EnumValue1",
+    "key2": "EnumValue2"
+  },
+  "requiredModel": {
+    "name": "Example Thing",
+    "requiredUnion": "mockUnion",
+    "requiredBadDescription": "This is a description with potentially problematic characters like < or >.",
+    "requiredNullableList": [1, 2, 3],
+    "requiredLiteralString": "accept",
+    "requiredLiteralInt": 123,
+    "requiredLiteralFloat": 1.23,
+    "requiredLiteralBool": false,
+    "optionalLiteralString": null,
+    "optionalLiteralInt": 456,
+    "optionalLiteralFloat": 4.56,
+    "optionalLiteralBool": false,
+    "optionalNullableList": []
+  },
+  "intExtensibleEnum": 1,
+  "intExtensibleEnumCollection": [1, 3],
+  "floatExtensibleEnum": 1.1,
+  "floatExtensibleEnumWithIntValue": 1,
+  "floatExtensibleEnumCollection": [1.1, 2.2],
+  "floatFixedEnumCollection": [1.1, 2.2],
+  "floatFixedEnum": 1.1,
+  "floatFixedEnumWithIntValue": 1,
+  "intFixedEnum": 1,
+  "intFixedEnumCollection": [1, 2],
+  "stringFixedEnum": "1",
+  "requiredUnknown": "foo",
+  "requiredRecordUnknown": {
+    "recordKey1": "foo",
+    "recordKey2": "bar"
+  },
+  "optionalRecordUnknown": {
+    "recordKey1": "foo",
+    "recordKey2": "bar"
+  },
+  "readOnlyRequiredRecordUnknown": {
+    "recordKey1": "foo",
+    "recordKey2": "bar"
+  },
+  "readOnlyOptionalRecordUnknown": {
+    "recordKey1": "foo",
+    "recordKey2": "bar"
+  },
+  "modelWithRequiredNullable": {
+    "requiredNullablePrimitive": null,
+    "requiredExtensibleEnum": "Non-null value",
+    "requiredFixedEnum": "1"
+  },
+  "requiredBytes": "aGVsbG8=",
+  "extra": "stuff"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/RoundTripModel/RoundTripModelWireFormat.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/RoundTripModel/RoundTripModelWireFormat.json
@@ -1,0 +1,50 @@
+{
+  "requiredString": "Example String",
+  "requiredInt": 42,
+  "requiredCollection": ["1"],
+  "requiredDictionary": {
+    "key1": "EnumValue1",
+    "key2": "EnumValue2"
+  },
+  "requiredModel": {
+    "name": "Example Thing",
+    "requiredUnion": "mockUnion",
+    "requiredBadDescription": "This is a description with potentially problematic characters like < or >.",
+    "requiredNullableList": [1, 2, 3],
+    "requiredLiteralString": "accept",
+    "requiredLiteralInt": 123,
+    "requiredLiteralFloat": 1.23,
+    "requiredLiteralBool": false,
+    "optionalLiteralString": null,
+    "optionalLiteralInt": 456,
+    "optionalLiteralFloat": 4.56,
+    "optionalLiteralBool": false,
+    "optionalNullableList": []
+  },
+  "intExtensibleEnum": 1,
+  "intExtensibleEnumCollection": [1, 3],
+  "floatExtensibleEnum": 1.1,
+  "floatExtensibleEnumWithIntValue": 1,
+  "floatExtensibleEnumCollection": [1.1, 2.2],
+  "floatFixedEnumCollection": [1.1, 2.2],
+  "floatFixedEnum": 1.1,
+  "floatFixedEnumWithIntValue": 1,
+  "intFixedEnum": 1,
+  "intFixedEnumCollection": [1, 2],
+  "stringFixedEnum": "1",
+  "requiredUnknown": "foo",
+  "requiredRecordUnknown": {
+    "recordKey1": "foo",
+    "recordKey2": "bar"
+  },
+  "optionalRecordUnknown": {
+    "recordKey1": "foo",
+    "recordKey2": "bar"
+  },
+  "modelWithRequiredNullable": {
+    "requiredNullablePrimitive": null,
+    "requiredExtensibleEnum": "Non-null value",
+    "requiredFixedEnum": "1"
+  },
+  "requiredBytes": "aGVsbG8="
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Thing/Thing.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Thing/Thing.json
@@ -1,0 +1,16 @@
+{
+  "name": "Example Thing",
+  "requiredUnion": "mockUnion",
+  "requiredBadDescription": "This is a description with potentially problematic characters like < or >.",
+  "requiredNullableList": [1, 2, 3],
+  "requiredLiteralString": "accept",
+  "requiredLiteralInt": 123,
+  "requiredLiteralFloat": 1.23,
+  "requiredLiteralBool": false,
+  "optionalLiteralString": "hi",
+  "optionalLiteralInt": 456,
+  "optionalLiteralFloat": 4.56,
+  "optionalLiteralBool": false,
+  "optionalNullableList": [],
+  "extra": "stuff"
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Thing/ThingWireFormat.json
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/TestData/Thing/ThingWireFormat.json
@@ -1,0 +1,15 @@
+{
+  "name": "Example Thing",
+  "requiredUnion": "mockUnion",
+  "requiredBadDescription": "This is a description with potentially problematic characters like < or >.",
+  "requiredNullableList": [1, 2, 3],
+  "requiredLiteralString": "accept",
+  "requiredLiteralInt": 123,
+  "requiredLiteralFloat": 1.23,
+  "requiredLiteralBool": false,
+  "optionalLiteralString": "hi",
+  "optionalLiteralInt": 456,
+  "optionalLiteralFloat": 4.56,
+  "optionalLiteralBool": false,
+  "optionalNullableList": []
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ThingTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/ModelReaderWriterValidation/TestProjects/Unbranded-TypeSpec/ThingTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Text.Json;
+using NUnit.Framework;
+using UnbrandedTypeSpec.Models;
+
+namespace Microsoft.Generator.CSharp.ClientModel.Tests.ModelReaderWriterValidation
+{
+    internal class ThingTests : ModelJsonTests<Thing>
+    {
+        protected override string JsonPayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/Thing/Thing.json"));
+        protected override string WirePayload => File.ReadAllText(TestData.GetLocation("Unbranded-TypeSpec/TestData/Thing/ThingWireFormat.json"));
+
+        protected override void CompareModels(Thing model, Thing model2, string format)
+        {
+            Assert.AreEqual(model.Name, model2.Name);
+            Assert.AreEqual(model.RequiredUnion.ToString(), model2.RequiredUnion.ToString());
+            Assert.AreEqual(model.RequiredLiteralString, model2.RequiredLiteralString);
+            Assert.AreEqual(model.RequiredLiteralInt, model2.RequiredLiteralInt);
+            Assert.AreEqual(model.RequiredLiteralFloat, model2.RequiredLiteralFloat);
+            Assert.AreEqual(model.RequiredLiteralBool, model2.RequiredLiteralBool);
+            Assert.AreEqual(model.OptionalLiteralString, model2.OptionalLiteralString);
+            Assert.AreEqual(model.OptionalLiteralInt, model2.OptionalLiteralInt);
+            Assert.AreEqual(model.OptionalLiteralFloat, model2.OptionalLiteralFloat);
+            Assert.AreEqual(model.OptionalLiteralBool, model2.OptionalLiteralBool);
+            Assert.AreEqual(model.RequiredBadDescription, model2.RequiredBadDescription);
+            Assert.AreEqual(model.OptionalNullableList, model2.OptionalNullableList);
+            Assert.AreEqual(model.RequiredNullableList, model2.RequiredNullableList);
+
+            if (format == "J")
+            {
+                var rawData = GetRawData(model);
+                var rawData2 = GetRawData(model2);
+                Assert.IsNotNull(rawData);
+                Assert.IsNotNull(rawData2);
+                Assert.AreEqual(rawData.Count, rawData2.Count);
+                Assert.AreEqual(rawData["extra"].ToObjectFromJson<string>(), rawData2["extra"].ToObjectFromJson<string>());
+            }
+        }
+
+        protected override void VerifyModel(Thing model, string format)
+        {
+            var parsedWireJson = JsonDocument.Parse(WirePayload).RootElement;
+            Assert.IsNotNull(parsedWireJson);
+            Assert.AreEqual(parsedWireJson.GetProperty("name").GetString(), model.Name);
+            Assert.AreEqual("\"mockUnion\"", model.RequiredUnion.ToString());
+            Assert.AreEqual(parsedWireJson.GetProperty("requiredBadDescription").GetString(), model.RequiredBadDescription);
+            Assert.AreEqual(parsedWireJson.GetProperty("requiredNullableList").GetArrayLength(), model.RequiredNullableList.Count);
+            Assert.AreEqual(new ThingRequiredLiteralString(parsedWireJson.GetProperty("requiredLiteralString").GetString()), model.RequiredLiteralString);
+            Assert.AreEqual(new ThingRequiredLiteralInt(parsedWireJson.GetProperty("requiredLiteralInt").GetInt32()), model.RequiredLiteralInt);
+            Assert.AreEqual(new ThingRequiredLiteralFloat(parsedWireJson.GetProperty("requiredLiteralFloat").GetSingle()), model.RequiredLiteralFloat);
+            Assert.AreEqual(parsedWireJson.GetProperty("requiredLiteralBool").GetBoolean(), model.RequiredLiteralBool);
+            Assert.AreEqual(new ThingOptionalLiteralString(parsedWireJson.GetProperty("optionalLiteralString").GetString()), model.OptionalLiteralString);
+            Assert.AreEqual(new ThingOptionalLiteralInt(parsedWireJson.GetProperty("optionalLiteralInt").GetInt32()), model.OptionalLiteralInt);
+            Assert.AreEqual(new ThingOptionalLiteralFloat(parsedWireJson.GetProperty("optionalLiteralFloat").GetSingle()), model.OptionalLiteralFloat);
+            Assert.AreEqual(parsedWireJson.GetProperty("optionalLiteralBool").GetBoolean(), model.OptionalLiteralBool);
+            Assert.AreEqual(parsedWireJson.GetProperty("optionalNullableList").GetArrayLength(), model.OptionalNullableList.Count);
+
+
+            var rawData = GetRawData(model);
+            Assert.IsNotNull(rawData);
+            if (format == "J")
+            {
+                var parsedJson = JsonDocument.Parse(JsonPayload).RootElement;
+                Assert.AreEqual(parsedJson.GetProperty("extra").GetString(), rawData["extra"].ToObjectFromJson<string>());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a set of tests that validates the generated serialization methods for the models in the `Unbranded-TypeSpec` test project.