### PR TITLE
Fix upload of playground package bundle

### DIFF
--- a/packages/bundle-uploader/src/upload-browser-package.ts
+++ b/packages/bundle-uploader/src/upload-browser-package.ts
@@ -102,8 +102,7 @@ export class TypeSpecBundledPackageUploader {
     const blob = this.#container.getBlockBlobClient(
       normalizePath(join(pkgName, version, file.filename))
     );
-    const content = file.content;
-    await blob.upload(content, content.length, {
+    await blob.uploadData(Buffer.from(file.content), {
       blobHTTPHeaders: {
         blobContentType: "application/javascript; charset=utf-8",
       },


### PR DESCRIPTION
A recent break in storage blob SDK corrupted the uploading of certain files https://github.com/Azure/azure-sdk-for-js/issues/30138 when using the `upload(text, length)` method. Switching to converting to a buffer and uploading fixes the issue.