### PR TITLE
Updates tsp-openapi3 to emit main.tsp even when formatter fails

### DIFF
--- a/.chronus/changes/tsp-openapi3-emit-on-bad-format-2024-6-9-16-12-22.md
+++ b/.chronus/changes/tsp-openapi3-emit-on-bad-format-2024-6-9-16-12-22.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Updates tsp-openapi3 to always emit main.tsp when formatting encounters an error.

--- a/packages/openapi3/src/cli/actions/convert/convert.ts
+++ b/packages/openapi3/src/cli/actions/convert/convert.ts
@@ -1,8 +1,17 @@
+import { formatTypeSpec } from "@typespec/compiler";
 import { OpenAPI3Document } from "../../../types.js";
 import { generateMain } from "./generators/generate-main.js";
 import { transform } from "./transforms/transforms.js";
 
 export async function convertOpenAPI3Document(document: OpenAPI3Document) {
   const program = transform(document);
-  return await generateMain(program);
+  const content = generateMain(program);
+  try {
+    return await formatTypeSpec(content, {
+      printWidth: 100,
+      tabWidth: 2,
+    });
+  } catch {
+    return content;
+  }
 }

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-main.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-main.ts
@@ -1,11 +1,10 @@
-import { formatTypeSpec } from "@typespec/compiler";
 import { TypeSpecProgram } from "../interfaces.js";
 import { generateModel } from "./generate-model.js";
 import { generateOperation } from "./generate-operation.js";
 import { generateServiceInformation } from "./generate-service-info.js";
 
-export async function generateMain(program: TypeSpecProgram): Promise<string> {
-  const content = `
+export function generateMain(program: TypeSpecProgram): string {
+  return `
   import "@typespec/http";
   import "@typespec/openapi";
   import "@typespec/openapi3";
@@ -19,9 +18,4 @@ export async function generateMain(program: TypeSpecProgram): Promise<string> {
 
   ${program.operations.map(generateOperation).join("\n\n")}
   `;
-
-  return formatTypeSpec(content, {
-    printWidth: 100,
-    tabWidth: 2,
-  });
 }

--- a/packages/openapi3/test/tsp-openapi3/convert-openapi3-doc.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/convert-openapi3-doc.test.ts
@@ -1,30 +1,29 @@
 import { formatTypeSpec } from "@typespec/compiler";
 import { strictEqual } from "node:assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { convertOpenAPI3Document } from "../../src/index.js";
 
-describe("tsp-openapi: convertOpenAPI3Document", () => {
-  it("should convert an OpenAPI3 document to a formatted TypeSpec program", async () => {
-    const tsp = await convertOpenAPI3Document({
-      info: {
-        title: "Test Service",
-        version: "1.0.0",
-      },
-      openapi: "3.0.0",
-      paths: {},
-      components: {
-        schemas: {
-          Foo: {
-            type: "string",
-          },
+it("should convert an OpenAPI3 document to a formatted TypeSpec program", async () => {
+  const tsp = await convertOpenAPI3Document({
+    info: {
+      title: "Test Service",
+      version: "1.0.0",
+    },
+    openapi: "3.0.0",
+    paths: {},
+    components: {
+      schemas: {
+        Foo: {
+          type: "string",
         },
       },
-    });
+    },
+  });
 
-    strictEqual(
-      tsp,
-      await formatTypeSpec(
-        `
+  strictEqual(
+    tsp,
+    await formatTypeSpec(
+      `
       import "@typespec/http";
       import "@typespec/openapi";
       import "@typespec/openapi3";
@@ -42,8 +41,7 @@ describe("tsp-openapi: convertOpenAPI3Document", () => {
 
       scalar Foo extends string;
         `,
-        { printWidth: 100, tabWidth: 2 }
-      )
-    );
-  });
+      { printWidth: 100, tabWidth: 2 }
+    )
+  );
 });

--- a/packages/openapi3/test/tsp-openapi3/convert-openapi3-doc.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/convert-openapi3-doc.test.ts
@@ -1,0 +1,49 @@
+import { formatTypeSpec } from "@typespec/compiler";
+import { strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import { convertOpenAPI3Document } from "../../src/index.js";
+
+describe("tsp-openapi: convertOpenAPI3Document", () => {
+  it("should convert an OpenAPI3 document to a formatted TypeSpec program", async () => {
+    const tsp = await convertOpenAPI3Document({
+      info: {
+        title: "Test Service",
+        version: "1.0.0",
+      },
+      openapi: "3.0.0",
+      paths: {},
+      components: {
+        schemas: {
+          Foo: {
+            type: "string",
+          },
+        },
+      },
+    });
+
+    strictEqual(
+      tsp,
+      await formatTypeSpec(
+        `
+      import "@typespec/http";
+      import "@typespec/openapi";
+      import "@typespec/openapi3";
+
+      using Http;
+      using OpenAPI;
+
+      @service({
+        title: "Test Service",
+      })
+      @info({
+        version: "1.0.0",
+      })
+      namespace TestService;
+
+      scalar Foo extends string;
+        `,
+        { printWidth: 100, tabWidth: 2 }
+      )
+    );
+  });
+});


### PR DESCRIPTION
This updates the `tsp-openapi3` CLI so that it emits `main.tsp` even when the formatter detects an issue. The CLI will still throw the error after it is done emitting the file.

The `convertOpenAPI3Document` function used by the website does not throw on formatter errors - the playground will highlight any TSP errors already.

Playground example with bad emission:
![image](https://github.com/microsoft/typespec/assets/14189820/cbddf049-5928-4969-b1fa-cbf98ea95bc0)
