### PR TITLE
Fix breaking change with `formatIdentifier` renamed to `printIdentifier`

### DIFF
--- a/.chronus/changes/fix-breaking-change-2024-6-10-19-47-36.md
+++ b/.chronus/changes/fix-breaking-change-2024-6-10-19-47-36.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+
+Fix breaking change with `formatIdentifier` renamed to `printIdentifier`

--- a/packages/compiler/src/core/helpers/index.ts
+++ b/packages/compiler/src/core/helpers/index.ts
@@ -9,6 +9,6 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   stringTemplateToString,
 } from "./string-template-utils.js";
-export { printIdentifier } from "./syntax-utils.js";
+export { printIdentifier as formatIdentifier, printIdentifier } from "./syntax-utils.js";
 export * from "./type-name-utils.js";
 export * from "./usage-resolver.js";


### PR DESCRIPTION
Keeping both for now, could also add `@deprecated` on`formatIdentifier` to give ide guidance