### PR TITLE
tsp-openapi3 - update to group items by namespace when separated by dot, and escaped otherwise invalid identifiers

### DIFF
--- a/.chronus/changes/tsp-openapi3-namespacing-2024-6-15-22-37-45.md
+++ b/.chronus/changes/tsp-openapi3-namespacing-2024-6-15-22-37-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Updates tsp-openapi3 to escape identifiers that would otherwise be invalid, and automatically resolve namespaces for schemas with dots in their names.

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-main.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-main.ts
@@ -1,5 +1,6 @@
 import { TypeSpecProgram } from "../interfaces.js";
 import { generateModel } from "./generate-model.js";
+import { generateNamespace } from "./generate-namespace.js";
 import { generateOperation } from "./generate-operation.js";
 import { generateServiceInformation } from "./generate-service-info.js";
 
@@ -17,5 +18,9 @@ export function generateMain(program: TypeSpecProgram): string {
   ${program.models.map(generateModel).join("\n\n")}
 
   ${program.operations.map(generateOperation).join("\n\n")}
+
+  ${Object.entries(program.namespaces)
+    .map(([name, namespace]) => generateNamespace(name, namespace))
+    .join("\n\n")}
   `;
 }

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-namespace.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-namespace.ts
@@ -1,0 +1,18 @@
+import { TypeSpecNamespace } from "../interfaces.js";
+import { generateModel } from "./generate-model.js";
+import { generateOperation } from "./generate-operation.js";
+
+export function generateNamespace(name: string, namespace: TypeSpecNamespace): string {
+  const definitions: string[] = [];
+  definitions.push(`namespace ${name} {`);
+
+  definitions.push(...namespace.models.map(generateModel));
+  definitions.push(...namespace.operations.map(generateOperation));
+
+  for (const [namespaceName, nestedNamespace] of Object.entries(namespace.namespaces)) {
+    definitions.push(generateNamespace(namespaceName, nestedNamespace));
+  }
+
+  definitions.push("}");
+  return definitions.join("\n");
+}

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
@@ -1,3 +1,4 @@
+import { printIdentifier } from "@typespec/compiler";
 import { OpenAPI3Schema, Refable } from "../../../../types.js";
 import { getDecoratorsForSchema } from "../utils/decorators.js";
 import { generateDecorators } from "./generate-decorators.js";
@@ -47,8 +48,7 @@ function getTypeFromSchema(schema: OpenAPI3Schema): string {
 
 export function getRefName(ref: string): string {
   const name = ref.split("/").pop() ?? "";
-  // TODO: account for `.` in the name
-  return name;
+  return name.split(".").map(printIdentifier).join(".");
 }
 
 function getAnyOfType(schema: OpenAPI3Schema): string {

--- a/packages/openapi3/src/cli/actions/convert/interfaces.ts
+++ b/packages/openapi3/src/cli/actions/convert/interfaces.ts
@@ -1,5 +1,5 @@
 import { Contact, License } from "@typespec/openapi";
-import { OpenAPI3Encoding, OpenAPI3Responses, OpenAPI3Schema, Refable } from "../../../types.js";
+import { OpenAPI3Encoding, OpenAPI3Schema, Refable } from "../../../types.js";
 
 export interface TypeSpecProgram {
   serviceInfo: TypeSpecServiceInfo;
@@ -78,7 +78,7 @@ export interface TypeSpecOperation extends TypeSpecDeclaration {
   operationId?: string;
   parameters: Refable<TypeSpecOperationParameter>[];
   requestBodies: TypeSpecRequestBody[];
-  responses: OpenAPI3Responses;
+  responseTypes: string[];
   tags: string[];
 }
 

--- a/packages/openapi3/src/cli/actions/convert/interfaces.ts
+++ b/packages/openapi3/src/cli/actions/convert/interfaces.ts
@@ -3,8 +3,21 @@ import { OpenAPI3Encoding, OpenAPI3Responses, OpenAPI3Schema, Refable } from "..
 
 export interface TypeSpecProgram {
   serviceInfo: TypeSpecServiceInfo;
+  namespaces: Record<string, TypeSpecNamespace>;
   models: TypeSpecModel[];
   augmentations: TypeSpecAugmentation[];
+  operations: TypeSpecOperation[];
+}
+
+export interface TypeSpecDeclaration {
+  name: string;
+  doc?: string;
+  scope: string[];
+}
+
+export interface TypeSpecNamespace {
+  namespaces: Record<string, TypeSpecNamespace>;
+  models: TypeSpecModel[];
   operations: TypeSpecOperation[];
 }
 
@@ -27,9 +40,7 @@ export interface TypeSpecAugmentation extends TypeSpecDecorator {
   target: string;
 }
 
-export interface TypeSpecModel {
-  name: string;
-  doc?: string;
+export interface TypeSpecModel extends TypeSpecDeclaration {
   decorators: TypeSpecDecorator[];
   properties: TypeSpecModelProperty[];
   additionalProperties?: Refable<OpenAPI3Schema>;
@@ -60,7 +71,7 @@ export interface TypeSpecModelProperty {
   schema: Refable<OpenAPI3Schema>;
 }
 
-export interface TypeSpecOperation {
+export interface TypeSpecOperation extends TypeSpecDeclaration {
   name: string;
   doc?: string;
   decorators: TypeSpecDecorator[];

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-component-parameters.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-component-parameters.ts
@@ -1,3 +1,4 @@
+import { printIdentifier } from "@typespec/compiler";
 import { OpenAPI3Components, OpenAPI3Parameter } from "../../../../types.js";
 import { TypeSpecModel, TypeSpecModelProperty } from "../interfaces.js";
 import { getParameterDecorators } from "../utils/decorators.js";
@@ -57,7 +58,7 @@ function transformComponentParameter(
 
 function getModelPropertyFromParameter(parameter: OpenAPI3Parameter): TypeSpecModelProperty {
   return {
-    name: parameter.name,
+    name: printIdentifier(parameter.name),
     isOptional: !parameter.required,
     doc: parameter.description ?? parameter.schema.description,
     decorators: getParameterDecorators(parameter),

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-component-schemas.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-component-schemas.ts
@@ -8,6 +8,7 @@ import {
 } from "../generators/generate-types.js";
 import { TypeSpecModel, TypeSpecModelProperty } from "../interfaces.js";
 import { getDecoratorsForSchema } from "../utils/decorators.js";
+import { getScopeAndName } from "../utils/get-scope-and-name.js";
 
 /**
  * Transforms #/components/schemas into TypeSpec models.
@@ -24,20 +25,28 @@ export function transformComponentSchemas(
 
   for (const name of Object.keys(schemas)) {
     const schema = schemas[name];
-    const extendsParent = getModelExtends(schema);
-    const isParent = getModelIs(schema);
-    models.push({
-      name: name.replace(/-/g, "_"),
-      decorators: [...getDecoratorsForSchema(schema)],
-      doc: schema.description,
-      properties: getModelPropertiesFromObjectSchema(schema),
-      additionalProperties:
-        typeof schema.additionalProperties === "object" ? schema.additionalProperties : undefined,
-      extends: extendsParent,
-      is: isParent,
-      type: schema.type,
-    });
+    transformComponentSchema(models, name, schema);
   }
+}
+
+function transformComponentSchema(
+  models: TypeSpecModel[],
+  name: string,
+  schema: OpenAPI3Schema
+): void {
+  const extendsParent = getModelExtends(schema);
+  const isParent = getModelIs(schema);
+  models.push({
+    ...getScopeAndName(name),
+    decorators: [...getDecoratorsForSchema(schema)],
+    doc: schema.description,
+    properties: getModelPropertiesFromObjectSchema(schema),
+    additionalProperties:
+      typeof schema.additionalProperties === "object" ? schema.additionalProperties : undefined,
+    extends: extendsParent,
+    is: isParent,
+    type: schema.type,
+  });
 }
 
 function getModelExtends(schema: OpenAPI3Schema): string | undefined {

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-component-schemas.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-component-schemas.ts
@@ -1,3 +1,4 @@
+import { printIdentifier } from "@typespec/compiler";
 import { OpenAPI3Components, OpenAPI3Schema } from "../../../../types.js";
 import {
   getArrayType,
@@ -97,7 +98,7 @@ function getModelPropertiesFromObjectSchema({
     const property = properties[name];
 
     modelProperties.push({
-      name,
+      name: printIdentifier(name),
       doc: property.description,
       schema: property,
       isOptional: !required.includes(name),

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-namespaces.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-namespaces.ts
@@ -1,0 +1,77 @@
+import {
+  TypeSpecModel,
+  TypeSpecNamespace,
+  TypeSpecOperation,
+  TypeSpecProgram,
+} from "../interfaces.js";
+
+type TypeSpecProgramDeclarations = Pick<TypeSpecProgram, "models" | "operations" | "namespaces">;
+export function transformNamespaces(
+  models: TypeSpecModel[],
+  operations: TypeSpecOperation[]
+): TypeSpecProgramDeclarations {
+  // There can only be 1 file namespace - so if scopes is empty then entity belongs at root level
+  const programDecs: TypeSpecProgramDeclarations = {
+    models: [],
+    operations: [],
+    namespaces: {},
+  };
+
+  expandModels(programDecs, models);
+  expandOperations(programDecs, operations);
+
+  return programDecs;
+}
+
+function expandModels(programDecs: TypeSpecProgramDeclarations, models: TypeSpecModel[]): void {
+  for (const model of models) {
+    const { scope } = model;
+    const namespace = getNamespace(programDecs, scope) ?? createNamespace(programDecs, scope);
+    namespace.models.push(model);
+  }
+}
+
+function expandOperations(
+  programDecs: TypeSpecProgramDeclarations,
+  operations: TypeSpecOperation[]
+): void {
+  for (const operation of operations) {
+    const { scope } = operation;
+    const namespace = getNamespace(programDecs, scope) ?? createNamespace(programDecs, scope);
+    namespace.operations.push(operation);
+  }
+}
+
+function getNamespace(
+  programDecs: TypeSpecProgramDeclarations,
+  scope: string[]
+): TypeSpecNamespace | undefined {
+  if (!scope.length) return programDecs;
+
+  let namespace: TypeSpecNamespace = programDecs;
+  for (const fragment of scope) {
+    if (!namespace) return;
+    namespace = namespace.namespaces[fragment];
+  }
+
+  return namespace;
+}
+
+function createNamespace(
+  programDecs: TypeSpecProgramDeclarations,
+  scope: string[]
+): TypeSpecNamespace {
+  let namespace: TypeSpecNamespace = programDecs;
+  for (const fragment of scope) {
+    if (!namespace.namespaces[fragment]) {
+      namespace.namespaces[fragment] = {
+        namespaces: {},
+        models: [],
+        operations: [],
+      };
+    }
+    namespace = namespace.namespaces[fragment];
+  }
+
+  return namespace;
+}

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-operation-responses.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-operation-responses.ts
@@ -9,6 +9,7 @@ import {
 import { TypeSpecDecorator, TypeSpecModel, TypeSpecModelProperty } from "../interfaces.js";
 import { convertHeaderName } from "../utils/convert-header-name.js";
 import { getDecoratorsForSchema, getExtensions } from "../utils/decorators.js";
+import { getScopeAndName } from "../utils/get-scope-and-name.js";
 import { supportedHttpMethods } from "../utils/supported-http-methods.js";
 
 type OperationResponseInfo = {
@@ -86,10 +87,13 @@ function transformOperationResponses(
       decorators.push({ name: "error", args: [] });
     }
 
+    const scopeAndName = getScopeAndName(operationId!);
+
     if (!response.content) {
       // This is common when there is no actual request body, just a statusCode, e.g. for errors
       models.push({
-        name: generateResponseModelName(operationId, statusCode),
+        scope: scopeAndName.scope,
+        name: generateResponseModelName(scopeAndName.name, statusCode),
         decorators,
         properties: commonProperties,
         doc: response.description,
@@ -121,7 +125,8 @@ function transformOperationResponses(
         }
 
         models.push({
-          name: generateResponseModelName(operationId, statusCode, contentType),
+          scope: scopeAndName.scope,
+          name: generateResponseModelName(scopeAndName.name, statusCode, contentType),
           decorators,
           properties,
           doc: response.description,

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
@@ -10,6 +10,7 @@ import {
   TypeSpecRequestBody,
 } from "../interfaces.js";
 import { getExtensions, getParameterDecorators } from "../utils/decorators.js";
+import { getScopeAndName } from "../utils/get-scope-and-name.js";
 import { supportedHttpMethods } from "../utils/supported-http-methods.js";
 
 /**
@@ -30,7 +31,7 @@ export function transformPaths(paths: Record<string, OpenAPI3PathItem>): TypeSpe
       const tags = operation.tags?.map((t) => t) ?? [];
 
       operations.push({
-        name: operation.operationId!,
+        ...getScopeAndName(operation.operationId!),
         decorators: [
           ...getExtensions(operation),
           { name: "route", args: [route] },

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
@@ -1,3 +1,4 @@
+import { printIdentifier } from "@typespec/compiler";
 import {
   OpenAPI3Parameter,
   OpenAPI3PathItem,
@@ -5,6 +6,7 @@ import {
   Refable,
 } from "../../../../types.js";
 import {
+  TypeSpecModel,
   TypeSpecOperation,
   TypeSpecOperationParameter,
   TypeSpecRequestBody,
@@ -12,13 +14,18 @@ import {
 import { getExtensions, getParameterDecorators } from "../utils/decorators.js";
 import { getScopeAndName } from "../utils/get-scope-and-name.js";
 import { supportedHttpMethods } from "../utils/supported-http-methods.js";
+import { collectOperationResponses } from "./transform-operation-responses.js";
 
 /**
  * Transforms each operation defined under #/paths/{route}/{httpMethod} into a TypeSpec operation.
+ * @params models - The array of models to populate with any new models generated from the operation.
  * @param paths
  * @returns
  */
-export function transformPaths(paths: Record<string, OpenAPI3PathItem>): TypeSpecOperation[] {
+export function transformPaths(
+  models: TypeSpecModel[],
+  paths: Record<string, OpenAPI3PathItem>
+): TypeSpecOperation[] {
   const operations: TypeSpecOperation[] = [];
 
   for (const route of Object.keys(paths)) {
@@ -29,6 +36,10 @@ export function transformPaths(paths: Record<string, OpenAPI3PathItem>): TypeSpe
 
       const parameters = operation.parameters?.map(transformOperationParameter) ?? [];
       const tags = operation.tags?.map((t) => t) ?? [];
+
+      const operationResponses = operation.responses ?? {};
+      const responseModels = collectOperationResponses(operation.operationId!, operationResponses);
+      models.push(...responseModels);
 
       operations.push({
         ...getScopeAndName(operation.operationId!),
@@ -41,7 +52,7 @@ export function transformPaths(paths: Record<string, OpenAPI3PathItem>): TypeSpe
         doc: operation.description,
         operationId: operation.operationId,
         requestBodies: transformRequestBodies(operation.requestBody),
-        responses: operation.responses ?? {},
+        responseTypes: responseModels.map((m) => m.name),
         tags: tags,
       });
     }
@@ -58,7 +69,7 @@ function transformOperationParameter(
   }
 
   return {
-    name: parameter.name,
+    name: printIdentifier(parameter.name),
     doc: parameter.description,
     decorators: getParameterDecorators(parameter),
     isOptional: !parameter.required,

--- a/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
@@ -1,13 +1,8 @@
 import { OpenAPI3Document } from "../../../../types.js";
-import {
-  TypeSpecModel,
-  TypeSpecNamespace,
-  TypeSpecOperation,
-  TypeSpecProgram,
-  TypeSpecServiceInfo,
-} from "../interfaces.js";
+import { TypeSpecModel, TypeSpecProgram } from "../interfaces.js";
 import { transformComponentParameters } from "./transform-component-parameters.js";
 import { transformComponentSchemas } from "./transform-component-schemas.js";
+import { transformNamespaces } from "./transform-namespaces.js";
 import { transformAllOperationResponses } from "./transform-operation-responses.js";
 import { transformPaths } from "./transform-paths.js";
 import { transformServiceInfo } from "./transform-service-info.js";
@@ -18,7 +13,7 @@ export function transform(openapi: OpenAPI3Document): TypeSpecProgram {
 
   return {
     serviceInfo: transformServiceInfo(openapi.info),
-    ...populateProgramDeclarations(models, operations),
+    ...transformNamespaces(models, operations),
     augmentations: [],
   };
 }
@@ -34,79 +29,4 @@ function collectModels(document: OpenAPI3Document): TypeSpecModel[] {
   transformAllOperationResponses(models, document);
 
   return models;
-}
-
-function getFileNamespaceName(serviceInfo: TypeSpecServiceInfo): string {
-  return serviceInfo.name.replaceAll(/[^\w^\d_]+/g, "");
-}
-
-type TypeSpecProgramDeclarations = Pick<TypeSpecProgram, "models" | "operations" | "namespaces">;
-function populateProgramDeclarations(
-  models: TypeSpecModel[],
-  operations: TypeSpecOperation[]
-): TypeSpecProgramDeclarations {
-  // There can only be 1 file namespace - so if scopes is empty then entity belongs at root level
-  const programDecs: TypeSpecProgramDeclarations = {
-    models: [],
-    operations: [],
-    namespaces: {},
-  };
-
-  expandModels(programDecs, models);
-  expandOperations(programDecs, operations);
-
-  return programDecs;
-}
-
-function expandModels(programDecs: TypeSpecProgramDeclarations, models: TypeSpecModel[]): void {
-  for (const model of models) {
-    const { scope } = model;
-    const namespace = getNamespace(programDecs, scope) ?? createNamespace(programDecs, scope);
-    namespace.models.push(model);
-  }
-}
-
-function expandOperations(
-  programDecs: TypeSpecProgramDeclarations,
-  operations: TypeSpecOperation[]
-): void {
-  for (const operation of operations) {
-    const { scope } = operation;
-    const namespace = getNamespace(programDecs, scope) ?? createNamespace(programDecs, scope);
-    namespace.operations.push(operation);
-  }
-}
-
-function getNamespace(
-  programDecs: TypeSpecProgramDeclarations,
-  scope: string[]
-): TypeSpecNamespace | undefined {
-  if (!scope.length) return programDecs;
-
-  let namespace: TypeSpecNamespace = programDecs;
-  for (const fragment of scope) {
-    if (!namespace) return;
-    namespace = namespace.namespaces[fragment];
-  }
-
-  return namespace;
-}
-
-function createNamespace(
-  programDecs: TypeSpecProgramDeclarations,
-  scope: string[]
-): TypeSpecNamespace {
-  let namespace: TypeSpecNamespace = programDecs;
-  for (const fragment of scope) {
-    if (!namespace.namespaces[fragment]) {
-      namespace.namespaces[fragment] = {
-        namespaces: {},
-        models: [],
-        operations: [],
-      };
-    }
-    namespace = namespace.namespaces[fragment];
-  }
-
-  return namespace;
 }

--- a/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
@@ -1,5 +1,11 @@
 import { OpenAPI3Document } from "../../../../types.js";
-import { TypeSpecModel, TypeSpecProgram } from "../interfaces.js";
+import {
+  TypeSpecModel,
+  TypeSpecNamespace,
+  TypeSpecOperation,
+  TypeSpecProgram,
+  TypeSpecServiceInfo,
+} from "../interfaces.js";
 import { transformComponentParameters } from "./transform-component-parameters.js";
 import { transformComponentSchemas } from "./transform-component-schemas.js";
 import { transformAllOperationResponses } from "./transform-operation-responses.js";
@@ -8,12 +14,12 @@ import { transformServiceInfo } from "./transform-service-info.js";
 
 export function transform(openapi: OpenAPI3Document): TypeSpecProgram {
   const models = collectModels(openapi);
+  const operations = transformPaths(openapi.paths);
 
   return {
     serviceInfo: transformServiceInfo(openapi.info),
-    models,
+    ...populateProgramDeclarations(models, operations),
     augmentations: [],
-    operations: transformPaths(openapi.paths),
   };
 }
 
@@ -28,4 +34,79 @@ function collectModels(document: OpenAPI3Document): TypeSpecModel[] {
   transformAllOperationResponses(models, document);
 
   return models;
+}
+
+function getFileNamespaceName(serviceInfo: TypeSpecServiceInfo): string {
+  return serviceInfo.name.replaceAll(/[^\w^\d_]+/g, "");
+}
+
+type TypeSpecProgramDeclarations = Pick<TypeSpecProgram, "models" | "operations" | "namespaces">;
+function populateProgramDeclarations(
+  models: TypeSpecModel[],
+  operations: TypeSpecOperation[]
+): TypeSpecProgramDeclarations {
+  // There can only be 1 file namespace - so if scopes is empty then entity belongs at root level
+  const programDecs: TypeSpecProgramDeclarations = {
+    models: [],
+    operations: [],
+    namespaces: {},
+  };
+
+  expandModels(programDecs, models);
+  expandOperations(programDecs, operations);
+
+  return programDecs;
+}
+
+function expandModels(programDecs: TypeSpecProgramDeclarations, models: TypeSpecModel[]): void {
+  for (const model of models) {
+    const { scope } = model;
+    const namespace = getNamespace(programDecs, scope) ?? createNamespace(programDecs, scope);
+    namespace.models.push(model);
+  }
+}
+
+function expandOperations(
+  programDecs: TypeSpecProgramDeclarations,
+  operations: TypeSpecOperation[]
+): void {
+  for (const operation of operations) {
+    const { scope } = operation;
+    const namespace = getNamespace(programDecs, scope) ?? createNamespace(programDecs, scope);
+    namespace.operations.push(operation);
+  }
+}
+
+function getNamespace(
+  programDecs: TypeSpecProgramDeclarations,
+  scope: string[]
+): TypeSpecNamespace | undefined {
+  if (!scope.length) return programDecs;
+
+  let namespace: TypeSpecNamespace = programDecs;
+  for (const fragment of scope) {
+    if (!namespace) return;
+    namespace = namespace.namespaces[fragment];
+  }
+
+  return namespace;
+}
+
+function createNamespace(
+  programDecs: TypeSpecProgramDeclarations,
+  scope: string[]
+): TypeSpecNamespace {
+  let namespace: TypeSpecNamespace = programDecs;
+  for (const fragment of scope) {
+    if (!namespace.namespaces[fragment]) {
+      namespace.namespaces[fragment] = {
+        namespaces: {},
+        models: [],
+        operations: [],
+      };
+    }
+    namespace = namespace.namespaces[fragment];
+  }
+
+  return namespace;
 }

--- a/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
@@ -3,13 +3,12 @@ import { TypeSpecModel, TypeSpecProgram } from "../interfaces.js";
 import { transformComponentParameters } from "./transform-component-parameters.js";
 import { transformComponentSchemas } from "./transform-component-schemas.js";
 import { transformNamespaces } from "./transform-namespaces.js";
-import { transformAllOperationResponses } from "./transform-operation-responses.js";
 import { transformPaths } from "./transform-paths.js";
 import { transformServiceInfo } from "./transform-service-info.js";
 
 export function transform(openapi: OpenAPI3Document): TypeSpecProgram {
   const models = collectModels(openapi);
-  const operations = transformPaths(openapi.paths);
+  const operations = transformPaths(models, openapi.paths);
 
   return {
     serviceInfo: transformServiceInfo(openapi.info),
@@ -25,8 +24,6 @@ function collectModels(document: OpenAPI3Document): TypeSpecModel[] {
   transformComponentSchemas(models, components?.schemas);
   // get models from `#/components/parameters
   transformComponentParameters(models, components?.parameters);
-  // get models from #/paths/{route}/{httpMethod}/responses
-  transformAllOperationResponses(models, document);
 
   return models;
 }

--- a/packages/openapi3/src/cli/actions/convert/utils/get-scope-and-name.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/get-scope-and-name.ts
@@ -1,0 +1,14 @@
+import { formatIdentifier } from "@typespec/compiler";
+
+type ScopeAndName = { scope: string[]; name: string };
+export function getScopeAndName(originalName: string): ScopeAndName {
+  const path = originalName.split(".").map(formatIdentifier);
+  const name = path.pop()!;
+
+  return { scope: path, name };
+}
+
+export function scopesMatch(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((scope, i) => scope === b[i]);
+}

--- a/packages/openapi3/src/cli/actions/convert/utils/get-scope-and-name.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/get-scope-and-name.ts
@@ -1,11 +1,11 @@
 import { printIdentifier } from "@typespec/compiler";
 
-type ScopeAndName = { scope: string[]; name: string };
+type ScopeAndName = { scope: string[]; name: string; rawName: string };
 export function getScopeAndName(originalName: string): ScopeAndName {
-  const path = originalName.split(".").map(printIdentifier);
+  const path = originalName.split(".");
   const name = path.pop()!;
 
-  return { scope: path, name };
+  return { scope: path.map(printIdentifier), name: printIdentifier(name), rawName: name };
 }
 
 export function scopesMatch(a: string[], b: string[]): boolean {

--- a/packages/openapi3/src/cli/actions/convert/utils/get-scope-and-name.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/get-scope-and-name.ts
@@ -1,8 +1,8 @@
-import { formatIdentifier } from "@typespec/compiler";
+import { printIdentifier } from "@typespec/compiler";
 
 type ScopeAndName = { scope: string[]; name: string };
 export function getScopeAndName(originalName: string): ScopeAndName {
-  const path = originalName.split(".").map(formatIdentifier);
+  const path = originalName.split(".").map(printIdentifier);
   const name = path.pop()!;
 
   return { scope: path, name };

--- a/packages/openapi3/test/tsp-openapi3/output/escaped-identifiers/main.tsp
+++ b/packages/openapi3/test/tsp-openapi3/output/escaped-identifiers/main.tsp
@@ -1,0 +1,33 @@
+import "@typespec/http";
+import "@typespec/openapi";
+import "@typespec/openapi3";
+
+using Http;
+using OpenAPI;
+
+@service({
+  title: "Sample API",
+})
+@info({
+  version: "1.0.0",
+})
+namespace SampleAPI;
+
+scalar `Foo-Bar` extends string;
+
+model `Escaped-Model` {
+  id: string;
+  @path `escaped-property`: string;
+}
+
+/**
+ * Success
+ */
+@defaultResponse
+model `get-thingDefaultResponse` {}
+
+@route("/{escaped-property}") @get op `get-thing`(
+  @query `weird@param`?: `Foo-Bar`,
+  `escaped-property`: `Escaped-Model`.`escaped-property`,
+  @bodyRoot body: `Escaped-Model`,
+): `get-thingDefaultResponse`;

--- a/packages/openapi3/test/tsp-openapi3/output/nested/main.tsp
+++ b/packages/openapi3/test/tsp-openapi3/output/nested/main.tsp
@@ -1,0 +1,70 @@
+import "@typespec/http";
+import "@typespec/openapi";
+import "@typespec/openapi3";
+
+using Http;
+using OpenAPI;
+
+@service({
+  title: "Nested sample",
+})
+@info({
+  version: "0.0.0",
+})
+namespace Nestedsample;
+
+namespace SubA {
+  model Thing {
+    id: int64;
+  }
+  namespace SubSubA {
+    model Thing {
+      name: string;
+    }
+  }
+}
+
+namespace SubB {
+  model Thing {
+    id: int64;
+  }
+  /**
+   * The request has succeeded.
+   */
+  model doSomething200ApplicationJsonResponse {
+    @statusCode statusCode: 200;
+    @bodyRoot body: string;
+  }
+  @route("/sub/b") @post op doSomething(
+    @bodyRoot body: SubB.Thing,
+  ): SubB.doSomething200ApplicationJsonResponse;
+}
+
+namespace SubC {
+  /**
+   * The request has succeeded.
+   */
+  model anotherOp200ApplicationJsonResponse {
+    @statusCode statusCode: 200;
+    @bodyRoot body: string;
+  }
+  @route("/") @post op anotherOp(
+    @bodyRoot body: {
+      thing: SubA.Thing;
+      thing2: SubA.Thing;
+    },
+  ): SubC.anotherOp200ApplicationJsonResponse;
+}
+
+namespace SubSubA {
+  /**
+   * The request has succeeded.
+   */
+  model doSomething200ApplicationJsonResponse {
+    @statusCode statusCode: 200;
+    @bodyRoot body: string;
+  }
+  @route("/sub/a/subsub") @post op doSomething(
+    @bodyRoot body: SubA.SubSubA.Thing,
+  ): SubSubA.doSomething200ApplicationJsonResponse;
+}

--- a/packages/openapi3/test/tsp-openapi3/output/nested/main.tsp
+++ b/packages/openapi3/test/tsp-openapi3/output/nested/main.tsp
@@ -21,6 +21,16 @@ namespace SubA {
     model Thing {
       name: string;
     }
+    /**
+     * The request has succeeded.
+     */
+    model doSomething200ApplicationJsonResponse {
+      @statusCode statusCode: 200;
+      @bodyRoot body: string;
+    }
+    @route("/sub/a/subsub") @post op doSomething(
+      @bodyRoot body: SubA.SubSubA.Thing,
+    ): doSomething200ApplicationJsonResponse;
   }
 }
 
@@ -37,7 +47,7 @@ namespace SubB {
   }
   @route("/sub/b") @post op doSomething(
     @bodyRoot body: SubB.Thing,
-  ): SubB.doSomething200ApplicationJsonResponse;
+  ): doSomething200ApplicationJsonResponse;
 }
 
 namespace SubC {
@@ -53,18 +63,5 @@ namespace SubC {
       thing: SubA.Thing;
       thing2: SubA.Thing;
     },
-  ): SubC.anotherOp200ApplicationJsonResponse;
-}
-
-namespace SubSubA {
-  /**
-   * The request has succeeded.
-   */
-  model doSomething200ApplicationJsonResponse {
-    @statusCode statusCode: 200;
-    @bodyRoot body: string;
-  }
-  @route("/sub/a/subsub") @post op doSomething(
-    @bodyRoot body: SubA.SubSubA.Thing,
-  ): SubSubA.doSomething200ApplicationJsonResponse;
+  ): anotherOp200ApplicationJsonResponse;
 }

--- a/packages/openapi3/test/tsp-openapi3/specs/escaped-identifiers/service.json
+++ b/packages/openapi3/test/tsp-openapi3/specs/escaped-identifiers/service.json
@@ -61,6 +61,9 @@
         "properties": {
           "id": {
             "type": "string"
+          },
+          "escaped-property": {
+            "type": "string"
           }
         }
       }

--- a/packages/openapi3/test/tsp-openapi3/specs/escaped-identifiers/service.json
+++ b/packages/openapi3/test/tsp-openapi3/specs/escaped-identifiers/service.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Sample API",
+    "version": "1.0.0"
+  },
+  "tags": [],
+  "paths": {
+    "/{escaped-property}": {
+      "get": {
+        "operationId": "get-thing",
+        "parameters": [
+          {
+            "name": "weird@param",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Foo-Bar"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Escaped-Model.escaped-property"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Success"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Escaped-Model"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "Escaped-Model.escaped-property": {
+        "name": "escaped-property",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "schemas": {
+      "Foo-Bar": {
+        "type": "string"
+      },
+      "Escaped-Model": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/openapi3/test/tsp-openapi3/specs/nested/service.yml
+++ b/packages/openapi3/test/tsp-openapi3/specs/nested/service.yml
@@ -31,7 +31,7 @@ paths:
                 - thing2
   /sub/a/subsub:
     post:
-      operationId: SubSubA.doSomething
+      operationId: SubA.SubSubA.doSomething
       parameters: []
       responses:
         "200":

--- a/packages/openapi3/test/tsp-openapi3/specs/nested/service.yml
+++ b/packages/openapi3/test/tsp-openapi3/specs/nested/service.yml
@@ -1,0 +1,90 @@
+openapi: 3.0.0
+info:
+  title: Nested sample
+  version: 0.0.0
+tags: []
+paths:
+  /:
+    post:
+      operationId: SubC.anotherOp
+      parameters: []
+      responses:
+        "200":
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                thing:
+                  $ref: "#/components/schemas/SubA.Thing"
+                thing2:
+                  $ref: "#/components/schemas/SubA.Thing"
+              required:
+                - thing
+                - thing2
+  /sub/a/subsub:
+    post:
+      operationId: SubSubA.doSomething
+      parameters: []
+      responses:
+        "200":
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubA.SubSubA.Thing"
+  /sub/b:
+    post:
+      operationId: SubB.doSomething
+      parameters: []
+      responses:
+        "200":
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubB.Thing"
+components:
+  schemas:
+    SubA.SubSubA.Thing:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+    SubA.Thing:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+    SubB.Thing:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64


### PR DESCRIPTION
Fixes #3810 and replaces #3808

This PR does 2 things:
1. Groups operations/models into namespaces based on the dots in their schema names/operationIds.
2. Escapes invalid identifiers by surrounding them with backticks.

