### PR TITLE
Fix issues with examples

### DIFF
--- a/.chronus/changes/fix-examples-issues-2024-6-17-15-39-58.md
+++ b/.chronus/changes/fix-examples-issues-2024-6-17-15-39-58.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix issues with examples not working with `Array`, `Record`, `Union` and `unknown` types


### PR DESCRIPTION
fix #3874 (Examples not working with nested model in array)
fix #3872 (Examples not working when type is union)

Additionally found the following issues that this fix:
- not working when type was `unknown`
- not working with `Record`