### PR TITLE
fixes bug rendering backslashes when present as last character in doc comment line

### DIFF
--- a/.chronus/changes/fix-get-doc-2024-6-17-16-36-18.md
+++ b/.chronus/changes/fix-get-doc-2024-6-17-16-36-18.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fixes a bug where ending a non-terminal line in a multi-line comment with a backslash caused the next star to show up in the parsed doc string.

--- a/packages/compiler/src/core/scanner.ts
+++ b/packages/compiler/src/core/scanner.ts
@@ -661,8 +661,11 @@ export function createScanner(
           return next(Token.NewLine);
 
         case CharCode.Backslash:
-          tokenFlags |= TokenFlags.Escaped;
-          return position === endPosition - 1 ? next(Token.DocText) : next(Token.DocText, 2);
+          if (lookAhead(1) === CharCode.At) {
+            tokenFlags |= TokenFlags.Escaped;
+            return next(Token.DocText, 2);
+          }
+          return next(Token.DocText);
 
         case CharCode.Space:
         case CharCode.Tab:

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -1037,7 +1037,7 @@ describe("compiler: parser", () => {
            *\`\`\`
            *
            * \`This is not a @tag either because we're in a code span\`.
-           * 
+           *
            * This is not a \\@tag because it is escaped.
            *
            * @param x the param
@@ -1103,6 +1103,24 @@ describe("compiler: parser", () => {
             strictEqual(pretend.kind, SyntaxKind.DocUnknownTag as const);
             strictEqual(pretend.tagName.sv, "pretend");
             strictEqual(pretend.content[0].text, "this an unknown tag");
+          },
+        ],
+        [
+          `
+          /**
+           * Lines that end with \\
+           * don't create an extra star.
+           */
+          model M {}
+          `,
+          (script) => {
+            const docs = script.statements[0].docs;
+            strictEqual(docs?.length, 1);
+            strictEqual(docs[0].content.length, 1);
+            strictEqual(
+              docs[0].content[0].text,
+              "Lines that end with \\\ndon't create an extra star."
+            );
           },
         ],
       ],


### PR DESCRIPTION
Fixes #3646

Updated `scanDoc` to only update the escaped flag when a backslash precedes `@`. This is the only character we currently unescape later on in this scenario currently.