### PR TITLE
Attach namespace extensions to the root of the doc

### DIFF
--- a/.chronus/changes/mk-set-root-extensions-2024-6-18-19-20-36.md
+++ b/.chronus/changes/mk-set-root-extensions-2024-6-18-19-20-36.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/openapi3"
 ---
 
-Adds extensions defined on a namespace to the root of the OAS document
+`@extension` used on the service namespace will set extension at the root of the document

--- a/.chronus/changes/mk-set-root-extensions-2024-6-18-19-20-36.md
+++ b/.chronus/changes/mk-set-root-extensions-2024-6-18-19-20-36.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Adds extensions defined on a namespace to the root of the OAS document

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -347,6 +347,7 @@ function createOAPIEmitter(
       root.servers = resolveServers(servers);
     }
 
+    attachExtensions(program, service.type, root);
     serviceNamespaceName = getNamespaceFullName(service.type);
     currentPath = root.paths;
 

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -252,7 +252,7 @@ describe("openapi3: extension decorator", () => {
   it("adds an extension to a namespace", async () => {
     const oapi = await openApiFor(`
       @extension("x-model-extension", "foobar")
-      @service namespace Suno {};      
+      @service namespace Service {};      
     `);
 
     strictEqual(oapi["x-model-extension"], "foobar");

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -252,18 +252,10 @@ describe("openapi3: extension decorator", () => {
   it("adds an extension to a namespace", async () => {
     const oapi = await openApiFor(`
       @extension("x-model-extension", "foobar")
-      @route("/createSong")
-      namespace Suno {
-        @get op createSong(
-          /** The requested song description, eg. \`a country song about Thanksgiving\` */
-          @query topic: string
-          ): string;
-      }      
+      @service namespace Suno {};      
     `);
 
-    ok(oapi);
-    const extensions = oapi.getExtensions();
-    strictEqual(extensions["x-model-extension"], "foobar");
+    strictEqual(oapi["x-model-extension"], "foobar");
   })
 
   it("check format and pattern decorator on model", async () => {

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -249,6 +249,23 @@ describe("openapi3: extension decorator", () => {
     strictEqual(oapi.components.parameters.PetId["x-parameter-extension"], "foobaz");
   });
 
+  it("adds an extension to a namespace", async () => {
+    const oapi = await openApiFor(`
+      @extension("x-model-extension", "foobar")
+      @route("/createSong")
+      namespace Suno {
+        @get op createSong(
+          /** The requested song description, eg. \`a country song about Thanksgiving\` */
+          @query topic: string
+          ): string;
+      }      
+    `);
+
+    ok(oapi);
+    const extensions = oapi.getExtensions();
+    strictEqual(extensions["x-model-extension"], "foobar");
+  })
+
   it("check format and pattern decorator on model", async () => {
     const oapi = await openApiFor(
       `

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -250,13 +250,15 @@ describe("openapi3: extension decorator", () => {
   });
 
   it("adds an extension to a namespace", async () => {
-    const oapi = await openApiFor(`
-      @extension("x-model-extension", "foobar")
-      @service namespace Service {};      
-    `);
+    const oapi = await openApiFor(
+      `
+      @extension("x-namespace-extension", "foobar")
+      @service namespace Service {};
+      `
+    );
 
-    strictEqual(oapi["x-model-extension"], "foobar");
-  })
+    strictEqual(oapi["x-namespace-extension"], "foobar");
+  });
 
   it("check format and pattern decorator on model", async () => {
     const oapi = await openApiFor(


### PR DESCRIPTION
This PR seeks to update the emitter by adding the extensions defined on a namespace to the root of the OpenApi document.
Fixes #3837