### PR TITLE
[@typespec/openapi3] Add $ref to Response Object

### DIFF
--- a/.chronus/changes/Issue3601-2024-6-18-17-42-35.md
+++ b/.chronus/changes/Issue3601-2024-6-18-17-42-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Add '$ref' to the model. Refer [3601](https://github.com/microsoft/typespec/pull/3894) for further details.

--- a/.chronus/changes/Issue3601-2024-6-18-17-42-35.md
+++ b/.chronus/changes/Issue3601-2024-6-18-17-42-35.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/openapi3"
 ---
 
-Add '$ref' to the model. Refer [3601](https://github.com/microsoft/typespec/pull/3894) for further details.
+Add support for `@useRef` on responses

--- a/.chronus/changes/Issue3601-2024-6-18-17-42-35.md
+++ b/.chronus/changes/Issue3601-2024-6-18-17-42-35.md
@@ -1,5 +1,5 @@
 ---
-changeKind: fix
+changeKind: feature
 packages:
   - "@typespec/openapi3"
 ---

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -991,6 +991,10 @@ function createOAPIEmitter(
     const openApiResponse = currentEndpoint.responses[statusCode] ?? {
       description: response.description ?? getResponseDescriptionForStatusCode(statusCode),
     };
+    const refUrl = getRef(program, response.type);
+    if (refUrl) {
+      openApiResponse.$ref = refUrl;
+    }
     emitResponseHeaders(openApiResponse, response.responses, response.type);
     emitResponseContent(operation, openApiResponse, response.responses);
     currentEndpoint.responses[statusCode] = openApiResponse;

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -289,3 +289,40 @@ describe("openapi3: extension decorator", () => {
     strictEqual(oapi.components.parameters.PetId.schema.pattern, "^[a-zA-Z0-9-]{3,24}$");
   });
 });
+
+describe("openapi3: useRef decorator", () => {
+  it("adds a ref extension to a model", async () => {
+    const oapi = await openApiFor(`
+      @test @useRef("../common.json#/definitions/Foo")
+      model Foo {
+        @statusCode
+        status: 200;
+        name: string;
+      }
+      @get op get(): Foo;
+    `);
+    ok(oapi.paths["/"].get);
+    strictEqual(oapi.paths["/"].get.responses["200"]["$ref"], "../common.json#/definitions/Foo");
+  });
+
+  it("adds a ref extension to a multiple models", async () => {
+    const oapi = await openApiFor(`
+      @test @useRef("../common.json#/definitions/Foo")
+      model Foo {
+        @statusCode
+        status: 200;
+        name: string;
+      }
+      @test @useRef("https://example.com/example.yml")
+      model Foo2 {
+        @statusCode
+        status: 201;
+        name: string;
+      }
+      @get op get(): Foo | Foo2;
+    `);
+    ok(oapi.paths["/"].get);
+    strictEqual(oapi.paths["/"].get.responses["200"]["$ref"], "../common.json#/definitions/Foo");
+    strictEqual(oapi.paths["/"].get.responses["201"]["$ref"], "https://example.com/example.yml");
+  });
+});


### PR DESCRIPTION
Per the requirement in [Issue 3601](https://github.com/microsoft/typespec/issues/3601), the 'useRef' plugin must be respected and used correctly. This PR does that.

**Before Changes**
![image](https://github.com/user-attachments/assets/be4bdeb3-4c1e-4f4a-a1ed-75abfee3f98c)

**After Changes**
![image](https://github.com/user-attachments/assets/55978f2b-25d4-4e85-91a1-4b313ade62de)
