### PR TITLE
openapi3 - fixes bug with circular references in unions

### DIFF
--- a/.chronus/changes/openapi3-fix-circ-ref-unions-2024-6-19-10-0-54.md
+++ b/.chronus/changes/openapi3-fix-circ-ref-unions-2024-6-19-10-0-54.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Fixes bug where circular references in unions caused an empty object to be emitted instead of a ref.

--- a/packages/openapi3/test/circular-references.test.ts
+++ b/packages/openapi3/test/circular-references.test.ts
@@ -34,4 +34,20 @@ describe("openapi3: circular reference", () => {
       },
     });
   });
+
+  it("can reference itself via a union property", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      model Pet { parents?: string | Pet };
+      `
+    );
+
+    deepStrictEqual(res.schemas.Pet, {
+      type: "object",
+      properties: {
+        parents: { anyOf: [{ type: "string" }, { $ref: "#/components/schemas/Pet" }] },
+      },
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3811 

Root cause seemed to be that when encountering 2+ non-null items in a union, placeholders weren't getting wrapped by ObjectBuilder and thus the emitter wasn't resolving circular references correctly.