### PR TITLE
Allow spreading a model that has props added in previous version

### DIFF
--- a/.chronus/changes/allow-spreading-model-previous-version-2024-6-19-18-50-40.md
+++ b/.chronus/changes/allow-spreading-model-previous-version-2024-6-19-18-50-40.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/versioning"
+---
+
+Allow spreading a model that has props added in previous version

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -13,6 +13,8 @@ import {
   type TypeNameOptions,
 } from "@typespec/compiler";
 import {
+  $added,
+  $removed,
   findVersionedNamespace,
   getMadeOptionalOn,
   getMadeRequiredOn,
@@ -787,10 +789,12 @@ function canIgnoreVersioningOnProperty(
   if (prop.sourceProperty === undefined) {
     return false;
   }
+
+  const decoratorFn = versioning === "added" ? $added : $removed;
   // Check if the decorator was defined on this property or a source property. If source property ignore.
-  const selfDecorators = prop.decorators.filter((x) => x.definition?.name === `@${versioning}`);
+  const selfDecorators = prop.decorators.filter((x) => x.decorator === decoratorFn);
   const sourceDecorators = prop.sourceProperty.decorators.filter(
-    (x) => x.definition?.name === `@${versioning}`
+    (x) => x.decorator === decoratorFn
   );
   return !selfDecorators.some((x) => !sourceDecorators.some((y) => x.node === y.node));
 }

--- a/packages/versioning/test/incompatible-versioning.test.ts
+++ b/packages/versioning/test/incompatible-versioning.test.ts
@@ -412,6 +412,34 @@ describe("versioning: validate incompatible references", () => {
       expectDiagnosticEmpty(diagnostics);
     });
 
+    it("succeed when spreading a model that might have add properties added in previous versions", async () => {
+      const diagnostics = await runner.diagnose(`
+        model Base {
+          @added(Versions.v1) name: string;
+        }
+
+        @added(Versions.v2)
+        model Child {
+          ...Base;
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
+    it("succeed when spreading a model that might have add properties removed after the model", async () => {
+      const diagnostics = await runner.diagnose(`
+        model Base {
+          @removed(Versions.v3) name: string;
+        }
+
+        @removed(Versions.v2)
+        model Child {
+          ...Base;
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
     it("emit diagnostic when model property was added before model itself", async () => {
       const diagnostics = await runner.diagnose(`
         @added(Versions.v3)


### PR DESCRIPTION
fix [#3639](https://github.com/microsoft/typespec/issues/3639)

Allow this scenario

```

model Base {
  @added(Versions.v1) name: string;
}

@added(Versions.v2)
model Child {
  ...Base;
}

```