### PR TITLE
[docs/libraries/http] Fix incorrect reference to @header annotation in statusCode documentation.

### DIFF
--- a/docs/libraries/http/operations.md
+++ b/docs/libraries/http/operations.md
@@ -133,7 +133,7 @@ namespace Pets {
 
 **Configure:**
 
-Use the `@header` decorator on a property named `statusCode` to declare a status code for a response. Generally, setting this to just `int32` isn't particularly useful. Instead, use number literal types to create a discriminated union of response types. Let's add status codes to our responses, and add a 404 response to our read endpoint.
+Use the `@statusCode` decorator on a property to declare a status code for a response. Generally, setting this to just `int32` isn't particularly useful. Instead, use number literal types to create a discriminated union of response types. Let's add status codes to our responses, and add a 404 response to our read endpoint.
 
 ```typespec
 @route("/pets")


### PR DESCRIPTION
I believe this mistakenly says to use the `@header` annotation on a property and should say `@statusCode`.