### PR TITLE
fix the input type deserialization issue

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputNamespaceConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/TypeSpecInputNamespaceConverter.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Generator.CSharp.Input
             enums ??= Array.Empty<InputEnumType>();
             models ??= Array.Empty<InputModelType>();
             clients ??= Array.Empty<InputClient>();
+            // it is possible that no auth is defined in the typespec, in this case, we just create an empty auth.
+            auth ??= new InputAuth();
 
             return new InputNamespace(
                 name ?? throw new JsonException(),
@@ -63,7 +65,7 @@ namespace Microsoft.Generator.CSharp.Input
                 enums,
                 models,
                 clients,
-                auth ?? throw new JsonException());
+                auth);
         }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/microsoft/typespec/issues/3938

In `autorest.csharp` we do not have a `InputNamespace` converter - but we have one here, and we are asserting the auth to never be null, but it is not true, some project does not define their auth.