### PR TITLE
Refactor openapi3 shared route to reuse logic better

### DIFF
--- a/.chronus/changes/refactor-shared-routes-2024-6-29-19-52-22.md
+++ b/.chronus/changes/refactor-shared-routes-2024-6-29-19-52-22.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/openapi3"
+---
+
+Refactor openapi3 shared route to reuse logic better

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-operation-responses.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-operation-responses.ts
@@ -34,9 +34,11 @@ export function collectOperationResponses(
 
     // These headers will be applied to all of the models for this operation/statusCode
     const commonProperties: TypeSpecModelProperty[] = [];
-    for (const name of Object.keys(response.headers ?? {})) {
-      const property = convertHeaderToProperty(name, response.headers[name]);
-      if (property) commonProperties.push(property);
+    if (response.headers) {
+      for (const name of Object.keys(response.headers)) {
+        const property = convertHeaderToProperty(name, response.headers[name]);
+        if (property) commonProperties.push(property);
+      }
     }
 
     decorators.push(...getExtensions(response));

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -766,8 +766,8 @@ function createOAPIEmitter(
     const verb = operations[0].verb;
     const path = operations[0].path;
     const oai3Operation: OpenAPI3Operation = {
-      parameters: [],
       operationId: computeSharedOperationId(shared),
+      parameters: [],
       description: joinOps(operations, getDoc, " "),
       summary: joinOps(operations, getSummary, " "),
       responses: getSharedResponses(shared),
@@ -843,9 +843,9 @@ function createOAPIEmitter(
     const visibility = resolveRequestVisibility(program, operation.operation, verb);
 
     const oai3Operation: OpenAPI3Operation = {
+      operationId: resolveOperationId(program, operation.operation),
       summary: getSummary(program, operation.operation),
       description: getDoc(program, operation.operation),
-      operationId: resolveOperationId(program, operation.operation),
       parameters: getEndpointParameters(parameters.parameters, visibility),
       responses: getResponses(operation, operation.responses),
     };
@@ -1399,8 +1399,8 @@ function createOAPIEmitter(
       return undefined;
     }
     const requestBody: OpenAPI3RequestBody = {
-      content: {},
       required: bodies.every((body) => (body.property ? !body.property.optional : true)),
+      content: {},
     };
     const schemaMap = new Map<string, OpenAPI3MediaType[]>();
     for (const body of bodies.filter((x) => !isVoidType(x.type))) {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -668,8 +668,7 @@ function createOAPIEmitter(
     return codes;
   }
 
-  function buildSharedOperations(operations: HttpOperation[]): SharedHttpOperation[] {
-    const results: SharedHttpOperation[] = [];
+  function buildSharedOperation(operations: HttpOperation[]): SharedHttpOperation {
     const paramMap = new Map<string, HttpOperation[]>();
     const responseMap = new Map<string, HttpOperation[]>();
 
@@ -719,8 +718,7 @@ function createOAPIEmitter(
     for (const [statusCode, ops] of responseMap) {
       shared.responses.set(statusCode, validateCommonResponses(statusCode, ops));
     }
-    results.push(shared);
-    return results;
+    return shared;
   }
 
   /**
@@ -743,10 +741,7 @@ function createOAPIEmitter(
       if (ops.length === 1) {
         result.push(ops[0]);
       } else {
-        const sharedOps = buildSharedOperations(ops);
-        for (const op of sharedOps) {
-          result.push(op);
-        }
+        result.push(buildSharedOperation(ops));
       }
     }
     return result;

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -671,7 +671,7 @@ export type OpenAPI3Operation = Extensions & {
   tags?: string[];
   operationId?: string;
   requestBody?: OpenAPI3RequestBody;
-  parameters: OpenAPI3Parameter[];
+  parameters: Refable<OpenAPI3Parameter>[];
   deprecated?: boolean;
   security?: Record<string, string[]>[];
 };

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -214,7 +214,7 @@ export type OpenAPI3Encoding = Extensions & {
  */
 export type OpenAPI3RequestBody = Extensions & {
   /** A brief description of the request body. This could contain examples of use. CommonMark syntax MAY be used for rich text representation. */
-  description: string;
+  description?: string;
 
   /** The content of the request body. The key is a media type or media type range and the value describes it. For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/* */
   content: Record<string, OpenAPI3MediaType>;
@@ -670,7 +670,7 @@ export type OpenAPI3Operation = Extensions & {
   responses?: any;
   tags?: string[];
   operationId?: string;
-  requestBody?: any;
+  requestBody?: OpenAPI3RequestBody;
   parameters: OpenAPI3Parameter[];
   deprecated?: boolean;
   security?: Record<string, string[]>[];

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -157,7 +157,7 @@ export type OpenAPI3Response = Extensions & {
   description: string;
 
   /** Maps a header name to its definition. RFC7230 states header names are case insensitive. If a response header is defined with the name "Content-Type", it SHALL be ignored. */
-  headers: Record<string, Refable<OpenAPI3Header>>;
+  headers?: Record<string, Refable<OpenAPI3Header>>;
 
   /** A map containing descriptions of potential response payloads. The key is a media type or media type range and the value describes it. For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/* */
   content?: Record<string, OpenAPI3MediaType>;

--- a/packages/openapi3/test/examples.test.ts
+++ b/packages/openapi3/test/examples.test.ts
@@ -47,7 +47,7 @@ describe("operation examples", () => {
 
       `
     );
-    expect(res.paths["/"].post?.requestBody.content["application/json"].example).toEqual({
+    expect(res.paths["/"].post?.requestBody?.content["application/json"].example).toEqual({
       name: "Fluffy",
       age: 2,
     });
@@ -67,7 +67,7 @@ describe("operation examples", () => {
 
       `
     );
-    expect(res.paths["/"].post?.requestBody.content["application/json"].examples).toEqual({
+    expect(res.paths["/"].post?.requestBody?.content["application/json"].examples).toEqual({
       MyExample: {
         summary: "MyExample",
         value: {

--- a/packages/openapi3/test/overloads.test.ts
+++ b/packages/openapi3/test/overloads.test.ts
@@ -24,7 +24,7 @@ describe("openapi3: overloads", () => {
       const operation = res.paths["/upload"].post;
       ok(operation);
       strictEqual(operation.operationId, "upload");
-      deepStrictEqual(Object.keys(operation.requestBody.content), [
+      deepStrictEqual(Object.keys(operation.requestBody!.content), [
         "text/plain",
         "application/octet-stream",
       ]);
@@ -56,8 +56,8 @@ describe("openapi3: overloads", () => {
       strictEqual(stringOperation.operationId, "uploadString");
       strictEqual(bytesOperation.operationId, "uploadBytes");
 
-      deepStrictEqual(Object.keys(stringOperation.requestBody.content), ["text/plain"]);
-      deepStrictEqual(Object.keys(bytesOperation.requestBody.content), [
+      deepStrictEqual(Object.keys(stringOperation.requestBody!.content), ["text/plain"]);
+      deepStrictEqual(Object.keys(bytesOperation.requestBody!.content), [
         "application/octet-stream",
       ]);
     });
@@ -67,7 +67,7 @@ describe("openapi3: overloads", () => {
       ok(baseOperation);
       strictEqual(baseOperation.operationId, "upload");
 
-      deepStrictEqual(Object.keys(baseOperation.requestBody.content), [
+      deepStrictEqual(Object.keys(baseOperation.requestBody!.content), [
         "text/plain",
         "application/octet-stream",
       ]);

--- a/packages/openapi3/test/shared-routes.test.ts
+++ b/packages/openapi3/test/shared-routes.test.ts
@@ -264,6 +264,7 @@ describe("openapi3: shared routes", () => {
     );
     deepStrictEqual(results.paths["/1"].post.operationId, "processInt_processString");
     deepStrictEqual(results.paths["/1"].post.requestBody, {
+      required: true,
       content: {
         "application/json": {
           schema: {
@@ -282,6 +283,7 @@ describe("openapi3: shared routes", () => {
     });
     deepStrictEqual(results.paths["/2"].post.operationId, "updateInt_updateString");
     deepStrictEqual(results.paths["/2"].post.requestBody, {
+      required: true,
       content: {
         "application/json": {
           schema: {
@@ -382,7 +384,9 @@ describe("openapi3: shared routes", () => {
     );
     deepStrictEqual(results.paths["/"].post.operationId, "updateA_updateB");
     const requestBody = results.paths["/"].post.requestBody;
+
     deepStrictEqual(requestBody, {
+      required: true,
       content: {
         "application/json": {
           schema: {
@@ -434,6 +438,7 @@ describe("openapi3: shared routes", () => {
     deepStrictEqual(results.paths["/process"].post.operationId, "processInt_processString");
     const requestBody = results.paths["/process"].post.requestBody;
     deepStrictEqual(requestBody, {
+      required: true,
       content: {
         "application/json": {
           schema: {

--- a/packages/samples/test/output/grpc-kiosk-example/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/grpc-kiosk-example/@typespec/openapi3/openapi.yaml
@@ -7,8 +7,6 @@ tags:
 paths:
   /v1/kiosks:
     post:
-      tags:
-        - Display
       operationId: Display_createKiosk
       description: Create a kiosk. This enrolls the kiosk for sign display.
       parameters: []
@@ -25,6 +23,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+      tags:
+        - Display
       requestBody:
         required: true
         content:
@@ -32,8 +32,6 @@ paths:
             schema:
               $ref: '#/components/schemas/Kiosk'
     get:
-      tags:
-        - Display
       operationId: Display_listKiosks
       description: List active kiosks.
       parameters: []
@@ -50,10 +48,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/kiosks/{id}:
-    get:
       tags:
         - Display
+  /v1/kiosks/{id}:
+    get:
       operationId: Display_getKiosk
       description: Get a kiosk.
       parameters:
@@ -76,9 +74,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-    delete:
       tags:
         - Display
+    delete:
       operationId: Display_deleteKiosk
       description: Delete a kiosk.
       parameters:
@@ -97,10 +95,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/kiosks/{kiosk_id}/sign:
-    get:
       tags:
         - Display
+  /v1/kiosks/{kiosk_id}/sign:
+    get:
       operationId: Display_getSignIdForKioskId
       description: Get the sign that should be displayed on a kiosk.
       parameters:
@@ -123,10 +121,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/signs:
-    post:
       tags:
         - Display
+  /v1/signs:
+    post:
       operationId: Display_createSign
       description: Create a sign. This enrolls the sign for sign display.
       parameters: []
@@ -143,6 +141,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+      tags:
+        - Display
       requestBody:
         required: true
         content:
@@ -150,8 +150,6 @@ paths:
             schema:
               $ref: '#/components/schemas/Sign'
     get:
-      tags:
-        - Display
       operationId: Display_listSigns
       description: List active signs.
       parameters: []
@@ -162,10 +160,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListSignsResponse'
-  /v1/signs/{id}:
-    get:
       tags:
         - Display
+  /v1/signs/{id}:
+    get:
       operationId: Display_getSign
       description: Get a sign.
       parameters:
@@ -188,9 +186,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-    delete:
       tags:
         - Display
+    delete:
       operationId: Display_deleteSign
       description: Delete a sign.
       parameters:
@@ -209,10 +207,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/signs/{sign_id}:
-    post:
       tags:
         - Display
+  /v1/signs/{sign_id}:
+    post:
       operationId: Display_setSignIdForKioskIds
       description: Set a sign for display on one or more kiosks.
       parameters:
@@ -226,6 +224,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+      tags:
+        - Display
       requestBody:
         required: true
         content:

--- a/packages/samples/test/output/grpc-library-example/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/grpc-library-example/@typespec/openapi3/openapi.yaml
@@ -7,8 +7,6 @@ tags:
 paths:
   /v1/shelves:
     post:
-      tags:
-        - LibraryService
       operationId: LibraryService_createShelf
       description: Creates a shelf, and returns the new Shelf.
       parameters: []
@@ -25,16 +23,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+      tags:
+        - LibraryService
       requestBody:
-        description: The shelf to create.
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Shelf'
+        description: The shelf to create.
     get:
-      tags:
-        - LibraryService
       operationId: LibraryService_listShelves
       description: |-
         Lists shelves. The order is unspecified but deterministic. Newly created
@@ -55,10 +53,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/shelves/shelf_name/books/{name}:
-    get:
       tags:
         - LibraryService
+  /v1/shelves/shelf_name/books/{name}:
+    get:
       operationId: LibraryService_getBook
       description: Gets a book. Returns NOT_FOUND if the book does not exist.
       parameters:
@@ -76,9 +74,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-    delete:
       tags:
         - LibraryService
+    delete:
       operationId: LibraryService_deleteBook
       description: Deletes a book. Returns NOT_FOUND if the book does not exist.
       parameters:
@@ -92,10 +90,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/shelves/{name}:
-    get:
       tags:
         - LibraryService
+  /v1/shelves/{name}:
+    get:
       operationId: LibraryService_getShelf
       description: Gets a shelf. Returns NOT_FOUND if the shelf does not exist.
       parameters:
@@ -113,9 +111,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-    delete:
       tags:
         - LibraryService
+    delete:
       operationId: LibraryService_deleteShelf
       description: Deletes a shelf. Returns NOT_FOUND if the shelf does not exist.
       parameters:
@@ -129,10 +127,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/shelves/{name}/books:
-    post:
       tags:
         - LibraryService
+  /v1/shelves/{name}/books:
+    post:
       operationId: LibraryService_createBook
       description: Creates a book, and returns the new Book.
       parameters:
@@ -150,16 +148,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+      tags:
+        - LibraryService
       requestBody:
-        description: The book to create.
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Book'
+        description: The book to create.
     get:
-      tags:
-        - LibraryService
       operationId: LibraryService_listBooks
       description: |-
         Lists books in a shelf. The order is unspecified but deterministic. Newly
@@ -182,10 +180,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/shelves/{name}:merge:
-    post:
       tags:
         - LibraryService
+  /v1/shelves/{name}:merge:
+    post:
       operationId: LibraryService_mergeShelves
       description: |-
         Merges two shelves by adding all books from the shelf named
@@ -209,13 +207,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+      tags:
+        - LibraryService
       requestBody:
-        description: The name of the shelf we're removing books from and deleting.
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/shelf_name'
+        description: The name of the shelf we're removing books from and deleting.
 components:
   parameters:
     CreateBookRequest.name:

--- a/packages/samples/test/output/tags/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/tags/@typespec/openapi3/openapi.yaml
@@ -28,8 +28,6 @@ paths:
                   $ref: '#/components/schemas/Resp'
   /bar/{id}:
     post:
-      tags:
-        - tag3
       operationId: Bar_create
       description: one operation tag
       parameters:
@@ -42,11 +40,10 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
+      tags:
+        - tag3
   /foo/{id}:
     get:
-      tags:
-        - foo
-        - tag1
       operationId: Foo_read
       description: includes namespace tag
       parameters:
@@ -59,11 +56,10 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
-    post:
       tags:
         - foo
         - tag1
-        - tag2
+    post:
       operationId: Foo_create
       description: includes namespace tag and two operations tags
       parameters:
@@ -76,13 +72,12 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
+      tags:
+        - foo
+        - tag1
+        - tag2
   /nested/{id}:
     post:
-      tags:
-        - outer
-        - inner
-        - moreInner
-        - innerOp
       operationId: NestedMoreInner_createOther
       parameters:
         - name: id
@@ -94,6 +89,11 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
+      tags:
+        - outer
+        - inner
+        - moreInner
+        - innerOp
 components:
   schemas:
     Resp:

--- a/packages/samples/test/output/testserver/body-string/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-string/@typespec/openapi3/openapi.yaml
@@ -7,8 +7,6 @@ tags:
 paths:
   /string/base64Encoding:
     get:
-      tags:
-        - String Operations
       operationId: String_getBase64Encoding
       description: Get value that is base64 encoded
       parameters: []
@@ -26,9 +24,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    put:
       tags:
         - String Operations
+    put:
       operationId: String_putBase64Encoding
       description: Put value that is base64 encoded
       parameters: []
@@ -41,6 +39,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      tags:
+        - String Operations
       requestBody:
         required: true
         content:
@@ -50,8 +50,6 @@ paths:
               format: byte
   /string/empty:
     get:
-      tags:
-        - String Operations
       operationId: String_getEmpty
       description: Get empty string value
       parameters: []
@@ -70,9 +68,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    put:
       tags:
         - String Operations
+    put:
       operationId: String_putEmpty
       description: Put empty string value
       parameters: []
@@ -85,6 +83,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      tags:
+        - String Operations
       requestBody:
         required: true
         content:
@@ -95,8 +95,6 @@ paths:
                 - ''
   /string/enum/constant:
     get:
-      tags:
-        - String Operations
       operationId: Enums_getConstant
       description: Gets value 'green-color' from a constant
       parameters: []
@@ -113,9 +111,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    put:
       tags:
         - String Operations
+    put:
       operationId: Enums_putConstant
       description: Sends value 'green-color' from a constant
       parameters: []
@@ -128,6 +126,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      tags:
+        - String Operations
       requestBody:
         required: true
         content:
@@ -136,8 +136,6 @@ paths:
               $ref: '#/components/schemas/Colors'
   /string/enum/empty:
     get:
-      tags:
-        - String Operations
       operationId: Enums_getNotExpandable
       description: Get non expandable string enum value
       parameters: []
@@ -154,9 +152,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    put:
       tags:
         - String Operations
+    put:
       operationId: Enums_putNotExpandable
       description: Put non expandable string enum value
       parameters: []
@@ -169,6 +167,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      tags:
+        - String Operations
       requestBody:
         required: true
         content:
@@ -177,8 +177,6 @@ paths:
               $ref: '#/components/schemas/Colors'
   /string/mbcs:
     get:
-      tags:
-        - String Operations
       operationId: String_getMbcs
       description: Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
       parameters: []
@@ -197,9 +195,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    put:
       tags:
         - String Operations
+    put:
       operationId: String_putMbCs
       description: Put mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
       parameters: []
@@ -212,6 +210,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      tags:
+        - String Operations
       requestBody:
         required: true
         content:
@@ -222,8 +222,6 @@ paths:
                 - 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
   /string/null:
     get:
-      tags:
-        - String Operations
       operationId: String_getNull
       description: Get null string value
       parameters: []
@@ -241,9 +239,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    put:
       tags:
         - String Operations
+    put:
       operationId: String_putNull
       description: Put null string value
       parameters: []
@@ -256,6 +254,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      tags:
+        - String Operations
       requestBody:
         required: true
         content:
@@ -265,8 +265,6 @@ paths:
               nullable: true
   /string/whitespace:
     get:
-      tags:
-        - String Operations
       operationId: String_getWhitespace
       description: Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
       parameters: []
@@ -285,9 +283,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    put:
       tags:
         - String Operations
+    put:
       operationId: String_putWhitespace
       description: Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
       parameters: []
@@ -300,6 +298,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      tags:
+        - String Operations
       requestBody:
         required: true
         content:

--- a/packages/samples/test/output/testserver/media-types/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/testserver/media-types/@typespec/openapi3/openapi.yaml
@@ -17,7 +17,6 @@ paths:
               schema:
                 type: string
       requestBody:
-        description: Input parameter.
         required: true
         content:
           application/pdf:
@@ -35,6 +34,7 @@ paths:
           image/tiff:
             schema:
               $ref: '#/components/schemas/SourcePath'
+        description: Input parameter.
   /mediatypes/contentTypeWithEncoding:
     post:
       operationId: contentTypeWithEncoding
@@ -48,12 +48,12 @@ paths:
               schema:
                 type: string
       requestBody:
-        description: Input parameter.
         required: true
         content:
           text/plain:
             schema:
               $ref: '#/components/schemas/SourcePath'
+        description: Input parameter.
 components:
   schemas:
     Input:


### PR DESCRIPTION
There was a lot of duplicate code that made it very annoying to update and error prone.

Additionally I got rid of the `currentEndpoint` state to depend more on functional resolution