### PR TITLE
Ignore restclient.cs files when detecting stubs

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Get-CadlRanch-Coverage.ps1
+++ b/packages/http-client-csharp/eng/scripts/Get-CadlRanch-Coverage.ps1
@@ -40,7 +40,7 @@ foreach ($directory in $directories) {
 }
 
 # test all
-Write-Host "Testing $subPath" -ForegroundColor Cyan
+Write-Host "Generating CadlRanch coverage" -ForegroundColor Cyan
 $command  = "dotnet test $cadlRanchCsproj"
 Invoke $command
 # exit if the testing failed

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
@@ -25,6 +25,8 @@ namespace TestProjects.CadlRanch.Tests
             string clientCodeDirectory = GetGeneratedDirectory(test);
 
             var clientCsFile = GetClientCsFile(clientCodeDirectory);
+
+            TestContext.Progress.WriteLine($"Checking if '{clientCsFile}' is a stubbed implementation.");
             if (clientCsFile is null || IsLibraryStubbed(clientCsFile))
             {
                 SkipTest(test);
@@ -56,13 +58,14 @@ namespace TestProjects.CadlRanch.Tests
         private static void SkipTest(Test test)
         {
             test.RunState = RunState.Ignored;
+            TestContext.Progress.WriteLine($"Test skipped because {test.FullName} is currently a stubbed implementation.");
             test.Properties.Set(PropertyNames.SkipReason, $"Test skipped because {test.FullName} is currently a stubbed implementation.");
         }
 
         private static string? GetClientCsFile(string clientCodeDirectory)
         {
             return Directory.GetFiles(clientCodeDirectory, "*.cs", SearchOption.TopDirectoryOnly)
-                .Where(f => f.EndsWith("Client.cs", StringComparison.Ordinal))
+                .Where(f => f.EndsWith("Client.cs", StringComparison.Ordinal) && !f.EndsWith("RestClient.cs", StringComparison.Ordinal))
                 .FirstOrDefault();
         }
 


### PR DESCRIPTION
Follow up to https://github.com/microsoft/typespec/issues/4017 because linux has a different ordering than windows when it comes to Directory.GetFiles