### PR TITLE
Update resolution of options for formatting command in extension

### DIFF
--- a/.chronus/changes/fix-stop-respecting-vscode-space-config-2024-6-31-22-23-57.md
+++ b/.chronus/changes/fix-stop-respecting-vscode-space-config-2024-6-31-22-23-57.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+IDE: Stop respecting VSCode space/tabs config for extension formatter

--- a/.chronus/changes/fix-stop-respecting-vscode-space-config-2024-6-31-22-23-57.md
+++ b/.chronus/changes/fix-stop-respecting-vscode-space-config-2024-6-31-22-23-57.md
@@ -5,4 +5,4 @@ packages:
   - "@typespec/compiler"
 ---
 
-IDE: Stop respecting VSCode space/tabs config for extension formatter
+IDE: Formatting command will use prettier config if provided over the editor's configuration.

--- a/docs/handbook/formatter.md
+++ b/docs/handbook/formatter.md
@@ -31,6 +31,39 @@ When you use the extensions for VS Code or Visual Studio, the tsp formatter beco
 
 If you're working within a TypeSpec file, you can format the document using the default keyboard shortcut for formatting, `alt+shift+F`.
 
+### Configuration - Prettier
+
+If a prettier config (`.prettierrc.yaml`, `.prettierrc.json`, etc.) is present in the project, the formatter will use the configuration from there.
+By default this will then use the typespec style guide without any explicit option.
+
+:::note
+This only affect the formatting, when using `tab` key to indent it will still use the editor's configuration, so recommend setting one of the configuration below.
+:::
+
+### Configuration - VSCode
+
+For VSCode to respect the TypeSpec standard style set the following options style
+
+```json
+{
+  ["typespec"]: {
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+  }
+}
+```
+
+### Configuration - EditorConfig
+
+If using `.editorconfig` with the editor config extension
+
+```editorconfig
+[*.tsp]
+indent_size = 2
+indent_style = space
+```
+
 ## Via prettier
 
 The tsp formatter is essentially a `prettier` plugin. If you already have a `prettier` configuration set up for other languages, it can be quite handy to simply integrate TypeSpec into this existing pipeline.

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -590,10 +590,7 @@ export function createServer(host: ServerHost): Server {
     if (document === undefined) {
       return [];
     }
-    const formattedText = await formatTypeSpec(document.getText(), {
-      tabWidth: params.options.tabSize,
-      useTabs: !params.options.insertSpaces,
-    });
+    const formattedText = await formatTypeSpec(document.getText());
     return [minimalEdit(document, formattedText)];
   }
 

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -1,5 +1,3 @@
-import { resolveConfig } from "prettier";
-import { inspect } from "util";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   CodeAction,
@@ -593,17 +591,27 @@ export function createServer(host: ServerHost): Server {
       return [];
     }
     const path = await fileService.fileURLToRealPath(params.textDocument.uri);
-    const prettierConfig = await resolveConfig(path);
+    const prettierConfig = await resolvePrettierConfig(path);
     const resolvedConfig = prettierConfig ?? {
       tabWidth: params.options.tabSize,
       useTabs: !params.options.insertSpaces,
     };
     log({
       level: "info",
-      message: `Formatting TypeSpec document: ${inspect({ fileUri: params.textDocument.uri, vscodeOptions: params.options, prettierConfig, resolvedConfig })}`,
+      message: `Formatting TypeSpec document: ${JSON.stringify({ fileUri: params.textDocument.uri, vscodeOptions: params.options, prettierConfig, resolvedConfig }, null, 2)}`,
     });
     const formattedText = await formatTypeSpec(document.getText(), resolvedConfig);
     return [minimalEdit(document, formattedText)];
+  }
+
+  async function resolvePrettierConfig(path: string) {
+    try {
+      // Resolve prettier if it is installed.
+      const prettier = await import("prettier");
+      return prettier.resolveConfig(path);
+    } catch (e) {
+      return null;
+    }
   }
 
   function minimalEdit(document: TextDocument, string1: string): TextEdit {


### PR DESCRIPTION
VSCode has this detectIndent setting which seems to prefer 4 space by default and then update the TypeSpec formatter to format that way.