### PR TITLE
Properly Generate Variables of Reference Types

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Expressions/VariableExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Expressions/VariableExpression.cs
@@ -5,12 +5,13 @@ using Microsoft.Generator.CSharp.Primitives;
 
 namespace Microsoft.Generator.CSharp.Expressions
 {
-    public record VariableExpression(CSharpType Type, CodeWriterDeclaration Declaration) : ValueExpression
+    public record VariableExpression(CSharpType Type, CodeWriterDeclaration Declaration, bool IsRef = false) : ValueExpression
     {
-        public VariableExpression(CSharpType type, string name) : this(type, new CodeWriterDeclaration(name)) { }
+        public VariableExpression(CSharpType type, string name, bool isRef = false) : this(type, new CodeWriterDeclaration(name), isRef) { }
 
         internal override void Write(CodeWriter writer)
         {
+            writer.AppendRawIf("ref ", IsRef);
             writer.Append(Declaration);
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Primitives/CodeWriterDeclaration.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Primitives/CodeWriterDeclaration.cs
@@ -12,16 +12,14 @@ namespace Microsoft.Generator.CSharp.Primitives
 
         public bool HasBeenDeclared => _actualName != null;
 
-        public CodeWriterDeclaration(string name, bool isRef = false)
+        public CodeWriterDeclaration(string name)
         {
             RequestedName = name;
-            IsRef = isRef;
         }
 
         public string RequestedName { get; }
 
         public string ActualName => _actualName ?? _debuggerName ?? throw new InvalidOperationException($"Declaration {RequestedName} is not initialized");
-        internal bool IsRef { get; }
 
         internal void SetActualName(string? actualName)
         {

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ParameterProvider.cs
@@ -151,9 +151,9 @@ namespace Microsoft.Generator.CSharp.Providers
         {
             if (parameter._asVariable == null)
             {
-                var decl = new CodeWriterDeclaration(parameter.Name, parameter.IsRef);
+                var decl = new CodeWriterDeclaration(parameter.Name);
                 decl.SetActualName(parameter.Name);
-                parameter._asVariable = new VariableExpression(parameter.Type, decl);
+                parameter._asVariable = new VariableExpression(parameter.Type, decl, parameter.IsRef);
             }
 
             return parameter._asVariable;

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Writers/CodeWriter.cs
@@ -883,7 +883,6 @@ namespace Microsoft.Generator.CSharp
         {
             if (declaration.HasBeenDeclared)
             {
-                AppendRawIf("ref ", declaration.IsRef);
                 WriteIdentifier(declaration.ActualName);
             }
             else

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Expressions/VariableExpressionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Expressions/VariableExpressionTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Generator.CSharp.Expressions;
+using Microsoft.Generator.CSharp.Primitives;
+using NUnit.Framework;
+
+namespace Microsoft.Generator.CSharp.Tests.Expressions
+{
+    public class VariableExpressionTests
+    {
+        [Test]
+        public void VariableExpressionWithoutRef()
+        {
+            var variableExpression = new VariableExpression(typeof(int), "foo");
+            using CodeWriter writer = new CodeWriter();
+            variableExpression.Write(writer);
+
+            Assert.AreEqual("foo", writer.ToString(false));
+        }
+
+        [Test]
+        public void VariableExpressionWithRef()
+        {
+            var variableExpression = new VariableExpression(typeof(int), "foo", true);
+            using CodeWriter writer = new CodeWriter();
+            variableExpression.Write(writer);
+
+            Assert.AreEqual("ref foo", writer.ToString(false));
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/microsoft/typespec/issues/3747