### PR TITLE
Float for preview of next two releases for peer dependencies

### DIFF
--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -46,13 +46,13 @@
     "json-serialize-refs": "0.1.0-0"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
-    "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
-    "@typespec/compiler": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/http": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/openapi": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/rest": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/versioning": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0"
+    "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
+    "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
+    "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/http": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0"
   },
   "devDependencies": {
     "@azure-tools/typespec-azure-core": "0.44.0",

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -46,13 +46,13 @@
     "json-serialize-refs": "0.1.0-0"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0",
-    "@typespec/compiler": ">=0.50.0 <1.0.0",
-    "@typespec/http": ">=0.50.0 <1.0.0",
-    "@typespec/openapi": ">=0.50.0 <1.0.0",
-    "@typespec/rest": ">=0.50.0 <1.0.0",
-    "@typespec/versioning": ">=0.50.0 <1.0.0"
+    "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
+    "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
+    "@typespec/compiler": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/http": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/openapi": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/rest": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+    "@typespec/versioning": ">=0.50.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0"
   },
   "devDependencies": {
     "@azure-tools/typespec-azure-core": "0.44.0",


### PR DESCRIPTION
This will allow us to match next two preview releases to avoid issues when we might be a little slow to adopt a release.