### PR TITLE
Uri template: Encode reserved chars

### DIFF
--- a/.chronus/changes/fix-uri-template-encode-reserved-char-2024-7-6-18-53-32.md
+++ b/.chronus/changes/fix-uri-template-encode-reserved-char-2024-7-6-18-53-32.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+

--- a/packages/http/src/route.ts
+++ b/packages/http/src/route.ts
@@ -82,7 +82,8 @@ export function resolvePathAndParameters(
   // Ensure that all of the parameters defined in the route are accounted for in
   // the operation parameters
   for (const routeParam of parsedUriTemplate.parameters) {
-    if (!paramByName.has(routeParam.name)) {
+    const decoded = decodeURIComponent(routeParam.name);
+    if (!paramByName.has(routeParam.name) && !paramByName.has(decoded)) {
       diagnostics.add(
         createDiagnostic({
           code: "missing-uri-param",
@@ -233,8 +234,15 @@ function addOperationTemplateToUriTemplate(uriTemplate: string, params: HttpOper
 
   const pathPart = joinPathSegments([uriTemplate, ...pathParams]);
   return (
-    pathPart + (queryParams.length > 0 ? `{?${queryParams.map((x) => x.name).join(",")}}` : "")
+    pathPart +
+    (queryParams.length > 0
+      ? `{?${queryParams.map((x) => escapeUriTemplateParamName(x.name)).join(",")}}`
+      : "")
   );
+}
+
+function escapeUriTemplateParamName(name: string) {
+  return name.replaceAll(":", "%3A");
 }
 
 export function setRouteProducer(

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -590,7 +590,7 @@ describe("uri template", () => {
       ["@path(#{allowReserved: true, explode: true}) one: string", "/foo/{+one*}"],
       ["@query one: string", "/foo{?one}"],
       // cspell:ignore Atwo
-      [`@query("one:two") one: string`, "/foo/{?one%3Atwo}"],
+      [`@query("one:two") one: string`, "/foo{?one%3Atwo}"],
     ])("%s -> %s", async (param, expectedUri) => {
       const op = await getOp(`@route("/foo") op foo(${param}): void;`);
       expect(op.uriTemplate).toEqual(expectedUri);

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -589,6 +589,8 @@ describe("uri template", () => {
       [`@path(#{style: "path"}) one: string`, "/foo/{/one}"],
       ["@path(#{allowReserved: true, explode: true}) one: string", "/foo/{+one*}"],
       ["@query one: string", "/foo{?one}"],
+      // cspell:ignore Atwo
+      [`@query("one:two") one: string`, "/foo/{?one%3Atwo}"],
     ])("%s -> %s", async (param, expectedUri) => {
       const op = await getOp(`@route("/foo") op foo(${param}): void;`);
       expect(op.uriTemplate).toEqual(expectedUri);


### PR DESCRIPTION
```tsp
op test(
  @query("attr:qualifiedName")
  attribute?: string,
): void;
```

For cases like that the uri tempalte should look like `{?attr%3AqualifiedName}`


For now only did that for `:` and query parameter as for path the param name doesn't matter