### PR TITLE
[http-server-javascript] Fix an annoying bug with router path matching.

### DIFF
--- a/.chronus/changes/witemple-msft-hsj-router-param-bug-2024-7-7-15-20-46.md
+++ b/.chronus/changes/witemple-msft-hsj-router-param-bug-2024-7-7-15-20-46.md
@@ -1,0 +1,8 @@
+---
+changeKind: fix
+packages:
+  - typespec-vs
+  - "@typespec/http-server-javascript"
+---
+
+Fixed a router bug where paths would sometimes fail to match after a parameter was bound.

--- a/packages/http-server-javascript/src/http/server/router.ts
+++ b/packages/http-server-javascript/src/http/server/router.ts
@@ -248,8 +248,11 @@ function* emitRouteHandler(
 
     yield `else {`;
     const paramName = parameters.length === 1 ? parameters[0] : "param";
-    yield `  const [${paramName}, rest] = path.split("/", 1);`;
-    yield `  path = rest ?? "";`;
+    const idxName = `__${parseCase(paramName).snakeCase}_idx`;
+    yield `  let ${idxName} = path.indexOf("/");`;
+    yield `  ${idxName} = ${idxName} === -1 ? path.length : ${idxName};`;
+    yield `  const ${paramName} = path.slice(0, ${idxName});`;
+    yield `  path = path.slice(${idxName});`;
     if (parameters.length !== 1) {
       for (const p of parameters) {
         yield `  const ${parseCase(p).camelCase} = param;`;


### PR DESCRIPTION
This PR fixes a bug where path parameters in the middle of a path would fail to match because they incorrectly removed the leading "/" from the `rest` of the path segment after matching. The "/" trailing a parameter was never included as part of the path but was discarded by a call to `String.split`. The logic in this PR is more robust, always using indices and slices.