### PR TITLE
Only default to csv or multi if the type was array

### DIFF
--- a/.chronus/changes/fix-tsp-default-csv1-2024-7-7-14-31-14.md
+++ b/.chronus/changes/fix-tsp-default-csv1-2024-7-7-14-31-14.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -144,9 +144,19 @@ export const $query: QueryDecorator = (
     type: "query",
     explode:
       userOptions.explode ?? (userOptions.format === "multi" || userOptions.format === "form"),
-    format: userOptions.format ?? (userOptions.explode ? "multi" : "csv"),
+    format: userOptions.format,
     name: paramName,
   };
+
+  if (
+    entity.type.kind === "Model" &&
+    isArrayModelType(context.program, entity.type) &&
+    // eslint-disable-next-line deprecation/deprecation
+    options.format === undefined
+  ) {
+    // eslint-disable-next-line deprecation/deprecation
+    options.format = userOptions.explode ? "multi" : "csv";
+  }
   context.program.stateMap(HttpStateKeys.query).set(entity, options);
 };
 


### PR DESCRIPTION
Some emitters are doing some bad things and not respecting the real meaning of format. To try to reduce breaking change we will only set the format if the type was an array which is when you needed to use it before