### PR TITLE
Make diagnostic code link to linter rule doc in IDE

### DIFF
--- a/.chronus/changes/lsp-diag-url-2024-7-12-14-53-19.md
+++ b/.chronus/changes/lsp-diag-url-2024-7-12-14-53-19.md
@@ -1,6 +1,6 @@
 ---
 # Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
+changeKind: feature
 packages:
   - "@typespec/compiler"
 ---

--- a/.chronus/changes/lsp-diag-url-2024-7-12-14-53-19.md
+++ b/.chronus/changes/lsp-diag-url-2024-7-12-14-53-19.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Diagnostic code in IDE now link to the linter rule documentation url if applicable

--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -21,6 +21,9 @@ import {
 export interface Linter {
   extendRuleSet(ruleSet: LinterRuleSet): Promise<readonly Diagnostic[]>;
   lint(): readonly Diagnostic[];
+
+  /** @internal */
+  getRuleUrl(ruleId: string): string | undefined;
 }
 
 /**
@@ -64,7 +67,12 @@ export function createLinter(
   return {
     extendRuleSet,
     lint,
+    getRuleUrl,
   };
+
+  function getRuleUrl(ruleId: string): string | undefined {
+    return ruleMap.get(ruleId)?.url;
+  }
 
   async function extendRuleSet(ruleSet: LinterRuleSet): Promise<readonly Diagnostic[]> {
     tracer.trace("extend-rule-set.start", JSON.stringify(ruleSet, null, 2));

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -120,6 +120,9 @@ export interface Program {
    * Project root. If a tsconfig was found/specified this is the directory for the tsconfig.json. Otherwise directory where the entrypoint is located.
    */
   readonly projectRoot: string;
+
+  /** @internal */
+  getDiagnosticUrl(diagnostic: Diagnostic): string | undefined;
 }
 
 interface EmitterRef {
@@ -192,6 +195,7 @@ export async function compile(
     resolveTypeReference,
     getSourceFileLocationContext,
     projectRoot: getDirectoryPath(options.config ?? resolvedMain ?? ""),
+    getDiagnosticUrl,
   };
 
   trace("compiler.options", JSON.stringify(options, null, 2));
@@ -204,6 +208,10 @@ export async function compile(
   await loadIntrinsicTypes();
   if (!options?.nostdlib) {
     await loadStandardLibrary();
+  }
+
+  function getDiagnosticUrl(diagnostic: Diagnostic): string | undefined {
+    return linter.getRuleUrl(diagnostic.code);
   }
 
   // Load additional imports prior to compilation

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -397,6 +397,13 @@ export function createServer(host: ServerHost): Server {
       const range = Range.create(start, end);
       const severity = convertSeverity(each.severity);
       const diagnostic = VSDiagnostic.create(range, each.message, severity, each.code, "TypeSpec");
+
+      const url = program.getDiagnosticUrl(each);
+      if (url) {
+        diagnostic.codeDescription = {
+          href: url,
+        };
+      }
       if (each.code === "deprecated") {
         diagnostic.tags = [DiagnosticTag.Deprecated];
       }


### PR DESCRIPTION
Saw that eslint extension was doing this. Part solution to https://github.com/microsoft/typespec/issues/3043 which could also provide an explicit `Open documentation Url` command

<img width="568" alt="image" src="https://github.com/user-attachments/assets/c3a322d2-17c7-45d9-962c-028c1e9cc93c">

For now all the API that gives that is limited to linter as other diagnostic cannot define a url. Due to this limited usage I left the API internal. The goal would be that any diagnostic can define a documentation url and connect to this.