### PR TITLE
Fix regression using dep

### DIFF
--- a/.chronus/changes/fix-regression-using-dep-2024-7-13-2-12-20.md
+++ b/.chronus/changes/fix-regression-using-dep-2024-7-13-2-12-20.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/versioning"
+---
+
+Fix regression using dep

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -376,6 +376,7 @@ function validateVersionedNamespaceUsage(
       const sourceVersionedNamespace = source && findVersionedNamespace(program, source);
       if (
         targetVersionedNamespace !== undefined &&
+        !(source && (isSubNamespace(target, source) || isSubNamespace(source, target))) &&
         sourceVersionedNamespace !== targetVersionedNamespace &&
         dependencies?.get(targetVersionedNamespace) === undefined
       ) {
@@ -438,6 +439,19 @@ function validateVersionedPropertyNames(program: Program, source: Type) {
       }
     }
   }
+}
+
+function isSubNamespace(parent: Namespace, child: Namespace): boolean {
+  let current: Namespace | undefined = child;
+
+  while (current && current.name !== "") {
+    if (current === parent) {
+      return true;
+    }
+    current = current.namespace;
+  }
+
+  return false;
 }
 
 function validateMadeOptional(program: Program, target: Type) {

--- a/packages/versioning/test/versioned-dependencies.test.ts
+++ b/packages/versioning/test/versioned-dependencies.test.ts
@@ -449,6 +449,24 @@ describe("versioning: reference versioned library", () => {
       expectDiagnosticEmpty(diagnostics);
     });
 
+    // LEGACY test due to arm depending on it. Should remove when we relax using-versioned-library rule
+    it("doesn't emit diagnostic when parent namespace reference sub namespace that is versioned differently", async () => {
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace MyService {
+          enum Versions {m1}
+          model Foo is SubNamespace.Bar;
+          
+          @versioned(SubNamespace.Versions)
+          namespace SubNamespace {
+            enum Versions { s1 }
+            model Bar {}
+          }
+        }
+    `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
     it("succeed if sub namespace of versioned service reference versioned library", async () => {
       const diagnostics = await runner.diagnose(`
         @versioned(Versions)


### PR DESCRIPTION
Previous PR https://github.com/microsoft/typespec/pull/4145/files fix an issue with referencing items from another sub namespace and simplified the logic but seems like this is making the typespec-azure-resource-manager library error.

The way the library was written kinda makes it seems like there is indeed an error but can't change that right now so just reverting as we plan to get rid of this error anyway