### PR TITLE
Fix: Revert unix style warning

### DIFF
--- a/.chronus/changes/fix-revert-unix-path-warning-2024-7-13-17-50-15.md
+++ b/.chronus/changes/fix-revert-unix-path-warning-2024-7-13-17-50-15.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix: Revert `unix-style` warning that was preventing windows path via the CLI as well

--- a/packages/compiler/src/config/config-loader.ts
+++ b/packages/compiler/src/config/config-loader.ts
@@ -260,13 +260,13 @@ function validatePathAbsolute(
       target: target === NoTarget ? target : getLocationInYamlScript(target.file, target.path),
     });
   }
-  if (path.includes("\\")) {
-    return createDiagnostic({
-      code: "path-unix-style",
-      format: { path },
-      target: target === NoTarget ? target : getLocationInYamlScript(target.file, target.path),
-    });
-  }
+  // if (path.includes("\\")) {
+  //   return createDiagnostic({
+  //     code: "path-unix-style",
+  //     format: { path },
+  //     target: target === NoTarget ? target : getLocationInYamlScript(target.file, target.path),
+  //   });
+  // }
 
   return undefined;
 }

--- a/packages/compiler/src/core/schema-validator.ts
+++ b/packages/compiler/src/core/schema-validator.ts
@@ -22,9 +22,9 @@ function absolutePathStatus(path: string): "valid" | "not-absolute" | "windows-s
   if (path.startsWith(".") || !isPathAbsolute(path)) {
     return "not-absolute";
   }
-  if (path.includes("\\")) {
-    return "windows-style";
-  }
+  // if (path.includes("\\")) {
+  //   return "windows-style";
+  // }
   return "valid";
 }
 
@@ -75,20 +75,11 @@ function ajvErrorToDiagnostic(
   const tspTarget = resolveTarget(error, target);
   if (error.params.format === "absolute-path") {
     const value = getErrorValue(obj, error) as any;
-    const status = absolutePathStatus(value);
-    if (status === "windows-style") {
-      return createDiagnostic({
-        code: "path-unix-style",
-        format: { path: value },
-        target: tspTarget,
-      });
-    } else {
-      return createDiagnostic({
-        code: "config-path-absolute",
-        format: { path: value },
-        target: tspTarget,
-      });
-    }
+    return createDiagnostic({
+      code: "config-path-absolute",
+      format: { path: value },
+      target: tspTarget,
+    });
   }
 
   const messageLines = [`Schema violation: ${error.message} (${error.instancePath || "/"})`];

--- a/packages/compiler/test/core/emitter-options.test.ts
+++ b/packages/compiler/test/core/emitter-options.test.ts
@@ -118,7 +118,7 @@ describe("compiler: emitter options", () => {
       });
     });
 
-    // This was disabled
+    // This was disabled due to making it impossible to use windows path via the cli https://github.com/microsoft/typespec/pull/4173
     it.skip("emit diagnostic if passing windows style path", async () => {
       const diagnostics = await diagnoseEmitterOptions({
         "asset-dir": "C:\\abc\\def",

--- a/packages/compiler/test/core/emitter-options.test.ts
+++ b/packages/compiler/test/core/emitter-options.test.ts
@@ -118,7 +118,8 @@ describe("compiler: emitter options", () => {
       });
     });
 
-    it("emit diagnostic if passing windows style path", async () => {
+    // This was disabled
+    it.skip("emit diagnostic if passing windows style path", async () => {
       const diagnostics = await diagnoseEmitterOptions({
         "asset-dir": "C:\\abc\\def",
       });


### PR DESCRIPTION
This actually prevent passing windows style path via the CLI in emitter options which is really a blocker