### PR TITLE
Java codegen - clean up build steps

### DIFF
--- a/packages/http-client-java/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Build-Packages.ps1
@@ -52,15 +52,11 @@ Push-Location "$packageRoot/generator"
 try {
     Write-Host "Working in $PWD"
    
-    Write-Host "Current PATH: $env:PATH"
-    Write-Host "Current JAVA_HOME: $Env:JAVA_HOME"
     $env:JAVA_HOME = $env:JAVA_HOME_21_X64
-    Write-Host "Updated JAVA_HOME: $Env:JAVA_HOME"
+    Write-Host "JAVA_HOME: $Env:JAVA_HOME"
 
     $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
   
-    Write-Host "Updated PATH: $env:PATH"
-
     Invoke-LoggedCommand "java -version"
     Invoke-LoggedCommand "mvn -version"
 

--- a/packages/http-client-java/eng/scripts/Generate.ps1
+++ b/packages/http-client-java/eng/scripts/Generate.ps1
@@ -4,14 +4,10 @@ Import-Module "$PSScriptRoot\Generation.psm1" -DisableNameChecking -Force;
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
 
-Write-Host "Current PATH: $env:PATH"
-Write-Host "Current JAVA_HOME: $Env:JAVA_HOME"
 $env:JAVA_HOME = $env:JAVA_HOME_21_X64
-Write-Host "Updated JAVA_HOME: $Env:JAVA_HOME"
+Write-Host "JAVA_HOME: $Env:JAVA_HOME"
 
 $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
-
-Write-Host "Updated PATH: $env:PATH"
 
 Invoke "npm run build:generator"
 Invoke "npm run build:emitter"

--- a/packages/http-client-java/eng/scripts/Initialize-Repository.ps1
+++ b/packages/http-client-java/eng/scripts/Initialize-Repository.ps1
@@ -17,57 +17,57 @@ try {
         Remove-Item -Recurse -Force "./node_modules"
     }
 
-    Write-Host "Current PATH: $env:PATH"
-    # install Java 21
+    # Write-Host "Current PATH: $env:PATH"
+    # # install Java LTS
     
-    # Query Adoptium for the list of installs for the JDK feature version.
-    $adoptiumApiUrl = "https://api.adoptium.net"
-    $jdkFeatureVersion = "21"
-    $os = "linux"
+    # # Query Adoptium for the list of installs for the JDK feature version.
+    # $adoptiumApiUrl = "https://api.adoptium.net"
+    # $jdkFeatureVersion = "21"
+    # $os = "linux"
 
-    if ($IsWindows) {
-        $os = "windows"
-    } elseif ($IsMacOS) {
-        $os = "mac"
-    } 
+    # if ($IsWindows) {
+    #     $os = "windows"
+    # } elseif ($IsMacOS) {
+    #     $os = "mac"
+    # } 
 
-    $getInstalls = "$adoptiumApiUrl/v3/assets/latest/$jdkFeatureVersion/hotspot?architecture=x64&image_type=jdk&os=$os&vendor=eclipse"
-    $jdkUnzipName = "jdk-$jdkFeatureVersion"
+    # $getInstalls = "$adoptiumApiUrl/v3/assets/latest/$jdkFeatureVersion/hotspot?architecture=x64&image_type=jdk&os=$os&vendor=eclipse"
+    # $jdkUnzipName = "jdk-$jdkFeatureVersion"
 
-    Write-Host "Downloading latest JDK to" (Get-Location)
+    # Write-Host "Downloading latest JDK to" (Get-Location)
 
-    if (!(Test-Path -Path $jdkUnzipName -PathType container)) {
-        # Query Adoptium for the list of installs for the JDK feature version.
-        Write-Host "Invoking web request to '$getInstalls' to find JDK $jdkFeatureVersion installs available on $os."
-        $installsAvailable = Invoke-WebRequest -URI $getInstalls | ConvertFrom-Json
-        $jdkLink = $installsAvailable.binary.package.link
-        $jdkZipName = $jdkLink.split("/")[-1]
+    # if (!(Test-Path -Path $jdkUnzipName -PathType container)) {
+    #     # Query Adoptium for the list of installs for the JDK feature version.
+    #     Write-Host "Invoking web request to '$getInstalls' to find JDK $jdkFeatureVersion installs available on $os."
+    #     $installsAvailable = Invoke-WebRequest -URI $getInstalls | ConvertFrom-Json
+    #     $jdkLink = $installsAvailable.binary.package.link
+    #     $jdkZipName = $jdkLink.split("/")[-1]
 
-        Write-Host "Downloading install from '$jdkLink' to '$jdkZipName'."
-        Invoke-WebRequest -URI $jdkLink -OutFile $jdkZipName
+    #     Write-Host "Downloading install from '$jdkLink' to '$jdkZipName'."
+    #     Invoke-WebRequest -URI $jdkLink -OutFile $jdkZipName
 
-        if ($IsWindows) {
-            Expand-Archive -Path $jdkZipName -Destination "jdk-temp"
-            Move-Item -Path (Join-Path -Path "jdk-temp" -ChildPath (Get-ChildItem "jdk-temp")[0].Name) -Destination $jdkUnzipName
-        } else {
-            New-Item -Path "jdk-temp" -ItemType "directory"
-            tar -xvf $jdkZipName -C "jdk-temp"
-            Move-Item -Path (Join-Path -Path "jdk-temp" -ChildPath (Get-ChildItem "jdk-temp")[0].Name) -Destination $jdkUnzipName
-        }
-    }
+    #     if ($IsWindows) {
+    #         Expand-Archive -Path $jdkZipName -Destination "jdk-temp"
+    #         Move-Item -Path (Join-Path -Path "jdk-temp" -ChildPath (Get-ChildItem "jdk-temp")[0].Name) -Destination $jdkUnzipName
+    #     } else {
+    #         New-Item -Path "jdk-temp" -ItemType "directory"
+    #         tar -xvf $jdkZipName -C "jdk-temp"
+    #         Move-Item -Path (Join-Path -Path "jdk-temp" -ChildPath (Get-ChildItem "jdk-temp")[0].Name) -Destination $jdkUnzipName
+    #     }
+    # }
 
-    $javaHome = (Convert-Path $jdkUnzipName)
-    Write-Host "Latest JDK: $javaHome"
+    # $javaHome = (Convert-Path $jdkUnzipName)
+    # Write-Host "Latest JDK: $javaHome"
 
-    Write-Host "Current JAVA_HOME: $Env:JAVA_HOME"
-    $env:JAVA_HOME = $javaHome
-    Write-Host "Updated JAVA_HOME: $Env:JAVA_HOME"
+    # Write-Host "Current JAVA_HOME: $Env:JAVA_HOME"
+    # $env:JAVA_HOME = $javaHome
+    # Write-Host "Updated JAVA_HOME: $Env:JAVA_HOME"
 
-    $env:PATH = "$javaHome\bin;$env:PATH"
+    # $env:PATH = "$javaHome\bin;$env:PATH"
   
-    Write-Host "Updated PATH: $env:PATH"
-    Invoke-LoggedCommand "java -version"
-    Invoke-LoggedCommand "mvn -version"
+    # Write-Host "Updated PATH: $env:PATH"
+    # Invoke-LoggedCommand "java -version"
+    # Invoke-LoggedCommand "mvn -version"
 
     # install and list npm packages
     if ($BuildArtifactsPath) {

--- a/packages/http-client-java/generator/http-client-generator-test/CadlRanch-Tests.ps1
+++ b/packages/http-client-java/generator/http-client-generator-test/CadlRanch-Tests.ps1
@@ -5,17 +5,12 @@ Set-StrictMode -Version 3.0
 
 try {
     Write-Host "Running cadl ranch tests"
-
-    if (Test-Path node_modules/\@azure-tools/cadl-ranch/dist/cli/cli.js) {
-        Write-Host "Starting the test server"
-        npm run testserver-start
-        mvn clean test
-        Write-Host "Stopping the test server"
-        npm run testserver-stop
-    } else {
-        Get-ChildItem -Path node_modules/\@azure-tools/ -Recurse -Name
-        Write-Host "cadl-ranch is not installed. Skipping the tests"
-    }
+    Write-Host "Starting the test server"
+    npm run testserver-start
+    mvn clean test
+    Write-Host "Stopping the test server"
+    npm run testserver-stop
+    
 }
 finally {
     Write-Host "Finished running the cadl ranch tests"


### PR DESCRIPTION
This PR cleans up some of the build steps that are not required. Latest JDK LTS version (Java 21) is pre-installed in 1es hosts and we don't need to explicitly download and install this. So, this PR comments out the code that does this as we might still need this in the future to install newer versions of Java that are not available on 1es.