### PR TITLE
Remove extra space to fix VS debug attachment

### DIFF
--- a/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/packages/http-client-csharp/emitter/src/emitter.ts
@@ -139,7 +139,7 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
         const existingProjectOption = options["existing-project-folder"]
           ? `--existing-project-folder ${options["existing-project-folder"]}`
           : "";
-        const debugFlag = (options.debug ?? false) ? " --debug" : "";
+        const debugFlag = (options.debug ?? false) ? "--debug" : "";
 
         const emitterPath = options["emitter-extension-path"] ?? import.meta.url;
         const projectRoot = findProjectRoot(dirname(fileURLToPath(emitterPath)));

--- a/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/packages/http-client-csharp/emitter/src/emitter.ts
@@ -180,7 +180,7 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
   }
 }
 
-function constructCommandArg(arg: string): String {
+function constructCommandArg(arg: string): string {
   return arg !== "" ? ` ${arg}` : "";
 }
 

--- a/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/packages/http-client-csharp/emitter/src/emitter.ts
@@ -147,7 +147,7 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
           projectRoot + "/dist/generator/Microsoft.Generator.CSharp.dll"
         );
 
-        const command = `dotnet --roll-forward Major ${generatorPath} ${outputFolder} -p ${options["plugin-name"]} ${newProjectOption} ${existingProjectOption}${debugFlag}`;
+        const command = `dotnet --roll-forward Major ${generatorPath} ${outputFolder} -p ${options["plugin-name"]}${constructCommandArg(newProjectOption)}${constructCommandArg(existingProjectOption)}${constructCommandArg(debugFlag)}`;
         Logger.getInstance().info(command);
 
         const result = await execAsync(
@@ -178,6 +178,10 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
       }
     }
   }
+}
+
+function constructCommandArg(arg: string): String {
+  return arg !== "" ? ` ${arg}` : "";
 }
 
 async function execAsync(


### PR DESCRIPTION
Resolves https://github.com/microsoft/typespec/issues/4332

extra space in argument for `child_process.spawn` ended up into missing