### PR TITLE
Java codegen: disable dependency transfer logging

### DIFF
--- a/packages/http-client-java/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Build-Packages.ps1
@@ -60,7 +60,7 @@ try {
     Invoke-LoggedCommand "java -version"
     Invoke-LoggedCommand "mvn -version"
 
-    Invoke-LoggedCommand "mvn clean install -f ./pom.xml"
+    Invoke-LoggedCommand "mvn clean install --no-transfer-progress -T 1C -f ./pom.xml"
 }
 finally {
     Pop-Location

--- a/packages/http-client-java/generator/http-client-generator-test/CadlRanch-Tests.ps1
+++ b/packages/http-client-java/generator/http-client-generator-test/CadlRanch-Tests.ps1
@@ -7,7 +7,7 @@ try {
     Write-Host "Running cadl ranch tests"
     Write-Host "Starting the test server"
     npm run testserver-start
-    mvn clean test
+    mvn clean test --no-transfer-progress -T 1C
     Write-Host "Stopping the test server"
     npm run testserver-stop
     

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -28,7 +28,7 @@
     "clean": "rimraf ./dist ./temp ./generator/target/emitter.jar",
     "build": "npm run build:generator && npm run build:emitter",
     "build:emitter": "tsc -p ./emitter/tsconfig.build.json",
-    "build:generator": "mvn clean install -f ./generator/pom.xml",
+    "build:generator": "mvn clean install --no-transfer-progress -T 1C -f ./generator/pom.xml",
     "format": "pnpm -w format:dir packages/http-client-java",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Maven build logs all dependency transfers and is too verbose. This PR disables dependency transfer logging to keep the pipeline logs clean.