### PR TITLE
Add tests for changing property type/accessibility

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
 
             // the property should be added to the custom code view
             Assert.AreEqual(1, customCodeView!.Properties.Count);
-            Assert.AreEqual("Prop2", customCodeView.Properties[0].Name);
+            // the property type should be changed
             Assert.AreEqual(new CSharpType(typeof(int[])), customCodeView.Properties[0].Type);
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Generator.CSharp.Input;
+using Microsoft.Generator.CSharp.Primitives;
 using Microsoft.Generator.CSharp.Providers;
 using Microsoft.Generator.CSharp.Tests.Common;
 using NUnit.Framework;
@@ -58,6 +59,35 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
             // the property should be added to the custom code view
             Assert.AreEqual(1, customCodeView!.Properties.Count);
             Assert.AreEqual("Prop2", customCodeView.Properties[0].Name);
+        }
+
+        [Test]
+        public void TestCustomization_CanChangePropertyType()
+        {
+            MockHelpers.LoadMockPlugin(customization: Helpers.GetCompilationFromFile());
+
+            var props = new[]
+            {
+                InputFactory.Property("Prop1", InputFactory.Array(InputPrimitiveType.String))
+            };
+
+            var inputModel = InputFactory.Model("mockInputModel", properties: props);
+            var modelTypeProvider = new ModelProvider(inputModel);
+            var customCodeView = modelTypeProvider.CustomCodeView;
+
+            Assert.IsNotNull(customCodeView);
+            Assert.AreEqual("MockInputModel", modelTypeProvider.Type.Name);
+            Assert.AreEqual("Sample.Models", modelTypeProvider.Type.Namespace);
+            Assert.AreEqual(customCodeView?.Name, modelTypeProvider.Type.Name);
+            Assert.AreEqual(customCodeView?.Type.Namespace, modelTypeProvider.Type.Namespace);
+
+            // the property should be filtered from the model provider
+            Assert.AreEqual(0, modelTypeProvider.Properties.Count);
+
+            // the property should be added to the custom code view
+            Assert.AreEqual(1, customCodeView!.Properties.Count);
+            Assert.AreEqual("Prop2", customCodeView.Properties[0].Name);
+            Assert.AreEqual(new CSharpType(typeof(int[])), customCodeView.Properties[0].Type);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -89,5 +89,34 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
             // the property type should be changed
             Assert.AreEqual(new CSharpType(typeof(int[])), customCodeView.Properties[0].Type);
         }
+
+        [Test]
+        public void TestCustomization_CanChangePropertyAccessibility()
+        {
+            MockHelpers.LoadMockPlugin(customization: Helpers.GetCompilationFromFile());
+
+            var props = new[]
+            {
+                InputFactory.Property("Prop1", InputFactory.Array(InputPrimitiveType.String))
+            };
+
+            var inputModel = InputFactory.Model("mockInputModel", properties: props);
+            var modelTypeProvider = new ModelProvider(inputModel);
+            var customCodeView = modelTypeProvider.CustomCodeView;
+
+            Assert.IsNotNull(customCodeView);
+            Assert.AreEqual("MockInputModel", modelTypeProvider.Type.Name);
+            Assert.AreEqual("Sample.Models", modelTypeProvider.Type.Namespace);
+            Assert.AreEqual(customCodeView?.Name, modelTypeProvider.Type.Name);
+            Assert.AreEqual(customCodeView?.Type.Namespace, modelTypeProvider.Type.Namespace);
+
+            // the property should be filtered from the model provider
+            Assert.AreEqual(0, modelTypeProvider.Properties.Count);
+
+            // the property should be added to the custom code view
+            Assert.AreEqual(1, customCodeView!.Properties.Count);
+            // the property accessibility should be changed
+            Assert.IsTrue(customCodeView.Properties[0].Modifiers.HasFlag(MethodSignatureModifiers.Internal));
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -26,11 +26,7 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
             var modelTypeProvider = new ModelProvider(inputModel);
             var customCodeView = modelTypeProvider.CustomCodeView;
 
-            Assert.IsNotNull(customCodeView);
-            Assert.AreEqual("CustomizedModel", modelTypeProvider.Type.Name);
-            Assert.AreEqual("NewNamespace.Models", modelTypeProvider.Type.Namespace);
-            Assert.AreEqual(customCodeView?.Name, modelTypeProvider.Type.Name);
-            Assert.AreEqual(customCodeView?.Type.Namespace, modelTypeProvider.Type.Namespace);
+            AssertCommon(customCodeView, modelTypeProvider, "NewNamespace.Models", "CustomizedModel");
         }
 
         [Test]
@@ -47,11 +43,7 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
             var modelTypeProvider = new ModelProvider(inputModel);
             var customCodeView = modelTypeProvider.CustomCodeView;
 
-            Assert.IsNotNull(customCodeView);
-            Assert.AreEqual("MockInputModel", modelTypeProvider.Type.Name);
-            Assert.AreEqual("Sample.Models", modelTypeProvider.Type.Namespace);
-            Assert.AreEqual(customCodeView?.Name, modelTypeProvider.Type.Name);
-            Assert.AreEqual(customCodeView?.Type.Namespace, modelTypeProvider.Type.Namespace);
+            AssertCommon(customCodeView, modelTypeProvider, "Sample.Models", "MockInputModel");
 
             // the property should be filtered from the model provider
             Assert.AreEqual(0, modelTypeProvider.Properties.Count);
@@ -75,11 +67,7 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
             var modelTypeProvider = new ModelProvider(inputModel);
             var customCodeView = modelTypeProvider.CustomCodeView;
 
-            Assert.IsNotNull(customCodeView);
-            Assert.AreEqual("MockInputModel", modelTypeProvider.Type.Name);
-            Assert.AreEqual("Sample.Models", modelTypeProvider.Type.Namespace);
-            Assert.AreEqual(customCodeView?.Name, modelTypeProvider.Type.Name);
-            Assert.AreEqual(customCodeView?.Type.Namespace, modelTypeProvider.Type.Namespace);
+            AssertCommon(customCodeView, modelTypeProvider, "Sample.Models", "MockInputModel");
 
             // the property should be filtered from the model provider
             Assert.AreEqual(0, modelTypeProvider.Properties.Count);
@@ -104,11 +92,7 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
             var modelTypeProvider = new ModelProvider(inputModel);
             var customCodeView = modelTypeProvider.CustomCodeView;
 
-            Assert.IsNotNull(customCodeView);
-            Assert.AreEqual("MockInputModel", modelTypeProvider.Type.Name);
-            Assert.AreEqual("Sample.Models", modelTypeProvider.Type.Namespace);
-            Assert.AreEqual(customCodeView?.Name, modelTypeProvider.Type.Name);
-            Assert.AreEqual(customCodeView?.Type.Namespace, modelTypeProvider.Type.Namespace);
+            AssertCommon(customCodeView, modelTypeProvider, "Sample.Models", "MockInputModel");
 
             // the property should be filtered from the model provider
             Assert.AreEqual(0, modelTypeProvider.Properties.Count);
@@ -117,6 +101,15 @@ namespace Microsoft.Generator.CSharp.Tests.Providers // the namespace here is cr
             Assert.AreEqual(1, customCodeView!.Properties.Count);
             // the property accessibility should be changed
             Assert.IsTrue(customCodeView.Properties[0].Modifiers.HasFlag(MethodSignatureModifiers.Internal));
+        }
+
+        private static void AssertCommon(TypeProvider? customCodeView, ModelProvider modelTypeProvider, string expectedNamespace, string expectedName)
+        {
+            Assert.IsNotNull(customCodeView);
+            Assert.AreEqual(expectedNamespace, modelTypeProvider.Type.Namespace);
+            Assert.AreEqual(expectedName, modelTypeProvider.Type.Name);
+            Assert.AreEqual(customCodeView?.Name, modelTypeProvider.Type.Name);
+            Assert.AreEqual(customCodeView?.Type.Namespace, modelTypeProvider.Type.Namespace);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/TestData/ModelCustomizationTests/TestCustomization_CanChangePropertyAccessibility.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/TestData/ModelCustomizationTests/TestCustomization_CanChangePropertyAccessibility.cs
@@ -1,0 +1,27 @@
+#nullable disable
+
+using System;
+
+namespace Sample
+{
+    // TODO: if we decide to use the public APIs, we do not have to define this attribute here. Tracking: https://github.com/Azure/autorest.csharp/issues/4551
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    internal class CodeGenMemberAttribute : Attribute
+    {
+        public CodeGenMemberAttribute() : base(null)
+        {
+        }
+
+        public CodeGenMemberAttribute(string originalName) : base(originalName)
+        {
+        }
+    }
+}
+namespace Sample.Models
+{
+    public partial class MockInputModel
+    {
+        [CodeGenMember("Prop1")]
+        internal string[] Prop2 { get; set; }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/TestData/ModelCustomizationTests/TestCustomization_CanChangePropertyType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/TestData/ModelCustomizationTests/TestCustomization_CanChangePropertyType.cs
@@ -1,0 +1,27 @@
+#nullable disable
+
+using System;
+
+namespace Sample
+{
+    // TODO: if we decide to use the public APIs, we do not have to define this attribute here. Tracking: https://github.com/Azure/autorest.csharp/issues/4551
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    internal class CodeGenMemberAttribute : Attribute
+    {
+        public CodeGenMemberAttribute() : base(null)
+        {
+        }
+
+        public CodeGenMemberAttribute(string originalName) : base(originalName)
+        {
+        }
+    }
+}
+namespace Sample.Models
+{
+    public partial class MockInputModel
+    {
+        [CodeGenMember("Prop1")]
+        public int[] Prop2 { get; set; }
+    }
+}


### PR DESCRIPTION
Validates that https://github.com/microsoft/typespec/issues/4258 and https://github.com/microsoft/typespec/issues/4265 are fixed. They were fixed by https://github.com/microsoft/typespec/pull/4362.