### PR TITLE
Move property name set to ModelProvider

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
@@ -165,6 +165,19 @@ namespace Microsoft.Generator.CSharp.Providers
 
             Dictionary<string, InputModelProperty> baseProperties = _inputModel.BaseModel?.Properties.ToDictionary(p => p.Name) ?? [];
 
+            var customPropertyNames = new HashSet<string>();
+            foreach (var customProperty in CustomCodeView?.Properties ?? [])
+            {
+                customPropertyNames.Add(customProperty.Name);
+                foreach (var attribute in customProperty.Attributes ?? [])
+                {
+                    if (CodeGenAttributes.TryGetCodeGenMemberAttributeValue(attribute, out var name))
+                    {
+                        customPropertyNames.Add(name);
+                    }
+                }
+            }
+
             for (int i = 0; i < propertiesCount; i++)
             {
                 var property = _inputModel.Properties[i];
@@ -176,7 +189,7 @@ namespace Microsoft.Generator.CSharp.Providers
                 if (outputProperty is null)
                     continue;
 
-                if (HasCustomProperty(outputProperty))
+                if (customPropertyNames.Contains(property.Name))
                     continue;
 
                 if (!property.IsDiscriminator)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
@@ -231,27 +231,6 @@ namespace Microsoft.Generator.CSharp.Providers
             return [.. properties];
         }
 
-        private bool HasCustomProperty(PropertyProvider property)
-        {
-            if (CustomCodeView == null)
-                return false;
-
-            var customPropertyNames = new HashSet<string>();
-            foreach (var customProperty in CustomCodeView.Properties)
-            {
-                customPropertyNames.Add(customProperty.Name);
-                foreach (var attribute in customProperty.Attributes ?? [])
-                {
-                    if (CodeGenAttributes.TryGetCodeGenMemberAttributeValue(attribute, out var name))
-                    {
-                        customPropertyNames.Add(name);
-                    }
-                }
-            }
-
-            return customPropertyNames.Contains(property.Name);
-        }
-
         private static bool DomainEqual(InputModelProperty baseProperty, InputModelProperty derivedProperty)
         {
             if (baseProperty.IsRequired != derivedProperty.IsRequired)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.Generator.CSharp.Expressions;
 using Microsoft.Generator.CSharp.Input;
 using Microsoft.Generator.CSharp.Primitives;
 using Microsoft.Generator.CSharp.Snippets;
+using Microsoft.Generator.CSharp.SourceInput;
 using Microsoft.Generator.CSharp.Statements;
 using static Microsoft.Generator.CSharp.Snippets.Snippet;
 
@@ -222,7 +223,20 @@ namespace Microsoft.Generator.CSharp.Providers
             if (CustomCodeView == null)
                 return false;
 
-            return CustomCodeView.PropertyNames.Contains(property.Name);
+            var customPropertyNames = new HashSet<string>();
+            foreach (var customProperty in CustomCodeView.Properties)
+            {
+                customPropertyNames.Add(customProperty.Name);
+                foreach (var attribute in customProperty.Attributes ?? [])
+                {
+                    if (CodeGenAttributes.TryGetCodeGenMemberAttributeValue(attribute, out var name))
+                    {
+                        customPropertyNames.Add(name);
+                    }
+                }
+            }
+
+            return customPropertyNames.Contains(property.Name);
         }
 
         private static bool DomainEqual(InputModelProperty baseProperty, InputModelProperty derivedProperty)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/TypeProvider.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Generator.CSharp.Providers
     public abstract class TypeProvider
     {
         private Lazy<TypeProvider?> _customCodeView;
-        private HashSet<string>? _propertyNames;
 
         protected TypeProvider()
         {
@@ -124,8 +123,6 @@ namespace Microsoft.Generator.CSharp.Providers
 
         private IReadOnlyList<PropertyProvider>? _properties;
         public IReadOnlyList<PropertyProvider> Properties => _properties ??= BuildProperties();
-
-        internal HashSet<string> PropertyNames => _propertyNames ??= BuildPropertyNames();
 
         private IReadOnlyList<MethodProvider>? _methods;
         public IReadOnlyList<MethodProvider> Methods => _methods ??= BuildMethods();


### PR DESCRIPTION
Avoids having two separate backing lists which could become out of sync.