### PR TITLE
Fixes versioning when using versioned named union variants

### DIFF
--- a/.chronus/changes/fix-named-union-versioning-2024-8-11-15-19-14.md
+++ b/.chronus/changes/fix-named-union-versioning-2024-8-11-15-19-14.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/versioning"
+---
+
+Fixes versioning when using versioned named union variants

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -533,9 +533,8 @@ function validateReference(program: Program, source: Type | Type[], target: Type
 
   switch (target.kind) {
     case "Union":
-      for (const variant of target.variants.values()) {
-        // Not a named union, so check reference directly
-        if (typeof variant.name !== "string") {
+      if (typeof target.name !== "string") {
+        for (const variant of target.variants.values()) {
           validateReference(program, source, variant.type);
         }
       }

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -534,7 +534,10 @@ function validateReference(program: Program, source: Type | Type[], target: Type
   switch (target.kind) {
     case "Union":
       for (const variant of target.variants.values()) {
-        validateReference(program, source, variant.type);
+        // Not a named union, so check reference directly
+        if (typeof variant.name !== "string") {
+          validateReference(program, source, variant.type);
+        }
       }
       break;
     case "Tuple":

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -680,6 +680,31 @@ describe("versioning: logic", () => {
       strictEqual((v6 as any as IntrinsicType).name, "never");
     });
 
+    it("does not emit diagnostic when using named versioned union variant in incompatible versioned source", async () => {
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace TestService {
+          enum Versions {v1, v2}
+
+          @added(Versions.v2)
+          model Versioned {}
+
+          union NamedUnion {
+            string;
+
+            @added(Versions.v2)
+            Versioned: Versioned;
+          }
+          
+          @added(Versions.v1)
+          model Foo {
+            content: NamedUnion;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
     async function versionedUnion(versions: string[], union: string) {
       const { Test } = (await runner.compile(`
       @versioned(Versions)

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -693,7 +693,7 @@ describe("versioning: logic", () => {
             string;
 
             @added(Versions.v2)
-            Versioned: Versioned;
+            Versioned;
           }
           
           @added(Versions.v1)


### PR DESCRIPTION
Example of bug: [playground](https://typespec.io/playground?c=aW1wb3J0ICJAdHlwZXNwZWMvaHR0cCI7CtIZcmVzdNUZdmVyc2lvbmluZyI7Cgp1c2luZyBUeXBlU3BlYy5WyR070BtIdHRw0RVSZXN0OwoKQMdVZWQox0JzKQpAc2VydmljZSh7CiAgdGl0bGU6ICJXaWRnZXQgU8YbIiwKfSkKbmFtZXNwYWNlIERlbW%2FHGzsKCmVudW0gyFAgxEZ2MSzEBjIsCn0KCnVuaW9uIEZvb0NvbnRlbnTFInN0cmluZywKCiAgQGFkZOsAkS52MikKIMQwOsQFW13FRdQlbW9kZWzEJMVS5AE5OsdYO9UzMcgzQ2hhdFJlcXVlc%2BYAjWPmAJnFcOcApTsKICDkAPA%2FzVNhbGlhcyBPdGhlclXlANY9xx4gfMQ8W107Cg%3D%3D&e=%40typespec%2Fopenapi3&options=%7B%7D)