### PR TITLE
fix the keyCredential issue

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Primitives/ScmKnownParameters.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Primitives/ScmKnownParameters.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Generator.CSharp.ClientModel.Primitives
         public static readonly ParameterProvider Data = new("data", FormattableStringHelpers.Empty, typeof(BinaryData));
         public static ParameterProvider ClientOptions(CSharpType clientOptionsType)
             => new("options", $"The options for configuring the client.", clientOptionsType.WithNullable(true), initializationValue: New.Instance(clientOptionsType.WithNullable(true)));
-        public static readonly ParameterProvider TokenAuth = new("tokenCredential", $"The token credential to copy", ClientModelPlugin.Instance.TypeFactory.TokenCredentialType());
-        public static readonly ParameterProvider MatchConditionsParameter = new("matchConditions", $"The content to send as the request conditions of the request.", ClientModelPlugin.Instance.TypeFactory.MatchConditionsType(), DefaultOf(ClientModelPlugin.Instance.TypeFactory.MatchConditionsType()));
+        public static readonly ParameterProvider KeyAuth = new("keyCredential", $"The token credential to copy", ClientModelPlugin.Instance.TypeFactory.KeyCredentialType);
+        public static readonly ParameterProvider MatchConditionsParameter = new("matchConditions", $"The content to send as the request conditions of the request.", ClientModelPlugin.Instance.TypeFactory.MatchConditionsType, DefaultOf(ClientModelPlugin.Instance.TypeFactory.MatchConditionsType));
         public static readonly ParameterProvider RequestOptions = new("options", $"The request options, which can override default behaviors of the client pipeline on a per-call basis.", typeof(RequestOptions));
         public static readonly ParameterProvider BinaryContent = new("content", $"The content to send as the body of the request.", typeof(BinaryContent), location: ParameterLocation.Body) { Validation = ParameterValidationType.AssertNotNull };
 

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             var apiKey = _inputAuth?.ApiKey;
             _apiKeyAuthField = apiKey != null ? new FieldProvider(
                 FieldModifiers.Private | FieldModifiers.ReadOnly,
-                typeof(ApiKeyCredential),
+                ClientModelPlugin.Instance.TypeFactory.KeyCredentialType,
                 ApiKeyCredentialFieldName,
                 this,
                 description: $"A credential used to authenticate to the service.") : null;

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
@@ -19,6 +20,8 @@ namespace Microsoft.Generator.CSharp.ClientModel
         public virtual CSharpType MatchConditionsType => typeof(PipelineMessageClassifier);
 
         public virtual CSharpType KeyCredentialType => typeof(ApiKeyCredential);
+
+        public virtual CSharpType TokenCredentialType => throw new NotImplementedException("Token credential is not supported in Scm libraries yet");
 
         /// <summary>
         /// Returns the serialization type providers for the given input type.

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Generator.CSharp.ClientModel
         private Dictionary<InputClient, ClientProvider>? _clientCache;
         private Dictionary<InputClient, ClientProvider> ClientCache => _clientCache ??= [];
 
-        public virtual CSharpType MatchConditionsType() => typeof(PipelineMessageClassifier);
+        public virtual CSharpType MatchConditionsType => typeof(PipelineMessageClassifier);
 
-        public virtual CSharpType TokenCredentialType() => typeof(ApiKeyCredential);
+        public virtual CSharpType KeyCredentialType => typeof(ApiKeyCredential);
 
         /// <summary>
         /// Returns the serialization type providers for the given input type.

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/OutputTypes/ScmKnownParametersTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/OutputTypes/ScmKnownParametersTests.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.OutputTypes
         [Test]
         public void TestTokenAuth()
         {
-            MockHelpers.LoadMockPlugin(tokenCredentialType: () => typeof(int));
+            MockHelpers.LoadMockPlugin(keyCredentialType: () => typeof(int));
 
-            var result = ClientModelPlugin.Instance.TypeFactory.TokenCredentialType();
+            var result = ClientModelPlugin.Instance.TypeFactory.KeyCredentialType;
             Assert.IsNotNull(result);
             Assert.AreEqual(new CSharpType(typeof(int)), result);
         }
@@ -23,7 +23,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.OutputTypes
         {
             MockHelpers.LoadMockPlugin(matchConditionsType: () => typeof(int));
 
-            var result = ClientModelPlugin.Instance.TypeFactory.MatchConditionsType();
+            var result = ClientModelPlugin.Instance.TypeFactory.MatchConditionsType;
             Assert.IsNotNull(result);
             Assert.AreEqual(new CSharpType(typeof(int)), result);
         }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/TestHelpers/MockHelpers.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
             Func<InputType, TypeProvider, IReadOnlyList<TypeProvider>>? createSerializationsCore = null,
             Func<InputType, CSharpType>? createCSharpTypeCore = null,
             Func<CSharpType>? matchConditionsType = null,
-            Func<CSharpType>? tokenCredentialType = null,
+            Func<CSharpType>? keyCredentialType = null,
             Func<InputParameter, ParameterProvider>? createParameterCore = null,
             Func<InputApiKeyAuth>? apiKeyAuth = null,
             Func<IReadOnlyList<string>>? apiVersions = null,
@@ -53,12 +53,12 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
 
             if (matchConditionsType is not null)
             {
-                mockTypeFactory.Setup(p => p.MatchConditionsType()).Returns(matchConditionsType);
+                mockTypeFactory.Setup(p => p.MatchConditionsType).Returns(matchConditionsType);
             }
 
-            if (tokenCredentialType is not null)
+            if (keyCredentialType is not null)
             {
-                mockTypeFactory.Setup(p => p.TokenCredentialType()).Returns(tokenCredentialType);
+                mockTypeFactory.Setup(p => p.KeyCredentialType).Returns(keyCredentialType);
             }
 
             if (createParameterCore is not null)


### PR DESCRIPTION
Fixes #4411
This change gives the azure plugin the ability to change the type of the credentials, but it will still have to override everything in ClientProvider to use the token credential.
Maybe only a credential abstraction change could solve it, but it needs more discussions.