### PR TITLE
http-client-java, access/usage on namespace

### DIFF
--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -367,16 +367,6 @@ export class CodeModelBuilder {
 
   private processModels() {
     const processedSdkModels: Set<SdkModelType | SdkEnumType> = new Set();
-
-    // lambda to mark model as public
-    const modelAsPublic = (model: SdkModelType | SdkEnumType) => {
-      const schema = this.processSchemaFromSdkType(model, "");
-
-      this.trackSchemaUsage(schema, {
-        usage: [SchemaContext.Public],
-      });
-    };
-
     const sdkModels: (SdkModelType | SdkEnumType)[] = getAllModels(this.sdkContext);
 
     // process sdk models
@@ -384,7 +374,11 @@ export class CodeModelBuilder {
       if (!processedSdkModels.has(model)) {
         const access = getAccess(model.__raw);
         if (access === "public") {
-          modelAsPublic(model);
+          const schema = this.processSchemaFromSdkType(model, "");
+
+          this.trackSchemaUsage(schema, {
+            usage: [SchemaContext.Public],
+          });
         } else if (access === "internal") {
           const schema = this.processSchemaFromSdkType(model, model.name);
 

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -367,6 +367,10 @@ export class CodeModelBuilder {
 
   private processModels() {
     const processedSdkModels: Set<SdkModelType | SdkEnumType> = new Set();
+
+    // cache resolved value of access/usage for the namespace
+    // the value can be set as undefined
+    // it resolves the value from that namespace and its parent namespaces
     const accessCache: Map<Namespace, string | undefined> = new Map();
     const usageCache: Map<Namespace, SchemaContext[] | undefined> = new Map();
 

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -367,12 +367,15 @@ export class CodeModelBuilder {
 
   private processModels() {
     const processedSdkModels: Set<SdkModelType | SdkEnumType> = new Set();
+    const accessCache: Map<Namespace, string | undefined> = new Map();
+    const usageCache: Map<Namespace, SchemaContext[] | undefined> = new Map();
+
     const sdkModels: (SdkModelType | SdkEnumType)[] = getAllModels(this.sdkContext);
 
     // process sdk models
     for (const model of sdkModels) {
       if (!processedSdkModels.has(model)) {
-        const access = getAccess(model.__raw);
+        const access = getAccess(model.__raw, accessCache);
         if (access === "public") {
           const schema = this.processSchemaFromSdkType(model, "");
 
@@ -387,7 +390,7 @@ export class CodeModelBuilder {
           });
         }
 
-        const usage = getUsage(model.__raw);
+        const usage = getUsage(model.__raw, usageCache);
         if (usage) {
           const schema = this.processSchemaFromSdkType(model, "");
 

--- a/packages/http-client-java/emitter/src/models.ts
+++ b/packages/http-client-java/emitter/src/models.ts
@@ -1,14 +1,6 @@
 import { ApiVersions, Parameter } from "@autorest/codemodel";
-import { getOperationLink } from "@azure-tools/typespec-azure-core";
-import {
-  SdkClient,
-  SdkContext,
-  listOperationGroups,
-  listOperationsInOperationGroup,
-} from "@azure-tools/typespec-client-generator-core";
 import { Operation } from "@typespec/compiler";
 import { Version } from "@typespec/versioning";
-import { getAccess } from "./type-utils.js";
 
 export class ClientContext {
   baseUri: string;
@@ -57,32 +49,5 @@ export class ClientContext {
       }
     }
     return addedVersions;
-  }
-
-  preProcessOperations(sdkContext: SdkContext, client: SdkClient) {
-    const operationGroups = listOperationGroups(sdkContext, client);
-    const operations = listOperationsInOperationGroup(sdkContext, client);
-    for (const operation of operations) {
-      const opLink = getOperationLink(sdkContext.program, operation, "polling");
-      if (opLink && opLink.linkedOperation) {
-        const access = getAccess(opLink.linkedOperation);
-        if (access !== "public") {
-          this.ignoredOperations.add(opLink.linkedOperation);
-        }
-      }
-    }
-
-    for (const operationGroup of operationGroups) {
-      const operations = listOperationsInOperationGroup(sdkContext, operationGroup);
-      for (const operation of operations) {
-        const opLink = getOperationLink(sdkContext.program, operation, "polling");
-        if (opLink && opLink.linkedOperation) {
-          const access = getAccess(opLink.linkedOperation);
-          if (access !== "public") {
-            this.ignoredOperations.add(opLink.linkedOperation);
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
1. basic logic is that if there is not access/usage decorator on model, check the decorator on its parent
2. a cache is put so that one namespace is only checked once (`undefined` is also included as a result) <-- it is just performance

There is a corner case that

```ts
@usage(Usage.input)
namespace L1 {
  @usage(Usage.output)
  namespace L2 {
    model M {}
  }
}
```
that in some interpretation M may be input+output. But TCGC and the logic in PR both gives output. I guess this be OK.

Local test (as TCGC seems not able to handle my case in cadl-ranch, that models is defined in a sub namespace)
```
@supportedBy("dpg")
@scenarioService("/client/initialization")
@access(Access.public)
@usage(Usage.output)
namespace Client.AccessTest;

// public output
model OutputModel {
  name: string;
}

// public output
model OutputModel2 {
  name: string;
}

// internal input+output
@access(Access.internal)
@usage(Usage.input | Usage.output)
model Model3 {
  name: string;
}

@access(Access.internal)
namespace InternalOperations {
// internal
  op get(): OutputModel;
}
```