### PR TITLE
Use shell for execution of .cmd (tsp-server.cmd)

### DIFF
--- a/.chronus/changes/use-shell-for-cmd-2024-8-13-11-39-59.md
+++ b/.chronus/changes/use-shell-for-cmd-2024-8-13-11-39-59.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - typespec-vscode
+---
+
+Use shell execution for spawn execution for .cmd file(i.e. tsp-server) in windows

--- a/.chronus/changes/use-shell-for-cmd-2024-8-13-11-39-59.md
+++ b/.chronus/changes/use-shell-for-cmd-2024-8-13-11-39-59.md
@@ -4,4 +4,4 @@ packages:
   - typespec-vscode
 ---
 
-Use shell execution for spawn execution for .cmd file(i.e. tsp-server) in windows
+Use "shell" when spawning execution of .cmd file(i.e. tsp-server.cmd) in windows

--- a/packages/typespec-vscode/src/extension.ts
+++ b/packages/typespec-vscode/src/extension.ts
@@ -10,7 +10,7 @@ import {
 } from "vscode-languageclient/node.js";
 import logger from "./extension-logger.js";
 import { TypeSpecLogOutputChannel } from "./typespec-log-output-channel.js";
-import { normalizeSlash } from "./utils.js";
+import { normalizeSlash, useShellInExec } from "./utils.js";
 
 let client: LanguageClient | undefined;
 /**
@@ -233,7 +233,7 @@ async function resolveTypeSpecCli(absoluteTargetPath: string): Promise<Executabl
     logger.debug(
       `Can't resolve compiler path for tsp task, try to use default value ${executable}.`
     );
-    return { command: executable, args: [], options };
+    return useShellInExec({ command: executable, args: [], options });
   } else {
     logger.debug(`Compiler path resolved as: ${compilerPath}`);
     const jsPath = join(compilerPath, "cmd/tsp.js");
@@ -281,7 +281,7 @@ async function resolveTypeSpecServer(context: ExtensionContext): Promise<Executa
   if (!serverPath) {
     const executable = process.platform === "win32" ? "tsp-server.cmd" : "tsp-server";
     logger.debug(`Can't resolve server path, try to use default value ${executable}.`);
-    return { command: executable, args, options };
+    return useShellInExec({ command: executable, args, options });
   }
   const variableResolver = new VSCodeVariableResolver({
     workspaceFolder,
@@ -297,9 +297,9 @@ async function resolveTypeSpecServer(context: ExtensionContext): Promise<Executa
       const command =
         process.platform === "win32" && !serverPath.endsWith(".cmd")
           ? `${serverPath}.cmd`
-          : "tsp-server";
+          : serverPath;
 
-      return { command, args, options };
+      return useShellInExec({ command, args, options });
     } else {
       serverPath = join(serverPath, "cmd/tsp-server.js");
     }

--- a/packages/typespec-vscode/src/utils.ts
+++ b/packages/typespec-vscode/src/utils.ts
@@ -1,4 +1,26 @@
+import { Executable } from "vscode-languageclient/node.js";
+
 /** normalize / and \\ to / */
 export function normalizeSlash(str: string): string {
   return str.replaceAll(/\\/g, "/");
+}
+
+/**
+ *
+ * @param exe
+ * @param win32Only only use Shell when the process.platform is "win32"
+ * @returns
+ */
+export function useShellInExec(exe: Executable, win32Only: boolean = true): Executable {
+  if (!win32Only || process.platform === "win32") {
+    if (exe.options) {
+      exe.options.shell = true;
+    } else {
+      exe.options = { shell: true };
+    }
+    if (exe.command.includes(" ")) {
+      exe.command = `"${exe.command}"`;
+    }
+  }
+  return exe;
 }


### PR DESCRIPTION
fixes #4343. shell needs to be used for executing .cmd file in newer nodejs version (a breaking change from nodejs security release). more detail can be found in the issue.