### PR TITLE
java mgmt, skip validate on resource properties

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ModelTemplate.java
@@ -45,11 +45,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1052,7 +1050,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         comment.methodThrows("IllegalArgumentException", "thrown if the instance is not valid");
       });
 
-      if (this.parentModelHasValidate(model.getParentModelName())) {
+      if (this.modelHasValidate(model.getParentModelName())) {
         classBlock.annotation("Override");
       }
       classBlock.publicMethod("void validate()", methodBlock -> {
@@ -1090,7 +1088,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
    * @return whether to call validate() on parent model
    */
   protected boolean callParentValidate(String parentModelName) {
-    return parentModelHasValidate(parentModelName);
+    return modelHasValidate(parentModelName);
   }
 
   /**
@@ -1114,13 +1112,13 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
   }
 
   /**
-   * Extension for validation on parent model.
+   * Extension for validation on model.
    *
-   * @param parentModelName the parent model name
-   * @return Whether validate() exists in parent model.
+   * @param modelName the model name
+   * @return Whether validate() exists in this model.
    */
-  protected boolean parentModelHasValidate(String parentModelName) {
-    return parentModelName != null;
+  protected boolean modelHasValidate(String modelName) {
+    return modelName != null;
   }
 
   /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/StreamSerializationModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/StreamSerializationModelTemplate.java
@@ -7,7 +7,6 @@ import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSe
 import com.microsoft.typespec.http.client.generator.core.implementation.ClientModelPropertiesManager;
 import com.microsoft.typespec.http.client.generator.core.implementation.ClientModelPropertyWithMetadata;
 import com.microsoft.typespec.http.client.generator.core.implementation.JsonFlattenedPropertiesTree;
-import com.microsoft.typespec.http.client.generator.core.mapper.ModelMapper;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModel;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModelProperty;
@@ -350,7 +349,9 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
   @Override
   protected List<ClientModelProperty> getValidationProperties(ClientModel model) {
     // in stream-style-serialization, since there are shadowing involved, we validate all properties locally
-    return Stream.concat(model.getProperties().stream(), ClientModelUtil.getParentProperties(model).stream())
+    return Stream.concat(
+        model.getProperties().stream(),
+        ClientModelUtil.getParentProperties(model, m -> modelHasValidate(m.getName())).stream())
       .collect(Collectors.toList());
   }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ClientModelUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ClientModelUtil.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -488,18 +489,43 @@ public class ClientModelUtil {
    * Gets all parent properties.
    *
    * @param model The client model.
+   * @param modelFilter Filter parent models.
+   * @return Returns all properties that are defined by super types of the client model.
+   */
+  public static List<ClientModelProperty> getParentProperties(ClientModel model, Predicate<ClientModel> modelFilter) {
+    return getParentProperties(model, true, modelFilter);
+  }
+
+  /**
+   * Gets all parent properties.
+   *
+   * @param model The client model.
    * @param parentPropertiesFirst whether parent properties are in the front of the return list
    * @return Returns all properties that are defined by super types of the client model.
    */
   public static List<ClientModelProperty> getParentProperties(ClientModel model, boolean parentPropertiesFirst) {
+    return getParentProperties(model, parentPropertiesFirst, m -> true);
+  }
+
+  /**
+   * Gets all parent properties.
+   *
+   * @param model The client model.
+   * @param parentPropertiesFirst whether parent properties are in the front of the return list
+   * @param modelFilter Filter parent models.
+   * @return Returns all properties that are defined by super types of the client model.
+   */
+  public static List<ClientModelProperty> getParentProperties(ClientModel model, boolean parentPropertiesFirst, Predicate<ClientModel> modelFilter) {
     String lastParentName = model.getName();
     ClientModel parentModel = getClientModel(model.getParentModelName());
     List<ClientModelProperty> parentProperties = new ArrayList<>();
     while (parentModel != null && !lastParentName.equals(parentModel.getName())) {
-      // Add the properties in inverse order as they be reverse at the end.
-      List<ClientModelProperty> parentProps = new ArrayList<>(parentModel.getProperties());
-      for (int i = parentProps.size() - 1; i >= 0; i--) {
-        parentProperties.add(parentProps.get(i));
+      if (modelFilter == null || modelFilter.test(parentModel)) {
+        // Add the properties in inverse order as they be reverse at the end.
+        List<ClientModelProperty> parentProps = new ArrayList<>(parentModel.getProperties());
+        for (int i = parentProps.size() - 1; i >= 0; i--) {
+          parentProperties.add(parentProps.get(i));
+        }
       }
 
       lastParentName = parentModel.getName();

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentModelTemplate.java
@@ -63,10 +63,10 @@ public class FluentModelTemplate extends ModelTemplate {
     }
 
     @Override
-    protected boolean parentModelHasValidate(String parentModelName) {
-        return parentModelName != null
-            && FluentType.nonResourceType(parentModelName)
-            && FluentType.nonManagementError(parentModelName);
+    protected boolean modelHasValidate(String modelName) {
+        return modelName != null
+            && FluentType.nonResourceType(modelName)
+            && FluentType.nonManagementError(modelName);
     }
 
     @Override

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentStreamStyleSerializationModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentStreamStyleSerializationModelTemplate.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.mgmt.template;
 
-import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
 import com.microsoft.typespec.http.client.generator.mgmt.model.arm.ErrorClientModel;
 import com.microsoft.typespec.http.client.generator.mgmt.util.FluentUtils;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModel;
@@ -27,8 +26,8 @@ public class FluentStreamStyleSerializationModelTemplate extends StreamSerializa
     }
 
     @Override
-    protected boolean parentModelHasValidate(String parentModelName) {
-        return FLUENT_MODEL_TEMPLATE.parentModelHasValidate(parentModelName);
+    protected boolean modelHasValidate(String modelName) {
+        return FLUENT_MODEL_TEMPLATE.modelHasValidate(modelName);
     }
 
     @Override

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/commontypes/managedidentity/fluent/models/ManagedIdentityTrackedResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/commontypes/managedidentity/fluent/models/ManagedIdentityTrackedResourceInner.java
@@ -7,7 +7,6 @@ package com.azure.resourcemanager.models.commontypes.managedidentity.fluent.mode
 import com.azure.core.annotation.Fluent;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
-import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -166,14 +165,7 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
         if (identity() != null) {
             identity().validate();
         }
-        if (location() == null) {
-            throw LOGGER.atError()
-                .log(new IllegalArgumentException(
-                    "Missing required property location in model ManagedIdentityTrackedResourceInner"));
-        }
     }
-
-    private static final ClientLogger LOGGER = new ClientLogger(ManagedIdentityTrackedResourceInner.class);
 
     /**
      * {@inheritDoc}

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/SingletonTrackedResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/SingletonTrackedResourceInner.java
@@ -7,7 +7,6 @@ package com.azure.resourcemanager.models.resources.fluent.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
-import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -137,14 +136,7 @@ public final class SingletonTrackedResourceInner extends Resource {
         if (properties() != null) {
             properties().validate();
         }
-        if (location() == null) {
-            throw LOGGER.atError()
-                .log(new IllegalArgumentException(
-                    "Missing required property location in model SingletonTrackedResourceInner"));
-        }
     }
-
-    private static final ClientLogger LOGGER = new ClientLogger(SingletonTrackedResourceInner.class);
 
     /**
      * {@inheritDoc}

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/TopLevelTrackedResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/fluent/models/TopLevelTrackedResourceInner.java
@@ -7,7 +7,6 @@ package com.azure.resourcemanager.models.resources.fluent.models;
 import com.azure.core.annotation.Fluent;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
-import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -137,14 +136,7 @@ public final class TopLevelTrackedResourceInner extends Resource {
         if (properties() != null) {
             properties().validate();
         }
-        if (location() == null) {
-            throw LOGGER.atError()
-                .log(new IllegalArgumentException(
-                    "Missing required property location in model TopLevelTrackedResourceInner"));
-        }
     }
-
-    private static final ClientLogger LOGGER = new ClientLogger(TopLevelTrackedResourceInner.class);
 
     /**
      * {@inheritDoc}

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/TopLevelArmResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armstreamstyleserialization/fluent/models/TopLevelArmResourceInner.java
@@ -7,7 +7,6 @@ package com.cadl.armstreamstyleserialization.fluent.models;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
-import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -108,14 +107,7 @@ public final class TopLevelArmResourceInner extends Resource {
         if (properties() != null) {
             properties().validate();
         }
-        if (location() == null) {
-            throw LOGGER.atError()
-                .log(new IllegalArgumentException(
-                    "Missing required property location in model TopLevelArmResourceInner"));
-        }
     }
-
-    private static final ClientLogger LOGGER = new ClientLogger(TopLevelArmResourceInner.class);
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
If parent model doesn't have validate() method on it, don't validate parent model's properties.
Specially for `Resource`'s `location` property. 