### PR TITLE
Fix the cleanup of file cache in server

### DIFF
--- a/.chronus/changes/fix-server-file-cache-2024-8-18-11-4-8.md
+++ b/.chronus/changes/fix-server-file-cache-2024-8-18-11-4-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Changing tspconfig.yaml won't take effect in LSP server because of the cache

--- a/packages/compiler/src/server/file-system-cache.ts
+++ b/packages/compiler/src/server/file-system-cache.ts
@@ -72,8 +72,8 @@ export function createFileSystemCache({
         entry.data = data;
       }
     },
-    notify(changes: FileEvent[]) {
-      changes.push(...changes);
+    notify(events: FileEvent[]) {
+      changes.push(...events);
     },
   };
 }


### PR DESCRIPTION
Fix #4278 , without the cleanup, editing tspconfig.yaml won't take effect in LSP server