### PR TITLE
Align the peer dependency with dependency for http-client-csharp

### DIFF
--- a/packages/http-client-csharp/package-lock.json
+++ b/packages/http-client-csharp/package-lock.json
@@ -34,13 +34,13 @@
         "vitest": "^1.4.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
-        "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-        "@typespec/http": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-        "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-        "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-        "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0"
+        "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.47.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.47.0-0",
+        "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+        "@typespec/http": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+        "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+        "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+        "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.61.0-0"
       }
     },
     "../http-client-csharp-generator/artifacts/bin/Microsoft.Generator.CSharp.ClientModel/Debug/net8.0": {

--- a/packages/http-client-csharp/package-lock.json
+++ b/packages/http-client-csharp/package-lock.json
@@ -34,13 +34,13 @@
         "vitest": "^1.4.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
-        "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-        "@typespec/http": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-        "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-        "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-        "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0"
+        "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
+        "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+        "@typespec/http": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+        "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+        "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+        "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0"
       }
     },
     "../http-client-csharp-generator/artifacts/bin/Microsoft.Generator.CSharp.ClientModel/Debug/net8.0": {

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -46,13 +46,13 @@
     "json-serialize-refs": "0.1.0-0"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
-    "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
-    "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-    "@typespec/http": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-    "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-    "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
-    "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0"
+    "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.47.0-0",
+    "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.47.0-0",
+    "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/http": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.61.0-0"
   },
   "devDependencies": {
     "@azure-tools/cadl-ranch": "0.14.5",

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -46,13 +46,13 @@
     "json-serialize-refs": "0.1.0-0"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.47.0-0",
-    "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.47.0-0",
-    "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.61.0-0",
-    "@typespec/http": ">=0.58.0 <1.0.0 || ~0.61.0-0",
-    "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.61.0-0",
-    "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.61.0-0",
-    "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.61.0-0"
+    "@azure-tools/typespec-azure-core": ">=0.46.0 <1.0.0 || ~0.47.0-0",
+    "@azure-tools/typespec-client-generator-core": ">=0.46.0 <1.0.0 || ~0.47.0-0",
+    "@typespec/compiler": ">=0.60.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/http": ">=0.60.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/openapi": ">=0.60.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/rest": ">=0.60.0 <1.0.0 || ~0.61.0-0",
+    "@typespec/versioning": ">=0.60.0 <1.0.0 || ~0.61.0-0"
   },
   "devDependencies": {
     "@azure-tools/cadl-ranch": "0.14.5",

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -46,13 +46,13 @@
     "json-serialize-refs": "0.1.0-0"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
-    "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
-    "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/http": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
-    "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0"
+    "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
+    "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.46.0-0 || ~0.47.0-0",
+    "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+    "@typespec/http": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+    "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+    "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0",
+    "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.60.0-0 || ~0.61.0-0"
   },
   "devDependencies": {
     "@azure-tools/cadl-ranch": "0.14.5",


### PR DESCRIPTION
As titled. Otherwise the typespec next pipeline will fail at `npm list` stage like [this](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4155411&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=164b9cb9-850d-5194-a052-63f5151be232&l=189).