### PR TITLE
http-client-java, emitter, deprecate description and details

### DIFF
--- a/packages/http-client-java/Setup.ps1
+++ b/packages/http-client-java/Setup.ps1
@@ -1,5 +1,4 @@
 # re-build http-client-java
 npm install 
 npm run clean && npm run build
-npm run lint
 npm pack

--- a/packages/http-client-java/Setup.ps1
+++ b/packages/http-client-java/Setup.ps1
@@ -1,4 +1,5 @@
 # re-build http-client-java
 npm install 
 npm run clean && npm run build
+npm run lint
 npm pack

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -280,7 +280,7 @@ export class CodeModelBuilder {
         this.trackSchemaUsage(schema, {
           usage: [SchemaContext.Input, SchemaContext.Output /*SchemaContext.Public*/],
         });
-        parameter = new Parameter(arg.name, arg.description ?? "", schema, {
+        parameter = new Parameter(arg.name, arg.doc ?? "", schema, {
           implementation: ImplementationLocation.Client,
           origin: "modelerfour:synthesized/host",
           required: true,
@@ -496,8 +496,8 @@ export class CodeModelBuilder {
         javaNamespace = this.getJavaNamespace(this.namespace + "." + clientSubNamespace);
       }
 
-      const codeModelClient = new CodeModelClient(clientName, client.details ?? "", {
-        summary: client.description,
+      const codeModelClient = new CodeModelClient(clientName, client.doc ?? "", {
+        summary: client.summary,
         language: {
           default: {
             namespace: this.namespace,
@@ -759,9 +759,9 @@ export class CodeModelBuilder {
 
     const operationExamples = this.getOperationExample(sdkMethod);
 
-    const codeModelOperation = new CodeModelOperation(operationName, sdkMethod.details ?? "", {
+    const codeModelOperation = new CodeModelOperation(operationName, sdkMethod.doc ?? "", {
       operationId: operationId,
-      summary: sdkMethod.description,
+      summary: sdkMethod.summary,
       extensions: {
         "x-ms-examples": operationExamples,
       },
@@ -1166,8 +1166,8 @@ export class CodeModelBuilder {
         param.correspondingMethodParams[0].onClient;
 
       const nullable = param.type.kind === "nullable";
-      const parameter = new Parameter(param.name, param.details ?? "", schema, {
-        summary: param.description,
+      const parameter = new Parameter(param.name, param.doc ?? "", schema, {
+        summary: param.summary,
         implementation: parameterOnClient
           ? ImplementationLocation.Client
           : ImplementationLocation.Method,
@@ -1365,8 +1365,8 @@ export class CodeModelBuilder {
     }
 
     const parameterName = sdkBody.name;
-    const parameter = new Parameter(parameterName, sdkBody.description ?? "", schema, {
-      summary: sdkBody.details,
+    const parameter = new Parameter(parameterName, sdkBody.doc ?? "", schema, {
+      summary: sdkBody.summary,
       implementation: ImplementationLocation.Method,
       required: !sdkBody.optional,
       protocol: {
@@ -1625,7 +1625,7 @@ export class CodeModelBuilder {
             language: {
               default: {
                 name: header.serializedName,
-                description: header.description ?? header.details,
+                description: header.summary ?? header.doc,
               },
             },
           }),
@@ -1831,8 +1831,8 @@ export class CodeModelBuilder {
 
   private processStringSchema(type: SdkBuiltInType, name: string): StringSchema {
     return this.codeModel.schemas.add(
-      new StringSchema(name, type.details ?? "", {
-        summary: type.description,
+      new StringSchema(name, type.doc ?? "", {
+        summary: type.summary,
       }),
     );
   }
@@ -1840,8 +1840,8 @@ export class CodeModelBuilder {
   private processByteArraySchema(type: SdkBuiltInType, name: string): ByteArraySchema {
     const base64Encoded: boolean = type.encode === "base64url";
     return this.codeModel.schemas.add(
-      new ByteArraySchema(name, type.details ?? "", {
-        summary: type.description,
+      new ByteArraySchema(name, type.doc ?? "", {
+        summary: type.summary,
         format: base64Encoded ? "base64url" : "byte",
       }),
     );
@@ -1852,8 +1852,8 @@ export class CodeModelBuilder {
     name: string,
     precision: number,
   ): NumberSchema {
-    const schema = new NumberSchema(name, type.details ?? "", SchemaType.Integer, precision, {
-      summary: type.description,
+    const schema = new NumberSchema(name, type.doc ?? "", SchemaType.Integer, precision, {
+      summary: type.summary,
     });
     if (type.encode === "string") {
       (schema as EncodedSchema).encode = type.encode;
@@ -1863,8 +1863,8 @@ export class CodeModelBuilder {
 
   private processNumberSchema(type: SdkBuiltInType, name: string): NumberSchema {
     return this.codeModel.schemas.add(
-      new NumberSchema(name, type.details ?? "", SchemaType.Number, 64, {
-        summary: type.description,
+      new NumberSchema(name, type.doc ?? "", SchemaType.Number, 64, {
+        summary: type.summary,
       }),
     );
   }
@@ -1872,16 +1872,16 @@ export class CodeModelBuilder {
   private processDecimalSchema(type: SdkBuiltInType, name: string): NumberSchema {
     // "Infinity" maps to "BigDecimal" in Java
     return this.codeModel.schemas.add(
-      new NumberSchema(name, type.details ?? "", SchemaType.Number, Infinity, {
-        summary: type.description,
+      new NumberSchema(name, type.doc ?? "", SchemaType.Number, Infinity, {
+        summary: type.summary,
       }),
     );
   }
 
   private processBooleanSchema(type: SdkBuiltInType, name: string): BooleanSchema {
     return this.codeModel.schemas.add(
-      new BooleanSchema(name, type.details ?? "", {
-        summary: type.description,
+      new BooleanSchema(name, type.doc ?? "", {
+        summary: type.summary,
       }),
     );
   }
@@ -1896,16 +1896,16 @@ export class CodeModelBuilder {
 
     const elementSchema = this.processSchema(elementType, name);
     return this.codeModel.schemas.add(
-      new ArraySchema(name, type.details ?? "", elementSchema, {
-        summary: type.description,
+      new ArraySchema(name, type.doc ?? "", elementSchema, {
+        summary: type.summary,
         nullableItems: nullableItems,
       }),
     );
   }
 
   private processDictionarySchema(type: SdkDictionaryType, name: string): DictionarySchema {
-    const dictSchema = new DictionarySchema<any>(name, type.details ?? "", null, {
-      summary: type.description,
+    const dictSchema = new DictionarySchema<any>(name, type.doc ?? "", null, {
+      summary: type.summary,
     });
 
     // cache this now before we accidentally recurse on this type.
@@ -1937,13 +1937,13 @@ export class CodeModelBuilder {
 
     const choices: ChoiceValue[] = [];
     type.values.forEach((it: SdkEnumValueType) =>
-      choices.push(new ChoiceValue(it.name, it.description ?? "", it.value ?? it.name)),
+      choices.push(new ChoiceValue(it.name, it.doc ?? "", it.value ?? it.name)),
     );
 
     const schemaType = type.isFixed ? SealedChoiceSchema : ChoiceSchema;
 
-    const schema = new schemaType(type.name ?? name, type.details ?? "", {
-      summary: type.description,
+    const schema = new schemaType(type.name ?? name, type.doc ?? "", {
+      summary: type.summary,
       choiceType: valueType as any,
       choices: choices,
       language: {
@@ -1963,8 +1963,8 @@ export class CodeModelBuilder {
     const valueType = this.processSchema(type.valueType, type.valueType.kind);
 
     return this.codeModel.schemas.add(
-      new ConstantSchema(type.name ?? name, type.details ?? "", {
-        summary: type.description,
+      new ConstantSchema(type.name ?? name, type.doc ?? "", {
+        summary: type.summary,
         valueType: valueType,
         value: new ConstantValue(type.value),
       }),
@@ -1975,8 +1975,8 @@ export class CodeModelBuilder {
     const valueType = this.processSchema(type.enumType, type.enumType.name);
 
     return this.codeModel.schemas.add(
-      new ConstantSchema(type.name ?? name, type.details ?? "", {
-        summary: type.description,
+      new ConstantSchema(type.name ?? name, type.doc ?? "", {
+        summary: type.summary,
         valueType: valueType,
         value: new ConstantValue(type.value ?? type.name),
       }),
@@ -1985,8 +1985,8 @@ export class CodeModelBuilder {
 
   private processUnixTimeSchema(type: SdkDateTimeType, name: string): UnixTimeSchema {
     return this.codeModel.schemas.add(
-      new UnixTimeSchema(name, type.details ?? "", {
-        summary: type.description,
+      new UnixTimeSchema(name, type.doc ?? "", {
+        summary: type.summary,
       }),
     );
   }
@@ -1997,8 +1997,8 @@ export class CodeModelBuilder {
     rfc1123: boolean,
   ): DateTimeSchema {
     return this.codeModel.schemas.add(
-      new DateTimeSchema(name, type.details ?? "", {
-        summary: type.description,
+      new DateTimeSchema(name, type.doc ?? "", {
+        summary: type.summary,
         format: rfc1123 ? "date-time-rfc1123" : "date-time",
       }),
     );
@@ -2006,16 +2006,16 @@ export class CodeModelBuilder {
 
   private processDateSchema(type: SdkBuiltInType, name: string): DateSchema {
     return this.codeModel.schemas.add(
-      new DateSchema(name, type.details ?? "", {
-        summary: type.description,
+      new DateSchema(name, type.doc ?? "", {
+        summary: type.summary,
       }),
     );
   }
 
   private processTimeSchema(type: SdkBuiltInType, name: string): TimeSchema {
     return this.codeModel.schemas.add(
-      new TimeSchema(name, type.details ?? "", {
-        summary: type.description,
+      new TimeSchema(name, type.doc ?? "", {
+        summary: type.summary,
       }),
     );
   }
@@ -2026,8 +2026,8 @@ export class CodeModelBuilder {
     format: DurationSchema["format"] = "duration-rfc3339",
   ): DurationSchema {
     return this.codeModel.schemas.add(
-      new DurationSchema(name, type.details ?? "", {
-        summary: type.description,
+      new DurationSchema(name, type.doc ?? "", {
+        summary: type.summary,
         format: format,
       }),
     );
@@ -2035,8 +2035,8 @@ export class CodeModelBuilder {
 
   private processUrlSchema(type: SdkBuiltInType, name: string): UriSchema {
     return this.codeModel.schemas.add(
-      new UriSchema(name, type.details ?? "", {
-        summary: type.description,
+      new UriSchema(name, type.doc ?? "", {
+        summary: type.summary,
       }),
     );
   }
@@ -2044,8 +2044,8 @@ export class CodeModelBuilder {
   private processObjectSchema(type: SdkModelType, name: string): ObjectSchema {
     const rawModelType = type.__raw;
     const namespace = getNamespace(rawModelType);
-    const objectSchema = new ObjectSchema(name, type.details ?? "", {
-      summary: type.description,
+    const objectSchema = new ObjectSchema(name, type.doc ?? "", {
+      summary: type.summary,
       language: {
         default: {
           namespace: namespace,
@@ -2111,7 +2111,7 @@ export class CodeModelBuilder {
           name: "string",
           crossLanguageDefinitionId: type.crossLanguageDefinitionId,
         },
-        description: type.description,
+        description: type.doc,
         valueType: type.additionalProperties,
         decorators: [],
       };
@@ -2196,8 +2196,8 @@ export class CodeModelBuilder {
       schema = this.processSchema(nonNullType, "");
     }
 
-    return new Property(prop.name, prop.details ?? "", schema, {
-      summary: prop.description,
+    return new Property(prop.name, prop.doc ?? "", schema, {
+      summary: prop.summary,
       required: !prop.optional,
       nullable: nullable,
       readOnly: this.isReadOnly(prop),
@@ -2216,8 +2216,8 @@ export class CodeModelBuilder {
     this.logWarning(
       `Convert TypeSpec Union '${getUnionDescription(rawUnionType, this.typeNameOptions)}' to Class '${baseName}'`,
     );
-    const unionSchema = new OrSchema(baseName + "Base", type.details ?? "", {
-      summary: type.description,
+    const unionSchema = new OrSchema(baseName + "Base", type.doc ?? "", {
+      summary: type.summary,
     });
     unionSchema.anyOf = [];
     type.variantTypes.forEach((it) => {
@@ -2226,8 +2226,8 @@ export class CodeModelBuilder {
       const propertyName = "value";
 
       // these ObjectSchema is not added to codeModel.schemas
-      const objectSchema = new ObjectSchema(modelName, it.details ?? "", {
-        summary: it.description,
+      const objectSchema = new ObjectSchema(modelName, it.doc ?? "", {
+        summary: it.summary,
         language: {
           default: {
             namespace: namespace,
@@ -2240,8 +2240,8 @@ export class CodeModelBuilder {
 
       const variantSchema = this.processSchema(it, variantName);
       objectSchema.addProperty(
-        new Property(propertyName, type.details ?? "", variantSchema, {
-          summary: type.description,
+        new Property(propertyName, type.doc ?? "", variantSchema, {
+          summary: type.summary,
           required: true,
           readOnly: false,
         }),
@@ -2253,8 +2253,8 @@ export class CodeModelBuilder {
 
   private processBinarySchema(type: SdkBuiltInType): BinarySchema {
     return this.codeModel.schemas.add(
-      new BinarySchema(type.description ?? "", {
-        summary: type.details,
+      new BinarySchema(type.doc ?? "", {
+        summary: type.summary,
       }),
     );
   }
@@ -2352,7 +2352,7 @@ export class CodeModelBuilder {
           processSchemaFunc,
         ),
         {
-          summary: property.description,
+          summary: property.summary,
         },
       );
     } else {
@@ -2589,7 +2589,7 @@ export class CodeModelBuilder {
 
   private subscriptionIdParameter(parameter: SdkPathParameter): Parameter {
     if (!this._subscriptionParameter) {
-      const description = parameter.description;
+      const description = parameter.doc;
       this._subscriptionParameter = new Parameter(
         "subscriptionId",
         description ? description : "The ID of the target subscription.",

--- a/packages/http-client-java/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Build-Packages.ps1
@@ -74,6 +74,9 @@ try {
 
     Invoke-LoggedCommand "npm run build" -GroupOutput
 
+    # linting
+    Invoke-LoggedCommand "npm run build" -GroupOutput
+
     #pack the emitter
     $file = Invoke-LoggedCommand "npm pack -q"
     Copy-Item $file -Destination "$outputPath/packages"

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/_specs_/azure/core/page/implementation/PageClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/_specs_/azure/core/page/implementation/PageClientImpl.java
@@ -814,8 +814,6 @@ public final class PageClientImpl {
     }
 
     /**
-     * List with Azure.Core.Page&lt;&gt;.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -856,8 +854,6 @@ public final class PageClientImpl {
     }
 
     /**
-     * List with Azure.Core.Page&lt;&gt;.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -896,8 +892,6 @@ public final class PageClientImpl {
     }
 
     /**
-     * List with extensible enum parameter Azure.Core.Page&lt;&gt;.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -937,8 +931,6 @@ public final class PageClientImpl {
     }
 
     /**
-     * List with extensible enum parameter Azure.Core.Page&lt;&gt;.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -977,8 +969,6 @@ public final class PageClientImpl {
     }
 
     /**
-     * List with custom page model.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -1019,8 +1009,6 @@ public final class PageClientImpl {
     }
 
     /**
-     * List with custom page model.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/_specs_/azure/core/page/implementation/TwoModelsAsPageItemsImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/_specs_/azure/core/page/implementation/TwoModelsAsPageItemsImpl.java
@@ -394,9 +394,6 @@ public final class TwoModelsAsPageItemsImpl {
     }
 
     /**
-     * Two operations with two different page item types should be successfully generated. Should generate model for
-     * FirstItem.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -428,9 +425,6 @@ public final class TwoModelsAsPageItemsImpl {
     }
 
     /**
-     * Two operations with two different page item types should be successfully generated. Should generate model for
-     * FirstItem.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -460,9 +454,6 @@ public final class TwoModelsAsPageItemsImpl {
     }
 
     /**
-     * Two operations with two different page item types should be successfully generated. Should generate model for
-     * SecondItem.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -494,9 +485,6 @@ public final class TwoModelsAsPageItemsImpl {
     }
 
     /**
-     * Two operations with two different page item types should be successfully generated. Should generate model for
-     * SecondItem.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/implementation/NestedProxyResourcesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/implementation/NestedProxyResourcesClientImpl.java
@@ -1198,8 +1198,6 @@ public final class NestedProxyResourcesClientImpl implements NestedProxyResource
     }
 
     /**
-     * List NestedProxyResource resources by TopLevelTrackedResource
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1228,8 +1226,6 @@ public final class NestedProxyResourcesClientImpl implements NestedProxyResource
     }
 
     /**
-     * List NestedProxyResource resources by TopLevelTrackedResource
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/implementation/SingletonTrackedResourcesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/implementation/SingletonTrackedResourcesClientImpl.java
@@ -707,8 +707,6 @@ public final class SingletonTrackedResourcesClientImpl implements SingletonTrack
     }
 
     /**
-     * List SingletonTrackedResource resources by resource group
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -737,8 +735,6 @@ public final class SingletonTrackedResourcesClientImpl implements SingletonTrack
     }
 
     /**
-     * List SingletonTrackedResource resources by resource group
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/implementation/TopLevelTrackedResourcesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/azure/resourcemanager/models/resources/implementation/TopLevelTrackedResourcesClientImpl.java
@@ -1369,8 +1369,6 @@ public final class TopLevelTrackedResourcesClientImpl implements TopLevelTracked
     }
 
     /**
-     * List TopLevelTrackedResource resources by resource group
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1399,8 +1397,6 @@ public final class TopLevelTrackedResourcesClientImpl implements TopLevelTracked
     }
 
     /**
-     * List TopLevelTrackedResource resources by resource group
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1429,8 +1425,6 @@ public final class TopLevelTrackedResourcesClientImpl implements TopLevelTracked
     }
 
     /**
-     * List TopLevelTrackedResource resources by subscription ID
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1459,8 +1453,6 @@ public final class TopLevelTrackedResourcesClientImpl implements TopLevelTracked
     }
 
     /**
-     * List TopLevelTrackedResource resources by subscription ID
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/ChildExtensionResourceInterfacesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/ChildExtensionResourceInterfacesClientImpl.java
@@ -1025,8 +1025,6 @@ public final class ChildExtensionResourceInterfacesClientImpl implements ChildEx
     }
 
     /**
-     * List ChildExtensionResource resources by TopLevelArmResource
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1056,8 +1054,6 @@ public final class ChildExtensionResourceInterfacesClientImpl implements ChildEx
     }
 
     /**
-     * List ChildExtensionResource resources by TopLevelArmResource
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/ChildResourcesInterfacesClientImpl.java
@@ -1315,8 +1315,6 @@ public final class ChildResourcesInterfacesClientImpl implements ChildResourcesI
     }
 
     /**
-     * List ChildResource resources by TopLevelArmResource
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1345,8 +1343,6 @@ public final class ChildResourcesInterfacesClientImpl implements ChildResourcesI
     }
 
     /**
-     * List ChildResource resources by TopLevelArmResource
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/OperationsClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/OperationsClientImpl.java
@@ -181,8 +181,6 @@ public final class OperationsClientImpl implements OperationsClient {
     }
 
     /**
-     * List the operations for the provider
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -209,8 +207,6 @@ public final class OperationsClientImpl implements OperationsClient {
     }
 
     /**
-     * List the operations for the provider
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/TopLevelArmResourceInterfacesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/armresourceprovider/implementation/TopLevelArmResourceInterfacesClientImpl.java
@@ -1322,8 +1322,6 @@ public final class TopLevelArmResourceInterfacesClientImpl implements TopLevelAr
     }
 
     /**
-     * List TopLevelArmResource resources by resource group
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1352,8 +1350,6 @@ public final class TopLevelArmResourceInterfacesClientImpl implements TopLevelAr
     }
 
     /**
-     * List TopLevelArmResource resources by resource group
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1382,8 +1378,6 @@ public final class TopLevelArmResourceInterfacesClientImpl implements TopLevelAr
     }
 
     /**
-     * List TopLevelArmResource resources by subscription ID
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.
@@ -1412,8 +1406,6 @@ public final class TopLevelArmResourceInterfacesClientImpl implements TopLevelAr
     }
 
     /**
-     * List TopLevelArmResource resources by subscription ID
-     * 
      * Get the next page of items.
      * 
      * @param nextLink The URL to get the next list of items.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/protocolandconvenient/implementation/ProtocolAndConvenienceOpsImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/protocolandconvenient/implementation/ProtocolAndConvenienceOpsImpl.java
@@ -1033,8 +1033,6 @@ public final class ProtocolAndConvenienceOpsImpl {
     }
 
     /**
-     * Paging operation
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -1068,8 +1066,6 @@ public final class ProtocolAndConvenienceOpsImpl {
     }
 
     /**
-     * Paging operation
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/specialheaders/implementation/EtagHeadersImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/specialheaders/implementation/EtagHeadersImpl.java
@@ -529,8 +529,6 @@ public final class EtagHeadersImpl {
     }
 
     /**
-     * Resource list operation template.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -565,8 +563,6 @@ public final class EtagHeadersImpl {
     }
 
     /**
-     * Resource list operation template.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/versioning/implementation/VersioningOpsImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/cadl/versioning/implementation/VersioningOpsImpl.java
@@ -933,8 +933,6 @@ public final class VersioningOpsImpl {
     }
 
     /**
-     * Resource list operation template.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -968,8 +966,6 @@ public final class VersioningOpsImpl {
     }
 
     /**
-     * Resource list operation template.
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/payload/pageable/implementation/PageableClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/payload/pageable/implementation/PageableClientImpl.java
@@ -349,8 +349,6 @@ public final class PageableClientImpl {
     }
 
     /**
-     * List users
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 
@@ -380,8 +378,6 @@ public final class PageableClientImpl {
     }
 
     /**
-     * List users
-     * 
      * Get the next page of items.
      * <p><strong>Response Body Schema</strong></p>
      * 


### PR DESCRIPTION
Fix https://github.com/microsoft/typespec/issues/4394

Code changes: 
1. deprecate `description` and `details`, use `doc` and `summary` instead.
2. add `npm run lint` in `Build-Packages.ps1`. So that deprecation warning will be thrown.


I quickly checked the generation diff. The generation diffs are in cases where the operation uses tsp template, previously, the `description` will get tempalte's doc, but now `doc` or  `summary` will not. **It only impacts impl classes**. I think it is acceptable.
eg., [code](https://github.com/microsoft/typespec/pull/4529/files#diff-71f0d715f644a82637d8db144d6d3a999b65d05a7b44bd1570306e46c2c83beeL532), below highlighted template's doc will disappear now.
```diff
  @get
  listWithEtag is StandardResourceOperations.ResourceList<
    Resource,
    ResponseHeadersTrait<EtagResponseEnvelope>
  >;

  /**
++   * Resource list operation template.
   * @template Resource Resource type.
   * @template Traits Object describing the traits of the operation.
   */
  @Foundations.Private.ensureVerb("ResourceList", "GET")
  ResourceList<
    Resource extends TypeSpec.Reflection.Model,
    Traits extends TypeSpec.Reflection.Model = {}
  > is Foundations.ResourceList<
    Resource,
    TraitProperties<Traits & InterfaceTraits, TraitLocation.Parameters, TraitContext.List>,
    Foundations.CustomPage<Resource, Traits & InterfaceTraits>,
    Traits & InterfaceTraits,
    ErrorResponse
  >;
```