### PR TITLE
No longer generate JUnit, Reactor Test, and SLF4J Simple dependencies

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/PomMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/PomMapper.java
@@ -47,15 +47,12 @@ public class PomMapper implements IMapper<Project, Pom> {
         addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.AZURE_CORE, false);
         addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes,
             Project.Dependency.AZURE_CORE_HTTP_NETTY, false);
-        addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.JUNIT_JUPITER_API,
-            true);
-        addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.JUNIT_JUPITER_ENGINE,
-            true);
+        // JUnit, Reactor Test, and SLF4J Simple no longer need to be added to generated POMs as these are now
+        // dependencies managed through azure-core-test.
         addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.AZURE_CORE_TEST,
             true);
         addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.AZURE_IDENTITY,
             true);
-        addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.SLF4J_SIMPLE, true);
 
         // merge dependencies in POM and dependencies added above
         dependencyIdentifiers.addAll(project.getPomDependencyIdentifiers()

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/projectmodel/Project.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/projectmodel/Project.java
@@ -66,15 +66,7 @@ public class Project {
         AZURE_CORE_EXPERIMENTAL("com.azure", "azure-core-experimental", "1.0.0-beta.53"),
 
         CLIENTCORE("io.clientcore", "core", "1.0.0-beta.1"),
-        CLIENTCORE_JSON("io.clientcore", "core-json", "1.0.0-beta.1"),
-
-        // external
-        JUNIT_JUPITER_API("org.junit.jupiter", "junit-jupiter-api", "5.9.3"),
-        JUNIT_JUPITER_ENGINE("org.junit.jupiter", "junit-jupiter-engine", "5.9.3"),
-        MOCKITO_CORE("org.mockito", "mockito-core", "4.11.0"),
-        BYTE_BUDDY("net.bytebuddy", "byte-buddy", "1.14.12"),
-        BYTE_BUDDY_AGENT("net.bytebuddy", "byte-buddy-agent", "1.14.12"),
-        SLF4J_SIMPLE("org.slf4j", "slf4j-simple", "1.7.36");
+        CLIENTCORE_JSON("io.clientcore", "core-json", "1.0.0-beta.1");
 
         private final String groupId;
         private final String artifactId;
@@ -104,7 +96,7 @@ public class Project {
         }
 
         public String getDependencyIdentifier() {
-            return String.format("%s:%s:%s", groupId, artifactId, version);
+            return groupId + ":" + artifactId + ":" + version;
         }
     }
 

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/mapper/FluentPomMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/mapper/FluentPomMapper.java
@@ -35,16 +35,11 @@ public class FluentPomMapper extends PomMapper {
         addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes,
             Project.Dependency.AZURE_CORE_MANAGEMENT, false);
         if (JavaSettings.getInstance().isGenerateTests()) {
+            // JUnit, Reactor Test, and SLF4J Simple no longer need to be added to generated POMs as these are now
+            // dependencies managed through azure-core-test.
             addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.AZURE_CORE_TEST,
                 true);
             addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.AZURE_IDENTITY,
-                true);
-            addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes,
-                Project.Dependency.JUNIT_JUPITER_API, true);
-            addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes,
-                Project.Dependency.JUNIT_JUPITER_ENGINE, true);
-
-            addDependencyIdentifier(dependencyIdentifiers, addedDependencyPrefixes, Project.Dependency.SLF4J_SIMPLE,
                 true);
         }
 


### PR DESCRIPTION
No longer generate JUnit, Reactor Test, and SLF4J Simple dependencies in test in POMs. These dependencies are now managed by azure-core-test and should not be added manually.