### PR TITLE
Allow to import specific file from library (#4562)

### DIFF
--- a/packages/compiler/src/core/module-resolver.ts
+++ b/packages/compiler/src/core/module-resolver.ts
@@ -158,12 +158,16 @@ export async function resolveModule(
   async function findAsNodeModule(
     name: string,
     baseDir: string,
-  ): Promise<ResolvedModule | undefined> {
+  ): Promise<ResolvedModule | ResolvedFile | undefined> {
     const dirs = getPackageCandidates(name, baseDir);
     for (const { type, path } of dirs) {
       if (type === "node_modules") {
         if (await isDirectory(host, path)) {
           const n = await loadAsDirectory(path, true);
+          if (n) return n;
+        }
+        if (await isFile(host, path)) {
+          const n = await loadAsFile(path);
           if (n) return n;
         }
       } else if (type === "self") {

--- a/packages/compiler/test/checker/imports.test.ts
+++ b/packages/compiler/test/checker/imports.test.ts
@@ -142,6 +142,41 @@ describe("compiler: imports", () => {
     ok(file, "File exists");
   });
 
+  it("import specific file from library", async () => {
+    host.addTypeSpecFile(
+      "main.tsp",
+      `
+      import "my-lib/lib/lib1.tsp";
+
+      model A { x: C }
+      `,
+    );
+    host.addTypeSpecFile(
+      "node_modules/my-lib/package.json",
+      JSON.stringify({
+        name: "my-lib",
+        tspMain: "./main.tsp",
+      }),
+    );
+    host.addTypeSpecFile(
+      "node_modules/my-lib/main.tsp",
+      `
+      import "./lib/lib1.tsp"
+      `,
+    );
+    host.addTypeSpecFile(
+      "node_modules/my-lib/lib/lib1.tsp",
+      `
+      model C { }
+      `,
+    );
+
+    await host.compile("main.tsp");
+    expectFileLoaded({ typespec: ["main.tsp", "node_modules/my-lib/lib/lib1.tsp"] });
+    const file = host.program.sourceFiles.get(resolveVirtualPath("node_modules/my-lib/lib/lib1.tsp"));
+    ok(file, "File exists");
+  });
+
   it("emit diagnostic when trying to load invalid relative file", async () => {
     host.addTypeSpecFile(
       "main.tsp",

--- a/packages/compiler/test/checker/imports.test.ts
+++ b/packages/compiler/test/checker/imports.test.ts
@@ -173,7 +173,9 @@ describe("compiler: imports", () => {
 
     await host.compile("main.tsp");
     expectFileLoaded({ typespec: ["main.tsp", "node_modules/my-lib/lib/lib1.tsp"] });
-    const file = host.program.sourceFiles.get(resolveVirtualPath("node_modules/my-lib/lib/lib1.tsp"));
+    const file = host.program.sourceFiles.get(
+      resolveVirtualPath("node_modules/my-lib/lib/lib1.tsp"),
+    );
     ok(file, "File exists");
   });
 

--- a/packages/compiler/test/server/goto-definition.test.ts
+++ b/packages/compiler/test/server/goto-definition.test.ts
@@ -70,4 +70,29 @@ describe("go to imports", () => {
       },
     ]);
   });
+
+  it("go to a specific file from library", async () => {
+    const locations = await goToDefinitionAtCursor(
+      `
+    import "┆test-lib/lib/lib1.tsp";
+  `,
+      {
+        "node_modules/test-lib/package.json": JSON.stringify({
+          name: "test-lib",
+          tspMain: "./main.tsp",
+        }),
+        "node_modules/test-lib/main.tsp": `import "./lib/lib1.tsp";`,
+        "node_modules/test-lib/lib/lib1.tsp": "model Other1 {}",
+      },
+    );
+    expect(locations).toEqual([
+      {
+        range: {
+          end: { character: 0, line: 0 },
+          start: { character: 0, line: 0 },
+        },
+        uri: resolveVirtualPathUri("node_modules/test-lib/lib/lib1.tsp"),
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Related issue
#4562 

## Description

This PR provides a more selective way to import files from libraries in TypeSpec. The current mechanism only allows importing the main.tsp file from a library, resulting in unnecessary entities being bundled into the output schema, leading to bloated schemas and reduced efficiency in language services.

Developers can now import specific files from libraries, allowing for greater granularity and flexibility, reducing build complexity and improving performance. The new file import mechanism uses a new syntax for import statements, allowing developers to specify the path of the file they want to import.

:warning: _Note that this PR does not contradict [the approach](https://github.com/microsoft/typespec/issues/4562#issuecomment-2379603488) of using the `exports` field in `package.json` for node.js libraries, which will be implemented in a separate PR. This PR only enhances the **file import mechanism** for TypeSpec._

## Example

```ts
import "@org/typespec-library/lib/entities/particular-file.tsp";
import "@org/typespec-library/lib/version.tsp";
```