### PR TITLE
[@typespec/http-specs] Add withKeys Logic for server-test and payload/content-negotiation service

### DIFF
--- a/.chronus/changes/payload_content_negotiation-2024-8-30-13-27-48.md
+++ b/.chronus/changes/payload_content_negotiation-2024-8-30-13-27-48.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-specs"
+---
+
+Added withServiceKeys scenario and payload/content-negotiation service test

--- a/packages/http-specs/specs/payload/content-negotiation/main.tsp
+++ b/packages/http-specs/specs/payload/content-negotiation/main.tsp
@@ -5,11 +5,11 @@ using Http;
 using SpecLib;
 
 @doc("Test describing optionality of the request body.")
-@SpecLib.scenarioService("/content-negotiation")
+@scenarioService("/content-negotiation")
 namespace Payload.ContentNegotiation;
 
-@SpecLib.scenario
-@SpecLib.scenarioDoc("""
+@scenario
+@scenarioDoc("""
   Scenario that returns a different file encoding depending on the accept header.
   
   - image/png return a png image
@@ -34,8 +34,8 @@ namespace SameBody {
   op getAvatarAsJpeg(@header accept: "image/jpeg"): JpegImage;
 }
 
-@SpecLib.scenario
-@SpecLib.scenarioDoc("""
+@scenario
+@scenarioDoc("""
   Scenario that a different payload depending on the accept header.
   
   - application/json return a png image in a Json object

--- a/packages/http-specs/specs/payload/content-negotiation/main.tsp
+++ b/packages/http-specs/specs/payload/content-negotiation/main.tsp
@@ -1,0 +1,61 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+
+using Http;
+using SpecLib;
+
+@doc("Test describing optionality of the request body.")
+@SpecLib.scenarioService("/content-negotiation")
+namespace Payload.ContentNegotiation;
+
+@SpecLib.scenario
+@SpecLib.scenarioDoc("""
+  Scenario that returns a different file encoding depending on the accept header.
+  
+  - image/png return a png image
+  - image/jpeg return a jpeg image
+  """)
+@route("same-body")
+namespace SameBody {
+  model PngImage {
+    @header contentType: "image/png";
+    @body image: bytes;
+  }
+
+  model JpegImage {
+    @header contentType: "image/jpeg";
+    @body image: bytes;
+  }
+
+  @sharedRoute
+  op getAvatarAsPng(@header accept: "image/png"): PngImage;
+
+  @sharedRoute
+  op getAvatarAsJpeg(@header accept: "image/jpeg"): JpegImage;
+}
+
+@SpecLib.scenario
+@SpecLib.scenarioDoc("""
+  Scenario that a different payload depending on the accept header.
+  
+  - application/json return a png image in a Json object
+  - image/png return the png image
+  """)
+@route("different-body")
+namespace DifferentBody {
+  model PngImage {
+    @header contentType: "image/png";
+    @body image: bytes;
+  }
+
+  model PngImageAsJson {
+    @header contentType: "application/json";
+    content: bytes;
+  }
+
+  @sharedRoute
+  op getAvatarAsPng(@header accept: "image/png"): PngImage;
+
+  @sharedRoute
+  op getAvatarAsJson(@header accept: "application/json"): PngImageAsJson;
+}

--- a/packages/http-specs/specs/payload/content-negotiation/mockapi.ts
+++ b/packages/http-specs/specs/payload/content-negotiation/mockapi.ts
@@ -1,0 +1,188 @@
+import {
+  json,
+  MockRequest,
+  ScenarioMockApi,
+  ValidationError,
+  withServiceKeys,
+} from "@typespec/spec-api";
+import { jpgFile, pngFile } from "../../helper.js";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+function sameBodyHandler(req: MockRequest) {
+  switch (req.headers["accept"]) {
+    case "image/png":
+      return {
+        pass: "image/png",
+        status: 200,
+        body: {
+          contentType: "image/png",
+          rawContent: pngFile,
+        },
+      } as const;
+    case "image/jpeg":
+      return {
+        pass: "image/jpeg",
+
+        status: 200,
+        body: {
+          contentType: "image/jpeg",
+          rawContent: jpgFile,
+        },
+      } as const;
+    default:
+      throw new ValidationError(
+        "Unsupported Accept header",
+        `"image/png" | "image/jpeg"`,
+        req.headers["accept"],
+      );
+  }
+}
+
+function differentBodyHandler(req: MockRequest) {
+  switch (req.headers["accept"]) {
+    case "image/png":
+      return {
+        pass: "image/png",
+        status: 200,
+        body: {
+          contentType: "image/png",
+          rawContent: pngFile,
+        },
+      } as const;
+    case "application/json":
+      return {
+        pass: "application/json",
+        status: 200,
+        body: json({
+          content: pngFile.toString("base64"),
+        }),
+      } as const;
+    default:
+      throw new ValidationError(
+        "Unsupported Accept header",
+        `"image/png" | "application/json"`,
+        req.headers["accept"],
+      );
+  }
+}
+
+Scenarios.Payload_ContentNegotiation_SameBody = withServiceKeys(["image/png", "image/jpeg"]).pass([
+  {
+    uri: "/content-negotiation/same-body",
+    method: "get",
+    request: {
+      headers: {
+        accept: "image/png",
+      },
+    },
+    response: {
+      body: {
+        contentType: "image/png",
+        rawContent: pngFile,
+      },
+      status: 200,
+    },
+    handler: (req) => sameBodyHandler(req),
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/content-negotiation/same-body",
+    method: "get",
+    request: {
+      headers: {
+        accept: "image/jpeg",
+      },
+    },
+    response: {
+      body: {
+        contentType: "image/jpeg",
+        rawContent: jpgFile,
+      },
+      status: 200,
+    },
+    handler: (req) => sameBodyHandler(req),
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/content-negotiation/same-body",
+    method: "get",
+    request: {
+      status: 400,
+      headers: {
+        accept: "wrongAccept",
+      },
+    },
+    response: {
+      status: 400,
+      body: json({
+        message: "Unsupported Accept header",
+        expected: `"image/png" | "image/jpeg"`,
+        actual: "wrongAccept",
+      }),
+    },
+    handler: sameBodyHandler,
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Payload_ContentNegotiation_DifferentBody = withServiceKeys([
+  "image/png",
+  "application/json",
+]).pass([
+  {
+    uri: "/content-negotiation/different-body",
+    method: "get",
+    request: {
+      headers: {
+        accept: "image/png",
+      },
+    },
+    response: {
+      status: 200,
+      body: {
+        contentType: "image/png",
+        rawContent: pngFile,
+      },
+    },
+    handler: differentBodyHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/content-negotiation/different-body",
+    method: "get",
+    request: {
+      headers: {
+        accept: "application/json",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({
+        content: pngFile.toString("base64"),
+      }),
+    },
+    handler: differentBodyHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/content-negotiation/different-body",
+    method: "get",
+    request: {
+      status: 400,
+      headers: {
+        accept: "wrongAccept",
+      },
+    },
+    response: {
+      status: 400,
+      body: json({
+        message: "Unsupported Accept header",
+        expected: `"image/png" | "application/json"`,
+        actual: "wrongAccept",
+      }),
+    },
+    handler: differentBodyHandler,
+    kind: "MockApiDefinition",
+  },
+]);

--- a/packages/http-specs/specs/payload/content-negotiation/mockapi.ts
+++ b/packages/http-specs/specs/payload/content-negotiation/mockapi.ts
@@ -67,122 +67,122 @@ function differentBodyHandler(req: MockRequest) {
   }
 }
 
-Scenarios.Payload_ContentNegotiation_SameBody = withServiceKeys(["image/png", "image/jpeg"]).pass([
-  {
-    uri: "/content-negotiation/same-body",
-    method: "get",
-    request: {
-      headers: {
-        accept: "image/png",
+Scenarios.Payload_ContentNegotiation_SameBody = withServiceKeys(["image/png", "image/jpeg"]).pass(
+  [
+    {
+      uri: "/content-negotiation/same-body",
+      method: "get",
+      request: {
+        headers: {
+          accept: "image/png",
+        },
       },
-    },
-    response: {
-      body: {
-        contentType: "image/png",
-        rawContent: pngFile,
+      response: {
+        body: {
+          contentType: "image/png",
+          rawContent: pngFile,
+        },
+        status: 200,
       },
-      status: 200,
+      kind: "MockApiDefinition",
     },
-    handler: (req) => sameBodyHandler(req),
-    kind: "MockApiDefinition",
-  },
-  {
-    uri: "/content-negotiation/same-body",
-    method: "get",
-    request: {
-      headers: {
-        accept: "image/jpeg",
+    {
+      uri: "/content-negotiation/same-body",
+      method: "get",
+      request: {
+        headers: {
+          accept: "image/jpeg",
+        },
       },
-    },
-    response: {
-      body: {
-        contentType: "image/jpeg",
-        rawContent: jpgFile,
+      response: {
+        body: {
+          contentType: "image/jpeg",
+          rawContent: jpgFile,
+        },
+        status: 200,
       },
-      status: 200,
+      kind: "MockApiDefinition",
     },
-    handler: (req) => sameBodyHandler(req),
-    kind: "MockApiDefinition",
-  },
-  {
-    uri: "/content-negotiation/same-body",
-    method: "get",
-    request: {
-      status: 400,
-      headers: {
-        accept: "wrongAccept",
+    {
+      uri: "/content-negotiation/same-body",
+      method: "get",
+      request: {
+        status: 400,
+        headers: {
+          accept: "wrongAccept",
+        },
       },
+      response: {
+        status: 400,
+        body: json({
+          message: "Unsupported Accept header",
+          expected: `"image/png" | "image/jpeg"`,
+          actual: "wrongAccept",
+        }),
+      },
+      kind: "MockApiDefinition",
     },
-    response: {
-      status: 400,
-      body: json({
-        message: "Unsupported Accept header",
-        expected: `"image/png" | "image/jpeg"`,
-        actual: "wrongAccept",
-      }),
-    },
-    handler: sameBodyHandler,
-    kind: "MockApiDefinition",
-  },
-]);
+  ],
+  sameBodyHandler,
+);
 
 Scenarios.Payload_ContentNegotiation_DifferentBody = withServiceKeys([
   "image/png",
   "application/json",
-]).pass([
-  {
-    uri: "/content-negotiation/different-body",
-    method: "get",
-    request: {
-      headers: {
-        accept: "image/png",
+]).pass(
+  [
+    {
+      uri: "/content-negotiation/different-body",
+      method: "get",
+      request: {
+        headers: {
+          accept: "image/png",
+        },
       },
-    },
-    response: {
-      status: 200,
-      body: {
-        contentType: "image/png",
-        rawContent: pngFile,
+      response: {
+        status: 200,
+        body: {
+          contentType: "image/png",
+          rawContent: pngFile,
+        },
       },
+      kind: "MockApiDefinition",
     },
-    handler: differentBodyHandler,
-    kind: "MockApiDefinition",
-  },
-  {
-    uri: "/content-negotiation/different-body",
-    method: "get",
-    request: {
-      headers: {
-        accept: "application/json",
+    {
+      uri: "/content-negotiation/different-body",
+      method: "get",
+      request: {
+        headers: {
+          accept: "application/json",
+        },
       },
-    },
-    response: {
-      status: 200,
-      body: json({
-        content: pngFile.toString("base64"),
-      }),
-    },
-    handler: differentBodyHandler,
-    kind: "MockApiDefinition",
-  },
-  {
-    uri: "/content-negotiation/different-body",
-    method: "get",
-    request: {
-      status: 400,
-      headers: {
-        accept: "wrongAccept",
+      response: {
+        status: 200,
+        body: json({
+          content: pngFile.toString("base64"),
+        }),
       },
+      kind: "MockApiDefinition",
     },
-    response: {
-      status: 400,
-      body: json({
-        message: "Unsupported Accept header",
-        expected: `"image/png" | "application/json"`,
-        actual: "wrongAccept",
-      }),
+    {
+      uri: "/content-negotiation/different-body",
+      method: "get",
+      request: {
+        status: 400,
+        headers: {
+          accept: "wrongAccept",
+        },
+      },
+      response: {
+        status: 400,
+        body: json({
+          message: "Unsupported Accept header",
+          expected: `"image/png" | "application/json"`,
+          actual: "wrongAccept",
+        }),
+      },
+      kind: "MockApiDefinition",
     },
-    handler: differentBodyHandler,
-    kind: "MockApiDefinition",
-  },
-]);
+  ],
+  differentBodyHandler,
+);

--- a/packages/spec-api/src/index.ts
+++ b/packages/spec-api/src/index.ts
@@ -15,7 +15,13 @@ export {
 } from "./request-validations.js";
 export { json, xml } from "./response-utils.js";
 export { mockapi } from "./routes.js";
-export { WithKeysScenarioExpect, passOnCode, passOnSuccess, withKeys } from "./scenarios.js";
+export {
+  WithKeysScenarioExpect,
+  passOnCode,
+  passOnSuccess,
+  withKeys,
+  withServiceKeys,
+} from "./scenarios.js";
 export {
   CollectionFormat,
   Fail,
@@ -30,6 +36,7 @@ export {
   MockResponse,
   MockResponseBody,
   PassByKeyScenario,
+  PassByServiceKeyScenario,
   PassOnCodeScenario,
   PassOnSuccessScenario,
   RequestExt,

--- a/packages/spec-api/src/scenarios.ts
+++ b/packages/spec-api/src/scenarios.ts
@@ -1,6 +1,7 @@
 import {
   KeyedMockApi,
   KeyedMockApiDefinition,
+  KeyedMockRequestHandler,
   MockApi,
   MockApiDefinition,
   PassByKeyScenario,
@@ -58,14 +59,25 @@ export function withKeys<const K extends string>(keys: K[]): WithKeysScenarioExp
 }
 
 export interface WithServiceKeysScenarioExpect<K extends string> {
-  pass(api: KeyedMockApiDefinition<K> | KeyedMockApiDefinition<K>[]): PassByServiceKeyScenario<K>;
+  pass(
+    api: KeyedMockApiDefinition<K> | KeyedMockApiDefinition<K>[],
+    handler?: KeyedMockRequestHandler<K>,
+  ): PassByServiceKeyScenario<K>;
 }
 
 export function withServiceKeys<const K extends string>(
   keys: K[],
 ): WithServiceKeysScenarioExpect<K> {
   return {
-    pass: (api: KeyedMockApiDefinition<K> | KeyedMockApiDefinition<K>[]) => {
+    pass: (
+      api: KeyedMockApiDefinition<K> | KeyedMockApiDefinition<K>[],
+      handler?: KeyedMockRequestHandler<K>,
+    ) => {
+      if (handler && Array.isArray(api)) {
+        api.forEach((a) => {
+          a.handler = handler;
+        });
+      }
       return {
         passCondition: "by-key",
         keys,

--- a/packages/spec-api/src/scenarios.ts
+++ b/packages/spec-api/src/scenarios.ts
@@ -1,8 +1,10 @@
 import {
   KeyedMockApi,
+  KeyedMockApiDefinition,
   MockApi,
   MockApiDefinition,
   PassByKeyScenario,
+  PassByServiceKeyScenario,
   PassOnCodeScenario,
   PassOnSuccessScenario,
 } from "./types.js";
@@ -50,6 +52,24 @@ export function withKeys<const K extends string>(keys: K[]): WithKeysScenarioExp
         passCondition: "by-key",
         keys,
         apis: [api],
+      };
+    },
+  };
+}
+
+export interface WithServiceKeysScenarioExpect<K extends string> {
+  pass(api: KeyedMockApiDefinition<K> | KeyedMockApiDefinition<K>[]): PassByServiceKeyScenario<K>;
+}
+
+export function withServiceKeys<const K extends string>(
+  keys: K[],
+): WithServiceKeysScenarioExpect<K> {
+  return {
+    pass: (api: KeyedMockApiDefinition<K> | KeyedMockApiDefinition<K>[]) => {
+      return {
+        passCondition: "by-key",
+        keys,
+        apis: Array.isArray(api) ? api : [api],
       };
     },
   };

--- a/packages/spec-api/src/types.ts
+++ b/packages/spec-api/src/types.ts
@@ -87,7 +87,7 @@ export interface KeyedMockApi<K extends string> extends MockApi {
   handler: KeyedMockRequestHandler<K>;
 }
 export interface KeyedMockApiDefinition<K extends string> extends MockApiDefinition {
-  handler: KeyedMockRequestHandler<K>;
+  handler?: KeyedMockRequestHandler<K>;
 }
 
 export interface MockResponse {

--- a/packages/spec-api/src/types.ts
+++ b/packages/spec-api/src/types.ts
@@ -31,12 +31,24 @@ export interface PassByKeyScenario<K extends string = string> {
   keys: K[];
   apis: KeyedMockApi<K>[];
 }
+export interface PassByServiceKeyScenario<K extends string = string> {
+  passCondition: "by-key";
+  keys: K[];
+  apis: KeyedMockApiDefinition<K>[];
+}
 
-export type ScenarioMockApi = PassOnSuccessScenario | PassOnCodeScenario | PassByKeyScenario;
+export type ScenarioMockApi =
+  | PassOnSuccessScenario
+  | PassOnCodeScenario
+  | PassByKeyScenario
+  | PassByServiceKeyScenario;
 export type MockRequestHandler = SimpleMockRequestHandler | KeyedMockRequestHandler;
 export type SimpleMockRequestHandler = (req: MockRequest) => MockResponse | Promise<MockResponse>;
 export type KeyedMockRequestHandler<T extends string = string> = (
   req: MockRequest,
+) => KeyedMockResponse<T> | Promise<KeyedMockResponse<T>>;
+export type KeyedServiceRequestHandler<T extends string = string> = (
+  req: ServiceRequest,
 ) => KeyedMockResponse<T> | Promise<KeyedMockResponse<T>>;
 
 export type HttpMethod = "get" | "post" | "put" | "patch" | "delete" | "head" | "options";
@@ -72,6 +84,9 @@ export interface ServiceRequest {
 
 export const Fail = Symbol.for("Fail");
 export interface KeyedMockApi<K extends string> extends MockApi {
+  handler: KeyedMockRequestHandler<K>;
+}
+export interface KeyedMockApiDefinition<K extends string> extends MockApiDefinition {
   handler: KeyedMockRequestHandler<K>;
 }
 

--- a/packages/spec-core/src/coverage/coverage-tracker.ts
+++ b/packages/spec-core/src/coverage/coverage-tracker.ts
@@ -1,4 +1,4 @@
-import { Fail, KeyedMockResponse, MockResponse, PassByKeyScenario, ScenarioMockApi } from "@typespec/spec-api";
+import { Fail, KeyedMockResponse, MockResponse, PassByKeyScenario, PassByServiceKeyScenario, ScenarioMockApi } from "@typespec/spec-api";
 import { logger } from "../logger.js";
 import { CoverageReport, ScenariosMetadata, ScenarioStatus } from "@typespec/spec-coverage-sdk";
 import { writeFileSync } from "fs";
@@ -88,7 +88,7 @@ export class CoverageTracker {
       return "pass";
     }
 
-    function checkByKeys(scenario: PassByKeyScenario) {
+    function checkByKeys(scenario: PassByKeyScenario | PassByServiceKeyScenario) {
       for (const endpoint of scenario.apis) {
         const hits = scenarioHits?.get(endpoint.uri);
         if (hits === undefined) {


### PR DESCRIPTION
During the migration of `cadl-ranch-specs` package from `cadl-ranch` repository to `typespec` repository (as `http-spec` package), the `payload\content-negotiation` service was not migrated. Because, it was based on keys which was not implemented for the `server-test` scenarios. 

In this PR, the implementation is completed and the `payload\content-negotiation` service has been added back.

1. I considered adding `|` to `withKeys` instead of adding `withServiceKeys`. But, it was creating build issues with incompatible types. The new `withServiceKeys` implementation is simpler and cleaner approach. 
2. The previous `cadl-ranch` package has [2 scenarios](https://github.com/Azure/cadl-ranch/blob/main/packages/cadl-ranch-specs/http/payload/content-negotiation/mockapi.ts):
    a. Scenarios.Payload_ContentNegotiation_SameBody
    b. Scenarios.Payload_ContentNegotiation_DifferentBody
The same 2 scenarios are added in the new file also.
3. The `server-test` of the 2 new scenarios is successful. Also, the `validate-scenarios` and `validate-mock-api` have been successful for the new scenarios. Here are the associated snapshots:

![Screenshot 2024-09-30 130737](https://github.com/user-attachments/assets/c2b52759-0537-4c17-8fbd-faa23c184859)

![Screenshot 2024-09-30 130754](https://github.com/user-attachments/assets/9b08ebee-52d4-4280-a706-e499616e57a6)

Please review and approve this PR. Thanks
