### PR TITLE
[@typespec/http-specs] Add routes service 

### DIFF
--- a/packages/http-specs/specs/routes/mockapi.ts
+++ b/packages/http-specs/specs/routes/mockapi.ts
@@ -1,11 +1,19 @@
-import { mockapi, passOnSuccess, ScenarioMockApi, ValidationError } from "@typespec/spec-api";
+import { MockRequest, passOnSuccess, ScenarioMockApi, ValidationError } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-function defineUri(uri: string) {
-  const url = new URL("http://example.com" + uri);
-  return passOnSuccess(
-    mockapi.get(url.pathname, (req) => {
+function createTests(uri: string, serverUri?: string, params?: Record<string, any>) {
+  return passOnSuccess({
+    uri: uri,
+    method: "get",
+    request: {
+      params: params,
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      const url = new URL("http://example.com" + serverUri);
       for (const [key, value] of url.searchParams.entries()) {
         req.expect.containsQueryParam(key, value);
       }
@@ -19,140 +27,213 @@ function defineUri(uri: string) {
         }
       }
       return { status: 204 };
-    }),
-  );
+    },
+    kind: "MockApiDefinition",
+  });
 }
 
-Scenarios.Routes_InInterface = defineUri("/routes/fixed");
-Scenarios.Routes_fixed = defineUri("/routes/in-interface/fixed");
+Scenarios.Routes_InInterface = createTests("/routes/fixed");
+Scenarios.Routes_fixed = createTests("/routes/in-interface/fixed");
 
-Scenarios.Routes_PathParameters_templateOnly = defineUri("/routes/path/template-only/a");
-Scenarios.Routes_PathParameters_explicit = defineUri("/routes/path/explicit/a");
-Scenarios.Routes_PathParameters_annotationOnly = defineUri("/routes/path/annotation-only/a");
+Scenarios.Routes_PathParameters_templateOnly = createTests("/routes/path/template-only/a");
+Scenarios.Routes_PathParameters_explicit = createTests("/routes/path/explicit/a");
+Scenarios.Routes_PathParameters_annotationOnly = createTests("/routes/path/annotation-only/a");
 
-Scenarios.Routes_PathParameters_ReservedExpansion_template = defineUri(
+Scenarios.Routes_PathParameters_ReservedExpansion_template = createTests(
   "/routes/path/reserved-expansion/template/foo/bar%20baz",
 );
-Scenarios.Routes_PathParameters_ReservedExpansion_annotation = defineUri(
+Scenarios.Routes_PathParameters_ReservedExpansion_annotation = createTests(
   "/routes/path/reserved-expansion/annotation/foo/bar%20baz",
 );
 
-Scenarios.Routes_PathParameters_SimpleExpansion_Standard_primitive = defineUri(
+Scenarios.Routes_PathParameters_SimpleExpansion_Standard_primitive = createTests(
   "/routes/simple/standard/primitivea",
 );
-Scenarios.Routes_PathParameters_SimpleExpansion_Standard_array = defineUri(
+Scenarios.Routes_PathParameters_SimpleExpansion_Standard_array = createTests(
   "/routes/simple/standard/arraya,b",
 );
-Scenarios.Routes_PathParameters_SimpleExpansion_Standard_record = defineUri(
+Scenarios.Routes_PathParameters_SimpleExpansion_Standard_record = createTests(
   "/routes/simple/standard/recorda,1,b,2",
 );
-Scenarios.Routes_PathParameters_SimpleExpansion_Explode_primitive = defineUri(
+Scenarios.Routes_PathParameters_SimpleExpansion_Explode_primitive = createTests(
   "/routes/simple/standard/primitivea",
 );
-Scenarios.Routes_PathParameters_SimpleExpansion_Explode_array = defineUri(
+Scenarios.Routes_PathParameters_SimpleExpansion_Explode_array = createTests(
   "/routes/simple/standard/arraya,b",
 );
-Scenarios.Routes_PathParameters_SimpleExpansion_Explode_record = defineUri(
+Scenarios.Routes_PathParameters_SimpleExpansion_Explode_record = createTests(
   "/routes/simple/standard/recorda=1,b=2",
 );
 
-Scenarios.Routes_PathParameters_PathExpansion_Standard_primitive = defineUri(
+Scenarios.Routes_PathParameters_PathExpansion_Standard_primitive = createTests(
   "/routes/path/standard/primitive/a",
 );
-Scenarios.Routes_PathParameters_PathExpansion_Standard_array = defineUri(
+Scenarios.Routes_PathParameters_PathExpansion_Standard_array = createTests(
   "/routes/path/standard/array/a,b",
 );
-Scenarios.Routes_PathParameters_PathExpansion_Standard_record = defineUri(
+Scenarios.Routes_PathParameters_PathExpansion_Standard_record = createTests(
   "/routes/path/standard/record/a,1,b,2",
 );
-Scenarios.Routes_PathParameters_PathExpansion_Explode_primitive = defineUri(
+Scenarios.Routes_PathParameters_PathExpansion_Explode_primitive = createTests(
   "/routes/path/standard/primitive/a",
 );
-Scenarios.Routes_PathParameters_PathExpansion_Explode_array = defineUri(
+Scenarios.Routes_PathParameters_PathExpansion_Explode_array = createTests(
   "/routes/path/standard/array/a/b",
 );
-Scenarios.Routes_PathParameters_PathExpansion_Explode_record = defineUri(
+Scenarios.Routes_PathParameters_PathExpansion_Explode_record = createTests(
   "/routes/path/standard/record/a=1/b=2",
 );
 
-Scenarios.Routes_PathParameters_LabelExpansion_Standard_primitive = defineUri(
+Scenarios.Routes_PathParameters_LabelExpansion_Standard_primitive = createTests(
   "/routes/label/standard/primitive.a",
 );
-Scenarios.Routes_PathParameters_LabelExpansion_Standard_array = defineUri(
+Scenarios.Routes_PathParameters_LabelExpansion_Standard_array = createTests(
   "/routes/label/standard/array.a,b",
 );
-Scenarios.Routes_PathParameters_LabelExpansion_Standard_record = defineUri(
+Scenarios.Routes_PathParameters_LabelExpansion_Standard_record = createTests(
   "/routes/label/standard/record.a,1,b,2",
 );
-Scenarios.Routes_PathParameters_LabelExpansion_Explode_primitive = defineUri(
+Scenarios.Routes_PathParameters_LabelExpansion_Explode_primitive = createTests(
   "/routes/label/standard/primitive.a",
 );
-Scenarios.Routes_PathParameters_LabelExpansion_Explode_array = defineUri(
+Scenarios.Routes_PathParameters_LabelExpansion_Explode_array = createTests(
   "/routes/label/standard/array.a.b",
 );
-Scenarios.Routes_PathParameters_LabelExpansion_Explode_record = defineUri(
+Scenarios.Routes_PathParameters_LabelExpansion_Explode_record = createTests(
   "/routes/label/standard/record.a=1.b=2",
 );
 
-Scenarios.Routes_PathParameters_MatrixExpansion_Standard_primitive = defineUri(
+Scenarios.Routes_PathParameters_MatrixExpansion_Standard_primitive = createTests(
   "/routes/matrix/standard/primitive;a",
 );
-Scenarios.Routes_PathParameters_MatrixExpansion_Standard_array = defineUri(
+Scenarios.Routes_PathParameters_MatrixExpansion_Standard_array = createTests(
   "/routes/matrix/standard/array;a,b",
 );
-Scenarios.Routes_PathParameters_MatrixExpansion_Standard_record = defineUri(
+Scenarios.Routes_PathParameters_MatrixExpansion_Standard_record = createTests(
   "/routes/matrix/standard/record;a,1,b,2",
 );
-Scenarios.Routes_PathParameters_MatrixExpansion_Explode_primitive = defineUri(
+Scenarios.Routes_PathParameters_MatrixExpansion_Explode_primitive = createTests(
   "/routes/matrix/standard/primitive;a",
 );
-Scenarios.Routes_PathParameters_MatrixExpansion_Explode_array = defineUri(
+Scenarios.Routes_PathParameters_MatrixExpansion_Explode_array = createTests(
   "/routes/matrix/standard/array;a;b",
 );
-Scenarios.Routes_PathParameters_MatrixExpansion_Explode_record = defineUri(
+Scenarios.Routes_PathParameters_MatrixExpansion_Explode_record = createTests(
   "/routes/matrix/standard/record;a=1;b=2",
 );
 
-Scenarios.Routes_QueryParameters_templateOnly = defineUri("/routes/query/template-only?param=a");
-Scenarios.Routes_QueryParameters_explicit = defineUri("/routes/query/explicit?param=a");
-Scenarios.Routes_QueryParameters_annotationOnly = defineUri(
+Scenarios.Routes_QueryParameters_templateOnly = createTests(
+  "/routes/query/template-only",
+  "/routes/query/template-only?param=a",
+  {
+    param: "a",
+  },
+);
+Scenarios.Routes_QueryParameters_explicit = createTests(
+  "/routes/query/explicit",
+  "/routes/query/explicit?param=a",
+  {
+    param: "a",
+  },
+);
+Scenarios.Routes_QueryParameters_annotationOnly = createTests(
+  "/routes/query/annotation-only",
   "/routes/query/annotation-only?param=a",
+  {
+    param: "a",
+  },
 );
 
-Scenarios.Routes_QueryParameters_QueryExpansion_Standard_primitive = defineUri(
+Scenarios.Routes_QueryParameters_QueryExpansion_Standard_primitive = createTests(
+  "/routes/query/query-expansion/standard/primitive",
   "/routes/query/query-expansion/standard/primitive?param=a",
+  {
+    param: "a",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryExpansion_Standard_array = defineUri(
+Scenarios.Routes_QueryParameters_QueryExpansion_Standard_array = createTests(
+  "/routes/query/query-expansion/standard/array",
   "/routes/query/query-expansion/standard/array?param=a,b",
+  {
+    param: "a,b",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryExpansion_Standard_record = defineUri(
+Scenarios.Routes_QueryParameters_QueryExpansion_Standard_record = createTests(
+  "/routes/query/query-expansion/standard/record",
   "/routes/query/query-expansion/standard/record?param=a,1,b,2",
+  {
+    param: "a,1,b,2",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryExpansion_Explode_primitive = defineUri(
+Scenarios.Routes_QueryParameters_QueryExpansion_Explode_primitive = createTests(
+  "/routes/query/query-expansion/explode/primitive",
   "/routes/query/query-expansion/explode/primitive?param=a",
+  {
+    param: "a",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryExpansion_Explode_array = defineUri(
-  "/routes/query/query-expansion/explode/array?param=a&param=b",
+Scenarios.Routes_QueryParameters_QueryExpansion_Explode_array = createTests(
+  "/routes/query/query-expansion/explode/array",
+  "/routes/query/query-expansion/explode/array?param=a,b",
+  {
+    param: "a,b",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryExpansion_Explode_record = defineUri(
+Scenarios.Routes_QueryParameters_QueryExpansion_Explode_record = createTests(
+  "/routes/query/query-expansion/explode/record",
   "/routes/query/query-expansion/explode/record?a=1&b=2",
+  {
+    a: "1",
+    b: "2",
+  },
 );
 
-Scenarios.Routes_QueryParameters_QueryContinuation_Standard_primitive = defineUri(
+Scenarios.Routes_QueryParameters_QueryContinuation_Standard_primitive = createTests(
+  "/routes/query/query-continuation/standard/primitive",
   "/routes/query/query-continuation/standard/primitive?fixed=true&param=a",
+  {
+    fixed: true,
+    param: "a",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryContinuation_Standard_array = defineUri(
+Scenarios.Routes_QueryParameters_QueryContinuation_Standard_array = createTests(
+  "/routes/query/query-continuation/standard/array",
   "/routes/query/query-continuation/standard/array?fixed=true&param=a,b",
+  {
+    fixed: true,
+    param: "a,b",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryContinuation_Standard_record = defineUri(
+Scenarios.Routes_QueryParameters_QueryContinuation_Standard_record = createTests(
+  "/routes/query/query-continuation/standard/record",
   "/routes/query/query-continuation/standard/record?fixed=true&param=a,1,b,2",
+  {
+    fixed: true,
+    param: "a,1,b,2",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryContinuation_Explode_primitive = defineUri(
+Scenarios.Routes_QueryParameters_QueryContinuation_Explode_primitive = createTests(
+  "/routes/query/query-continuation/explode/primitive",
   "/routes/query/query-continuation/explode/primitive?fixed=true&param=a",
+  {
+    fixed: true,
+    param: "a",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryContinuation_Explode_array = defineUri(
-  "/routes/query/query-continuation/explode/array?fixed=true&param=a&param=b",
+Scenarios.Routes_QueryParameters_QueryContinuation_Explode_array = createTests(
+  "/routes/query/query-continuation/explode/array",
+  "/routes/query/query-continuation/explode/array?fixed=true&param=a,b",
+  {
+    fixed: true,
+    param: "a,b",
+  },
 );
-Scenarios.Routes_QueryParameters_QueryContinuation_Explode_record = defineUri(
+Scenarios.Routes_QueryParameters_QueryContinuation_Explode_record = createTests(
+  "/routes/query/query-continuation/explode/record",
   "/routes/query/query-continuation/explode/record?fixed=true&a=1&b=2",
+  {
+    fixed: true,
+    a: "1",
+    b: "2",
+  },
 );

--- a/packages/http-specs/specs/routes/mockapi.ts
+++ b/packages/http-specs/specs/routes/mockapi.ts
@@ -2,13 +2,18 @@ import { MockRequest, passOnSuccess, ScenarioMockApi, ValidationError } from "@t
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-function createTests(uri: string, params?: Record<string, any>) {
+function createTests(uri: string) {
   const url = new URL("http://example.com" + uri);
+  const searchParams = url.searchParams;
+  const params: Record<string, any> = {};
+  for (const [key, value] of searchParams) {
+    params[key] = value;
+  }
   return passOnSuccess({
     uri: url.pathname,
     method: "get",
     request: {
-      params: params,
+      params,
     },
     response: {
       status: 204,
@@ -34,18 +39,15 @@ function createTests(uri: string, params?: Record<string, any>) {
 
 Scenarios.Routes_InInterface = createTests("/routes/fixed");
 Scenarios.Routes_fixed = createTests("/routes/in-interface/fixed");
-
 Scenarios.Routes_PathParameters_templateOnly = createTests("/routes/path/template-only/a");
 Scenarios.Routes_PathParameters_explicit = createTests("/routes/path/explicit/a");
 Scenarios.Routes_PathParameters_annotationOnly = createTests("/routes/path/annotation-only/a");
-
 Scenarios.Routes_PathParameters_ReservedExpansion_template = createTests(
   "/routes/path/reserved-expansion/template/foo/bar%20baz",
 );
 Scenarios.Routes_PathParameters_ReservedExpansion_annotation = createTests(
   "/routes/path/reserved-expansion/annotation/foo/bar%20baz",
 );
-
 Scenarios.Routes_PathParameters_SimpleExpansion_Standard_primitive = createTests(
   "/routes/simple/standard/primitivea",
 );
@@ -64,7 +66,6 @@ Scenarios.Routes_PathParameters_SimpleExpansion_Explode_array = createTests(
 Scenarios.Routes_PathParameters_SimpleExpansion_Explode_record = createTests(
   "/routes/simple/standard/recorda=1,b=2",
 );
-
 Scenarios.Routes_PathParameters_PathExpansion_Standard_primitive = createTests(
   "/routes/path/standard/primitive/a",
 );
@@ -83,7 +84,6 @@ Scenarios.Routes_PathParameters_PathExpansion_Explode_array = createTests(
 Scenarios.Routes_PathParameters_PathExpansion_Explode_record = createTests(
   "/routes/path/standard/record/a=1/b=2",
 );
-
 Scenarios.Routes_PathParameters_LabelExpansion_Standard_primitive = createTests(
   "/routes/label/standard/primitive.a",
 );
@@ -102,7 +102,6 @@ Scenarios.Routes_PathParameters_LabelExpansion_Explode_array = createTests(
 Scenarios.Routes_PathParameters_LabelExpansion_Explode_record = createTests(
   "/routes/label/standard/record.a=1.b=2",
 );
-
 Scenarios.Routes_PathParameters_MatrixExpansion_Standard_primitive = createTests(
   "/routes/matrix/standard/primitive;a",
 );
@@ -121,98 +120,44 @@ Scenarios.Routes_PathParameters_MatrixExpansion_Explode_array = createTests(
 Scenarios.Routes_PathParameters_MatrixExpansion_Explode_record = createTests(
   "/routes/matrix/standard/record;a=1;b=2",
 );
-
-Scenarios.Routes_QueryParameters_templateOnly = createTests("/routes/query/template-only?param=a", {
-  param: "a",
-});
-Scenarios.Routes_QueryParameters_explicit = createTests("/routes/query/explicit?param=a", {
-  param: "a",
-});
+Scenarios.Routes_QueryParameters_templateOnly = createTests("/routes/query/template-only?param=a");
+Scenarios.Routes_QueryParameters_explicit = createTests("/routes/query/explicit?param=a");
 Scenarios.Routes_QueryParameters_annotationOnly = createTests(
   "/routes/query/annotation-only?param=a",
-  {
-    param: "a",
-  },
 );
-
 Scenarios.Routes_QueryParameters_QueryExpansion_Standard_primitive = createTests(
   "/routes/query/query-expansion/standard/primitive?param=a",
-  {
-    param: "a",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Standard_array = createTests(
   "/routes/query/query-expansion/standard/array?param=a,b",
-  {
-    param: "a,b",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Standard_record = createTests(
   "/routes/query/query-expansion/standard/record?param=a,1,b,2",
-  {
-    param: "a,1,b,2",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_primitive = createTests(
   "/routes/query/query-expansion/explode/primitive?param=a",
-  {
-    param: "a",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_array = createTests(
   "/routes/query/query-expansion/explode/array?param=a,b",
-  {
-    param: "a,b",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_record = createTests(
   "/routes/query/query-expansion/explode/record?a=1&b=2",
-  {
-    a: "1",
-    b: "2",
-  },
 );
-
 Scenarios.Routes_QueryParameters_QueryContinuation_Standard_primitive = createTests(
   "/routes/query/query-continuation/standard/primitive?fixed=true&param=a",
-  {
-    fixed: true,
-    param: "a",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Standard_array = createTests(
   "/routes/query/query-continuation/standard/array?fixed=true&param=a,b",
-  {
-    fixed: true,
-    param: "a,b",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Standard_record = createTests(
   "/routes/query/query-continuation/standard/record?fixed=true&param=a,1,b,2",
-  {
-    fixed: true,
-    param: "a,1,b,2",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_primitive = createTests(
   "/routes/query/query-continuation/explode/primitive?fixed=true&param=a",
-  {
-    fixed: true,
-    param: "a",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_array = createTests(
   "/routes/query/query-continuation/explode/array?fixed=true&param=a,b",
-  {
-    fixed: true,
-    param: "a,b",
-  },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_record = createTests(
   "/routes/query/query-continuation/explode/record?fixed=true&a=1&b=2",
-  {
-    fixed: true,
-    a: "1",
-    b: "2",
-  },
 );

--- a/packages/http-specs/specs/routes/mockapi.ts
+++ b/packages/http-specs/specs/routes/mockapi.ts
@@ -2,9 +2,10 @@ import { MockRequest, passOnSuccess, ScenarioMockApi, ValidationError } from "@t
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-function createTests(uri: string, serverUri?: string, params?: Record<string, any>) {
+function createTests(uri: string, params?: Record<string, any>) {
+  const url = new URL("http://example.com" + uri);
   return passOnSuccess({
-    uri: uri,
+    uri: url.pathname,
     method: "get",
     request: {
       params: params,
@@ -13,7 +14,6 @@ function createTests(uri: string, serverUri?: string, params?: Record<string, an
       status: 204,
     },
     handler: (req: MockRequest) => {
-      const url = new URL("http://example.com" + serverUri);
       for (const [key, value] of url.searchParams.entries()) {
         req.expect.containsQueryParam(key, value);
       }
@@ -122,22 +122,13 @@ Scenarios.Routes_PathParameters_MatrixExpansion_Explode_record = createTests(
   "/routes/matrix/standard/record;a=1;b=2",
 );
 
-Scenarios.Routes_QueryParameters_templateOnly = createTests(
-  "/routes/query/template-only",
-  "/routes/query/template-only?param=a",
-  {
-    param: "a",
-  },
-);
-Scenarios.Routes_QueryParameters_explicit = createTests(
-  "/routes/query/explicit",
-  "/routes/query/explicit?param=a",
-  {
-    param: "a",
-  },
-);
+Scenarios.Routes_QueryParameters_templateOnly = createTests("/routes/query/template-only?param=a", {
+  param: "a",
+});
+Scenarios.Routes_QueryParameters_explicit = createTests("/routes/query/explicit?param=a", {
+  param: "a",
+});
 Scenarios.Routes_QueryParameters_annotationOnly = createTests(
-  "/routes/query/annotation-only",
   "/routes/query/annotation-only?param=a",
   {
     param: "a",
@@ -145,42 +136,36 @@ Scenarios.Routes_QueryParameters_annotationOnly = createTests(
 );
 
 Scenarios.Routes_QueryParameters_QueryExpansion_Standard_primitive = createTests(
-  "/routes/query/query-expansion/standard/primitive",
   "/routes/query/query-expansion/standard/primitive?param=a",
   {
     param: "a",
   },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Standard_array = createTests(
-  "/routes/query/query-expansion/standard/array",
   "/routes/query/query-expansion/standard/array?param=a,b",
   {
     param: "a,b",
   },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Standard_record = createTests(
-  "/routes/query/query-expansion/standard/record",
   "/routes/query/query-expansion/standard/record?param=a,1,b,2",
   {
     param: "a,1,b,2",
   },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_primitive = createTests(
-  "/routes/query/query-expansion/explode/primitive",
   "/routes/query/query-expansion/explode/primitive?param=a",
   {
     param: "a",
   },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_array = createTests(
-  "/routes/query/query-expansion/explode/array",
   "/routes/query/query-expansion/explode/array?param=a,b",
   {
     param: "a,b",
   },
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_record = createTests(
-  "/routes/query/query-expansion/explode/record",
   "/routes/query/query-expansion/explode/record?a=1&b=2",
   {
     a: "1",
@@ -189,7 +174,6 @@ Scenarios.Routes_QueryParameters_QueryExpansion_Explode_record = createTests(
 );
 
 Scenarios.Routes_QueryParameters_QueryContinuation_Standard_primitive = createTests(
-  "/routes/query/query-continuation/standard/primitive",
   "/routes/query/query-continuation/standard/primitive?fixed=true&param=a",
   {
     fixed: true,
@@ -197,7 +181,6 @@ Scenarios.Routes_QueryParameters_QueryContinuation_Standard_primitive = createTe
   },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Standard_array = createTests(
-  "/routes/query/query-continuation/standard/array",
   "/routes/query/query-continuation/standard/array?fixed=true&param=a,b",
   {
     fixed: true,
@@ -205,7 +188,6 @@ Scenarios.Routes_QueryParameters_QueryContinuation_Standard_array = createTests(
   },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Standard_record = createTests(
-  "/routes/query/query-continuation/standard/record",
   "/routes/query/query-continuation/standard/record?fixed=true&param=a,1,b,2",
   {
     fixed: true,
@@ -213,7 +195,6 @@ Scenarios.Routes_QueryParameters_QueryContinuation_Standard_record = createTests
   },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_primitive = createTests(
-  "/routes/query/query-continuation/explode/primitive",
   "/routes/query/query-continuation/explode/primitive?fixed=true&param=a",
   {
     fixed: true,
@@ -221,7 +202,6 @@ Scenarios.Routes_QueryParameters_QueryContinuation_Explode_primitive = createTes
   },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_array = createTests(
-  "/routes/query/query-continuation/explode/array",
   "/routes/query/query-continuation/explode/array?fixed=true&param=a,b",
   {
     fixed: true,
@@ -229,7 +209,6 @@ Scenarios.Routes_QueryParameters_QueryContinuation_Explode_array = createTests(
   },
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_record = createTests(
-  "/routes/query/query-continuation/explode/record",
   "/routes/query/query-continuation/explode/record?fixed=true&a=1&b=2",
   {
     fixed: true,


### PR DESCRIPTION
During the migration of cadl-ranch-specs package from cadl-ranch repository to typespec repository (as http-spec package), the routes service was not migrated. 

In this PR, the implementation is completed and the routes service has been added back. I have already run the `pnpm test:e2e` and it is successful.

Please review and approve this PR. Thanks



