### PR TITLE
[@typespec/http-specs] Add payload/multipart service

### DIFF
--- a/packages/http-specs/specs/payload/multipart/mockapi.ts
+++ b/packages/http-specs/specs/payload/multipart/mockapi.ts
@@ -1,11 +1,9 @@
 import {
-  mockapi,
-  MockApi,
   MockRequest,
   passOnSuccess,
   ScenarioMockApi,
   ValidationError,
-  withKeys,
+  withServiceKeys,
 } from "@typespec/spec-api";
 import { jpgFile, pngFile } from "../../helper.js";
 
@@ -116,111 +114,292 @@ function checkPictures(req: MockRequest) {
 function checkFloat(req: MockRequest) {
   req.expect.deepEqual(parseFloat(req.body.temperature), 0.5);
 }
-function createMockApis(route: string, checkList: ((param: MockRequest) => void)[]): MockApi {
-  const url = `/multipart/form-data/${route}`;
-  return mockapi.post(url, (req) => {
-    for (const callback of checkList) {
-      callback(req);
-    }
-    return { status: 204 };
-  });
+const files = [
+  {
+    fieldname: "profileImage",
+    originalname: "image.jpg",
+    buffer: jpgFile,
+    mimetype: "application/octet-stream",
+  },
+  {
+    fieldname: "pictures",
+    originalname: "image.png",
+    buffer: pngFile,
+    mimetype: "application/octet-stream",
+  },
+];
+function createHandler(req: MockRequest, checkList: ((req: MockRequest) => void)[]) {
+  for (const callback of checkList) {
+    callback(req);
+  }
+  return { status: 204 };
 }
-
-Scenarios.Payload_MultiPart_FormData_basic = passOnSuccess(
-  createMockApis("mixed-parts", [checkId, checkProfileImage]),
-);
-
-Scenarios.Payload_MultiPart_FormData_fileArrayAndBasic = passOnSuccess(
-  createMockApis("complex-parts", [checkId, checkAddress, checkAllFiles]),
-);
-
-Scenarios.Payload_MultiPart_FormData_jsonPart = passOnSuccess(
-  createMockApis("json-part", [checkAddress, checkProfileImage]),
-);
-
-Scenarios.Payload_MultiPart_FormData_binaryArrayParts = passOnSuccess(
-  createMockApis("binary-array-parts", [checkId, checkPictures]),
-);
-
-Scenarios.Payload_MultiPart_FormData_multiBinaryParts = withKeys([
+Scenarios.Payload_MultiPart_FormData_basic = passOnSuccess({
+  uri: "/multipart/form-data/mixed-parts",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    body: { id: 123 },
+    files: [files[0]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkId, checkProfileImage]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_fileArrayAndBasic = passOnSuccess({
+  uri: "/multipart/form-data/complex-parts",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    body: { id: 123, address: { city: "X" } },
+    files: [files[0], files[1], files[1]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkId, checkAddress, checkAllFiles]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_jsonPart = passOnSuccess({
+  uri: "/multipart/form-data/json-part",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    body: { address: { city: "X" } },
+    files: [files[0]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkAddress, checkProfileImage]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_binaryArrayParts = passOnSuccess({
+  uri: "/multipart/form-data/binary-array-parts",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    body: { id: 123 },
+    files: [files[1], files[1]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkId, checkPictures]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_multiBinaryParts = withServiceKeys([
   "profileImage",
   "profileImage,picture",
-]).pass(
-  mockapi.post("/multipart/form-data/multi-binary-parts", (req) => {
-    if (req.files instanceof Array) {
-      switch (req.files.length) {
-        case 1:
-          checkJpgFile(req, req.files[0]);
-          return { pass: "profileImage", status: 204 } as const;
-        case 2:
-          let profileImage = false;
-          let picture = false;
-          for (const file of req.files) {
-            if (file.fieldname === "profileImage") {
-              checkJpgFile(req, file);
-              profileImage = true;
-            } else if (file.fieldname === "picture") {
-              checkPngFile(req, file, "picture");
-              picture = true;
-            } else {
-              throw new ValidationError(
-                "unexpected fieldname",
-                "profileImage or picture",
-                file.fieldname,
-              );
+]).pass([
+  {
+    uri: "/multipart/form-data/multi-binary-parts",
+    method: "post",
+    request: {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+      files: [files[0]],
+    },
+    response: { status: 204 },
+    handler: (req: MockRequest) => {
+      if (req.files instanceof Array) {
+        switch (req.files.length) {
+          case 1:
+            checkJpgFile(req, req.files[0]);
+            return { pass: "profileImage", status: 204 } as const;
+          case 2:
+            let profileImage = false;
+            let picture = false;
+            for (const file of req.files) {
+              if (file.fieldname === "profileImage") {
+                checkJpgFile(req, file);
+                profileImage = true;
+              } else if (file.fieldname === "picture") {
+                checkPngFile(req, file, "picture");
+                picture = true;
+              } else {
+                throw new ValidationError(
+                  "unexpected fieldname",
+                  "profileImage or picture",
+                  file.fieldname,
+                );
+              }
             }
-          }
-          if (!profileImage) {
-            throw new ValidationError("No profileImage found", "jpg file is expected", req.body);
-          } else if (!picture) {
-            throw new ValidationError("No picture found", "png file are expected", req.body);
-          }
-          return { pass: "profileImage,picture", status: 204 } as const;
-        default:
-          throw new ValidationError(
-            "number of files is incorrect",
-            "1 or 2 files are expected",
-            req.body,
-          );
+            if (!profileImage) {
+              throw new ValidationError("No profileImage found", "jpg file is expected", req.body);
+            } else if (!picture) {
+              throw new ValidationError("No picture found", "png file are expected", req.body);
+            }
+            return { pass: "profileImage,picture", status: 204 } as const;
+          default:
+            throw new ValidationError(
+              "number of files is incorrect",
+              "1 or 2 files are expected",
+              req.body,
+            );
+        }
+      } else {
+        throw new ValidationError(
+          "Can't parse files from request",
+          "jpg/png files are expected",
+          req.body,
+        );
       }
-    } else {
-      throw new ValidationError(
-        "Can't parse files from request",
-        "jpg/png files are expected",
-        req.body,
-      );
-    }
-  }),
-);
-
-Scenarios.Payload_MultiPart_FormData_checkFileNameAndContentType = passOnSuccess(
-  createMockApis("check-filename-and-content-type", [checkId, checkFileNameAndContentType]),
-);
-
-Scenarios.Payload_MultiPart_FormData_anonymousModel = passOnSuccess(
-  createMockApis("anonymous-model", [checkProfileImage]),
-);
-
-Scenarios.Payload_MultiPart_FormData_HttpParts_ContentType_imageJpegContentType = passOnSuccess(
-  createMockApis("check-filename-and-specific-content-type-with-httppart", [
-    checkFileNameAndContentType,
-  ]),
-);
-
-Scenarios.Payload_MultiPart_FormData_HttpParts_ContentType_requiredContentType = passOnSuccess(
-  createMockApis("check-filename-and-required-content-type-with-httppart", [checkProfileImage]),
-);
-Scenarios.Payload_MultiPart_FormData_HttpParts_ContentType_optionalContentType = passOnSuccess(
-  createMockApis("file-with-http-part-optional-content-type", [checkOptionalContentType]),
-);
-Scenarios.Payload_MultiPart_FormData_HttpParts_jsonArrayAndFileArray = passOnSuccess(
-  createMockApis("complex-parts-with-httppart", [
-    checkId,
-    checkAddress,
-    checkPreviousAddresses,
-    checkAllFiles,
-  ]),
-);
-Scenarios.Payload_MultiPart_FormData_HttpParts_NonString_float = passOnSuccess(
-  createMockApis("non-string-float", [checkFloat]),
-);
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/multipart/form-data/multi-binary-parts",
+    method: "post",
+    request: {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+      files: [files[0], { ...files[1], fieldname: "picture" }],
+    },
+    response: { status: 204 },
+    handler: (req: MockRequest) => {
+      if (req.files instanceof Array) {
+        switch (req.files.length) {
+          case 1:
+            checkJpgFile(req, req.files[0]);
+            return { pass: "profileImage", status: 204 } as const;
+          case 2:
+            let profileImage = false;
+            let picture = false;
+            for (const file of req.files) {
+              if (file.fieldname === "profileImage") {
+                checkJpgFile(req, file);
+                profileImage = true;
+              } else if (file.fieldname === "picture") {
+                checkPngFile(req, file, "picture");
+                picture = true;
+              } else {
+                throw new ValidationError(
+                  "unexpected fieldname",
+                  "profileImage or picture",
+                  file.fieldname,
+                );
+              }
+            }
+            if (!profileImage) {
+              throw new ValidationError("No profileImage found", "jpg file is expected", req.body);
+            } else if (!picture) {
+              throw new ValidationError("No picture found", "png file are expected", req.body);
+            }
+            return { pass: "profileImage,picture", status: 204 } as const;
+          default:
+            throw new ValidationError(
+              "number of files is incorrect",
+              "1 or 2 files are expected",
+              req.body,
+            );
+        }
+      } else {
+        throw new ValidationError(
+          "Can't parse files from request",
+          "jpg/png files are expected",
+          req.body,
+        );
+      }
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+Scenarios.Payload_MultiPart_FormData_checkFileNameAndContentType = passOnSuccess({
+  uri: "/multipart/form-data/check-filename-and-content-type",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    body: { id: 123 },
+    files: [{ ...files[0], mimetype: "image/jpg", originalname: "hello.jpg" }],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkId, checkFileNameAndContentType]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_anonymousModel = passOnSuccess({
+  uri: "/multipart/form-data/anonymous-model",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    files: [files[0]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkProfileImage]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_HttpParts_ContentType_imageJpegContentType = passOnSuccess({
+  uri: "/multipart/form-data/check-filename-and-specific-content-type-with-httppart",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    files: [{ ...files[0], mimetype: "image/jpg", originalname: "hello.jpg" }],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkFileNameAndContentType]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_HttpParts_ContentType_requiredContentType = passOnSuccess({
+  uri: "/multipart/form-data/check-filename-and-required-content-type-with-httppart",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    files: [files[0]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkProfileImage]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_HttpParts_ContentType_optionalContentType = passOnSuccess({
+  uri: "/multipart/form-data/file-with-http-part-optional-content-type",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    files: [files[0]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkOptionalContentType]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_HttpParts_jsonArrayAndFileArray = passOnSuccess({
+  uri: "/multipart/form-data/complex-parts-with-httppart",
+  method: "post",
+  request: {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    body: { id: 123, address: { city: "X" }, previousAddresses: [{ city: "Y" }, { city: "Z" }] },
+    files: [files[0], files[1], files[1]],
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) =>
+    createHandler(req, [checkId, checkAddress, checkPreviousAddresses, checkAllFiles]),
+  kind: "MockApiDefinition",
+});
+Scenarios.Payload_MultiPart_FormData_HttpParts_NonString_float = passOnSuccess({
+  uri: "/multipart/form-data/non-string-float",
+  method: "post",
+  request: {
+    body: { temperature: 0.5 },
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => createHandler(req, [checkFloat]),
+  kind: "MockApiDefinition",
+});

--- a/packages/spec-api/src/index.ts
+++ b/packages/spec-api/src/index.ts
@@ -42,6 +42,7 @@ export {
   RequestExt,
   ScenarioMockApi,
   ScenarioPassCondition,
+  ServiceRequestFile,
   SimpleMockRequestHandler,
 } from "./types.js";
 export { ValidationError } from "./validation-error.js";

--- a/packages/spec-api/src/types.ts
+++ b/packages/spec-api/src/types.ts
@@ -72,6 +72,13 @@ export interface MockApiDefinition {
   kind: "MockApiDefinition";
 }
 
+export interface ServiceRequestFile {
+  fieldname: string;
+  originalname: string;
+  buffer: Buffer;
+  mimetype: string;
+}
+
 export interface ServiceRequest {
   body?: any;
   status?: number;
@@ -80,6 +87,7 @@ export interface ServiceRequest {
    */
   params?: Record<string, unknown>;
   headers?: Record<string, unknown>;
+  files?: ServiceRequestFile[];
 }
 
 export const Fail = Symbol.for("Fail");

--- a/packages/spec-core/package.json
+++ b/packages/spec-core/package.json
@@ -52,7 +52,8 @@
     "winston": "^3.8.2",
     "xml2js": "^0.6.2",
     "yargs": "~17.7.2",
-    "axios": "^1.7.5"
+    "axios": "^1.7.5",
+    "form-data": "^3.0.1"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.2",

--- a/packages/spec-core/src/actions/server-test.ts
+++ b/packages/spec-core/src/actions/server-test.ts
@@ -60,6 +60,7 @@ class ServerTestsGenerator {
       endPoint: `${this.serverBasePath}${this.mockApiDefinition.uri}`,
       options: {
         requestBody: this.mockApiDefinition.request.body,
+        files: this.mockApiDefinition.request.files,
         config: this.getConfigObj(),
       },
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,7 +330,7 @@ importers:
         version: link:../tmlanguage-generator
       ts-node:
         specifier: ~10.9.2
-        version: 10.9.2(@swc/core@1.7.28)(@types/node@22.7.3)(typescript@5.6.2)
+        version: 10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.8))(@types/node@22.7.3)(typescript@5.6.2)
       typescript:
         specifier: ~5.6.2
         version: 5.6.2
@@ -1468,6 +1468,9 @@ importers:
       express-promise-router:
         specifier: ^4.1.1
         version: 4.1.1(@types/express@4.17.21)(express@4.21.0)
+      form-data:
+        specifier: ^3.0.1
+        version: 3.0.1
       globby:
         specifier: ~14.0.2
         version: 14.0.2
@@ -7914,6 +7917,10 @@ packages:
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
+
+  form-data@3.0.1:
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+    engines: {node: '>= 6'}
 
   form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -20772,6 +20779,12 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
+  form-data@3.0.1:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
   form-data@4.0.0:
     dependencies:
       asynckit: 0.4.0
@@ -25501,7 +25514,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-node@10.9.2(@swc/core@1.7.28)(@types/node@22.7.3)(typescript@5.6.2):
+  ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.8))(@types/node@22.7.3)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11


### PR DESCRIPTION
During the migration of cadl-ranch-specs package from cadl-ranch repository to typespec repository (as http-spec package), the payload/multipart service was not migrated. (This is the last pending one)

In this PR, the implementation is completed and the routes service has been added back. I have already run the `pnpm test:e2e` and it is successful.

Please review and approve this PR. Thanks