### PR TITLE
Serialize customized properties that use the same name as the spec property

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/TypeProvider.cs
@@ -161,9 +161,9 @@ namespace Microsoft.Generator.CSharp.Providers
                 customProperties.Add(customProperty.Name, customProperty);
                 foreach (var attribute in customProperty.Attributes ?? [])
                 {
-                    if (CodeGenAttributes.TryGetCodeGenMemberAttributeValue(attribute, out var name))
+                    if (CodeGenAttributes.TryGetCodeGenMemberAttributeValue(attribute, out var originalName))
                     {
-                        renamedProperties.Add(name, customProperty);
+                        renamedProperties.Add(originalName, customProperty);
                     }
                 }
             }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Generator.CSharp.Tests.Providers.ModelProviders
             Assert.IsNotNull(wireInfo);
             Assert.AreEqual( "prop1", wireInfo!.SerializedName);
             Assert.AreEqual("Prop1", modelTypeProvider.CustomCodeView.Properties[1].Name);
+            Assert.IsNull(modelTypeProvider.CustomCodeView.Properties[1].WireInfo);
 
             Assert.AreEqual(0, modelTypeProvider.Properties.Count);
         }
@@ -130,6 +131,12 @@ namespace Microsoft.Generator.CSharp.Tests.Providers.ModelProviders
             Assert.AreEqual(1, modelTypeProvider.CustomCodeView!.Properties.Count);
             // the property accessibility should be changed
             Assert.IsTrue(modelTypeProvider.CustomCodeView.Properties[0].Modifiers.HasFlag(MethodSignatureModifiers.Internal));
+            // the wire info should be stored on the custom property
+            Assert.IsNotNull(modelTypeProvider.CustomCodeView.Properties[0].WireInfo);
+
+            var fullCtor = modelTypeProvider.Constructors.Last();
+            Assert.IsTrue(fullCtor.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal));
+            Assert.AreEqual(2, fullCtor.Signature.Parameters.Count);
         }
 
         private static void AssertCommon(TypeProvider typeProvider, string expectedNamespace, string expectedName)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanChangePropertyAccessibility/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanChangePropertyAccessibility/MockInputModel.cs
@@ -7,7 +7,6 @@ namespace Sample.Models
 {
     public partial class MockInputModel
     {
-        [CodeGenMember("Prop1")]
-        internal string[] Prop2 { get; set; }
+        internal string[] Prop1 { get; set; }
     }
 }


### PR DESCRIPTION
Fixes a bug where customized properties were not correctly included in the generated constructor and serialization code if they used the same name as a property in the spec, but did not use the CodeGenMember attribute.