### PR TITLE
Fix method/constructor parameter name matching

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/TypeProvider.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Generator.CSharp.Providers
 
             for (int i = 0; i < customMethod.Parameters.Count; i++)
             {
-                if (customMethod.Parameters[i].Type.Name != method.Parameters[i].Type.Name)
+                if (!customMethod.Parameters[i].Type.Name.EndsWith(method.Parameters[i].Type.Name))
                 {
                     return false;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -322,23 +322,30 @@ namespace Microsoft.Generator.CSharp.Tests.Providers.ModelProviders
         [Test]
         public async Task CanReplaceConstructor()
         {
+            var subModel = InputFactory.Model(
+                "subModel",
+                usage: InputModelTypeUsage.Input,
+                properties: new[] { InputFactory.Property("SubProperty", InputPrimitiveType.Int32) });
+
             var plugin = await MockHelpers.LoadMockPluginAsync(
                 inputModelTypes: new[] {
                     InputFactory.Model(
                         "mockInputModel",
                         // use Input so that we generate a public ctor
                         usage: InputModelTypeUsage.Input,
-                        properties: new[] { InputFactory.Property("Prop1", InputPrimitiveType.String) })
+                        properties: new[]
+                        {
+                            InputFactory.Property("Prop1", InputPrimitiveType.String),
+                            InputFactory.Property("SubModel", subModel)
+                        })
                 },
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
             var csharpGen = new CSharpGen();
 
             await csharpGen.ExecuteAsync();
 
-            // The generated code should only contain the single internal ctor containing the properties
-            var ctor = plugin.Object.OutputLibrary.TypeProviders.Single(t => t.Name == "MockInputModel").Constructors.Single();
-            Assert.IsTrue(ctor.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal));
-            Assert.AreEqual("prop1", ctor.Signature.Parameters.First().Name);
+            // The generated code should not contain any ctors
+            Assert.IsEmpty(plugin.Object.OutputLibrary.TypeProviders.Single(t => t.Name == "MockInputModel").Constructors);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanReplaceConstructor/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanReplaceConstructor/MockInputModel.cs
@@ -7,4 +7,12 @@ public partial class MockInputModel
     internal MockInputModel()
     {
     }
+
+    internal MockInputModel(string prop1, SubModel? subModel, IDictionary<string, BinaryData> serializedAdditionalRawData)
+    {
+    }
+}
+
+public readonly partial struct SubModel
+{
 }


### PR DESCRIPTION
Relax the matching to account for the type name containing the fully qualified type name for customized methods/ctors.