### PR TITLE
eng, java ci, bypass Generate-APIView-CodeFile.ps1 script error

### DIFF
--- a/packages/http-client-java/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Build-Packages.ps1
@@ -78,7 +78,10 @@ try {
     $file = Invoke-LoggedCommand "npm pack -q"
     Copy-Item $file -Destination "$outputPath/packages"
 
+    $exitCodeBeforeApiView = $global:LASTEXITCODE
     & "$packageRoot/../../eng/emitters/scripts/Generate-APIView-CodeFile.ps1" -ArtifactPath "$outputPath/packages"
+    # Generate-APIView-CodeFile.ps1 fails with "error TS5057"
+    $global:LASTEXITCODE = $exitCodeBeforeApiView
 
     Write-PackageInfo -packageName "typespec-http-client-java" -directoryPath "packages/http-client-java/emitter/src" -version $emitterVersion
 }


### PR DESCRIPTION
The error in `Generate-APIView-CodeFile.ps1` fails the CI. See https://github.com/microsoft/typespec/pull/4572

I've opened an issue to ts-genapi here https://github.com/Azure/azure-sdk-tools/issues/9119

Here I made a workaround to bypass this issue, to unblock.