### PR TITLE
Include Jinja templates in wheel

### DIFF
--- a/packages/http-client-python/generator/MANIFEST.in
+++ b/packages/http-client-python/generator/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include pygen/codegen/templates *.jinja2

--- a/packages/http-client-python/generator/setup.py
+++ b/packages/http-client-python/generator/setup.py
@@ -23,6 +23,7 @@ if not version:
 setup(
     name="pygen",
     version=version,
+    include_package_data=True,
     description="Core Library for Python Generation",
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Include Jinja templates in pygen wheel so that we can load the templates when we support generating with pyodide.