### PR TITLE
Improve diagnostics when fails to load js

### DIFF
--- a/.chronus/changes/improve-js-load-error-2024-9-15-18-0-27.md
+++ b/.chronus/changes/improve-js-load-error-2024-9-15-18-0-27.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Improve diagnostic when JS files fail to load due to a JS error

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -740,7 +740,13 @@ const diagnostics = {
   "invalid-emitter": {
     severity: "error",
     messages: {
-      default: paramMessage`Requested emitter package ${"emitterPackage"} does not provide an "onEmit" function.`,
+      default: paramMessage`Requested emitter package ${"emitterPackage"} does not provide an "$onEmit" function.`,
+    },
+  },
+  "js-error": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Failed to load ${"specifier"} due to the following JS error: ${"error"}`,
     },
   },
   "missing-import": {

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2082,7 +2082,7 @@ export interface LibraryLocationContext {
 
 export interface LibraryInstance {
   module: ModuleResolutionResult;
-  entrypoint: JsSourceFileNode | undefined;
+  entrypoint: JsSourceFileNode;
   metadata: LibraryMetadata;
   definition?: TypeSpecLibrary<any>;
   linter: LinterResolvedDefinition;

--- a/packages/compiler/test/core/linter.test.ts
+++ b/packages/compiler/test/core/linter.test.ts
@@ -44,7 +44,7 @@ describe("compiler: linter", () => {
     }
 
     const library: LibraryInstance = {
-      entrypoint: undefined,
+      entrypoint: {} as any,
       metadata: { type: "module", name: "@typespec/test-linter" },
       module: { type: "module", path: "", mainFile: "", manifest: { name: "", version: "" } },
       definition: createTypeSpecLibrary({

--- a/packages/compiler/test/e2e/scenarios/import-library-js-error/.gitignore
+++ b/packages/compiler/test/e2e/scenarios/import-library-js-error/.gitignore
@@ -1,0 +1,1 @@
+!node_modules/

--- a/packages/compiler/test/e2e/scenarios/import-library-js-error/main.tsp
+++ b/packages/compiler/test/e2e/scenarios/import-library-js-error/main.tsp
@@ -1,0 +1,2 @@
+// This scenario has a hard coded `node_modules` folder with a my-lib package that has invalid files.
+op test(): string;

--- a/packages/compiler/test/e2e/scenarios/import-library-js-error/node_modules/my-lib/index.js
+++ b/packages/compiler/test/e2e/scenarios/import-library-js-error/node_modules/my-lib/index.js
@@ -1,0 +1,1 @@
+import "./invalid-file-not-exists.js";

--- a/packages/compiler/test/e2e/scenarios/import-library-js-error/node_modules/my-lib/package.json
+++ b/packages/compiler/test/e2e/scenarios/import-library-js-error/node_modules/my-lib/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@typespec/my-lib",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "typespec": "./index.js"
+    }
+  }
+}

--- a/packages/compiler/test/e2e/scenarios/scenarios.e2e.ts
+++ b/packages/compiler/test/e2e/scenarios/scenarios.e2e.ts
@@ -61,6 +61,26 @@ describe("compiler: entrypoints", () => {
       });
     });
 
+    it("emit diagnostics if imported library has js load error", async () => {
+      const program = await compileScenario("import-library-js-error", {
+        additionalImports: ["my-lib"],
+      });
+      expectDiagnostics(program.diagnostics, {
+        code: "js-error",
+        message: `Failed to load ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js due to the following JS error: Cannot find module '${scenarioRoot}/import-library-js-error/node_modules/my-lib/invalid-file-not-exists.js' imported from ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js`,
+      });
+    });
+
+    it("emit diagnostics if emitter has js load error", async () => {
+      const program = await compileScenario("import-library-js-error", {
+        emit: ["my-lib"],
+      });
+      expectDiagnostics(program.diagnostics, {
+        code: "js-error",
+        message: `Failed to load ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js due to the following JS error: Cannot find module '${scenarioRoot}/import-library-js-error/node_modules/my-lib/invalid-file-not-exists.js' imported from ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js`,
+      });
+    });
+
     it("emit diagnostics if emitter require import that is not imported", async () => {
       const program = await compileScenario("emitter-require-import", {
         emit: ["@typespec/my-emitter"],


### PR DESCRIPTION
fix [#4582](https://github.com/microsoft/typespec/issues/4582)

Also fix allow resolving `import` as a named condition for emitters