### PR TITLE
[@typespec/spector] - Modify checks for headers & parameters

### DIFF
--- a/packages/spector/src/app/app.ts
+++ b/packages/spector/src/app/app.ts
@@ -94,7 +94,11 @@ function createHandler(apiDefinition: MockApiDefinition) {
     if (apiDefinition.request.headers) {
       Object.entries(apiDefinition.request.headers).forEach(([key, value]) => {
         if (key !== "Content-Type") {
-          req.expect.containsHeader(key, value as string);
+          if (Array.isArray(value)) {
+            req.expect.deepEqual(req.headers[key], value);
+          } else {
+            req.expect.containsHeader(key.toLowerCase(), String(value));
+          }
         }
       });
     }
@@ -102,7 +106,11 @@ function createHandler(apiDefinition: MockApiDefinition) {
     // Validate query params if present in the request
     if (apiDefinition.request.params) {
       Object.entries(apiDefinition.request.params).forEach(([key, value]) => {
-        req.expect.containsQueryParam(key, value as string);
+        if (Array.isArray(value)) {
+          req.expect.deepEqual(req.query[key], value);
+        } else {
+          req.expect.containsQueryParam(key, String(value));
+        }
       });
     }
 


### PR DESCRIPTION
As a continuation of https://github.com/microsoft/typespec/pull/4725, while working on removing the handler for the scenarios in the `typespec-azure` repository, I found some scenarios need added fix in the `spector` library.

This PR consists of 2 changes:

1. The header keys must be changed to lowercase before reading and comparing.
2. If the headers and parameters are array values, then we need to handle them seperately. 

I have tested this change with all the scenarios in both the `typespec` and `typespec-azure` repositories. Once this change is merged, I can open the PR for the scenario changes in `typespec-azure` repository.

Please review and approve this PR. Thanks