### PR TITLE
[http-client-python] release for 0.3.2

### DIFF
--- a/packages/http-client-python/package-lock.json
+++ b/packages/http-client-python/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typespec/http-client-python",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://typespec.io",


### PR DESCRIPTION
https://github.com/microsoft/typespec/pull/4718 will cause huge SDK diff so better to release a new version ASAP.