### PR TITLE
http-client-java, eng, bump npm packages

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -23,7 +23,7 @@
     "@typespec/versioning": "~0.61.0",
     "@typespec/openapi": "~0.61.0",
     "@typespec/xml": "~0.61.0",
-    "@azure-tools/typespec-azure-core": "~0.47.1",
+    "@azure-tools/typespec-azure-core": "~0.47.0",
     "@azure-tools/typespec-client-generator-core": "~0.47.2",
     "@azure-tools/typespec-azure-resource-manager": "~0.47.1",
     "@azure-tools/typespec-autorest": "~0.47.0"

--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -17,15 +17,15 @@
     "@typespec/http-client-java-tests": "file:"
   },
   "overrides": {
-    "@typespec/compiler": "~0.61.0",
+    "@typespec/compiler": "~0.61.2",
     "@typespec/http": "~0.61.0",
     "@typespec/rest": "~0.61.0",
     "@typespec/versioning": "~0.61.0",
     "@typespec/openapi": "~0.61.0",
     "@typespec/xml": "~0.61.0",
-    "@azure-tools/typespec-azure-core": "~0.47.0",
-    "@azure-tools/typespec-client-generator-core": "~0.47.1",
-    "@azure-tools/typespec-azure-resource-manager": "~0.47.0",
+    "@azure-tools/typespec-azure-core": "~0.47.1",
+    "@azure-tools/typespec-client-generator-core": "~0.47.2",
+    "@azure-tools/typespec-azure-resource-manager": "~0.47.1",
     "@azure-tools/typespec-autorest": "~0.47.0"
   },
   "private": true

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/EnumNestedDiscriminatorClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/com/type/model/inheritance/enumnesteddiscriminator/EnumNestedDiscriminatorClientBuilder.java
@@ -218,9 +218,8 @@ public final class EnumNestedDiscriminatorClientBuilder implements HttpTrait<Enu
     private EnumNestedDiscriminatorClientImpl buildInnerClient() {
         this.validateClient();
         HttpPipeline localPipeline = (pipeline != null) ? pipeline : createHttpPipeline();
-        String localEndpoint = (endpoint != null) ? endpoint : "http://localhost:3000";
         EnumNestedDiscriminatorClientImpl client = new EnumNestedDiscriminatorClientImpl(localPipeline,
-            JacksonAdapter.createDefaultSerializerAdapter(), localEndpoint);
+            JacksonAdapter.createDefaultSerializerAdapter(), this.endpoint);
         return client;
     }
 
@@ -228,6 +227,7 @@ public final class EnumNestedDiscriminatorClientBuilder implements HttpTrait<Enu
     private void validateClient() {
         // This method is invoked from 'buildInnerClient'/'buildClient' method.
         // Developer can customize this method, to validate that the necessary conditions are met for the new client.
+        Objects.requireNonNull(endpoint, "'endpoint' cannot be null.");
     }
 
     @Generated

--- a/packages/http-client-java/generator/http-client-generator-test/src/test/java/com/azure/resourcemanager/commonproperties/ManagedIdentityManagerTests.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/test/java/com/azure/resourcemanager/commonproperties/ManagedIdentityManagerTests.java
@@ -4,14 +4,13 @@
 package com.azure.resourcemanager.commonproperties;
 
 import com.azure.core.management.Region;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.azure.resourcemanager.commonproperties.models.ManagedIdentityTrackedResource;
 import com.azure.resourcemanager.commonproperties.models.ManagedIdentityTrackedResourceProperties;
 import com.azure.resourcemanager.commonproperties.models.ManagedServiceIdentity;
 import com.azure.resourcemanager.commonproperties.models.ManagedServiceIdentityType;
 import com.azure.resourcemanager.commonproperties.models.UserAssignedIdentity;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.utils.ArmUtils;

--- a/packages/http-client-java/generator/http-client-generator-test/src/test/java/com/type/model/inheritance/enumnesteddiscriminator/generated/EnumNestedDiscriminatorClientTestBase.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/test/java/com/type/model/inheritance/enumnesteddiscriminator/generated/EnumNestedDiscriminatorClientTestBase.java
@@ -23,7 +23,7 @@ class EnumNestedDiscriminatorClientTestBase extends TestProxyTestBase {
     protected void beforeTest() {
         EnumNestedDiscriminatorClientBuilder enumNestedDiscriminatorClientbuilder
             = new EnumNestedDiscriminatorClientBuilder()
-                .endpoint(Configuration.getGlobalConfiguration().get("ENDPOINT", "http://localhost:3000"))
+                .endpoint(Configuration.getGlobalConfiguration().get("ENDPOINT", "endpoint"))
                 .httpClient(getHttpClientOrUsePlayback(getHttpClients().findFirst().orElse(null)))
                 .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BASIC));
         if (getTestMode() == TestMode.RECORD) {

--- a/packages/http-client-java/generator/http-client-generator-test/tsp/nested-enum-discriminator.tsp
+++ b/packages/http-client-java/generator/http-client-generator-test/tsp/nested-enum-discriminator.tsp
@@ -1,10 +1,12 @@
 import "@typespec/http";
-import "@azure-tools/cadl-ranch-expect";
 
 using TypeSpec.Http;
 
 @doc("Illustrates multiple level inheritance with multiple enum discriminators.")
-@scenarioService("/type/model/inheritance/enum-nested-discriminator")
+@service({
+  title: "EnumNestedDiscriminator",
+})
+@route("/type/model/inheritance/enum-nested-discriminator")
 namespace Type.Model.Inheritance.EnumNestedDiscriminator;
 
 @doc("extensible enum type for discriminator")
@@ -63,186 +65,26 @@ model GoblinShark extends Shark {
   sharktype: SharkKind.Goblin;
 }
 
-@scenario
 @route("/model")
-@scenarioDoc("""
-  Generate and receive polymorphic model in multiple levels inheritance with 2 discriminators.
-  Expected response body:
-  ```json
-  {"age": 1, "kind": "shark",  "sharktype": "goblin"}
-  ```
-  """)
 @get
 op getModel(): Fish;
 
-@scenario
 @route("/model")
-@scenarioDoc("""
-  Generate and send polymorphic model in multiple levels inheritance with 2 discriminators.
-  Expected input body:
-  ```json
-  {"age": 1, "kind": "shark",  "sharktype": "goblin"}
-  ```
-  """)
 @put
 op putModel(@body input: Fish): NoContentResponse;
 
-@scenario
 @route("/recursivemodel")
-@scenarioDoc("""
-  Generate and receive polymorphic models has collection and dictionary properties referring to other polymorphic models.
-  Expected response body:
-  ```json
-  {
-    "age": 1,
-    "kind": "salmon",
-    "partner": {
-      "age": 2,
-      "kind": "shark",
-      "sharktype": "saw"
-    },
-    "friends": [
-      {
-        "age": 2,
-        "kind": "salmon",
-        "partner": {
-          "age": 3,
-          "kind": "salmon"
-        },
-        "hate": {
-          "key1": {
-            "age": 4,
-            "kind": "salmon"
-          },
-          "key2": {
-            "age": 2,
-            "kind": "shark",
-            "sharktype": "goblin"
-          }
-        }
-      },
-      {
-        "age": 3,
-        "kind": "shark",
-        "sharktype": "goblin"
-      }
-    ],
-    "hate": {
-      "key3": {
-        "age": 3,
-        "kind": "shark",
-        "sharktype": "saw"
-      },
-      "key4": {
-        "age": 2,
-        "kind": "salmon",
-        "friends": [
-          {
-            "age": 1,
-            "kind": "salmon"
-          },
-          {
-            "age": 4,
-            "kind": "shark",
-            "sharktype": "goblin"
-          }
-        ]
-      }
-    }
-  }
-  ```
-  """)
 @get
 op getRecursiveModel(): Fish;
 
-@scenario
 @route("/recursivemodel")
-@scenarioDoc("""
-  Generate and send polymorphic models has collection and dictionary properties referring to other polymorphic models.
-  Expected input body:
-  ```json
-  {
-    "age": 1,
-    "kind": "salmon",
-    "partner": {
-      "age": 2,
-      "kind": "shark",
-      "sharktype": "saw"
-    },
-    "friends": [
-      {
-        "age": 2,
-        "kind": "salmon",
-        "partner": {
-          "age": 3,
-          "kind": "salmon"
-        },
-        "hate": {
-          "key1": {
-            "age": 4,
-            "kind": "salmon"
-          },
-          "key2": {
-            "age": 2,
-            "kind": "shark",
-            "sharktype": "goblin"
-          }
-        }
-      },
-      {
-        "age": 3,
-        "kind": "shark",
-        "sharktype": "goblin"
-      }
-    ],
-    "hate": {
-      "key3": {
-        "age": 3,
-        "kind": "shark",
-        "sharktype": "saw"
-      },
-      "key4": {
-        "age": 2,
-        "kind": "salmon",
-        "friends": [
-          {
-            "age": 1,
-            "kind": "salmon"
-          },
-          {
-            "age": 4,
-            "kind": "shark",
-            "sharktype": "goblin"
-          }
-        ]
-      }
-    }
-  }
-  ```
-  """)
 @put
 op putRecursiveModel(@body input: Fish): NoContentResponse;
 
-@scenario
 @route("/missingdiscriminator")
-@scenarioDoc("""
-  Get a model omitting the discriminator.
-  Expected response body:
-  ```json
-  {"age": 1}
-  ```
-  """)
 @get
 op getMissingDiscriminator(): Fish;
 
-@scenario
 @route("/wrongdiscriminator")
-@scenarioDoc("""
-  Get a model containing discriminator value never defined.
-  Expected response body:
-  ```json
-  {"age": 1, "kind": "wrongKind" }
-  ```
-  """)
 @get
 op getWrongDiscriminator(): Fish;

--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -17,25 +17,25 @@
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.47.0",
         "@azure-tools/typespec-azure-core": "0.47.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.47.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.47.1",
         "@azure-tools/typespec-azure-rulesets": "0.47.0",
-        "@azure-tools/typespec-client-generator-core": "0.47.1",
-        "@microsoft/api-extractor": "^7.47.9",
+        "@azure-tools/typespec-client-generator-core": "0.47.2",
+        "@microsoft/api-extractor": "^7.47.11",
         "@microsoft/api-extractor-model": "^7.29.8",
         "@types/js-yaml": "~4.0.9",
         "@types/lodash": "~4.17.10",
-        "@types/node": "~22.7.5",
+        "@types/node": "~22.7.6",
         "@typespec/compiler": "0.61.2",
         "@typespec/http": "0.61.0",
         "@typespec/openapi": "0.61.0",
         "@typespec/rest": "0.61.0",
         "@typespec/versioning": "0.61.0",
-        "@vitest/coverage-v8": "^2.1.2",
-        "@vitest/ui": "^2.1.2",
+        "@vitest/coverage-v8": "^2.1.3",
+        "@vitest/ui": "^2.1.3",
         "c8": "~10.1.2",
         "rimraf": "~6.0.1",
         "typescript": "~5.6.3",
-        "vitest": "^2.1.2"
+        "vitest": "^2.1.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.47.0.tgz",
-      "integrity": "sha512-pe9XhHJezTZtVlSVKIMhL1kRATMg6QSaXUZQhQmQKSuozVRsRBxI4IAhK3RU4p6SA8A2CoCpPeJpRhQTvdt73Q==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.47.1.tgz",
+      "integrity": "sha512-ZTrnHwPsc6aMVu6QghF7tPcKPVkt/ErHiEGP+vPXtb9iQh8YKMkkAl6jpvfnqMUqa1h3JkvOBCZM9w5FA84a6Q==",
       "dev": true,
       "dependencies": {
         "change-case": "~5.4.4",
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.47.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.47.1.tgz",
-      "integrity": "sha512-kgjGnnOaHewa8PjmZcEY4+UrEMBrXhOpMxDuhlMnFfOvCo3uZc3FVryoNrDHkZ8weCn6sjxo8zHcj1lpCg4/uw==",
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.47.2.tgz",
+      "integrity": "sha512-mOsgeOuJcJa5CrQrT/BzqpbLDnb/X1TgSmfljhV3tJFB2dzZT6awzeAp5clV03Or/4xCMGbmHEABi4kCWot9Qw==",
       "dev": true,
       "dependencies": {
         "change-case": "~5.4.4",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.47.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.47.9.tgz",
-      "integrity": "sha512-TTq30M1rikVsO5wZVToQT/dGyJY7UXJmjiRtkHPLb74Prx3Etw8+bX7Bv7iLuby6ysb7fuu1NFWqma+csym8Jw==",
+      "version": "7.47.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.47.11.tgz",
+      "integrity": "sha512-lrudfbPub5wzBhymfFtgZKuBvXxoSIAdrvS2UbHjoMT2TjIEddq6Z13pcve7A03BAouw0x8sW8G4txdgfiSwpQ==",
       "dev": true,
       "dependencies": {
         "@microsoft/api-extractor-model": "7.29.8",
@@ -816,7 +816,7 @@
         "@rushstack/node-core-library": "5.9.0",
         "@rushstack/rig-package": "0.5.3",
         "@rushstack/terminal": "0.14.2",
-        "@rushstack/ts-command-line": "4.22.8",
+        "@rushstack/ts-command-line": "4.23.0",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
@@ -1295,9 +1295,9 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.22.8",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.22.8.tgz",
-      "integrity": "sha512-XbFjOoV7qZHJnSuFUHv0pKaFA4ixyCuki+xMjsMfDwfvQjs5MYG0IK5COal3tRnG7KCDe2l/G+9LrzYE/RJhgg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.0.tgz",
+      "integrity": "sha512-jYREBtsxduPV6ptNq8jOKp9+yx0ld1Tb/Tkdnlj8gTjazl1sF3DwX2VbluyYrNd0meWIL0bNeer7WDf5tKFjaQ==",
       "dev": true,
       "dependencies": {
         "@rushstack/terminal": "0.14.2",
@@ -1357,9 +1357,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
+      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -1522,9 +1522,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.2.tgz",
-      "integrity": "sha512-b7kHrFrs2urS0cOk5N10lttI8UdJ/yP3nB4JYTREvR5o18cR99yPpK4gK8oQgI42BVv0ILWYUSYB7AXkAUDc0g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.3.tgz",
+      "integrity": "sha512-2OJ3c7UPoFSmBZwqD2VEkUw6A/tzPF0LmW0ZZhhB8PFxuc+9IBG/FaSM+RLEenc7ljzFvGN+G0nGQoZnh7sy2A==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
@@ -1544,8 +1544,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "2.1.2",
-        "vitest": "2.1.2"
+        "@vitest/browser": "2.1.3",
+        "vitest": "2.1.3"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1554,13 +1554,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.2.tgz",
-      "integrity": "sha512-FEgtlN8mIUSEAAnlvn7mP8vzaWhEaAEvhSXCqrsijM7K6QqjB11qoRZYEd4AKSCDz8p0/+yH5LzhZ47qt+EyPg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.3.tgz",
+      "integrity": "sha512-SNBoPubeCJhZ48agjXruCI57DvxcsivVDdWz+SSsmjTT4QN/DfHk3zB/xKsJqMs26bLZ/pNRLnCf0j679i0uWQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "2.1.2",
-        "@vitest/utils": "2.1.2",
+        "@vitest/spy": "2.1.3",
+        "@vitest/utils": "2.1.3",
         "chai": "^5.1.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -1569,12 +1569,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.2.tgz",
-      "integrity": "sha512-ExElkCGMS13JAJy+812fw1aCv2QO/LBK6CyO4WOPAzLTmve50gydOlWhgdBJPx2ztbADUq3JVI0C5U+bShaeEA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.3.tgz",
+      "integrity": "sha512-eSpdY/eJDuOvuTA3ASzCjdithHa+GIF1L4PqtEELl6Qa3XafdMLBpBlZCIUCX2J+Q6sNmjmxtosAG62fK4BlqQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "^2.1.0-beta.1",
+        "@vitest/spy": "2.1.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.11"
       },
@@ -1582,7 +1582,7 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/spy": "2.1.2",
+        "@vitest/spy": "2.1.3",
         "msw": "^2.3.5",
         "vite": "^5.0.0"
       },
@@ -1596,9 +1596,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.2.tgz",
-      "integrity": "sha512-FIoglbHrSUlOJPDGIrh2bjX1sNars5HbxlcsFKCtKzu4+5lpsRhOCVcuzp0fEhAGHkPZRIXVNzPcpSlkoZ3LuA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.3.tgz",
+      "integrity": "sha512-XH1XdtoLZCpqV59KRbPrIhFCOO0hErxrQCMcvnQete3Vibb9UeIOX02uFPfVn3Z9ZXsq78etlfyhnkmIZSzIwQ==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^1.2.0"
@@ -1608,12 +1608,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.2.tgz",
-      "integrity": "sha512-UCsPtvluHO3u7jdoONGjOSil+uON5SSvU9buQh3lP7GgUXHp78guN1wRmZDX4wGK6J10f9NUtP6pO+SFquoMlw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.3.tgz",
+      "integrity": "sha512-JGzpWqmFJ4fq5ZKHtVO3Xuy1iF2rHGV4d/pdzgkYHm1+gOzNZtqjvyiaDGJytRyMU54qkxpNzCx+PErzJ1/JqQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.1.2",
+        "@vitest/utils": "2.1.3",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -1621,12 +1621,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.2.tgz",
-      "integrity": "sha512-xtAeNsZ++aRIYIUsek7VHzry/9AcxeULlegBvsdLncLmNCR6tR8SRjn8BbDP4naxtccvzTqZ+L1ltZlRCfBZFA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.3.tgz",
+      "integrity": "sha512-qWC2mWc7VAXmjAkEKxrScWHWFyCQx/cmiZtuGqMi+WwqQJ2iURsVY4ZfAK6dVo6K2smKRU6l3BPwqEBvhnpQGg==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.1.2",
+        "@vitest/pretty-format": "2.1.3",
         "magic-string": "^0.30.11",
         "pathe": "^1.1.2"
       },
@@ -1635,9 +1635,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.2.tgz",
-      "integrity": "sha512-GSUi5zoy+abNRJwmFhBDC0yRuVUn8WMlQscvnbbXdKLXX9dE59YbfwXxuJ/mth6eeqIzofU8BB5XDo/Ns/qK2A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.3.tgz",
+      "integrity": "sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^3.0.0"
@@ -1647,12 +1647,12 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.1.2.tgz",
-      "integrity": "sha512-92gcNzkDnmxOxyHzQrQYRsoV9Q0Aay0r4QMLnV+B+lbqlUWa8nDg9ivyLV5mMVTtGirHsYUGGh/zbIA55gBZqA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.1.3.tgz",
+      "integrity": "sha512-2XwTrHVJw3t9NYES26LQUYy51ZB8W4bRPgqUH2Eyda3kIuOlYw1ZdPNU22qcVlUVx4WKgECFQOSXuopsczuVjQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.1.2",
+        "@vitest/utils": "2.1.3",
         "fflate": "^0.8.2",
         "flatted": "^3.3.1",
         "pathe": "^1.1.2",
@@ -1664,16 +1664,16 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "2.1.2"
+        "vitest": "2.1.3"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.2.tgz",
-      "integrity": "sha512-zMO2KdYy6mx56btx9JvAqAZ6EyS3g49krMPPrgOp1yxGZiA93HumGk+bZ5jIZtOg5/VBYl5eBmGRQHqq4FG6uQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.3.tgz",
+      "integrity": "sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.1.2",
+        "@vitest/pretty-format": "2.1.3",
         "loupe": "^3.1.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -3221,9 +3221,9 @@
       "dev": true
     },
     "node_modules/tinyexec": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
-      "integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
       "dev": true
     },
     "node_modules/tinyglobby": {
@@ -3240,9 +3240,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
-      "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
       "dev": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
@@ -3384,9 +3384,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
+      "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -3443,9 +3443,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.2.tgz",
-      "integrity": "sha512-HPcGNN5g/7I2OtPjLqgOtCRu/qhVvBxTUD3qzitmL0SrG1cWFzxzhMDWussxSbrRYWqnKf8P2jiNhPMSN+ymsQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.3.tgz",
+      "integrity": "sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -3464,18 +3464,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.2.tgz",
-      "integrity": "sha512-veNjLizOMkRrJ6xxb+pvxN6/QAWg95mzcRjtmkepXdN87FNfxAss9RKe2far/G9cQpipfgP2taqg0KiWsquj8A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.3.tgz",
+      "integrity": "sha512-Zrxbg/WiIvUP2uEzelDNTXmEMJXuzJ1kCpbDvaKByFA9MNeO95V+7r/3ti0qzJzrxdyuUw5VduN7k+D3VmVOSA==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "2.1.2",
-        "@vitest/mocker": "2.1.2",
-        "@vitest/pretty-format": "^2.1.2",
-        "@vitest/runner": "2.1.2",
-        "@vitest/snapshot": "2.1.2",
-        "@vitest/spy": "2.1.2",
-        "@vitest/utils": "2.1.2",
+        "@vitest/expect": "2.1.3",
+        "@vitest/mocker": "2.1.3",
+        "@vitest/pretty-format": "^2.1.3",
+        "@vitest/runner": "2.1.3",
+        "@vitest/snapshot": "2.1.3",
+        "@vitest/spy": "2.1.3",
+        "@vitest/utils": "2.1.3",
         "chai": "^5.1.1",
         "debug": "^4.3.6",
         "magic-string": "^0.30.11",
@@ -3486,7 +3486,7 @@
         "tinypool": "^1.0.0",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.2",
+        "vite-node": "2.1.3",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -3501,8 +3501,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.2",
-        "@vitest/ui": "2.1.2",
+        "@vitest/browser": "2.1.3",
+        "@vitest/ui": "2.1.3",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -61,24 +61,24 @@
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.47.0",
     "@azure-tools/typespec-azure-core": "0.47.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.47.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.47.1",
     "@azure-tools/typespec-azure-rulesets": "0.47.0",
-    "@azure-tools/typespec-client-generator-core": "0.47.1",
-    "@microsoft/api-extractor": "^7.47.9",
+    "@azure-tools/typespec-client-generator-core": "0.47.2",
+    "@microsoft/api-extractor": "^7.47.11",
     "@microsoft/api-extractor-model": "^7.29.8",
     "@types/js-yaml": "~4.0.9",
     "@types/lodash": "~4.17.10",
-    "@types/node": "~22.7.5",
+    "@types/node": "~22.7.6",
     "@typespec/compiler": "0.61.2",
     "@typespec/http": "0.61.0",
     "@typespec/openapi": "0.61.0",
     "@typespec/rest": "0.61.0",
     "@typespec/versioning": "0.61.0",
-    "@vitest/coverage-v8": "^2.1.2",
-    "@vitest/ui": "^2.1.2",
+    "@vitest/coverage-v8": "^2.1.3",
+    "@vitest/ui": "^2.1.3",
     "c8": "~10.1.2",
     "rimraf": "~6.0.1",
     "typescript": "~5.6.3",
-    "vitest": "^2.1.2"
+    "vitest": "^2.1.3"
   }
 }


### PR DESCRIPTION
both tcgc and resource-manager got a patch bump, not sure what changed though.

preparing a patch release, before https://github.com/microsoft/typespec/pull/4738/
that patch mostly for bumping the npm dependencies, as these patch may intended to fix some problem (and we don't want them get mixed with the bigger PR). we do not expect sdk code change upon this patch.