### PR TITLE
[http-client-csharp] Fix: remove duplicate 'Client' suffix in subclients

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.Generator.CSharp.ClientModel.Primitives;
-using Microsoft.Generator.CSharp.ClientModel.Snippets;
 using Microsoft.Generator.CSharp.Expressions;
 using Microsoft.Generator.CSharp.Input;
 using Microsoft.Generator.CSharp.Primitives;
@@ -25,6 +23,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         private const string AuthorizationApiKeyPrefixConstName = "AuthorizationApiKeyPrefix";
         private const string ApiKeyCredentialFieldName = "_keyCredential";
         private const string EndpointFieldName = "_endpoint";
+        private const string ClientSuffix = "Client";
         private readonly FormattableString _publicCtorDescription;
         private readonly InputClient _inputClient;
         private readonly InputAuth? _inputAuth;
@@ -429,10 +428,13 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
                 var interlockedCompareExchange = Static(typeof(Interlocked)).Invoke(
                     nameof(Interlocked.CompareExchange),
                     [cachedClientFieldVar, New.Instance(subClientInstance.Type, subClientConstructorArgs), Null]);
+                var factoryMethodName = subClient.Value.Name.EndsWith(ClientSuffix, StringComparison.OrdinalIgnoreCase)
+                    ? $"Get{subClient.Value.Name}"
+                    : $"Get{subClient.Value.Name}{ClientSuffix}";
 
                 var factoryMethod = new MethodProvider(
                     new(
-                        $"Get{subClient.Value.Name}Client",
+                        factoryMethodName,
                         $"Initializes a new instance of {subClientInstance.Type.Name}",
                         MethodSignatureModifiers.Public | MethodSignatureModifiers.Virtual,
                         subClientInstance.Type,

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
         private static readonly InputClient _animalClient = new("animal", "AnimalClient description", [], [], TestClientName);
         private static readonly InputClient _dogClient = new("dog", "DogClient description", [], [], _animalClient.Name);
         private static readonly InputClient _catClient = new("cat", "CatClient description", [], [], _animalClient.Name);
+        private static readonly InputClient _hawkClient = new("hawkClient", "HawkClient description", [], [], _animalClient.Name);
         private static readonly InputClient _huskyClient = new("husky", "HuskyClient description", [], [], _dogClient.Name);
 
         [SetUp]
@@ -24,7 +25,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
         {
             MockHelpers.LoadMockPlugin(
                     apiKeyAuth: () => new InputApiKeyAuth("mock", null),
-                    clients: () => [_animalClient, _dogClient, _catClient, _huskyClient]);
+                    clients: () => [_animalClient, _dogClient, _catClient, _huskyClient, _hawkClient]);
         }
 
         // This test validates that the generated code is correct when the client has one direct subclient.
@@ -57,7 +58,8 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
             string[] expectedSubClientFactoryMethodNames =
             [
                 $"Get{_dogClient.Name.ToCleanName()}Client",
-                $"Get{_catClient.Name.ToCleanName()}Client"
+                $"Get{_catClient.Name.ToCleanName()}Client",
+                $"Get{_hawkClient.Name.ToCleanName()}"
             ];
             var clientProvider = new MockClientProvider(_animalClient, expectedSubClientFactoryMethodNames);
             var writer = new TypeProviderWriter(clientProvider);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanRenameSubClient/CanRenameSubClient.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanRenameSubClient/CanRenameSubClient.cs
@@ -1,0 +1,9 @@
+using Microsoft.Generator.CSharp.Customization;
+
+namespace Sample
+{
+    [CodeGenClient("Custom")]
+    internal partial class CustomClient
+    {
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderSubClientTests/SubClientWithMultipleSubClients.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderSubClientTests/SubClientWithMultipleSubClients.cs
@@ -20,5 +20,11 @@ namespace Sample
         {
             return (global::System.Threading.Volatile.Read(ref _cachedCat) ?? (global::System.Threading.Interlocked.CompareExchange(ref _cachedCat, new global::Sample.Cat(), null) ?? _cachedCat));
         }
+
+        /// <summary> Initializes a new instance of HawkClient. </summary>
+        public virtual global::Sample.HawkClient GetHawkClient()
+        {
+            return (global::System.Threading.Volatile.Read(ref _cachedHawkClient) ?? (global::System.Threading.Interlocked.CompareExchange(ref _cachedHawkClient, new global::Sample.HawkClient(), null) ?? _cachedHawkClient));
+        }
     }
 }


### PR DESCRIPTION
fixes: https://github.com/microsoft/typespec/issues/4777