### PR TITLE
[@typespec/http-specs] - Modify code to handle http-client-* packages tests

### DIFF
--- a/packages/http-specs/package.json
+++ b/packages/http-specs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typespec/http-specs",
   "private": true,
-  "version": "0.37.2",
+  "version": "0.1.0",
   "description": "Spec scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/http-specs/specs/encode/bytes/mockapi.ts
+++ b/packages/http-specs/specs/encode/bytes/mockapi.ts
@@ -1,5 +1,11 @@
 import { resolvePath } from "@typespec/compiler";
-import { CollectionFormat, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import {
+  CollectionFormat,
+  json,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+} from "@typespec/spec-api";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 
@@ -71,6 +77,7 @@ function createPropertyServerTests(uri: string, data: any, value: any) {
     },
     response: {
       status: 200,
+      body: json({ value: value }),
     },
     kind: "MockApiDefinition",
   });

--- a/packages/http-specs/specs/payload/json-merge-patch/mockapi.ts
+++ b/packages/http-specs/specs/payload/json-merge-patch/mockapi.ts
@@ -27,11 +27,9 @@ export const expectedCreateBody = {
 };
 
 export const expectedUpdateBody = {
-  name: "Madge",
   description: null,
   map: {
     key: {
-      name: "InnerMadge",
       description: null,
     },
     key2: null,

--- a/packages/http-specs/specs/payload/xml/mockapi.ts
+++ b/packages/http-specs/specs/payload/xml/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi, xml } from "@typespec/spec-api";
+import { MockRequest, passOnSuccess, ScenarioMockApi, xml } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -143,6 +143,13 @@ function createServerTests(uri: string, data?: any) {
         headers: {
           "content-type": "application/xml",
         },
+      },
+      handler: (req: MockRequest) => {
+        req.expect.containsHeader("content-type", "application/xml");
+        req.expect.xmlBodyEquals(data);
+        return {
+          status: 204,
+        };
       },
       response: {
         status: 204,


### PR DESCRIPTION
While working with China Team in https://github.com/Azure/cadl-ranch/pull/755/, I have found that a few changes are required in the specs to handle the test success in `http-client-java`, `http-client-net` and `http-client-python` packages. This PR handles those changes. The scenarios are also validated using the `test:e2e` script.

Please review and approve the PR. Thanks