### PR TITLE
[http-client-csharp] fix: use inputmodel name as default name in serialization provider

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.Serialization.cs");
 
-        protected override string BuildName() => _model.Name;
+        protected override string BuildName() => _inputModel.Name.ToCleanName();
 
         protected override IReadOnlyList<AttributeStatement> BuildAttributes()
         {

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/ModelCustomizationTests.cs
@@ -228,5 +228,27 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.MrwSerializatio
             var file = writer.Write();
             Assert.AreEqual(Helpers.GetExpectedFromFile(), file.Content);
         }
+
+        [Test]
+        public async Task CanCustomizeModelName()
+        {
+            await MockHelpers.LoadMockPluginAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var inputModel = InputFactory.Model("mockInputModel", properties: [], usage: InputModelTypeUsage.Json);
+
+            var plugin = await MockHelpers.LoadMockPluginAsync(
+                inputModels: () => [inputModel],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var modelProvider = plugin.Object.OutputLibrary.TypeProviders.Single(t => t is ModelProvider);
+            var serializationProvider = modelProvider.SerializationProviders.Single(t => t is MrwSerializationTypeDefinition);
+            Assert.IsNotNull(serializationProvider);
+
+            // both providers should have the custom name
+            Assert.AreEqual("CustomModel", modelProvider.Name);
+            Assert.AreEqual("CustomModel", serializationProvider.Name);
+
+            Assert.AreEqual("CustomModel", modelProvider.CustomCodeView?.Name);
+            Assert.AreEqual("CustomModel", serializationProvider.CustomCodeView?.Name);
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeModelName/CustomModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeModelName/CustomModel.cs
@@ -1,0 +1,9 @@
+#nullable disable
+
+using Microsoft.Generator.CSharp.Customization;
+
+namespace Sample.Models
+{
+    [CodeGenModel("MockInputModel")]
+    internal partial class CustomModel { }
+}


### PR DESCRIPTION
This PR fixes an issue where the name of the serialization provider for a model was being built incorrectly when the model is renamed and the renamed model is also further customized. It addresses this issue by ensuring the default name of the serialization provider is the name of the input model it is constructed from.

fixes: https://github.com/microsoft/typespec/issues/4793