### PR TITLE
[@typespec/spector] - Enable Multiple Scenario Paths

### DIFF
--- a/.chronus/changes/MultipleScenariosII-2024-9-24-16-24-37.md
+++ b/.chronus/changes/MultipleScenariosII-2024-9-24-16-24-37.md
@@ -1,0 +1,10 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-specs"
+  - "@typespec/spec-api"
+  - "@typespec/spec-coverage-sdk"
+  - "@typespec/spector"
+---
+
+Release cadl-ranch migrated packages to enable SDK and service testing

--- a/packages/http-specs/package.json
+++ b/packages/http-specs/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@typespec/http-specs",
-  "private": true,
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.0",
   "description": "Spec scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/spec-api/package.json
+++ b/packages/spec-api/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@typespec/spec-api",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.0",
   "description": "Spec api to implement mock api",
   "main": "dist/index.js",
   "type": "module",
-  "private": true,
   "scripts": {
     "watch": "tsc -p ./tsconfig.build.json --watch",
     "build": "tsc -p ./tsconfig.build.json",

--- a/packages/spec-coverage-sdk/package.json
+++ b/packages/spec-coverage-sdk/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@typespec/spec-coverage-sdk",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.0",
   "description": "Spec utility to manage the reported coverage",
   "main": "dist/index.js",
-  "private": true,
   "type": "module",
   "scripts": {
     "watch": "tsc -p ./tsconfig.build.json --watch",

--- a/packages/spector/package.json
+++ b/packages/spector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/spector",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.0",
   "description": "Typespec Core Tool to validate, run mock api, collect coverage.",
   "exports": {
     ".": {
@@ -8,7 +8,6 @@
       "typespec": "./lib/main.tsp"
     }
   },
-  "private": true,
   "type": "module",
   "bin": {
     "tsp-spector": "./cmd/cli.mjs"

--- a/packages/spector/src/actions/check-coverage.ts
+++ b/packages/spector/src/actions/check-coverage.ts
@@ -11,9 +11,11 @@ export interface CheckCoverageConfig {
   coverageFiles: string[];
   mergedCoverageFile: string;
   ignoreNotImplemented?: boolean;
+  exitDueToPreviousError?: boolean;
+  hasMoreScenarios?: boolean;
 }
 
-export async function checkCoverage(config: CheckCoverageConfig) {
+export async function checkCoverage(config: CheckCoverageConfig): Promise<boolean> {
   const inputCoverageFiles = (
     await Promise.all(config.coverageFiles.map((x) => findFilesFromPattern(x)))
   ).flat();
@@ -81,7 +83,17 @@ export async function checkCoverage(config: CheckCoverageConfig) {
   const coverageReport = createCoverageReport(config.scenariosPath, results);
   await writeFile(config.mergedCoverageFile, JSON.stringify(coverageReport, null, 2));
 
-  if (diagnosticsReporter.diagnostics.length) {
-    process.exit(1);
+  
+  if (diagnosticsReporter.diagnostics.length === 0) {
+    if (config.exitDueToPreviousError) {
+      process.exit(1);
+    }
+    return false;
+  } else {
+    if (config.hasMoreScenarios) {
+      return true;
+    } else {
+      process.exit(1);
+    }
   }
 }

--- a/packages/spector/src/actions/check-coverage.ts
+++ b/packages/spector/src/actions/check-coverage.ts
@@ -83,7 +83,6 @@ export async function checkCoverage(config: CheckCoverageConfig): Promise<boolea
   const coverageReport = createCoverageReport(config.scenariosPath, results);
   await writeFile(config.mergedCoverageFile, JSON.stringify(coverageReport, null, 2));
 
-  
   if (diagnosticsReporter.diagnostics.length === 0) {
     if (config.exitDueToPreviousError) {
       process.exit(1);

--- a/packages/spector/src/actions/generate-scenario-summary.ts
+++ b/packages/spector/src/actions/generate-scenario-summary.ts
@@ -29,7 +29,7 @@ export async function generateScenarioSummary({
     await writeFile(outputFile, `${existingContent}\n${summary}`);
   } else {
     await writeFile(outputFile, summary);
-  }  
+  }
   logger.info(`${pc.green("✓")} Scenario summary generated at ${outputFile}.`);
 }
 

--- a/packages/spector/src/actions/generate-scenario-summary.ts
+++ b/packages/spector/src/actions/generate-scenario-summary.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import pc from "picocolors";
 import prettier from "prettier";
 import type { Scenario, ScenarioEndpoint } from "../lib/decorators.js";
@@ -8,11 +8,13 @@ import { loadScenarios } from "../scenarios-resolver.js";
 export interface GenerateScenarioSummaryConfig {
   scenariosPath: string;
   outputFile: string;
+  overrideOutputFile?: boolean;
 }
 
 export async function generateScenarioSummary({
   scenariosPath,
   outputFile,
+  overrideOutputFile,
 }: GenerateScenarioSummaryConfig) {
   const [scenarios, diagnostics] = await loadScenarios(scenariosPath);
 
@@ -20,8 +22,14 @@ export async function generateScenarioSummary({
     process.exit(-1);
   }
 
-  const summary = await createScenarioSummary(scenarios);
-  await writeFile(outputFile, summary);
+  let summary = await createScenarioSummary(scenarios);
+  if (overrideOutputFile) {
+    const existingContent = await readFile(outputFile, "utf-8");
+    summary = summary.replace(/# Spec Project summary/, "");
+    await writeFile(outputFile, `${existingContent}\n${summary}`);
+  } else {
+    await writeFile(outputFile, summary);
+  }  
   logger.info(`${pc.green("✓")} Scenario summary generated at ${outputFile}.`);
 }
 

--- a/packages/spector/src/actions/serve.ts
+++ b/packages/spector/src/actions/serve.ts
@@ -1,12 +1,13 @@
 import { spawn } from "child_process";
 import fetch from "node-fetch";
+import { resolve } from "path";
 import { MockApiApp } from "../app/app.js";
 import { AdminUrls } from "../constants.js";
 import { logger } from "../logger.js";
 import { ensureScenariosPathExists } from "../utils/index.js";
 
 export interface ServeConfig {
-  scenariosPath: string;
+  scenariosPath: string | string[];
   coverageFile: string;
   port: number;
 }
@@ -16,7 +17,14 @@ export interface StopConfig {
 }
 
 export async function serve(config: ServeConfig) {
-  await ensureScenariosPathExists(config.scenariosPath);
+  if(Array.isArray(config.scenariosPath)) {
+    for (let idx = 0; idx < config.scenariosPath.length; idx++) {
+      config.scenariosPath[idx] = resolve(process.cwd(), config.scenariosPath[idx]);
+      await ensureScenariosPathExists(config.scenariosPath[idx]);
+    }
+  } else {
+    await ensureScenariosPathExists(config.scenariosPath);
+  }
 
   const server = new MockApiApp({
     port: config.port,
@@ -30,12 +38,13 @@ export async function startInBackground(config: ServeConfig) {
   return new Promise<void>((resolve) => {
     const [nodeExe, entrypoint] = process.argv;
     logger.info(`Starting server in background at port ${config.port}`);
+    const scenariosPath = Array.isArray(config.scenariosPath)? config.scenariosPath.join(" "): config.scenariosPath;
     const cp = spawn(
       nodeExe,
       [
         entrypoint,
         "serve",
-        config.scenariosPath,
+        scenariosPath,
         "--port",
         config.port.toString(),
         "--coverageFile",

--- a/packages/spector/src/actions/serve.ts
+++ b/packages/spector/src/actions/serve.ts
@@ -17,7 +17,7 @@ export interface StopConfig {
 }
 
 export async function serve(config: ServeConfig) {
-  if(Array.isArray(config.scenariosPath)) {
+  if (Array.isArray(config.scenariosPath)) {
     for (let idx = 0; idx < config.scenariosPath.length; idx++) {
       config.scenariosPath[idx] = resolve(process.cwd(), config.scenariosPath[idx]);
       await ensureScenariosPathExists(config.scenariosPath[idx]);
@@ -38,7 +38,9 @@ export async function startInBackground(config: ServeConfig) {
   return new Promise<void>((resolve) => {
     const [nodeExe, entrypoint] = process.argv;
     logger.info(`Starting server in background at port ${config.port}`);
-    const scenariosPath = Array.isArray(config.scenariosPath)? config.scenariosPath.join(" "): config.scenariosPath;
+    const scenariosPath = Array.isArray(config.scenariosPath)
+      ? config.scenariosPath.join(" ")
+      : config.scenariosPath;
     const cp = spawn(
       nodeExe,
       [

--- a/packages/spector/src/actions/validate-mock-apis.ts
+++ b/packages/spector/src/actions/validate-mock-apis.ts
@@ -79,7 +79,7 @@ export async function validateMockApis({
     if (exitDueToPreviousError && !hasMoreScenarios) {
       process.exit(1);
     }
-    return false;
+    return exitDueToPreviousError;
   } else {
     if (hasMoreScenarios) {
       return true;

--- a/packages/spector/src/actions/validate-mock-apis.ts
+++ b/packages/spector/src/actions/validate-mock-apis.ts
@@ -79,7 +79,8 @@ export async function validateMockApis({
     if (exitDueToPreviousError && !hasMoreScenarios) {
       process.exit(1);
     }
-    return exitDueToPreviousError;
+    if (exitDueToPreviousError) return exitDueToPreviousError;
+    else return false;
   } else {
     if (hasMoreScenarios) {
       return true;

--- a/packages/spector/src/actions/validate-mock-apis.ts
+++ b/packages/spector/src/actions/validate-mock-apis.ts
@@ -76,7 +76,7 @@ export async function validateMockApis({
   }
 
   if (diagnostics.diagnostics.length === 0) {
-    if (exitDueToPreviousError) {
+    if (exitDueToPreviousError && !hasMoreScenarios) {
       process.exit(1);
     }
     return false;

--- a/packages/spector/src/actions/validate-mock-apis.ts
+++ b/packages/spector/src/actions/validate-mock-apis.ts
@@ -10,7 +10,11 @@ export interface ValidateMockApisConfig {
   hasMoreScenarios?: boolean;
 }
 
-export async function validateMockApis({ scenariosPath, exitDueToPreviousError, hasMoreScenarios }: ValidateMockApisConfig) {
+export async function validateMockApis({
+  scenariosPath,
+  exitDueToPreviousError,
+  hasMoreScenarios,
+}: ValidateMockApisConfig) {
   const mockApis = await loadScenarioMockApiFiles(scenariosPath);
   const scenarioFiles = await findScenarioSpecFiles(scenariosPath);
 

--- a/packages/spector/src/actions/validate-mock-apis.ts
+++ b/packages/spector/src/actions/validate-mock-apis.ts
@@ -6,9 +6,11 @@ import { createDiagnosticReporter } from "../utils/diagnostic-reporter.js";
 
 export interface ValidateMockApisConfig {
   scenariosPath: string;
+  exitDueToPreviousError?: boolean;
+  hasMoreScenarios?: boolean;
 }
 
-export async function validateMockApis({ scenariosPath }: ValidateMockApisConfig) {
+export async function validateMockApis({ scenariosPath, exitDueToPreviousError, hasMoreScenarios }: ValidateMockApisConfig) {
   const mockApis = await loadScenarioMockApiFiles(scenariosPath);
   const scenarioFiles = await findScenarioSpecFiles(scenariosPath);
 
@@ -69,7 +71,16 @@ export async function validateMockApis({ scenariosPath }: ValidateMockApisConfig
     }
   }
 
-  if (diagnostics.diagnostics.length) {
-    process.exit(1);
+  if (diagnostics.diagnostics.length === 0) {
+    if (exitDueToPreviousError) {
+      process.exit(1);
+    }
+    return false;
+  } else {
+    if (hasMoreScenarios) {
+      return true;
+    } else {
+      process.exit(1);
+    }
   }
 }

--- a/packages/spector/src/actions/validate-scenarios.ts
+++ b/packages/spector/src/actions/validate-scenarios.ts
@@ -8,7 +8,11 @@ export interface ValidateScenarioConfig {
   hasMoreScenarios?: boolean;
 }
 
-export async function validateScenarios({ scenariosPath, exitDueToPreviousError, hasMoreScenarios }: ValidateScenarioConfig) {
+export async function validateScenarios({
+  scenariosPath,
+  exitDueToPreviousError,
+  hasMoreScenarios,
+}: ValidateScenarioConfig) {
   const [_, diagnostics] = await loadScenarios(scenariosPath);
 
   if (diagnostics.length === 0) {

--- a/packages/spector/src/actions/validate-scenarios.ts
+++ b/packages/spector/src/actions/validate-scenarios.ts
@@ -16,10 +16,10 @@ export async function validateScenarios({
   const [_, diagnostics] = await loadScenarios(scenariosPath);
 
   if (diagnostics.length === 0) {
-    if (exitDueToPreviousError) {
+    logger.info(`${pc.green("✓")} All scenarios are valid.`);
+    if (exitDueToPreviousError && !hasMoreScenarios) {
       process.exit(-1);
     }
-    logger.info(`${pc.green("✓")} All scenarios are valid.`);
     return false;
   } else {
     if (hasMoreScenarios) {

--- a/packages/spector/src/actions/validate-scenarios.ts
+++ b/packages/spector/src/actions/validate-scenarios.ts
@@ -20,7 +20,7 @@ export async function validateScenarios({
     if (exitDueToPreviousError && !hasMoreScenarios) {
       process.exit(-1);
     }
-    return false;
+    return exitDueToPreviousError;
   } else {
     if (hasMoreScenarios) {
       return true;

--- a/packages/spector/src/actions/validate-scenarios.ts
+++ b/packages/spector/src/actions/validate-scenarios.ts
@@ -20,7 +20,8 @@ export async function validateScenarios({
     if (exitDueToPreviousError && !hasMoreScenarios) {
       process.exit(-1);
     }
-    return exitDueToPreviousError;
+    if (exitDueToPreviousError) return exitDueToPreviousError;
+    else return false;
   } else {
     if (hasMoreScenarios) {
       return true;

--- a/packages/spector/src/actions/validate-scenarios.ts
+++ b/packages/spector/src/actions/validate-scenarios.ts
@@ -4,14 +4,24 @@ import { loadScenarios } from "../scenarios-resolver.js";
 
 export interface ValidateScenarioConfig {
   scenariosPath: string;
+  exitDueToPreviousError?: boolean;
+  hasMoreScenarios?: boolean;
 }
 
-export async function validateScenarios({ scenariosPath }: ValidateScenarioConfig) {
+export async function validateScenarios({ scenariosPath, exitDueToPreviousError, hasMoreScenarios }: ValidateScenarioConfig) {
   const [_, diagnostics] = await loadScenarios(scenariosPath);
 
-  if (diagnostics.length > 0) {
-    process.exit(-1);
-  } else {
+  if (diagnostics.length === 0) {
+    if (exitDueToPreviousError) {
+      process.exit(-1);
+    }
     logger.info(`${pc.green("✓")} All scenarios are valid.`);
+    return false;
+  } else {
+    if (hasMoreScenarios) {
+      return true;
+    } else {
+      process.exit(-1);
+    }
   }
 }

--- a/packages/spector/src/app/app.ts
+++ b/packages/spector/src/app/app.ts
@@ -1,4 +1,5 @@
 import { MockApiDefinition, MockRequest, RequestExt, ScenarioMockApi } from "@typespec/spec-api";
+import { ScenariosMetadata } from "@typespec/spec-coverage-sdk";
 import { Response, Router } from "express";
 import { getScenarioMetadata } from "../coverage/common.js";
 import { CoverageTracker } from "../coverage/coverage-tracker.js";
@@ -8,11 +9,10 @@ import { loadScenarioMockApis } from "../scenarios-resolver.js";
 import { MockApiServer } from "../server/index.js";
 import { ApiMockAppConfig } from "./config.js";
 import { processRequest } from "./request-processor.js";
-import { ScenariosMetadata } from "@typespec/spec-coverage-sdk";
 
 export interface ScenariosAndScenariosMetadata {
-  scenarios: Record<string, ScenarioMockApi>, 
-  scenariosMetadata: ScenariosMetadata
+  scenarios: Record<string, ScenarioMockApi>;
+  scenariosMetadata: ScenariosMetadata;
 }
 
 export class MockApiApp {
@@ -29,23 +29,21 @@ export class MockApiApp {
     this.server.use("/", internalRouter);
 
     const ScenariosAndScenariosMetadata: ScenariosAndScenariosMetadata[] = [];
-    if(Array.isArray(this.config.scenarioPath)) {
+    if (Array.isArray(this.config.scenarioPath)) {
       for (let idx = 0; idx < this.config.scenarioPath.length; idx++) {
         const scenarios = await loadScenarioMockApis(this.config.scenarioPath[idx]);
         const scenariosMetadata = await getScenarioMetadata(this.config.scenarioPath[idx]);
-        ScenariosAndScenariosMetadata.push({scenarios, scenariosMetadata});
+        ScenariosAndScenariosMetadata.push({ scenarios, scenariosMetadata });
       }
     } else {
       const scenarios = await loadScenarioMockApis(this.config.scenarioPath);
       const scenariosMetadata = await getScenarioMetadata(this.config.scenarioPath);
-      ScenariosAndScenariosMetadata.push({scenarios, scenariosMetadata});
+      ScenariosAndScenariosMetadata.push({ scenarios, scenariosMetadata });
     }
 
-    this.coverageTracker.setScenarios(
-      ScenariosAndScenariosMetadata
-    );
+    this.coverageTracker.setScenarios(ScenariosAndScenariosMetadata);
 
-    for (const {scenarios} of ScenariosAndScenariosMetadata) {
+    for (const { scenarios } of ScenariosAndScenariosMetadata) {
       for (const [name, scenario] of Object.entries(scenarios)) {
         this.registerScenario(name, scenario);
       }

--- a/packages/spector/src/app/config.ts
+++ b/packages/spector/src/app/config.ts
@@ -7,7 +7,7 @@ export interface ApiMockAppConfig {
   /**
    * Path where are the scenarios.
    */
-  scenarioPath: string;
+  scenarioPath: string | string[];
 
   /**
    * Coverage file Path.

--- a/packages/spector/src/cli/cli.ts
+++ b/packages/spector/src/cli/cli.ts
@@ -236,7 +236,7 @@ async function main() {
       async (args) => {
         let exitDueToPreviousError = false;
         let hasMoreScenarios = true;
-        for (let idx = 0; idx < args.scenariosPaths.length; idx++) { 
+        for (let idx = 0; idx < args.scenariosPaths.length; idx++) {
           logger.info(`Checking coverage for scenarios at ${args.scenariosPaths[idx]}`);
           if (idx === args.scenariosPaths.length - 1) hasMoreScenarios = false;
           exitDueToPreviousError = await checkCoverage({

--- a/packages/spector/src/cli/cli.ts
+++ b/packages/spector/src/cli/cli.ts
@@ -16,7 +16,7 @@ export const DEFAULT_PORT = 3000;
 
 async function main() {
   await yargs(process.argv.slice(2))
-    .scriptName("spec")
+    .scriptName("tsp-spector")
     .strict()
     .help()
     .strict()
@@ -35,29 +35,39 @@ async function main() {
       }
     })
     .command(
-      "validate-scenarios <scenariosPath>",
+      "validate-scenarios <scenariosPaths..>",
       "Compile and validate all the Spec scenarios.",
       (cmd) => {
-        return cmd.positional("scenariosPath", {
-          description: "Path to the scenarios",
+        return cmd.positional("scenariosPaths", {
+          description: "Path(s) to the scenarios",
           type: "string",
+          array: true,
           demandOption: true,
         });
       },
       async (args) => {
-        await validateScenarios({
-          scenariosPath: resolve(process.cwd(), args.scenariosPath),
-        });
+        let exitDueToPreviousError = false;
+        let hasMoreScenarios = true;
+        for (let idx = 0; idx < args.scenariosPaths.length; idx++) {
+          logger.info(`Validating scenarios at ${args.scenariosPaths[idx]}`);
+          if (idx === args.scenariosPaths.length - 1) hasMoreScenarios = false;
+          exitDueToPreviousError = await validateScenarios({
+            scenariosPath: resolve(process.cwd(), args.scenariosPaths[idx]),
+            exitDueToPreviousError,
+            hasMoreScenarios,
+          });
+        }
       },
     )
     .command(
-      "generate-scenarios-summary <scenariosPath>",
+      "generate-scenarios-summary <scenariosPaths..>",
       "Compile and validate all the Spec scenarios.",
       (cmd) => {
         return cmd
-          .positional("scenariosPath", {
-            description: "Path to the scenarios",
+          .positional("scenariosPaths", {
+            description: "Path(s) to the scenarios",
             type: "string",
+            array: true,
             demandOption: true,
           })
           .option("outputFile", {
@@ -67,10 +77,16 @@ async function main() {
           });
       },
       async (args) => {
-        await generateScenarioSummary({
-          scenariosPath: resolve(process.cwd(), args.scenariosPath),
-          outputFile: resolve(process.cwd(), args.outputFile),
-        });
+        let overrideOutputFile = false;
+        for (const scenariosPath of args.scenariosPaths) {
+          logger.info(`Generating scenarios summary for ${scenariosPath}`);
+          await generateScenarioSummary({
+            scenariosPath: resolve(process.cwd(), scenariosPath),
+            outputFile: resolve(process.cwd(), args.outputFile),
+            overrideOutputFile,
+          });
+          overrideOutputFile = true;
+        }
       },
     )
     .command("server", "Server management", (cmd) => {
@@ -119,13 +135,14 @@ async function main() {
         );
     })
     .command(
-      "serve <scenariosPath>",
+      "serve <scenariosPaths..>",
       "Serve the mock api at the given paths.",
       (cmd) => {
         return cmd
-          .positional("scenariosPath", {
-            description: "Path to the scenarios and mock apis",
+          .positional("scenariosPaths", {
+            description: "Path(s) to the scenarios and mock apis",
             type: "string",
+            array: true,
             demandOption: true,
           })
           .option("port", {
@@ -142,20 +159,21 @@ async function main() {
       },
       async (args) => {
         await serve({
-          scenariosPath: resolve(process.cwd(), args.scenariosPath),
+          scenariosPath: args.scenariosPaths,
           port: args.port,
           coverageFile: args.coverageFile,
         });
       },
     )
     .command(
-      "server-test <scenariosPath>",
+      "server-test <scenariosPaths..>",
       "Executes the test cases against the service",
       (cmd) => {
         return cmd
-          .positional("scenariosPath", {
-            description: "Path to the scenarios and mock apis",
+          .positional("scenariosPaths", {
+            description: "Path(s) to the scenarios and mock apis",
             type: "string",
+            array: true,
             demandOption: true,
           })
           .option("baseUrl", {
@@ -170,23 +188,26 @@ async function main() {
             description: "File that has the Scenarios to run",
             type: "string",
           })
-          .demandOption("scenariosPath", "serverBasePath");
+          .demandOption("scenariosPaths", "serverBasePath");
       },
       async (args) => {
-        await serverTest(args.scenariosPath, {
-          baseUrl: args.baseUrl,
-          runSingleScenario: args.runSingleScenario,
-          runScenariosFromFile: args.runScenariosFromFile,
-        });
+        for (const scenariosPath of args.scenariosPaths) {
+          logger.info(`Executing server tests for scenarios at ${scenariosPath}`);
+          await serverTest(scenariosPath, {
+            baseUrl: args.baseUrl,
+            runSingleScenario: args.runSingleScenario,
+            runScenariosFromFile: args.runScenariosFromFile,
+          });
+        }
       },
     )
     .command(
-      "check-coverage <scenariosPath>",
+      "check-coverage <scenariosPaths..>",
       "Serve the mock api at the given paths.",
       (cmd) => {
         return cmd
-          .positional("scenariosPath", {
-            description: "Path to the scenarios and mock apis",
+          .positional("scenariosPaths", {
+            description: "Path(s) to the scenarios and mock apis",
             type: "string",
             demandOption: true,
           })
@@ -213,39 +234,57 @@ async function main() {
           });
       },
       async (args) => {
-        await checkCoverage({
-          scenariosPath: resolve(process.cwd(), args.scenariosPath),
-          configFile: args.configFile,
-          mergedCoverageFile: resolve(process.cwd(), args.mergedCoverageFile),
-          coverageFiles: args.coverageFiles.map((x) => resolve(process.cwd(), x)),
-          ignoreNotImplemented: args.ignoreNotImplemented,
-        });
+        let exitDueToPreviousError = false;
+        let hasMoreScenarios = true;
+        for (let idx = 0; idx < args.scenariosPaths.length; idx++) { 
+          logger.info(`Checking coverage for scenarios at ${args.scenariosPaths[idx]}`);
+          if (idx === args.scenariosPaths.length - 1) hasMoreScenarios = false;
+          exitDueToPreviousError = await checkCoverage({
+            scenariosPath: resolve(process.cwd(), args.scenariosPaths[idx]),
+            configFile: args.configFile,
+            mergedCoverageFile: resolve(process.cwd(), args.mergedCoverageFile),
+            coverageFiles: args.coverageFiles.map((x) => resolve(process.cwd(), x)),
+            ignoreNotImplemented: args.ignoreNotImplemented,
+            exitDueToPreviousError,
+            hasMoreScenarios,
+          });
+        }
       },
     )
     .command(
-      "validate-mock-apis <scenariosPath>",
+      "validate-mock-apis <scenariosPaths..>",
       "Validate mock apis have all the scenarios specified",
       (cmd) => {
-        return cmd.positional("scenariosPath", {
+        return cmd.positional("scenariosPaths", {
           description: "Path to the scenarios and mock apis",
           type: "string",
+          array: true,
           demandOption: true,
         });
       },
       async (args) => {
-        await validateMockApis({
-          scenariosPath: resolve(process.cwd(), args.scenariosPath),
-        });
+        let exitDueToPreviousError = false;
+        let hasMoreScenarios = true;
+        for (let idx = 0; idx < args.scenariosPaths.length; idx++) {
+          logger.info(`Validating mock apis for scenarios at ${args.scenariosPaths[idx]}`);
+          if (idx === args.scenariosPaths.length - 1) hasMoreScenarios = false;
+          exitDueToPreviousError = await validateMockApis({
+            scenariosPath: resolve(process.cwd(), args.scenariosPaths[idx]),
+            exitDueToPreviousError,
+            hasMoreScenarios,
+          });
+        }
       },
     )
     .command(
-      "upload-manifest <scenariosPath>",
+      "upload-manifest <scenariosPaths..>",
       "Upload the scenario manifest. DO NOT CALL in generator.",
       (cmd) => {
         return cmd
-          .positional("scenariosPath", {
+          .positional("scenariosPaths", {
             description: "Path to the scenarios and mock apis",
             type: "string",
+            array: true,
             demandOption: true,
           })
           .option("storageAccountName", {
@@ -255,10 +294,13 @@ async function main() {
           .demandOption("storageAccountName");
       },
       async (args) => {
-        await uploadScenarioManifest({
-          scenariosPath: resolve(process.cwd(), args.scenariosPath),
-          storageAccountName: args.storageAccountName,
-        });
+        for (const scenariosPath of args.scenariosPaths) {
+          logger.info(`Uploading scenario manifest for scenarios at ${scenariosPath}`);
+          await uploadScenarioManifest({
+            scenariosPath: resolve(process.cwd(), scenariosPath),
+            storageAccountName: args.storageAccountName,
+          });
+        }
       },
     )
     .command(


### PR DESCRIPTION
Currently we could execute the `serve`/`server-test`/... command such as:

`pnpm .\cmd\cli.mjs serve ..\http-specs\specs`

i.e we could provide only one path of scenarios to execute. But, since we separated the scenarios to azure and non-azure specific cases to 2 different packages, we need a way to execute commands such as:

`pnpm .\cmd\cli.mjs serve ..\http-specs\specs ..\..\..\typespec-azure\packages\azure-http-specs\specs\`

The same procedure must be followed in all other commands such as `validate-scenarios`, `generate-scenarios-summary`, etc. Since we have to do it for all the commands and we need to change in all the places, it is much simpler to do it in one location where we copy the files to one common temp location and execute from there. 

Also, in this PR, I have removed the `private: true` option for all the 5 packages to start the rollout process. 

Please review and approve the PR. Thanks
