### PR TITLE
Allow trailing delimited in most locations

### DIFF
--- a/.chronus/changes/trailing-delimited-most-locations-2024-9-23-16-28-11.md
+++ b/.chronus/changes/trailing-delimited-most-locations-2024-9-23-16-28-11.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Allow trailing delimiter in array values, tuple, decorator declaration, scalar initializer, etc.

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -150,12 +150,6 @@ const diagnostics = {
       typeofTarget: "Typeof expects a value literal or value reference.",
     },
   },
-  "trailing-token": {
-    severity: "error",
-    messages: {
-      default: paramMessage`Trailing ${"token"}`,
-    },
-  },
   "unknown-directive": {
     severity: "error",
     messages: {

--- a/packages/compiler/src/core/parser.ts
+++ b/packages/compiler/src/core/parser.ts
@@ -171,7 +171,6 @@ interface ListKind {
   readonly delimiter: DelimiterToken;
   readonly toleratedDelimiter: DelimiterToken;
   readonly toleratedDelimiterIsValid: boolean;
-  readonly trailingDelimiterIsValid: boolean;
   readonly invalidAnnotationTarget?: string;
   readonly allowedStatementKeyword: Token;
 }
@@ -193,7 +192,6 @@ namespace ListKind {
   const PropertiesBase = {
     allowEmpty: true,
     toleratedDelimiterIsValid: true,
-    trailingDelimiterIsValid: true,
     allowedStatementKeyword: Token.None,
   } as const;
 
@@ -269,7 +267,6 @@ namespace ListKind {
     delimiter: Token.Comma,
     toleratedDelimiter: Token.Semicolon,
     toleratedDelimiterIsValid: false,
-    trailingDelimiterIsValid: true,
     invalidAnnotationTarget: "expression",
     allowedStatementKeyword: Token.None,
   } as const;
@@ -296,7 +293,6 @@ namespace ListKind {
   export const Heritage = {
     ...ExpresionsBase,
     allowEmpty: false,
-    trailingDelimiterIsValid: false,
     open: Token.None,
     close: Token.None,
   } as const;
@@ -3231,23 +3227,11 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
       }
 
       r.items.push(item);
-      const delimiter = token();
-      const delimiterPos = tokenPos();
 
       if (parseOptionalDelimiter(kind)) {
         // Delimiter found: check if it's trailing.
         if (parseOptional(kind.close)) {
           mutate(r.range).end = previousTokenEnd;
-          if (!kind.trailingDelimiterIsValid) {
-            error({
-              code: "trailing-token",
-              format: { token: TokenDisplay[delimiter] },
-              target: {
-                pos: delimiterPos,
-                end: delimiterPos + 1,
-              },
-            });
-          }
           // It was trailing and we've consumed the close token.
           break;
         }

--- a/packages/compiler/src/core/parser.ts
+++ b/packages/compiler/src/core/parser.ts
@@ -269,7 +269,7 @@ namespace ListKind {
     delimiter: Token.Comma,
     toleratedDelimiter: Token.Semicolon,
     toleratedDelimiterIsValid: false,
-    trailingDelimiterIsValid: false,
+    trailingDelimiterIsValid: true,
     invalidAnnotationTarget: "expression",
     allowedStatementKeyword: Token.None,
   } as const;
@@ -296,6 +296,7 @@ namespace ListKind {
   export const Heritage = {
     ...ExpresionsBase,
     allowEmpty: false,
+    trailingDelimiterIsValid: false,
     open: Token.None,
     close: Token.None,
   } as const;

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -168,9 +168,16 @@ describe("compiler: parser", () => {
       `scalar bar extends uuid {
         init fromOther(abc: string)
       }`,
+      `scalar bar extends uuid {
+        init trailingComma(abc: string, def: string,)
+      }`,
     ]);
 
     parseErrorEach([["scalar uuid is string;", [{ message: "'{' expected." }]]]);
+  });
+
+  describe("operation statements", () => {
+    parseEach(["op foo(): int32;", "op trailingCommas(a: string,b: other,): int32;"]);
   });
 
   describe("interface statements", () => {
@@ -190,6 +197,7 @@ describe("compiler: parser", () => {
       ["interface X { foo(a: string", [/'\)' expected/]],
       ["interface X { foo(@myDec", [/Property expected/]],
       ["interface X { foo(#suppress x", [/Property expected/]],
+      ["interface TrailingComma extends A, B, {}", [{ code: "token-expected" }]],
     ]);
   });
 
@@ -202,6 +210,7 @@ describe("compiler: parser", () => {
       'namespace A { op b(param: [number, string]): [1, "hi"]; }',
       "alias EmptyTuple =  [];",
       "model Template<T=[]> { }",
+      "alias TrailingComma = [1, 2,];",
     ]);
   });
 
@@ -245,6 +254,7 @@ describe("compiler: parser", () => {
       `const a = int8(123);`,
       `const a = utcDateTime.fromISO("abc");`,
       `const a = utcDateTime.fromISO("abc", "def");`,
+      `const trailingComma = utcDateTime.fromISO("abc", "def",);`,
     ]);
     parseErrorEach([
       [`const a = int8(123;`, [{ message: "')' expected." }]],
@@ -266,6 +276,7 @@ describe("compiler: parser", () => {
       `const A = #["abc"];`,
       `const A = #["abc", 123];`,
       `const A = #["abc", 123, #{nested: true}];`,
+      `const Trailing = #["abc", 123,];`,
     ]);
   });
 
@@ -814,6 +825,7 @@ describe("compiler: parser", () => {
       "extern dec myDec(target: Type, optional?: StringLiteral);",
       "extern dec myDec(target: Type, ...rest: StringLiteral[]);",
       "extern dec myDec(target, arg1, ...rest);",
+      "extern dec trailingComma(target, arg1: other, arg2: string,);",
     ]);
 
     parseErrorEach([
@@ -861,6 +873,7 @@ describe("compiler: parser", () => {
       "extern fn myDec(optional?: StringLiteral): void;",
       "extern fn myDec(...rest: StringLiteral[]): void;",
       "extern fn myDec(arg1, ...rest): void;",
+      "extern fn trailingComma(arg1: other, arg2: string,);",
     ]);
 
     parseErrorEach([
@@ -1235,6 +1248,14 @@ describe("compiler: parser", () => {
         strict: true,
       },
     );
+  });
+
+  describe("template parameters", () => {
+    parseEach(["model Foo<T> {}", "model TrailingComma<A, B,> {}"]);
+  });
+
+  describe("template arguments", () => {
+    parseEach(["alias Test = Foo<T>;", "alias TrailingComma = Foo<A, B,>;"]);
   });
 
   describe("annotations order", () => {

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -197,7 +197,6 @@ describe("compiler: parser", () => {
       ["interface X { foo(a: string", [/'\)' expected/]],
       ["interface X { foo(@myDec", [/Property expected/]],
       ["interface X { foo(#suppress x", [/Property expected/]],
-      ["interface TrailingComma extends A, B, {}", [{ code: "token-expected" }]],
     ]);
   });
 


### PR DESCRIPTION
fix #2284 
fix https://github.com/microsoft/typespec/issues/809

Extracted the parser change from pr #4372 and made it more generic to cover also issue #809