### PR TITLE
[http-client-csharp] Fix: Properly handle property wire nullability during deserialization

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DeserializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DeserializationTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Generator.CSharp.ClientModel.Providers;
 using Microsoft.Generator.CSharp.Input;
@@ -45,6 +47,51 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.MrwSerializatio
             var writer = new TypeProviderWriter(mrwProvider!);
             var file = writer.Write();
             Assert.AreEqual(Helpers.GetExpectedFromFile(), file.Content);
+        }
+
+        [TestCaseSource(nameof(TestDeserializationStatementTestCases))]
+        public void TestDeserializationStatement(InputModelProperty prop, bool hasNullCheck, bool hasNullAssignment)
+        {
+            var inputModel = InputFactory.Model("TestModel", properties: [prop]);
+
+            var mrwProvider = new ModelProvider(inputModel).SerializationProviders.FirstOrDefault();
+            Assert.IsNotNull(mrwProvider);
+
+            var deserializationMethod = mrwProvider!.Methods.Where(m => m.Signature.Name.StartsWith("Deserialize")).FirstOrDefault();
+            Assert.IsNotNull(deserializationMethod);
+
+            var deserializationStatements = deserializationMethod!.BodyStatements;
+
+            Assert.AreEqual(hasNullCheck, deserializationStatements!.ToDisplayString().Contains(
+               "if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))"));
+            Assert.AreEqual(hasNullAssignment, deserializationStatements!.ToDisplayString().Contains("prop1 = null;"));
+        }
+
+        public static IEnumerable<TestCaseData> TestDeserializationStatementTestCases
+        {
+            get
+            {
+                // non-nullable string property
+                yield return new TestCaseData(
+                    InputFactory.Property("prop1", InputPrimitiveType.String),
+                    false,
+                    false);
+                // nullable string property
+                yield return new TestCaseData(
+                    InputFactory.Property("prop1", new InputNullableType(InputPrimitiveType.String)),
+                    true,
+                    true);
+                // required string property
+                yield return new TestCaseData(
+                    InputFactory.Property("prop1", InputPrimitiveType.String, isRequired: true),
+                    false,
+                    false);
+                // reference type property
+                yield return new TestCaseData(
+                    InputFactory.Property("prop1", InputFactory.Model("TestModel2")),
+                    true,
+                    false);
+            }
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DeserializationTests/DeserializeStruct.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DeserializationTests/DeserializeStruct.cs
@@ -25,11 +25,6 @@ namespace Sample.Models
             {
                 if (prop.NameEquals("stringProperty"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        stringProperty = null;
-                        continue;
-                    }
                     stringProperty = prop.Value.GetString();
                     continue;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeEnumToFieldFrameworkType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeEnumToFieldFrameworkType.cs
@@ -81,7 +81,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = prop.Value.GetObject();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeEnumToFrameworkType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeEnumToFrameworkType.cs
@@ -81,7 +81,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = prop.Value.GetObject();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeFixedEnumString.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeFixedEnumString.cs
@@ -78,7 +78,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = prop.Value.GetString().ToMockInputEnum();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeNullableStringToFixedEnum.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeNullableStringToFixedEnum.cs
@@ -85,7 +85,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = prop.Value.GetString().ToMockInputEnum();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeStringToFixedEnum.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeStringToFixedEnum.cs
@@ -78,7 +78,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = prop.Value.GetString().ToMockInputEnum();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeUriProperty.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/ModelCustomizationTests/CanCustomizeUriProperty.cs
@@ -81,7 +81,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = new global::System.Uri(prop.Value.GetString());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangeDictionaryToBinaryData.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangeDictionaryToBinaryData.cs
@@ -88,7 +88,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = global::System.BinaryData.FromString(prop.Value.GetRawText());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangePropertyName.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangePropertyName.cs
@@ -91,7 +91,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop2 = null;
                         continue;
                     }
                     global::System.Collections.Generic.List<string> array = new global::System.Collections.Generic.List<string>();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangePropertySerializedName.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangePropertySerializedName.cs
@@ -91,31 +91,16 @@ namespace Sample.Models
             {
                 if (prop.NameEquals("customName"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        name = null;
-                        continue;
-                    }
                     name = prop.Value.GetString();
                     continue;
                 }
                 if (prop.NameEquals("flavor"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        flavor = null;
-                        continue;
-                    }
                     flavor = prop.Value.GetString();
                     continue;
                 }
                 if (prop.NameEquals("customColor2"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        customColor = null;
-                        continue;
-                    }
                     customColor = prop.Value.GetString();
                     continue;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangeToNonNullableProp/Model.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangeToNonNullableProp/Model.cs
@@ -1,0 +1,10 @@
+
+using Microsoft.Generator.CSharp.Customization;
+
+namespace Sample.Models
+{
+    public partial class Model
+    {
+        public int Prop1 { get; set; }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeExtensibleEnum(int32).cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeExtensibleEnum(int32).cs
@@ -78,7 +78,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = new global::Sample.Models.EnumType(prop.Value.GetInt32());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeExtensibleEnum(string).cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeExtensibleEnum(string).cs
@@ -78,7 +78,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = new global::Sample.Models.EnumType(prop.Value.GetString());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeLiteralExtensibleEnum(int32,1).cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeLiteralExtensibleEnum(int32,1).cs
@@ -78,7 +78,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = new global::Sample.Models.EnumType(prop.Value.GetInt32());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeLiteralExtensibleEnum(string,foo).cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeLiteralExtensibleEnum(string,foo).cs
@@ -78,7 +78,6 @@ namespace Sample.Models
                 {
                     if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
                     {
-                        prop1 = null;
                         continue;
                     }
                     prop1 = new global::Sample.Models.EnumType(prop.Value.GetString());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizePropertyUsingField.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizePropertyUsingField.cs
@@ -79,11 +79,6 @@ namespace Sample.Models
             {
                 if (prop.NameEquals("prop1"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        prop1 = null;
-                        continue;
-                    }
                     prop1 = prop.Value.GetString();
                     continue;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeSerializationMethod.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeSerializationMethod.cs
@@ -92,21 +92,11 @@ namespace Sample.Models
             {
                 if (prop.NameEquals("prop1"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        prop1 = null;
-                        continue;
-                    }
                     DeserializationMethod(prop, ref prop1);
                     continue;
                 }
                 if (prop.NameEquals("prop2"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        prop2 = null;
-                        continue;
-                    }
                     DeserializationMethod(prop, ref prop2);
                     continue;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeSerializationMethodForRenamedProperty.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanCustomizeSerializationMethodForRenamedProperty.cs
@@ -92,21 +92,11 @@ namespace Sample.Models
             {
                 if (prop.NameEquals("prop1"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        prop1 = null;
-                        continue;
-                    }
                     DeserializationMethod(prop, ref prop1);
                     continue;
                 }
                 if (prop.NameEquals("prop2"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        prop3 = null;
-                        continue;
-                    }
                     DeserializationMethod(prop, ref prop3);
                     continue;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanReplaceSerializationMethod.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanReplaceSerializationMethod.cs
@@ -49,11 +49,6 @@ namespace Sample.Models
             {
                 if (prop.NameEquals("prop1"u8))
                 {
-                    if ((prop.Value.ValueKind == global::System.Text.Json.JsonValueKind.Null))
-                    {
-                        prop1 = null;
-                        continue;
-                    }
                     prop1 = prop.Value.GetString();
                     continue;
                 }

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/RoundTripModel.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/RoundTripModel.Serialization.cs
@@ -348,7 +348,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        intExtensibleEnum = null;
                         continue;
                     }
                     intExtensibleEnum = new IntExtensibleEnum(prop.Value.GetInt32());
@@ -372,7 +371,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        floatExtensibleEnum = null;
                         continue;
                     }
                     floatExtensibleEnum = new FloatExtensibleEnum(prop.Value.GetSingle());
@@ -382,7 +380,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        floatExtensibleEnumWithIntValue = null;
                         continue;
                     }
                     floatExtensibleEnumWithIntValue = new FloatExtensibleEnumWithIntValue(prop.Value.GetSingle());
@@ -406,7 +403,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        floatFixedEnum = null;
                         continue;
                     }
                     floatFixedEnum = prop.Value.GetSingle().ToFloatFixedEnum();
@@ -416,7 +412,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        floatFixedEnumWithIntValue = null;
                         continue;
                     }
                     floatFixedEnumWithIntValue = prop.Value.GetInt32().ToFloatFixedEnumWithIntValue();
@@ -440,7 +435,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        intFixedEnum = null;
                         continue;
                     }
                     intFixedEnum = prop.Value.GetInt32().ToIntFixedEnum();
@@ -464,7 +458,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        stringFixedEnum = null;
                         continue;
                     }
                     stringFixedEnum = prop.Value.GetString().ToStringFixedEnum();
@@ -479,7 +472,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalUnknown = null;
                         continue;
                     }
                     optionalUnknown = BinaryData.FromString(prop.Value.GetRawText());

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/Thing.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/Thing.Serialization.cs
@@ -194,7 +194,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalLiteralString = null;
                         continue;
                     }
                     optionalLiteralString = new ThingOptionalLiteralString(prop.Value.GetString());
@@ -204,7 +203,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalLiteralInt = null;
                         continue;
                     }
                     optionalLiteralInt = new ThingOptionalLiteralInt(prop.Value.GetInt32());
@@ -214,7 +212,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalLiteralFloat = null;
                         continue;
                     }
                     optionalLiteralFloat = new ThingOptionalLiteralFloat(prop.Value.GetSingle());
@@ -224,7 +221,6 @@ namespace UnbrandedTypeSpec.Models
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalLiteralBool = null;
                         continue;
                     }
                     optionalLiteralBool = prop.Value.GetBoolean();


### PR DESCRIPTION
This PR adds a set of fixes related to the generated deserialization code and customization:
- Properties will be set to null during deserialization if both the customized type and the wire type are nullable. Previously, this exposed a corner case where the wire type was nullable but the customized type was not.
- Removed the unnecessary null check when a custom deserialization method hook is added for a property.

fixes: https://github.com/microsoft/typespec/issues/4813