### PR TITLE
[http-client-csharp] Fix: add support for 201 classifier

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/RestClientProvider.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Xml.Linq;
 using Microsoft.Generator.CSharp.ClientModel.Primitives;
 using Microsoft.Generator.CSharp.ClientModel.Snippets;
 using Microsoft.Generator.CSharp.Expressions;
@@ -37,10 +35,12 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         internal ClientProvider ClientProvider { get; }
 
         private FieldProvider _pipelineMessageClassifier200;
+        private FieldProvider _pipelineMessageClassifier201;
         private FieldProvider _pipelineMessageClassifier204;
         private FieldProvider _pipelineMessageClassifier2xxAnd4xx;
         private TypeProvider _classifier2xxAnd4xxDefinition;
 
+        private PropertyProvider _classifier201Property;
         private PropertyProvider _classifier200Property;
         private PropertyProvider _classifier204Property;
         private PropertyProvider _classifier2xxAnd4xxProperty;
@@ -50,10 +50,12 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             _inputClient = inputClient;
             ClientProvider = clientProvider;
             _pipelineMessageClassifier200 = new FieldProvider(FieldModifiers.Private | FieldModifiers.Static, ClientModelPlugin.Instance.TypeFactory.StatusCodeClassifierApi.ResponseClassifierType, "_pipelineMessageClassifier200", this);
+            _pipelineMessageClassifier201 = new FieldProvider(FieldModifiers.Private | FieldModifiers.Static, ClientModelPlugin.Instance.TypeFactory.StatusCodeClassifierApi.ResponseClassifierType, "_pipelineMessageClassifier201", this);
             _pipelineMessageClassifier204 = new FieldProvider(FieldModifiers.Private | FieldModifiers.Static, ClientModelPlugin.Instance.TypeFactory.StatusCodeClassifierApi.ResponseClassifierType, "_pipelineMessageClassifier204", this);
             _classifier2xxAnd4xxDefinition = new Classifier2xxAnd4xxDefinition(this);
             _pipelineMessageClassifier2xxAnd4xx = new FieldProvider(FieldModifiers.Private | FieldModifiers.Static, _classifier2xxAnd4xxDefinition.Type, "_pipelineMessageClassifier2xxAnd4xx", this);
             _classifier200Property = GetResponseClassifierProperty(_pipelineMessageClassifier200, 200);
+            _classifier201Property = GetResponseClassifierProperty(_pipelineMessageClassifier201, 201);
             _classifier204Property = GetResponseClassifierProperty(_pipelineMessageClassifier204, 204);
             _classifier2xxAnd4xxProperty = new PropertyProvider(
                 $"Gets the PipelineMessageClassifier2xxAnd4xx",
@@ -73,6 +75,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             return
             [
                 _classifier200Property,
+                _classifier201Property,
                 _classifier204Property,
                 _classifier2xxAnd4xxProperty
             ];
@@ -95,6 +98,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             return
             [
                 _pipelineMessageClassifier200,
+                _pipelineMessageClassifier201,
                 _pipelineMessageClassifier204,
                 _pipelineMessageClassifier2xxAnd4xx
             ];
@@ -196,6 +200,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
                 return response.StatusCodes[0] switch
                 {
                     200 => _classifier200Property,
+                    201 => _classifier201Property,
                     204 => _classifier204Property,
                     _ => throw new InvalidOperationException($"Unexpected status code {response.StatusCodes[0]}")
                 };

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/RestClientProviderTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
             var pipelineMessageClassifier201 = propertyHash["PipelineMessageClassifier201"];
             Assert.AreEqual("PipelineMessageClassifier", pipelineMessageClassifier201.Type.Name);
             Assert.AreEqual("PipelineMessageClassifier201", pipelineMessageClassifier201.Name);
-            Assert.AreEqual(MethodSignatureModifiers.Private | MethodSignatureModifiers.Static, pipelineMessageClassifier200.Modifiers);
+            Assert.AreEqual(MethodSignatureModifiers.Private | MethodSignatureModifiers.Static, pipelineMessageClassifier201.Modifiers);
             Assert.IsFalse(pipelineMessageClassifier201.Body.HasSetter);
 
             //validate _pipelineMessageClassifier204

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/RestClientProviderTests.cs
@@ -73,6 +73,13 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
             Assert.AreEqual("_pipelineMessageClassifier200", pipelineMessageClassifier200.Name);
             Assert.AreEqual(FieldModifiers.Private | FieldModifiers.Static, pipelineMessageClassifier200.Modifiers);
 
+            //validate _pipelineMessageClassifier201
+            Assert.IsTrue(fieldHash.ContainsKey("_pipelineMessageClassifier201"));
+            var pipelineMessageClassifier201 = fieldHash["_pipelineMessageClassifier201"];
+            Assert.AreEqual("PipelineMessageClassifier", pipelineMessageClassifier201.Type.Name);
+            Assert.AreEqual("_pipelineMessageClassifier201", pipelineMessageClassifier201.Name);
+            Assert.AreEqual(FieldModifiers.Private | FieldModifiers.Static, pipelineMessageClassifier201.Modifiers);
+
             //validate _pipelineMessageClassifier204
             Assert.IsTrue(fieldHash.ContainsKey("_pipelineMessageClassifier204"));
             var pipelineMessageClassifier204 = fieldHash["_pipelineMessageClassifier204"];
@@ -101,6 +108,14 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
             Assert.AreEqual("PipelineMessageClassifier200", pipelineMessageClassifier200.Name);
             Assert.AreEqual(MethodSignatureModifiers.Private | MethodSignatureModifiers.Static, pipelineMessageClassifier200.Modifiers);
             Assert.IsFalse(pipelineMessageClassifier200.Body.HasSetter);
+
+            //validate _pipelineMessageClassifier201
+            Assert.IsTrue(propertyHash.ContainsKey("PipelineMessageClassifier201"));
+            var pipelineMessageClassifier201 = propertyHash["PipelineMessageClassifier201"];
+            Assert.AreEqual("PipelineMessageClassifier", pipelineMessageClassifier201.Type.Name);
+            Assert.AreEqual("PipelineMessageClassifier201", pipelineMessageClassifier201.Name);
+            Assert.AreEqual(MethodSignatureModifiers.Private | MethodSignatureModifiers.Static, pipelineMessageClassifier200.Modifiers);
+            Assert.IsFalse(pipelineMessageClassifier201.Body.HasSetter);
 
             //validate _pipelineMessageClassifier204
             Assert.IsTrue(propertyHash.ContainsKey("PipelineMessageClassifier204"));
@@ -237,6 +252,32 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
             Assert.IsTrue(bodyStatements!.Statements.Any(s => s.ToDisplayString() == "uri.AppendPath(_apiVersion, true);\n"));
         }
 
+        [TestCaseSource(nameof(ValidateClientResponseClassifiersTestCases))]
+        public void ValidateClientResponseClassifiers(InputClient inputClient)
+        {
+            var restClientProvider = new ClientProvider(inputClient).RestClient;
+            var method = restClientProvider.Methods.FirstOrDefault(m => m.Signature.Name == "CreateTestOperationRequest");
+            Assert.IsNotNull(method);
+
+            var bodyStatements = method?.BodyStatements as MethodBodyStatements;
+            Assert.IsNotNull(bodyStatements);
+            /* verify that the expected classifier is present in the body */
+            var inputOp = inputClient.Operations.FirstOrDefault();
+            Assert.IsNotNull(inputOp);
+            var expectedStatusCode = inputOp!.Responses.FirstOrDefault()?.StatusCodes.FirstOrDefault();
+            Assert.IsNotNull(expectedStatusCode);
+            if (expectedStatusCode == 201)
+            {
+                Assert.IsTrue(bodyStatements!.Statements.Any(s => s.ToDisplayString() == "message.ResponseClassifier = PipelineMessageClassifier201;\n"));
+                Assert.IsFalse(bodyStatements!.Statements.Any(s => s.ToDisplayString() == "message.ResponseClassifier = PipelineMessageClassifier200;\n"));
+            }
+            else if (expectedStatusCode == 200)
+            {
+                Assert.IsTrue(bodyStatements!.Statements.Any(s => s.ToDisplayString() == "message.ResponseClassifier = PipelineMessageClassifier200;\n"));
+                Assert.IsFalse(bodyStatements!.Statements.Any(s => s.ToDisplayString() == "message.ResponseClassifier = PipelineMessageClassifier201;\n"));
+            }
+        }
+
         private readonly static InputOperation BasicOperation = InputFactory.Operation(
             "CreateMessage",
             parameters:
@@ -255,6 +296,22 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
                     isRequired: false),
                 InputFactory.Parameter("message", InputPrimitiveType.Boolean, isRequired: true)
             ]);
+
+        private static readonly InputOperation OperationWith201Resp = InputFactory.Operation(
+            "TestOperation",
+            parameters:
+            [
+                InputFactory.Parameter("message", InputPrimitiveType.Boolean, isRequired: true)
+            ],
+            responses: [InputFactory.OperationResponse([201])]);
+
+        private static readonly InputOperation OperationWith200Resp = InputFactory.Operation(
+            "TestOperation",
+            parameters:
+            [
+                InputFactory.Parameter("message", InputPrimitiveType.Boolean, isRequired: true)
+            ],
+            responses: [InputFactory.OperationResponse([200])]);
 
         private readonly static InputOperation OperationWithSpreadParam = InputFactory.Operation(
             "CreateMessageWithSpread",
@@ -365,6 +422,12 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
             new TestCaseData(OperationWithSpreadParam),
             new TestCaseData(BasicOperation),
             new TestCaseData(OperationWithMixedParamOrdering)
+        ];
+
+        private static IEnumerable<TestCaseData> ValidateClientResponseClassifiersTestCases =>
+        [
+            new TestCaseData(InputFactory.Client("TestClient", operations: [OperationWith201Resp])),
+            new TestCaseData(InputFactory.Client("TestClient", operations: [OperationWith200Resp]))
         ];
 
         private static IEnumerable<TestCaseData> GetSpreadParameterModelTestCases =>

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/RestClientProviderCustomizationTests/CanChangeClientNamespace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/RestClientProviderCustomizationTests/CanChangeClientNamespace.cs
@@ -11,10 +11,13 @@ namespace Sample.Custom
     public partial class TestClient
     {
         private static global::System.ClientModel.Primitives.PipelineMessageClassifier _pipelineMessageClassifier200;
+        private static global::System.ClientModel.Primitives.PipelineMessageClassifier _pipelineMessageClassifier201;
         private static global::System.ClientModel.Primitives.PipelineMessageClassifier _pipelineMessageClassifier204;
         private static global::Sample.Custom.TestClient.Classifier2xxAnd4xx _pipelineMessageClassifier2xxAnd4xx;
 
         private static global::System.ClientModel.Primitives.PipelineMessageClassifier PipelineMessageClassifier200 => _pipelineMessageClassifier200 = global::System.ClientModel.Primitives.PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
+
+        private static global::System.ClientModel.Primitives.PipelineMessageClassifier PipelineMessageClassifier201 => _pipelineMessageClassifier201 = global::System.ClientModel.Primitives.PipelineMessageClassifier.Create(stackalloc ushort[] { 201 });
 
         private static global::System.ClientModel.Primitives.PipelineMessageClassifier PipelineMessageClassifier204 => _pipelineMessageClassifier204 = global::System.ClientModel.Primitives.PipelineMessageClassifier.Create(stackalloc ushort[] { 204 });
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/UnbrandedTypeSpecClient.RestClient.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/UnbrandedTypeSpecClient.RestClient.cs
@@ -12,10 +12,13 @@ namespace UnbrandedTypeSpec
     public partial class UnbrandedTypeSpecClient
     {
         private static PipelineMessageClassifier _pipelineMessageClassifier200;
+        private static PipelineMessageClassifier _pipelineMessageClassifier201;
         private static PipelineMessageClassifier _pipelineMessageClassifier204;
         private static Classifier2xxAnd4xx _pipelineMessageClassifier2xxAnd4xx;
 
         private static PipelineMessageClassifier PipelineMessageClassifier200 => _pipelineMessageClassifier200 = PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
+
+        private static PipelineMessageClassifier PipelineMessageClassifier201 => _pipelineMessageClassifier201 = PipelineMessageClassifier.Create(stackalloc ushort[] { 201 });
 
         private static PipelineMessageClassifier PipelineMessageClassifier204 => _pipelineMessageClassifier204 = PipelineMessageClassifier.Create(stackalloc ushort[] { 204 });
 


### PR DESCRIPTION
Fixes an issue where an operation with a 201 response would cause the generator to crash since there is no corresponding classifier generated for a 201 response.

contributes to https://github.com/microsoft/typespec/issues/4865