### PR TITLE
Do not initialize ReadOnlyMemory in model factory methods

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelFactoryProvider.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Generator.CSharp.Providers
                 }
                 else
                 {
-                    if (!factoryParam.Type.IsReadOnlyMemory && factoryParam.Type.IsList)
+                    if (IsNonReadOnlyMemoryList(factoryParam))
                     {
                         expressions.Add(factoryParam.NullConditional().ToList());
                     }
@@ -167,7 +167,7 @@ namespace Microsoft.Generator.CSharp.Providers
             var statements = new List<MethodBodyStatement>();
             foreach (var param in signature.Parameters)
             {
-                if (param.Type.IsList || param.Type.IsDictionary)
+                if (IsNonReadOnlyMemoryList(param) || param.Type.IsDictionary)
                 {
                     statements.Add(param.Assign(New.Instance(param.Type.PropertyInitializationType), nullCoalesce: true).Terminate());
                 }
@@ -213,5 +213,8 @@ namespace Microsoft.Generator.CSharp.Providers
 
         private static bool IsEnumDiscriminator(ParameterProvider parameter) =>
             parameter.Property?.IsDiscriminator == true && parameter.Type.IsEnum;
+
+        private static bool IsNonReadOnlyMemoryList(ParameterProvider parameter) =>
+            parameter.Type is { IsList: true, IsReadOnlyMemory: false };
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizePropertyIntoReadOnlyMemory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizePropertyIntoReadOnlyMemory.cs
@@ -14,7 +14,6 @@ namespace Sample.Models
         /// <returns> A new <see cref="global::Sample.Models.MockInputModel"/> instance for mocking. </returns>
         public static global::Sample.Models.MockInputModel MockInputModel(global::System.ReadOnlyMemory<byte> prop1 = default)
         {
-            prop1 ??= new global::System.ReadOnlyMemory<byte>();
 
             return new global::Sample.Models.MockInputModel(prop1, null);
         }


### PR DESCRIPTION
ROM is a struct, so there is no point in doing the empty initialization. This would result in build errors if the parameter was not defined as nullable as the null coalescing operator can't be used with a struct.