### PR TITLE
tsp-openapi3 - support generating summary decorator

### DIFF
--- a/.chronus/changes/tsp-openapi3-fix-summary-2024-9-29-15-5-49.md
+++ b/.chronus/changes/tsp-openapi3-fix-summary-2024-9-29-15-5-49.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Updates tsp-openapi3 to support generating @summary decorators for models and operations from schema title and path item summary fields.

--- a/.chronus/changes/tsp-openapi3-fix-summary-2024-9-29-15-5-49.md
+++ b/.chronus/changes/tsp-openapi3-fix-summary-2024-9-29-15-5-49.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/openapi3"
 ---
 
-Updates tsp-openapi3 to support generating @summary decorators for models and operations from schema title and path item summary fields.
+Updates tsp-openapi3 to support generating `@summary` decorators for models and operations from schema title and path item summary fields.

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
@@ -42,13 +42,19 @@ export function transformPaths(
       const responseModels = collectOperationResponses(operation.operationId!, operationResponses);
       models.push(...responseModels);
 
+      const decorators = [
+        ...getExtensions(operation),
+        { name: "route", args: [route] },
+        { name: verb, args: [] },
+      ];
+
+      if (operation.summary) {
+        decorators.push({ name: "summary", args: [operation.summary] });
+      }
+
       operations.push({
         ...getScopeAndName(operation.operationId!),
-        decorators: [
-          ...getExtensions(operation),
-          { name: "route", args: [route] },
-          { name: verb, args: [] },
-        ],
+        decorators,
         parameters: dedupeParameters([...routeParameters, ...parameters]),
         doc: operation.description,
         operationId: operation.operationId,

--- a/packages/openapi3/src/cli/actions/convert/utils/decorators.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/decorators.ts
@@ -102,6 +102,10 @@ export function getDecoratorsForSchema(schema: Refable<OpenAPI3Schema>): TypeSpe
       break;
   }
 
+  if (schema.title) {
+    decorators.push({ name: "summary", args: [schema.title] });
+  }
+
   if (schema.discriminator) {
     decorators.push({ name: "discriminator", args: [schema.discriminator.propertyName] });
   }

--- a/packages/openapi3/test/tsp-openapi3/output/petstore-sample/main.tsp
+++ b/packages/openapi3/test/tsp-openapi3/output/petstore-sample/main.tsp
@@ -84,6 +84,7 @@ model showPetByIdDefaultApplicationJsonResponse {
 @tag("pets")
 @route("/pets")
 @get
+@summary("List all pets")
 op listPets(
   /**
    * How many items to return at one time (max 100)
@@ -94,11 +95,13 @@ op listPets(
 @tag("pets")
 @route("/pets")
 @post
+@summary("Create a pet")
 op createPets(): createPets201Response | createPetsDefaultApplicationJsonResponse;
 
 @tag("pets")
 @route("/pets/{petId}")
 @get
+@summary("Info for a specific pet")
 op showPetById(
   /**
    * The id of the pet to retrieve

--- a/packages/openapi3/test/tsp-openapi3/output/petstore-swagger/main.tsp
+++ b/packages/openapi3/test/tsp-openapi3/output/petstore-swagger/main.tsp
@@ -505,6 +505,7 @@ model updateUserDefaultResponse {}
 @tag("pet")
 @route("/pet")
 @post
+@summary("Add a new pet to the store")
 op addPet(
   @header contentType: "application/json" | "application/xml" | "application/x-www-form-urlencoded",
   @bodyRoot body: Pet,
@@ -516,6 +517,7 @@ op addPet(
 @tag("pet")
 @route("/pet")
 @put
+@summary("Update an existing pet")
 op updatePet(
   @header contentType: "application/json" | "application/xml" | "application/x-www-form-urlencoded",
   @bodyRoot body: Pet,
@@ -532,6 +534,7 @@ op updatePet(
 @tag("pet")
 @route("/pet/findByStatus")
 @get
+@summary("Finds Pets by status")
 op findPetsByStatus(
   /**
    * Status values that need to be considered for filter
@@ -548,6 +551,7 @@ op findPetsByStatus(
 @tag("pet")
 @route("/pet/findByTags")
 @get
+@summary("Finds Pets by tags")
 op findPetsByTags(
   /**
    * Tags to filter by
@@ -561,6 +565,7 @@ op findPetsByTags(
 @tag("pet")
 @route("/pet/{petId}")
 @delete
+@summary("Deletes a pet")
 op deletePet(
   @header api_key?: string,
 
@@ -576,6 +581,7 @@ op deletePet(
 @tag("pet")
 @route("/pet/{petId}")
 @get
+@summary("Find pet by ID")
 op getPetById(
   /**
    * ID of pet to return
@@ -590,6 +596,7 @@ op getPetById(
 @tag("pet")
 @route("/pet/{petId}")
 @post
+@summary("Updates a pet in the store with form data")
 op updatePetWithForm(
   /**
    * ID of pet that needs to be updated
@@ -610,6 +617,7 @@ op updatePetWithForm(
 @tag("pet")
 @route("/pet/{petId}/uploadImage")
 @post
+@summary("uploads an image")
 op uploadFile(
   /**
    * ID of pet to update
@@ -632,6 +640,7 @@ op uploadFile(
 @extension("x-swagger-router-controller", "OrderController")
 @route("/store/inventory")
 @get
+@summary("Returns pet inventories by status")
 op getInventory(): getInventory200ApplicationJsonResponse;
 
 /**
@@ -641,6 +650,7 @@ op getInventory(): getInventory200ApplicationJsonResponse;
 @extension("x-swagger-router-controller", "OrderController")
 @route("/store/order")
 @post
+@summary("Place an order for a pet")
 op placeOrder(
   @header contentType: "application/json" | "application/xml" | "application/x-www-form-urlencoded",
   @bodyRoot body: Order,
@@ -653,6 +663,7 @@ op placeOrder(
 @extension("x-swagger-router-controller", "OrderController")
 @route("/store/order/{orderId}")
 @delete
+@summary("Delete purchase order by ID")
 op deleteOrder(
   /**
    * ID of the order that needs to be deleted
@@ -667,6 +678,7 @@ op deleteOrder(
 @extension("x-swagger-router-controller", "OrderController")
 @route("/store/order/{orderId}")
 @get
+@summary("Find purchase order by ID")
 op getOrderById(
   /**
    * ID of order that needs to be fetched
@@ -684,6 +696,7 @@ op getOrderById(
 @tag("user")
 @route("/user")
 @post
+@summary("Create user")
 op createUser(
   @header contentType: "application/json" | "application/xml" | "application/x-www-form-urlencoded",
   @bodyRoot body: User,
@@ -696,6 +709,7 @@ op createUser(
 @extension("x-swagger-router-controller", "UserController")
 @route("/user/createWithList")
 @post
+@summary("Creates list of users with given input array")
 op createUsersWithListInput(
   @bodyRoot body: User[],
 ): createUsersWithListInput200ApplicationXmlResponse | createUsersWithListInput200ApplicationJsonResponse | createUsersWithListInputDefaultResponse;
@@ -703,6 +717,7 @@ op createUsersWithListInput(
 @tag("user")
 @route("/user/login")
 @get
+@summary("Logs user into the system")
 op loginUser(
   /**
    * The user name for login
@@ -718,6 +733,7 @@ op loginUser(
 @tag("user")
 @route("/user/logout")
 @get
+@summary("Logs out current logged in user session")
 op logoutUser(): logoutUserDefaultResponse;
 
 /**
@@ -726,6 +742,7 @@ op logoutUser(): logoutUserDefaultResponse;
 @tag("user")
 @route("/user/{username}")
 @delete
+@summary("Delete user")
 op deleteUser(
   /**
    * The name that needs to be deleted
@@ -736,6 +753,7 @@ op deleteUser(
 @tag("user")
 @route("/user/{username}")
 @get
+@summary("Get user by user name")
 op getUserByName(
   /**
    * The name that needs to be fetched. Use user1 for testing.
@@ -754,6 +772,7 @@ op getUserByName(
 @extension("x-swagger-router-controller", "UserController")
 @route("/user/{username}")
 @put
+@summary("Update user")
 op updateUser(
   /**
    * name that needs to be updated

--- a/packages/openapi3/test/tsp-openapi3/paths.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/paths.test.ts
@@ -267,3 +267,39 @@ it("supports overriding common params with operation params", async () => {
   assert(idPut.returnType.kind === "Model", "Expected model return type");
   expect(idPut.returnType.name).toBe("idPut200ApplicationJsonResponse");
 });
+
+it("supports operation summary", async () => {
+  const serviceNamespace = await tspForOpenAPI3({
+    paths: {
+      "/": {
+        get: {
+          operationId: "rootGet",
+          summary: "Root Get Summary",
+          parameters: [],
+          responses: {
+            "200": response,
+          },
+        },
+      },
+    },
+  });
+
+  const operations = serviceNamespace.operations;
+
+  expect(operations.size).toBe(1);
+
+  /* @route("/") @get op rootGet(): rootGet200ApplicationJsonResponse; */
+  const rootGet = operations.get("rootGet");
+  assert(rootGet, "rootGet operation not found");
+
+  /* @get @route("/") @summary("Root Get Summary") */
+  expectDecorators(rootGet.decorators, [
+    { name: "summary", args: [{ jsValue: "Root Get Summary" }] },
+    { name: "get" },
+    { name: "route", args: ["/"] },
+  ]);
+  // verify no operation parameters
+  expect(rootGet.parameters.properties.size).toBe(0);
+  assert(rootGet.returnType.kind === "Model", "Expected model return type");
+  expect(rootGet.returnType.name).toBe("rootGet200ApplicationJsonResponse");
+});

--- a/packages/openapi3/test/tsp-openapi3/utils/expect.ts
+++ b/packages/openapi3/test/tsp-openapi3/utils/expect.ts
@@ -1,5 +1,5 @@
 import { DecoratorApplication, isType, Numeric } from "@typespec/compiler";
-import { expect } from "vitest";
+import { assert, expect } from "vitest";
 
 export interface DecoratorMatch {
   /**
@@ -29,8 +29,12 @@ export function expectDecorators(
   }
 
   for (let i = 0; i < expectations.length; i++) {
-    const decorator = decorators[i];
     const expectation = expectations[i];
+    const decorator = options.strict
+      ? decorators[i]
+      : decorators.find((d) => d.definition?.name === `@${expectation.name}`);
+
+    assert(decorator, "Potential matching decorator not found");
 
     if (expectation.name) {
       expect(decorator.definition?.name).toBe(`@${expectation.name}`);


### PR DESCRIPTION
Fixes #4489 and fixes #4614

This now generates the `@summary` decorator based on either the Component schema `title` field, or the path item `summary` field.