### PR TITLE
openapi3 - adds an internal `output-spec-versions` emitter option

### DIFF
--- a/.chronus/changes/openapi3-output-spec-versions-2024-10-1-11-53-51.md
+++ b/.chronus/changes/openapi3-output-spec-versions-2024-10-1-11-53-51.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/openapi3"
+---
+

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -1,6 +1,7 @@
 import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
 
 export type FileType = "yaml" | "json";
+export type OutputSpecVersions = "v3.0" | "v3.1";
 export interface OpenAPI3EmitterOptions {
   /**
    * If the content should be serialized as YAML or JSON.
@@ -35,6 +36,16 @@ export interface OpenAPI3EmitterOptions {
    *  - `openapi.Org1.Service2.v1.1.yaml`
    */
   "output-file"?: string;
+
+  /**
+   * The Open API specification versions to emit.
+   * If more than one version is specified, then the output file
+   * will be created inside a directory matching each specification version.
+   *
+   * @default ["v3.0"]
+   * @internal
+   */
+  "output-spec-versions"?: OutputSpecVersions[];
 
   /**
    * Set the newline character for emitting files.
@@ -103,6 +114,16 @@ const EmitterOptionsSchema: JSONSchemaType<OpenAPI3EmitterOptions> = {
         "  - `openapi.Org1.Service2.v1.0.yaml`",
         "  - `openapi.Org1.Service2.v1.1.yaml`    ",
       ].join("\n"),
+    },
+    "output-spec-versions": {
+      type: "array",
+      items: {
+        type: "string",
+        enum: ["v3.0", "v3.1"],
+        nullable: true,
+        description: "The versions of OpenAPI to emit. Defaults to `v3.0`",
+      },
+      nullable: true,
     },
     "new-line": {
       type: "string",

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -1,7 +1,7 @@
 import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
 
 export type FileType = "yaml" | "json";
-export type OutputSpecVersions = "v3.0" | "v3.1";
+export type OpenAPIVersion = "3.0.0" | "3.1.0";
 export interface OpenAPI3EmitterOptions {
   /**
    * If the content should be serialized as YAML or JSON.
@@ -45,7 +45,7 @@ export interface OpenAPI3EmitterOptions {
    * @default ["v3.0"]
    * @internal
    */
-  "output-spec-versions"?: OutputSpecVersions[];
+  "openapi-versions"?: OpenAPIVersion[];
 
   /**
    * Set the newline character for emitting files.
@@ -115,11 +115,11 @@ const EmitterOptionsSchema: JSONSchemaType<OpenAPI3EmitterOptions> = {
         "  - `openapi.Org1.Service2.v1.1.yaml`    ",
       ].join("\n"),
     },
-    "output-spec-versions": {
+    "openapi-versions": {
       type: "array",
       items: {
         type: "string",
-        enum: ["v3.0", "v3.1"],
+        enum: ["3.0.0", "3.1.0"],
         nullable: true,
         description: "The versions of OpenAPI to emit. Defaults to `v3.0`",
       },

--- a/packages/openapi3/test/output-spec-versions.test.ts
+++ b/packages/openapi3/test/output-spec-versions.test.ts
@@ -32,17 +32,17 @@ function expectHasOutput(filename: string) {
 }
 
 it("creates nested directory if multiple spec versions are specified", async () => {
-  await compileOpenAPI({ "output-spec-versions": ["v3.0", "v3.1"] });
-  expectHasOutput("v3.0/openapi.yaml");
-  expectHasOutput("v3.1/openapi.yaml");
+  await compileOpenAPI({ "openapi-versions": ["3.0.0", "3.1.0"] });
+  expectHasOutput("3.0.0/openapi.yaml");
+  expectHasOutput("3.1.0/openapi.yaml");
 });
 
 it("does not create nested directory if only 1 spec version is specified", async () => {
-  await compileOpenAPI({ "output-spec-versions": ["v3.0"] });
+  await compileOpenAPI({ "openapi-versions": ["3.0.0"] });
   expectHasOutput("openapi.yaml");
 });
 
-it("defaults to v3.0 if not specified", async () => {
+it("defaults to 3.0.0 if not specified", async () => {
   await compileOpenAPI({ "file-type": "json" });
   const outPath = resolvePath(outputDir, "openapi.json");
   const content = runner.fs.get(outPath);

--- a/packages/openapi3/test/output-spec-versions.test.ts
+++ b/packages/openapi3/test/output-spec-versions.test.ts
@@ -1,0 +1,52 @@
+import { resolvePath } from "@typespec/compiler";
+import {
+  BasicTestRunner,
+  expectDiagnosticEmpty,
+  resolveVirtualPath,
+} from "@typespec/compiler/testing";
+import { ok } from "assert";
+import { beforeEach, expect, it } from "vitest";
+import { OpenAPI3EmitterOptions } from "../src/lib.js";
+import { createOpenAPITestRunner } from "./test-host.js";
+
+const outputDir = resolveVirtualPath("test-output");
+let runner: BasicTestRunner;
+beforeEach(async () => {
+  runner = await createOpenAPITestRunner();
+});
+
+async function compileOpenAPI(options: OpenAPI3EmitterOptions, code: string = ""): Promise<void> {
+  const diagnostics = await runner.diagnose(code, {
+    noEmit: false,
+    emit: ["@typespec/openapi3"],
+    options: { "@typespec/openapi3": { ...options, "emitter-output-dir": outputDir } },
+  });
+
+  expectDiagnosticEmpty(diagnostics);
+}
+
+function expectHasOutput(filename: string) {
+  const outPath = resolvePath(outputDir, filename);
+  const content = runner.fs.get(outPath);
+  ok(content, `Expected ${outPath} to exist.`);
+}
+
+it("creates nested directory if multiple spec versions are specified", async () => {
+  await compileOpenAPI({ "output-spec-versions": ["v3.0", "v3.1"] });
+  expectHasOutput("v3.0/openapi.yaml");
+  expectHasOutput("v3.1/openapi.yaml");
+});
+
+it("does not create nested directory if only 1 spec version is specified", async () => {
+  await compileOpenAPI({ "output-spec-versions": ["v3.0"] });
+  expectHasOutput("openapi.yaml");
+});
+
+it("defaults to v3.0 if not specified", async () => {
+  await compileOpenAPI({ "file-type": "json" });
+  const outPath = resolvePath(outputDir, "openapi.json");
+  const content = runner.fs.get(outPath);
+  ok(content, `Expected ${outPath} to exist.`);
+  const doc = JSON.parse(content);
+  expect(doc.openapi).toBe("3.0.0");
+});


### PR DESCRIPTION
This PR adds a new `@typespec/openapi3` emitter option to support specifying which Open API 3.x specs to output.

Currently marked as `@internal` since currently only 1 version is actually supported. Once `v3.1` is supported we can remove the `@internal` annotation.