### PR TITLE
Fix resolve allowed resolved even if @path is used explicitly

### DIFF
--- a/.chronus/changes/fix-path-explicit-allow-reserved-2024-10-7-20-13-23.md
+++ b/.chronus/changes/fix-path-explicit-allow-reserved-2024-10-7-20-13-23.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/http"
+---
+
+Uri template attributes were not extracted when parameter was explicitly mark with `@path` or `@query` as well

--- a/packages/http/src/http-property.ts
+++ b/packages/http/src/http-property.ts
@@ -100,6 +100,7 @@ function getHttpProperty(
   options: GetHttpPropertyOptions = {},
 ): [HttpProperty, readonly Diagnostic[]] {
   const diagnostics: Diagnostic[] = [];
+
   function createResult<T extends Omit<HttpProperty, "path" | "property">>(
     opts: T,
   ): [HttpProperty & T, readonly Diagnostic[]] {
@@ -162,14 +163,15 @@ function getHttpProperty(
       );
     }
   }
+  // if implicit just returns as it is. Validation above would have checked nothing was set explicitly apart from the type and that the type match
+  if (implicit) {
+    return createResult({
+      kind: implicit.type,
+      options: implicit as any,
+      property,
+    });
+  }
   if (defined.length === 0) {
-    if (implicit) {
-      return createResult({
-        kind: implicit.type,
-        options: implicit as any,
-        property,
-      });
-    }
     return createResult({ kind: "bodyProperty" });
   } else if (defined.length > 1) {
     diagnostics.push(

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -540,7 +540,7 @@ describe("uri template", () => {
       expectPathParameter(param, { style: "simple", allowReserved: true, explode: false });
     });
 
-    it("+ operator map to allowReserve even with @path set", async () => {
+    it("+ operator map to allowReserved even with @path set", async () => {
       const param = await getParameter(
         `@route("/bar/{+foo}") op foo(@path foo: string): void;`,
         "foo",

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -542,7 +542,7 @@ describe("uri template", () => {
 
     it("+ operator map to allowReserve even with @path set", async () => {
       const param = await getParameter(
-        `@route("/bar/{+foo}") @path op foo(foo: string): void;`,
+        `@route("/bar/{+foo}") op foo(@path foo: string): void;`,
         "foo",
       );
       expectPathParameter(param, { style: "simple", allowReserved: true, explode: false });

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -540,6 +540,14 @@ describe("uri template", () => {
       expectPathParameter(param, { style: "simple", allowReserved: true, explode: false });
     });
 
+    it("+ operator map to allowReserve even with @path set", async () => {
+      const param = await getParameter(
+        `@route("/bar/{+foo}") @path op foo(foo: string): void;`,
+        "foo",
+      );
+      expectPathParameter(param, { style: "simple", allowReserved: true, explode: false });
+    });
+
     it.each([
       [";", "matrix"],
       ["#", "fragment"],


### PR DESCRIPTION
fix #4967 