### PR TITLE
Add Angel Vargas to external reviewers for GraphQL emitter

### DIFF
--- a/.github/policies/prs.external-reviewers.yml
+++ b/.github/policies/prs.external-reviewers.yml
@@ -19,3 +19,5 @@ configuration:
                   reviewer: steverice
               - requestReview:
                   reviewer: swatkatz
+              - requestReview:
+                  reviewer: angelevargas


### PR DESCRIPTION
Angel is part of the team at Pinterest working on the GraphQL emitter.