### PR TITLE
fix(http-specs): dotnet compatibility failure

### DIFF
--- a/.chronus/changes/http-specs-fix-dotnet-compatibility-failure-2024-10-11-16-9-50.md
+++ b/.chronus/changes/http-specs-fix-dotnet-compatibility-failure-2024-10-11-16-9-50.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-specs"
+---
+
+Fix dotnet compatibility failure in http-specs

--- a/packages/http-specs/specs/type/dictionary/mockapi.ts
+++ b/packages/http-specs/specs/type/dictionary/mockapi.ts
@@ -23,6 +23,12 @@ function createServerTests(uri: string, data: any) {
       response: {
         status: 204,
       },
+      handler: (req) => {
+        req.expect.coercedBodyEquals(data);
+        return {
+          status: 204,
+        };
+      },
       kind: "MockApiDefinition",
     }),
   };

--- a/packages/http-specs/specs/type/property/additional-properties/mockapi.ts
+++ b/packages/http-specs/specs/type/property/additional-properties/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi, MockRequest } from "@typespec/spec-api";
+import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/http-specs/specs/type/property/additional-properties/mockapi.ts
+++ b/packages/http-specs/specs/type/property/additional-properties/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi, MockRequest } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -118,6 +118,13 @@ function createServerTests(url: string, value: any) {
       },
       response: {
         status: 204,
+      },
+      handler: (req: MockRequest) => {
+        const expectedBody = JSON.parse(JSON.stringify(value));
+        req.expect.coercedBodyEquals(expectedBody);
+        return {
+          status: 204,
+        };
       },
       kind: "MockApiDefinition",
     }),

--- a/packages/http-specs/specs/type/property/nullable/mockapi.ts
+++ b/packages/http-specs/specs/type/property/nullable/mockapi.ts
@@ -29,6 +29,15 @@ function createServerTests(url: string, value: unknown, patchNullableProperty?: 
       response: {
         status: 204,
       },
+      handler: (req) => {
+        req.expect.coercedBodyEquals({
+          requiredProperty: "foo",
+          nullableProperty: patchNullableProperty || null,
+        });
+        return {
+          status: 204,
+        };
+      },
       kind: "MockApiDefinition",
     }),
   };

--- a/packages/http-specs/specs/type/property/optionality/mockapi.ts
+++ b/packages/http-specs/specs/type/property/optionality/mockapi.ts
@@ -23,6 +23,12 @@ function createServerTests(url: string, value: unknown) {
       response: {
         status: 204,
       },
+      handler: (req) => {
+        req.expect.coercedBodyEquals(value);
+        return {
+          status: 204,
+        };
+      },
       kind: "MockApiDefinition",
     }),
   };

--- a/packages/http-specs/specs/type/property/value-types/mockapi.ts
+++ b/packages/http-specs/specs/type/property/value-types/mockapi.ts
@@ -23,6 +23,12 @@ function createServerTests(url: string, data: unknown) {
       response: {
         status: 204,
       },
+      handler: (req) => {
+        req.expect.coercedBodyEquals(data);
+        return {
+          status: 204,
+        };
+      },
       kind: "MockApiDefinition",
     }),
   };


### PR DESCRIPTION
This is a backport of https://github.com/Azure/cadl-ranch/pull/769
dotnet SDK uses a different but compatible datetime format, so we should use `coercedBodyEquals`, instead of exact match.
