### PR TITLE
http-client-java, add a basic readme

### DIFF
--- a/packages/http-client-java/README.md
+++ b/packages/http-client-java/README.md
@@ -1,0 +1,31 @@
+# TypeSpec Java Emitter Library
+
+This is a TypeSpec library that will emit a Java SDK from TypeSpec.
+
+## Prerequisite
+
+Install [Node.js](https://nodejs.org/) 20 or above. (Verify by running `node --version`)
+
+Install [Java](https://docs.microsoft.com/java/openjdk/download) 11 or above. (Verify by running `java --version`)
+
+## Getting started
+
+### Initialize TypeSpec Project
+
+Follow the [TypeSpec Getting Started](https://typespec.io/docs/) documentation to initialize your TypeSpec project.
+
+Ensure that `npx tsp compile .` runs correctly.
+
+### Add Java Emitter http-client-java
+
+Run the command `npm install @typespec/http-client-java`.
+
+### Generate Java Client SDK
+
+Run the command `npx tsp compile <path-to-typespec-file> --emit @typespec/http-client-java`
+
+e.g.
+
+```cmd
+npx tsp compile main.tsp --emit @typespec/http-client-java
+```


### PR DESCRIPTION
Add a very basic readme. I've omitted the emitter option part.

I think it should appear on npm package page, if http-client-java get released to npm.