### PR TITLE
Update package.json with additional metadata

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,21 @@
 {
   "name": "@typespec/graphql",
   "version": "0.1.0",
+  "author": "Microsoft Corporation",
+  "description": "TypeSpec library for emitting GraphQL",
+  "homepage": "https://typespec.io",
+  "readme": "https://github.com/microsoft/typespec/blob/main/README.md",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/typespec.git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/typespec/issues"
+  },
+  "keywords": [
+    "typespec"
+  ],
   "type": "module",
   "main": "dist/src/index.js",
   "exports": {
@@ -13,15 +28,8 @@
       "default": "./dist/src/testing/index.js"
     }
   },
-  "peerDependencies": {
-    "@typespec/compiler": "workspace:~"
-  },
-  "devDependencies": {
-    "@types/node": "~22.7.5",
-    "rimraf": "~6.0.1",
-    "source-map-support": "~0.5.21",
-    "typescript": "~5.6.3",
-    "vitest": "^2.1.2"
+  "engines": {
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",
@@ -32,5 +40,20 @@
     "lint": "eslint src/ test/ --report-unused-disable-directives --max-warnings=0",
     "lint:fix": "eslint . --report-unused-disable-directives --fix"
   },
-  "private": true
+  "files": [
+    "lib/*.tsp",
+    "dist/**",
+    "!dist/test/**"
+  ],
+  "peerDependencies": {
+    "@typespec/compiler": "workspace:~"
+  },
+  "devDependencies": {
+    "@types/node": "~22.7.5",
+    "@typespec/compiler": "workspace:~",
+    "rimraf": "~6.0.1",
+    "source-map-support": "~0.5.21",
+    "typescript": "~5.6.3",
+    "vitest": "^2.1.2"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,14 +452,13 @@ importers:
         version: 2.1.2(@types/node@22.7.5)(@vitest/ui@2.1.2)(happy-dom@15.10.2)(jsdom@25.0.1)(terser@5.34.1)
 
   packages/graphql:
-    dependencies:
-      '@typespec/compiler':
-        specifier: workspace:~
-        version: link:../compiler
     devDependencies:
       '@types/node':
         specifier: ~22.7.5
         version: 22.7.5
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
       rimraf:
         specifier: ~6.0.1
         version: 6.0.1


### PR DESCRIPTION
These are just some basic updates to the metadata in the `@typespec/graphql` `package.json`. This brings it in line with other packages like `@typespec/openapi3`.