### PR TITLE
Use Duration.toString when generating unbranded

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
@@ -321,8 +321,9 @@ public class ClassType implements IType {
     public static final ClassType DURATION = new Builder(false).knownClass(Duration.class)
         .defaultValueExpressionConverter(defaultValueExpression -> "Duration.parse(\"" + defaultValueExpression + "\")")
         .jsonToken("JsonToken.STRING")
-        .serializationValueGetterModifier(
-            valueGetter -> CORE_UTILS.getName() + ".durationToStringWithDays(" + valueGetter + ")")
+        .serializationValueGetterModifier(valueGetter -> JavaSettings.getInstance().isBranded()
+            ? CORE_UTILS.getName() + ".durationToStringWithDays(" + valueGetter + ")"
+            : "Objects.toString(" + valueGetter + ", null)")
         .jsonDeserializationMethod("getNullable(nonNullReader -> Duration.parse(nonNullReader.getString()))")
         .serializationMethodBase("writeString")
         .xmlElementDeserializationMethod("getNullableElement(Duration::parse)")


### PR DESCRIPTION
Fixes #5031 

Uses `Duration.toString` rather than the customized `Duration` to string converter in `CoreUtils` when generating an unbranded library.