### PR TITLE
Fix datetime tests namespace so the tests are not skipped

### DIFF
--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Encode/DateTime/DateTimeTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Encode/DateTime/DateTimeTests.cs
@@ -7,7 +7,7 @@ using Encode.Datetime;
 using Encode.Datetime.Models;
 using NUnit.Framework;
 
-namespace TestProjects.CadlRanch.Tests.Http.Encode.DateTime
+namespace TestProjects.CadlRanch.Tests.Http.Encode.Datetime
 {
     public class DateTimeTests : CadlRanchTestBase
     {


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/5094