### PR TITLE
Rename ClientPipelineApi.PerRetryPolicy to AuthorizationPolicy

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/Abstractions/ClientPipelineApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/Abstractions/ClientPipelineApi.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
 
         public abstract ValueExpression Create(ValueExpression options, ValueExpression perRetryPolicies);
 
-        public abstract ValueExpression ApplyAuthorizationPolicies(params ValueExpression[] authorizationPolicies);
+        public abstract ValueExpression AuthorizationPolicy(params ValueExpression[] arguments);
         public abstract ClientPipelineApi FromExpression(ValueExpression expression);
         public abstract ClientPipelineApi ToExpression();
     }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/Abstractions/ClientPipelineApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/Abstractions/ClientPipelineApi.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Generator.CSharp.Expressions;
 using Microsoft.Generator.CSharp.Primitives;
-using Microsoft.Generator.CSharp.Providers;
 using Microsoft.Generator.CSharp.Snippets;
 using Microsoft.Generator.CSharp.Statements;
 
@@ -28,7 +27,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
 
         public abstract ValueExpression Create(ValueExpression options, ValueExpression perRetryPolicies);
 
-        public abstract ValueExpression PerRetryPolicy(params ValueExpression[] arguments);
+        public abstract ValueExpression ApplyAuthorizationPolicies(params ValueExpression[] authorizationPolicies);
         public abstract ClientPipelineApi FromExpression(ValueExpression expression);
         public abstract ClientPipelineApi ToExpression();
     }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientPipelineProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientPipelineProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         public override ClientPipelineApi FromExpression(ValueExpression expression)
             => new ClientPipelineProvider(expression);
 
-        public override ValueExpression ApplyAuthorizationPolicies(params ValueExpression[] arguments)
+        public override ValueExpression AuthorizationPolicy(params ValueExpression[] arguments)
             => Static<ApiKeyAuthenticationPolicy>().Invoke(nameof(ApiKeyAuthenticationPolicy.CreateHeaderApiKeyPolicy), arguments).As<ApiKeyAuthenticationPolicy>();
 
         public override MethodBodyStatement Send(HttpMessageApi message, HttpRequestOptionsApi options)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientPipelineProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientPipelineProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         public override ClientPipelineApi FromExpression(ValueExpression expression)
             => new ClientPipelineProvider(expression);
 
-        public override ValueExpression PerRetryPolicy(params ValueExpression[] arguments)
+        public override ValueExpression ApplyAuthorizationPolicies(params ValueExpression[] arguments)
             => Static<ApiKeyAuthenticationPolicy>().Invoke(nameof(ApiKeyAuthenticationPolicy.CreateHeaderApiKeyPolicy), arguments).As<ApiKeyAuthenticationPolicy>();
 
         public override MethodBodyStatement Send(HttpMessageApi message, HttpRequestOptionsApi options)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
                 ValueExpression[] perRetryPolicyArgs = _authorizationApiKeyPrefixConstant != null
                     ? [_apiKeyAuthField, _authorizationHeaderConstant, _authorizationApiKeyPrefixConstant]
                     : [_apiKeyAuthField, _authorizationHeaderConstant];
-                perRetryPolicies = New.Array(ClientModelPlugin.Instance.TypeFactory.ClientPipelineApi.PipelinePolicyType, isInline: true, This.ToApi<ClientPipelineApi>().PerRetryPolicy(perRetryPolicyArgs));
+                perRetryPolicies = New.Array(ClientModelPlugin.Instance.TypeFactory.ClientPipelineApi.PipelinePolicyType, isInline: true, This.ToApi<ClientPipelineApi>().ApplyAuthorizationPolicies(perRetryPolicyArgs));
             }
 
             body.Add(PipelineProperty.Assign(This.ToApi<ClientPipelineApi>().Create(ClientOptionsParameter, perRetryPolicies)).Terminate());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
@@ -318,10 +318,10 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             if (_authorizationHeaderConstant != null && _apiKeyAuthField != null)
             {
                 // new PipelinePolicy[] { ApiKeyAuthenticationPolicy.CreateHeaderApiKeyPolicy(_keyCredential, AuthorizationHeader) }
-                ValueExpression[] perRetryPolicyArgs = _authorizationApiKeyPrefixConstant != null
+                ValueExpression[] authorizationPolicyArgs = _authorizationApiKeyPrefixConstant != null
                     ? [_apiKeyAuthField, _authorizationHeaderConstant, _authorizationApiKeyPrefixConstant]
                     : [_apiKeyAuthField, _authorizationHeaderConstant];
-                perRetryPolicies = New.Array(ClientModelPlugin.Instance.TypeFactory.ClientPipelineApi.PipelinePolicyType, isInline: true, This.ToApi<ClientPipelineApi>().AuthorizationPolicy(perRetryPolicyArgs));
+                perRetryPolicies = New.Array(ClientModelPlugin.Instance.TypeFactory.ClientPipelineApi.PipelinePolicyType, isInline: true, This.ToApi<ClientPipelineApi>().AuthorizationPolicy(authorizationPolicyArgs));
             }
 
             body.Add(PipelineProperty.Assign(This.ToApi<ClientPipelineApi>().Create(ClientOptionsParameter, perRetryPolicies)).Terminate());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
                 ValueExpression[] perRetryPolicyArgs = _authorizationApiKeyPrefixConstant != null
                     ? [_apiKeyAuthField, _authorizationHeaderConstant, _authorizationApiKeyPrefixConstant]
                     : [_apiKeyAuthField, _authorizationHeaderConstant];
-                perRetryPolicies = New.Array(ClientModelPlugin.Instance.TypeFactory.ClientPipelineApi.PipelinePolicyType, isInline: true, This.ToApi<ClientPipelineApi>().ApplyAuthorizationPolicies(perRetryPolicyArgs));
+                perRetryPolicies = New.Array(ClientModelPlugin.Instance.TypeFactory.ClientPipelineApi.PipelinePolicyType, isInline: true, This.ToApi<ClientPipelineApi>().AuthorizationPolicy(perRetryPolicyArgs));
             }
 
             body.Add(PipelineProperty.Assign(This.ToApi<ClientPipelineApi>().Create(ClientOptionsParameter, perRetryPolicies)).Terminate());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.Abstractions
                 => new TestClientPipelineApi(expression);
 
             public override ValueExpression ApplyAuthorizationPolicies(params ValueExpression[] arguments)
-                => Original.Invoke("GetFakePerRetryPolicy", arguments);
+                => Original.Invoke("GetFakeApplyAuthorizationPolicies", arguments);
 
             public override MethodBodyStatement Send(HttpMessageApi message, HttpRequestOptionsApi options)
                 => Original.Invoke("GetFakeSend", [message, options]).Terminate();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.Abstractions
             public override ClientPipelineApi FromExpression(ValueExpression expression)
                 => new TestClientPipelineApi(expression);
 
-            public override ValueExpression PerRetryPolicy(params ValueExpression[] arguments)
+            public override ValueExpression ApplyAuthorizationPolicies(params ValueExpression[] arguments)
                 => Original.Invoke("GetFakePerRetryPolicy", arguments);
 
             public override MethodBodyStatement Send(HttpMessageApi message, HttpRequestOptionsApi options)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
@@ -64,8 +64,8 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.Abstractions
             public override ClientPipelineApi FromExpression(ValueExpression expression)
                 => new TestClientPipelineApi(expression);
 
-            public override ValueExpression ApplyAuthorizationPolicies(params ValueExpression[] arguments)
-                => Original.Invoke("GetFakeApplyAuthorizationPolicies", arguments);
+            public override ValueExpression AuthorizationPolicy(params ValueExpression[] arguments)
+                => Original.Invoke("GetFakeAuthorizationPolicy", arguments);
 
             public override MethodBodyStatement Send(HttpMessageApi message, HttpRequestOptionsApi options)
                 => Original.Invoke("GetFakeSend", [message, options]).Terminate();


### PR DESCRIPTION
Rename based on https://github.com/Azure/azure-sdk-for-net/pull/47136#discussion_r1841379953
