### PR TITLE
http-client-java, eng, fix script for release pipeline

### DIFF
--- a/packages/http-client-java/eng/pipeline/publish.yml
+++ b/packages/http-client-java/eng/pipeline/publish.yml
@@ -28,5 +28,5 @@ extends:
           UnitTestArgs: -UnitTests
           StagePrefix: "Java"
           LanguageShortName: "java"
-          HasNugetPackages: true
+          HasNugetPackages: false
           CadlRanchName: "@typespec/http-client-java"

--- a/packages/http-client-java/eng/pipeline/publish.yml
+++ b/packages/http-client-java/eng/pipeline/publish.yml
@@ -17,7 +17,7 @@ extends:
         parameters:
           BuildPrereleaseVersion: true
           UseTypeSpecNext: false
-          Publish: "internal"
+          Publish: "public"
           PublishDependsOnTest: true
           PackagePath: /packages/http-client-java
           EmitterPackageJsonPath: packages/http-client-java/emitter/package.json

--- a/packages/http-client-java/eng/scripts/Test-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Test-Packages.ps1
@@ -36,7 +36,7 @@ try {
             $generatorTestDir = Join-Path $packageRoot 'generator/http-client-generator-test'
             Push-Location $generatorTestDir
             try {
-                npm run clean && npm install
+                & ./Setup.ps1
                 & ./CadlRanch-Tests.ps1
                 Set-Location $packageRoot
                 Write-Host 'Cadl ranch tests passed'

--- a/packages/http-client-java/eng/scripts/Test-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Test-Packages.ps1
@@ -64,6 +64,19 @@ try {
         catch {
             Write-Error "Cadl ranch tests failed:  $_"
         }
+
+        try {
+            $coverageReportDir = Join-Path $packageRoot 'generator/artifacts/coverage'
+            if (!(Test-Path $coverageReportDir)) {
+                New-Item -ItemType Directory -Path $coverageReportDir
+
+                $sourceFile = Join-Path $packageRoot 'generator/http-client-generator-test/cadl-ranch-coverage-java-standard.json'
+                $targetFile = Join-Path $coverageReportDir 'cadl-ranch-coverage-java-standard.json'
+                Copy-Item $sourceFile -Destination $targetFile
+            }
+        } catch {
+            Write-Error "Failed to copy coverage report file: $_"
+        }
     }
 }
 finally {

--- a/packages/http-client-java/eng/scripts/Test-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Test-Packages.ps1
@@ -34,15 +34,21 @@ try {
         # cadl-ranch tests
         try {
             $generatorTestDir = Join-Path $packageRoot 'generator/http-client-generator-test'
-            Set-Location $generatorTestDir
-            & ./CadlRanch-Tests.ps1
-            Set-Location $packageRoot
-            Write-Host 'Cadl ranch tests passed'
+            Push-Location $generatorTestDir
+            try {
+                npm run clean && npm install
+                & ./CadlRanch-Tests.ps1
+                Set-Location $packageRoot
+                Write-Host 'Cadl ranch tests passed'
+            }
+            finally {
+                Pop-Location
+            }
         } 
         catch {
             Write-Error "Cadl ranch tests failed:  $_"
         }
-
+        # copy coverage report to artifacts dir
         try {
             $coverageReportDir = Join-Path $packageRoot 'generator/artifacts/coverage'
             if (!(Test-Path $coverageReportDir)) {

--- a/packages/http-client-java/eng/scripts/Test-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Test-Packages.ps1
@@ -20,40 +20,18 @@ Invoke-LoggedCommand "mvn -version"
 Push-Location $packageRoot
 try {
     if ($UnitTests) {
-        Push-Location "$packageRoot"
-        try {
-            Write-Host "Current PATH: $env:PATH"
-            Write-Host "Current JAVA_HOME: $Env:JAVA_HOME"
-            $env:JAVA_HOME = $env:JAVA_HOME_21_X64
-            Write-Host "Updated JAVA_HOME: $Env:JAVA_HOME"
+        Write-Host "Current PATH: $env:PATH"
+        Write-Host "Current JAVA_HOME: $Env:JAVA_HOME"
+        $env:JAVA_HOME = $env:JAVA_HOME_21_X64
+        Write-Host "Updated JAVA_HOME: $Env:JAVA_HOME"
 
-            $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
+        $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
 
-            Write-Host "Updated PATH: $env:PATH"
-            # test the emitter
-            Invoke-LoggedCommand "npm run build" -GroupOutput
-            
-        }
-        finally {
-            Pop-Location
-        }
-    }
-    if ($GenerationChecks) {
-        Set-StrictMode -Version 1
-        # run E2E Test for TypeSpec emitter
-        Write-Host "Generating test projects ..."
-        & "$packageRoot/eng/scripts/Generate.ps1"
-        Write-Host 'Code generation is completed.'
-
-        try {
-            Write-Host 'Checking for differences in generated code...'
-            & "$packageRoot/eng/scripts/Check-GitChanges.ps1"
-            Write-Host 'Done. No code generation differences detected.'
-        }
-        catch {
-            Write-Error 'Generated code is not up to date. Please run: eng/Generate.ps1'
-        }
-
+        Write-Host "Updated PATH: $env:PATH"
+        # unit test the emitter
+        Invoke-LoggedCommand "npm run build" -GroupOutput
+        
+        # cadl-ranch tests
         try {
             $generatorTestDir = Join-Path $packageRoot 'generator/http-client-generator-test'
             Set-Location $generatorTestDir
@@ -76,6 +54,22 @@ try {
             }
         } catch {
             Write-Error "Failed to copy coverage report file: $_"
+        }
+    }
+    if ($GenerationChecks) {
+        Set-StrictMode -Version 1
+        # run E2E Test for TypeSpec emitter
+        Write-Host "Generating test projects ..."
+        & "$packageRoot/eng/scripts/Generate.ps1"
+        Write-Host 'Code generation is completed.'
+
+        try {
+            Write-Host 'Checking for differences in generated code...'
+            & "$packageRoot/eng/scripts/Check-GitChanges.ps1"
+            Write-Host 'Done. No code generation differences detected.'
+        }
+        catch {
+            Write-Error 'Generated code is not up to date. Please run: eng/Generate.ps1'
         }
     }
 }

--- a/packages/http-client-java/eng/scripts/Test-Packages.ps1
+++ b/packages/http-client-java/eng/scripts/Test-Packages.ps1
@@ -28,10 +28,8 @@ try {
         $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
 
         Write-Host "Updated PATH: $env:PATH"
-        # unit test the emitter
-        Invoke-LoggedCommand "npm run build" -GroupOutput
         
-        # cadl-ranch tests
+        # cadl-ranch tests (unit tests included in java/typescript package build)
         try {
             $generatorTestDir = Join-Path $packageRoot 'generator/http-client-generator-test'
             Push-Location $generatorTestDir

--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -7,9 +7,9 @@
     "format": "npm run -s prettier -- --write",
     "check-format": "npm run prettier -- --check",
     "prettier": "prettier --config ./.prettierrc.yaml **/*.tsp",
-    "testserver-run": "npx --no-install cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
-    "testserver-start": "npx --no-install cadl-ranch server start ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
-    "testserver-stop": "npx --no-install cadl-ranch server stop"
+    "testserver-run": "cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
+    "testserver-start": "cadl-ranch server start ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
+    "testserver-stop": "cadl-ranch server stop"
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.39.0",

--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -7,9 +7,9 @@
     "format": "npm run -s prettier -- --write",
     "check-format": "npm run prettier -- --check",
     "prettier": "prettier --config ./.prettierrc.yaml **/*.tsp",
-    "testserver-run": "npx cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
-    "testserver-start": "npx cadl-ranch server start ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
-    "testserver-stop": "npx cadl-ranch server stop"
+    "testserver-run": "npx --no-install cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
+    "testserver-start": "npx --no-install cadl-ranch server start ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
+    "testserver-stop": "npx --no-install cadl-ranch server stop"
   },
   "dependencies": {
     "@azure-tools/cadl-ranch-specs": "0.39.0",

--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -7,8 +7,8 @@
     "format": "npm run -s prettier -- --write",
     "check-format": "npm run prettier -- --check",
     "prettier": "prettier --config ./.prettierrc.yaml **/*.tsp",
-    "testserver-run": "npx cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java.json",
-    "testserver-start": "npx cadl-ranch server start ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java.json",
+    "testserver-run": "npx cadl-ranch serve ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
+    "testserver-start": "npx cadl-ranch server start ./node_modules/@azure-tools/cadl-ranch-specs/http --coverageFile ./cadl-ranch-coverage-java-standard.json",
     "testserver-stop": "npx cadl-ranch server stop"
   },
   "dependencies": {


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/5046

- Copy `cadl-ranch-coverage-java-standard.json` to the location that will be uploaded by shared script
- Move cadl-ranch test to "UnitTests" block ("GenerationChecks" is the diff on re-generated code -- it won't run in publish)
- Update publish.yml to disable NuGet, and enable release to "public"

Note that this coverage is actually not via unbranded. It is Azure.
We should be able to switch the cases to unbranded, when we got clientcore lib on maven.