### PR TITLE
fix a11y warnings in website

### DIFF
--- a/packages/astro-utils/src/components/theme-picker.astro
+++ b/packages/astro-utils/src/components/theme-picker.astro
@@ -17,6 +17,16 @@ import { Icon } from "@astrojs/starlight/components";
     background-color: var(--colorNeutralBackground3Hover);
   }
 
+  .theme-picker > input {
+    width: 0;
+    height: 0;
+    position: absolute;
+  }
+
+  .theme-picker:focus-within {
+    outline: auto;
+  }
+
   .theme-option {
     display: flex;
     padding: 2px;
@@ -43,21 +53,22 @@ import { Icon } from "@astrojs/starlight/components";
 
 <script>
   import { getTheme, setTheme } from "../utils/theme";
+  const themePickers = document.querySelectorAll(".theme-picker") as NodeListOf<HTMLDivElement>;
   const handleToggleClick = () => {
     const current = getTheme();
     const next = current === "dark" ? "light" : "dark";
     setTheme(next);
   };
 
-  const themePickers = document.querySelectorAll(".theme-picker");
-  themePickers.forEach((x) => x.addEventListener("click", handleToggleClick));
+  themePickers.forEach((x) => x.addEventListener("change", handleToggleClick));
 </script>
 
-<div class="theme-picker" aria-label="Toggle Light/Dark theme" tabindex="0">
+<label class="theme-picker">
+  <input type="checkbox" aria-label="Toggle Light/Dark theme" />
   <div title="Light mode" class="theme-option light">
     <Icon name="sun" />
   </div>
   <div title="Dark mode" class="theme-option dark">
     <Icon name="moon" />
   </div>
-</div>
+</label>

--- a/packages/astro-utils/src/css/light.css
+++ b/packages/astro-utils/src/css/light.css
@@ -32,7 +32,7 @@
   --colorCompoundBrandForeground1: #0f6cbd;
   --colorCompoundBrandForeground1Hover: #115ea3;
   --colorCompoundBrandForeground1Pressed: #0f548c;
-  --colorBrandForeground1: #0f6cbd;
+  --colorBrandForeground1: #1071c6;
   --colorBrandForeground2: #115ea3;
   --colorBrandForeground2Hover: #0f548c;
   --colorBrandForeground2Pressed: #0a2e4a;

--- a/website/src/components/header/header.astro
+++ b/website/src/components/header/header.astro
@@ -180,7 +180,7 @@ const { noDrawer } = Astro.props;
   }
 </style>
 <nav aria-label="Main" class="navbar">
-  <li class="brand-item"><Link href="/" class="brand"><b>TypeSpec</b></Link></li>
+  <span class="brand-item"><Link href="/" class="brand"><b>TypeSpec</b></Link></span>
 
   <div id="header-nav-content" class="nav-content">
     <div class="items">
@@ -205,13 +205,13 @@ const { noDrawer } = Astro.props;
         class="item icon link"
         href="https://github.com/microsoft/typespec"
         target="_blank"
-        rel="noopener noreferrer"><Icon name="github" /></Link
+        rel="noopener noreferrer"><Icon name="github" label="github" /></Link
       >
       <Link
         class="item icon link"
         href="https://aka.ms/typespec/discord"
         target="_blank"
-        rel="noopener noreferrer"><Icon name="discord" /></Link
+        rel="noopener noreferrer"><Icon name="discord" label="discord" /></Link
       >
       <div class="item">
         <ThemePicker />

--- a/website/src/components/header/search.astro
+++ b/website/src/components/header/search.astro
@@ -2,6 +2,12 @@
 import "@docsearch/css";
 ---
 
+<style>
+  sl-doc-search {
+    --docsearch-muted-color: #6c727e;
+  }
+</style>
+
 <sl-doc-search>
   <button type="button" class="DocSearch DocSearch-Button" aria-label="Search">
     <span class="DocSearch-Button-Container">

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -4,9 +4,12 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+:root,
+:root[data-theme="light"],
+:root[data-theme="dark"] {
   --header-height: 50px;
   --sl-color-text-accent: var(--colorBrandForeground1);
+  --sl-color-gray-2: var(--colorNeutralForeground1);
   --sl-color-gray-5: var(--colorNeutralStroke1);
   --sl-color-bg-inline-code: var(--ec-frm-edBg);
 }
@@ -30,7 +33,7 @@ img {
 
 a {
   color: var(--colorBrandForeground1);
-  text-decoration: var(--ifm-link-decoration);
+  text-decoration: none;
   transition: color var(--ifm-transition-fast) var(--ifm-transition-timing-default);
 }
 

--- a/website/src/layouts/base-layout.astro
+++ b/website/src/layouts/base-layout.astro
@@ -17,6 +17,7 @@ const { footer = true } = Astro.props;
     <link rel="icon" type="image/svg+xml" href={Astro.site + baseUrl("/img/favicon.svg")} />
     <link rel="og:image" type="image/svg+xml" href={baseUrl("/img/social.svg")} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>typespec.io</title>
     <script src="https://consentdeliveryfd.azurefd.net/mscc/lib/v2/wcp-consent.js" is:inline
     ></script>
     <script src={import.meta.env.BASE_URL + "1ds-init.js"} is:inline></script>


### PR DESCRIPTION
This update addresses fixing the a11y findings in #5133 

List of changes:
- link color contrast improved
- Light/Dark mode toggle can now be triggered by pressing spacebar when focused, fixed aria role
- Title exists on HTML pages
- labels added to various icons

Will need to rerun analysis as local analysis didn't capture every item in the original report.