### PR TITLE
[GitHub] add mq label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,10 +371,11 @@ Process labels
 
 Misc labels
 
-| Name                       | Color   | Description        |
-| -------------------------- | ------- | ------------------ |
-| `Client Emitter Migration` | #FD92F0 |                    |
-| `good first issue`         | #7057ff | Good for newcomers |
+| Name                       | Color   | Description           |
+| -------------------------- | ------- | --------------------- |
+| `Client Emitter Migration` | #FD92F0 |                       |
+| `good first issue`         | #7057ff | Good for newcomers    |
+| `mq`                       | #0969da | Good candidate for MQ |
 
 <!-- LABEL GENERATED REF END -->
 

--- a/eng/common/config/labels.ts
+++ b/eng/common/config/labels.ts
@@ -194,6 +194,10 @@ export default defineConfig({
           color: "7057ff",
           description: "Good for newcomers",
         },
+        mq: {
+          color: "0969da",
+          description: "Good candidate for MQ",
+        },
       },
     },
   },


### PR DESCRIPTION
Noticed a new `mq` label that may have been created manually - adding it so CI doesn't fail the verify labels check.