### PR TITLE
restore inline codeblock highlighting for light mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -11,7 +11,6 @@
   --sl-color-text-accent: var(--colorBrandForeground1);
   --sl-color-gray-2: var(--colorNeutralForeground1);
   --sl-color-gray-5: var(--colorNeutralStroke1);
-  --sl-color-bg-inline-code: var(--ec-frm-edBg);
 }
 
 .DocSearch-Button {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -13,6 +13,10 @@
   --sl-color-gray-5: var(--colorNeutralStroke1);
 }
 
+:root[data-theme="dark"] {
+  --sl-color-bg-inline-code: var(--ec-frm-edBg);
+}
+
 .DocSearch-Button {
   border-radius: 4px !important;
 


### PR DESCRIPTION
There was a css variable being set on the `:root` level that used to always be overridden in light mode until #5147.  This controls the background color of an inline code block. Moved this variable to only be defined in dark mode instead.