### PR TITLE
[http-server-js] Ignore unspeakable properties

### DIFF
--- a/.chronus/changes/witemple-msft-hsj-ignore-unspeakable-2024-10-25-15-54-27.md
+++ b/.chronus/changes/witemple-msft-hsj-ignore-unspeakable-2024-10-25-15-54-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-javascript"
+---
+
+Added logic to handle "unspeakable" identifier names (#5185)

--- a/packages/http-server-javascript/src/common/model.ts
+++ b/packages/http-server-javascript/src/common/model.ts
@@ -8,7 +8,7 @@ import {
   isTemplateInstance,
 } from "@typespec/compiler";
 import { JsContext, Module } from "../ctx.js";
-import { parseCase } from "../util/case.js";
+import { isUnspeakable, parseCase } from "../util/case.js";
 import { indent } from "../util/iter.js";
 import { KEYWORDS } from "../util/keywords.js";
 import { getFullyQualifiedTypeName } from "../util/name.js";
@@ -61,6 +61,11 @@ export function* emitModel(
   yield `export interface ${ifaceName} ${extendsClause}{`;
 
   for (const field of model.properties.values()) {
+    // Skip properties with unspeakable names.
+    if (isUnspeakable(field.name)) {
+      continue;
+    }
+
     const nameCase = parseCase(field.name);
     const basicName = nameCase.camelCase;
 

--- a/packages/http-server-javascript/src/lib.ts
+++ b/packages/http-server-javascript/src/lib.ts
@@ -95,6 +95,12 @@ export const $lib = createTypeSpecLibrary({
           "Union variant cannot be differentiated from other variants of the union an an ambiguous context.",
       },
     },
+    "unspeakable-status-code": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Status code property '${"name"}' is unspeakable and does not have an exact value. Provide an exact status code value or rename the property.`,
+      },
+    },
     "name-conflict": {
       severity: "error",
       messages: {

--- a/packages/http-server-javascript/src/util/case.ts
+++ b/packages/http-server-javascript/src/util/case.ts
@@ -2,6 +2,33 @@
 // Licensed under the MIT license.
 
 /**
+ * Separators recognized by the case parser.
+ */
+const SEPARATORS = /[\s:_\-./\\]/;
+
+/**
+ * Returns true if a name cannot be spoken. A name is unspeakable if:
+ *
+ * - It contains only separators and whitespace.
+ *
+ * OR
+ *
+ * - The first non-separator, non-whitespace character is a digit.
+ *
+ * @param name - a name in any case
+ * @returns true if the name is unspeakable
+ */
+export function isUnspeakable(name: string): boolean {
+  for (const c of name) {
+    if (!SEPARATORS.test(c)) {
+      return /[0-9]/.test(c);
+    }
+  }
+
+  return true;
+}
+
+/**
  * Destructures a name into its components.
  *
  * The following case conventions are supported:
@@ -49,7 +76,7 @@ export function parseCase(name: string): ReCase {
       }
     }
 
-    if (![":", "_", "-", ".", "/"].includes(char) && !/\s/.test(char)) {
+    if (!SEPARATORS.test(char)) {
       currentComponent += char.toLowerCase();
     }
 


### PR DESCRIPTION
Closes #5185

This adds some extra handling for properties with names like `_`. In the current implementation, our property name parser will parse an empty list of name segments that ultimately combines to an empty string in any case convention.

This PR addresses this problem by declaring certain properties "unspeakable". A property name is "unspeakable" if its parsed representation would be an empty string. Unspeakable properties are removed from the representation of a Model. If the value of an "unspeakable" property is demanded, the emitter will check that the property has a literal valued type and convert it to a value rather than trying to access the property in the subject value, or issue an error diagnostic if it is not a literal type (`@statusCode _: 200` is okay, `@statusCode _: uint16` is not). This effectively makes the types of unspeakable properties "associated constants" of the Model, rather than variable properties of the model. Unspeakable properties are ignored in the RTTI code generator, so that unspeakable properties will never be used to try to introspect the type of a value.

Further, the change uncovered a problem with model differentiation logic in which a property was not always guaranteed to exist on a type before its value was acquired, resulting in a type checking error. The code generation for checking properties that may not exist on object instances has been improved from `subject.prop === expected` to `"prop" in subject && subject.prop === expected`.

This fixes a problem with the generation of REST specs that commonly use `_` as the name of the statusCode property.