### PR TITLE
Fix json schema union crash

### DIFF
--- a/.chronus/changes/fix-json-schema-union-crash-2024-10-25-12-38-51.md
+++ b/.chronus/changes/fix-json-schema-union-crash-2024-10-25-12-38-51.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/json-schema"
+---
+
+Adds support for template instantiations with literal union template arguments by inlining template schema where referenced.

--- a/.chronus/changes/fix-json-schema-union-crash-2024-10-25-12-38-51.md
+++ b/.chronus/changes/fix-json-schema-union-crash-2024-10-25-12-38-51.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/json-schema"
 ---
 
-Adds support for template instantiations with literal union template arguments by inlining template schema where referenced.
+Fixes crash that occurred when a template instantiation's template argument was a union that references a declaration.

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -848,7 +848,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
 
   modelInstantiationContext(model: Model, name: string | undefined): Context {
     if (name === undefined) {
-      return {};
+      return { scope: this.emitter.createScope({}, "", this.emitter.getContext().scope) };
     } else {
       return this.#newFileScope(model);
     }


### PR DESCRIPTION
Fixes #5077 

This PR fixes an issue where passing in a literal union to a template would cause the `@typespec/json-schema` package to crash:
[playground](https://[typespec.io](https://typespec.io/playground/?c=aW1wb3J0ICJAdHlwZXNwZWMvanNvbi1zY2hlbWEiOw0KDQp1c2luZyBUeXBlU3BlYy5Kc29uU8UfxR5AxDDGEA0KbmFtZXNwYWNlIEV4YW1wbGXFI21vZGVsIEZvbyB7DQogIMRqOiBUZW1wbGF0ZTzEGHwgbnVsbD47DQp9yjHJIlQ%2Bxjlwcm9wOiBUxCY%3D&e=%40typespec%2Fjson-schema&options=%7B%22options%22%3A%7B%22%40typespec%2Fjson-schema%22%3A%7B%22emitAllRefs%22%3Atrue%2C%22emitAllModels%22%3Afalse%7D%7D%7D)/playground/?c=aW1wb3J0ICJAdHlwZXNwZWMvanNvbi1zY2hlbWEiOw0KDQp1c2luZyBUeXBlU3BlYy5Kc29uU8UfxR5AxDDGEA0KbmFtZXNwYWNlIEV4YW1wbGXFI21vZGVsIEZvbyB7DQogIMRqOiBUZW1wbGF0ZTzEGHwgbnVsbD47DQp9yjHJIlQ%2Bxjlwcm9wOiBUxCY%3D&e=%40typespec%2Fjson-schema&options=%7B%22options%22%3A%7B%22%40typespec%2Fjson-schema%22%3A%7B%22emitAllRefs%22%3Atrue%2C%22emitAllModels%22%3Afalse%7D%7D%7D)

In this scenario, the template instantiation will be inlined - similar to what the openapi3 emitter does. However, the scope of the parent referencing the model literal wasn't being preserved.

So where this used to crash:
```tsp
import "@typespec/json-schema";
using TypeSpec.JsonSchema;

@jsonSchema
namespace Example;

model Foo {
  type: Template<Foo | null>;
}

model Template<T> {
  prop: T;
}
```

This would now generate the output:
```yaml
$schema: https://json-schema.org/draft/2020-12/schema
$id: Foo.yaml
type: object
properties:
  type:
    type: object
    properties:
      prop:
        anyOf:
          - $ref: Foo.yaml
          - type: "null"
    required:
      - prop
required:
  - type
```