### PR TITLE
[Python] Fix crash if no valid client define in typespec file

### DIFF
--- a/packages/http-client-python/CHANGELOG.md
+++ b/packages/http-client-python/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log - @typespec/http-client-python
 
+## 0.3.11
+
+### Other Changes
+
+- Pad special property name in model to avoid conflict
+
+### Bug Fixes
+
+- Fix crash if no valid client define in typespec file
+
 ## 0.3.10
 
 ### Bug Fixes

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -45,7 +45,7 @@ function addDefaultOptions(sdkContext: SdkContext) {
   }
   if (!options["package-name"]) {
     options["package-name"] = removeUnderscoresFromNamespace(
-      sdkContext.sdkPackage.rootNamespace.toLowerCase(),
+      (sdkContext.sdkPackage.rootNamespace ?? "").toLowerCase(),
     ).replace(/\./g, "-");
   }
   if (options.flavor !== "azure") {
@@ -78,6 +78,12 @@ export async function $onEmit(context: EmitContext<PythonEmitterOptions>) {
   const root = path.join(dirname(fileURLToPath(import.meta.url)), "..", "..");
   const outputDir = context.emitterOutputDir;
   const yamlMap = emitCodeModel(sdkContext);
+  if (yamlMap.clients.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log("Warning: Can't generate Python SDK since there is no valid client defined!!!");
+    return;
+  }
+
   addDefaultOptions(sdkContext);
   const yamlPath = await saveCodeModelAsYaml("python-yaml-path", yamlMap);
   let venvPath = path.join(root, "venv");

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -4,14 +4,14 @@ import {
   SdkHttpOperation,
   SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
-import { EmitContext } from "@typespec/compiler";
+import { EmitContext, NoTarget } from "@typespec/compiler";
 import { execSync } from "child_process";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
 import { emitCodeModel } from "./code-model.js";
 import { saveCodeModelAsYaml } from "./external-process.js";
-import { PythonEmitterOptions, PythonSdkContext } from "./lib.js";
+import { PythonEmitterOptions, PythonSdkContext, reportDiagnostic } from "./lib.js";
 import { removeUnderscoresFromNamespace } from "./utils.js";
 
 export function getModelsMode(context: SdkContext): "dpg" | "none" {
@@ -79,8 +79,10 @@ export async function $onEmit(context: EmitContext<PythonEmitterOptions>) {
   const outputDir = context.emitterOutputDir;
   const yamlMap = emitCodeModel(sdkContext);
   if (yamlMap.clients.length === 0) {
-    // eslint-disable-next-line no-console
-    console.log("Warning: Can't generate Python SDK since there is no valid client defined!!!");
+    reportDiagnostic(program, {
+      code: "no-valid-client",
+      target: NoTarget,
+    });
     return;
   }
 

--- a/packages/http-client-python/emitter/src/lib.ts
+++ b/packages/http-client-python/emitter/src/lib.ts
@@ -49,7 +49,14 @@ const EmitterOptionsSchema: JSONSchemaType<PythonEmitterOptions> = {
 
 const libDef = {
   name: "@typespec/http-client-python",
-  diagnostics: {},
+  diagnostics: {
+    "no-valid-client": {
+      severity: "warning",
+      messages: {
+        default: "Can't generate Python SDK since no client defined in typespec file.",
+      },
+    },
+  },
   emitter: {
     options: EmitterOptionsSchema as JSONSchemaType<PythonEmitterOptions>,
   },

--- a/packages/http-client-python/generator/pygen/preprocess/python_mappings.py
+++ b/packages/http-client-python/generator/pygen/preprocess/python_mappings.py
@@ -107,6 +107,8 @@ RESERVED_MODEL_PROPERTIES = [
     "setdefault",
     "pop",
     "get",
+    "copy",
+    "as_dict",
 ]
 
 RESERVED_WORDS = {

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://typespec.io",


### PR DESCRIPTION
fix https://github.com/Azure/autorest.python/issues/2933

- Fix crash if no valid client define in typespec file
- Pad special property name in model to avoid conflict