### PR TITLE
[http-spec] add none visibility test

### DIFF
--- a/.chronus/changes/none_visibility-2024-10-27-17-8-46.md
+++ b/.chronus/changes/none_visibility-2024-10-27-17-8-46.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-specs"
+---
+
+add none visibility test

--- a/packages/http-specs/specs/type/model/visibility/main.tsp
+++ b/packages/http-specs/specs/type/model/visibility/main.tsp
@@ -32,7 +32,7 @@ model VisibilityModel {
 
   @doc("Property that does not exist in any payload.")
   @visibility("none")
-  noneProp: boolean;
+  noneProp: "none";
 }
 
 /** RoundTrip model with readonly optional properties. */

--- a/packages/http-specs/specs/type/model/visibility/main.tsp
+++ b/packages/http-specs/specs/type/model/visibility/main.tsp
@@ -29,6 +29,10 @@ model VisibilityModel {
   @doc("Required bool, illustrating a delete property.")
   @visibility("delete")
   deleteProp: boolean;
+
+  @doc("Property that does not exist in any payload.")
+  @visibility("none")
+  noneProp: boolean;
 }
 
 /** RoundTrip model with readonly optional properties. */


### PR DESCRIPTION
all emitter's test should not be affected by this change since the added property should not exist in any payload.