### PR TITLE
Replace Plugin.InputLibrary with InputNamespace

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientOptionsProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientOptionsProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         {
             _inputClient = inputClient;
             _clientProvider = clientProvider;
-            var inputEnumType = ClientModelPlugin.Instance.InputLibrary.InputNamespace.Enums
+            var inputEnumType = ClientModelPlugin.Instance.InputNamespace.Enums
                     .FirstOrDefault(e => e.Usage.HasFlag(InputModelTypeUsage.ApiVersionEnum));
             if (inputEnumType != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         public ClientProvider(InputClient inputClient)
         {
             _inputClient = inputClient;
-            _inputAuth = ClientModelPlugin.Instance.InputLibrary.InputNamespace.Auth;
+            _inputAuth = ClientModelPlugin.Instance.InputNamespace.Auth;
             _endpointParameter = BuildClientEndpointParameter();
             _publicCtorDescription = $"Initializes a new instance of {Name}.";
 
@@ -472,7 +472,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         // TODO: Update method to be more efficient
         private IReadOnlyList<Lazy<ClientProvider>> GetSubClients()
         {
-            var inputClients = ClientModelPlugin.Instance.InputLibrary.InputNamespace.Clients;
+            var inputClients = ClientModelPlugin.Instance.InputNamespace.Clients;
             var subClients = new List<Lazy<ClientProvider>>(inputClients.Count);
 
             foreach (var client in inputClients)

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmOutputLibrary.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmOutputLibrary.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Generator.CSharp.ClientModel
     {
         private static TypeProvider[] BuildClients()
         {
-            var inputClients = ClientModelPlugin.Instance.InputLibrary.InputNamespace.Clients;
+            var inputClients = ClientModelPlugin.Instance.InputNamespace.Clients;
             var clients = new List<TypeProvider>(inputClients.Count * 3);
             foreach (var inputClient in inputClients)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.Generator.CSharp.ClientModel
 
         private IEnumerable<TypeProvider> GetMultipartFormDataBinaryContentDefinition()
         {
-            if (ClientModelPlugin.Instance.InputLibrary.HasMultipartFormDataOperation)
+            if (ClientModelPlugin.Instance.InputNamespace.HasMultipartFormDataOperation)
             {
                 var multipart = new MultiPartFormDataBinaryContentDefinition();
                 ClientModelPlugin.Instance.AddTypeToKeep(multipart.Name);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/InputLibraryVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/InputLibraryVisitorTests.cs
@@ -14,33 +14,32 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
     public class InputLibraryVisitorTests
     {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private Mock<ClientModelPlugin> _mockPlugin;
         private Mock<ScmLibraryVisitor> _mockVisitor;
-        private Mock<InputLibrary> _mockInputLibrary;
+        private Mock<ClientModelPlugin> _mockPlugin;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [SetUp]
         public void Setup()
         {
-            _mockInputLibrary = new Mock<InputLibrary>();
-            _mockPlugin = MockHelpers.LoadMockPlugin(createInputLibrary: () => _mockInputLibrary.Object);
             _mockVisitor = new Mock<ScmLibraryVisitor> { CallBase = true };
+            _mockPlugin = MockHelpers.LoadMockPlugin();
         }
 
         [Test]
         public void PreVisitsMethods()
         {
-            _mockPlugin.Object.AddVisitor(_mockVisitor.Object);
             var inputModelProperty = InputFactory.Property("prop1", InputPrimitiveType.Any, isRequired: true, isReadOnly: true);
             var inputModel = InputFactory.Model("foo", access: "internal", usage: InputModelTypeUsage.Input, properties: [inputModelProperty]);
 
             var param = InputFactory.Parameter("param", InputFactory.Literal.String("bar"), location: RequestLocation.Header, isRequired: true, isResourceParameter: true);
             var inputOperation = InputFactory.Operation("testOperation", parameters: [param], responses: [InputFactory.OperationResponse(bodytype: InputPrimitiveType.Any)]);
-            var inputClient = InputFactory.Client("fooClient", operations: [inputOperation], parameters: [param]);
-            _mockInputLibrary.Setup(l => l.InputNamespace).Returns(InputFactory.Namespace(
+
+            _mockPlugin.Setup(p => p.InputNamespace).Returns(InputFactory.Namespace(
                 "test library",
                 models: [inputModel],
                 clients: [InputFactory.Client("fooClient", operations: [inputOperation], parameters: [param])]));
+            _mockPlugin.Object.AddVisitor(_mockVisitor.Object);
+            var inputClient = InputFactory.Client("fooClient", operations: [inputOperation], parameters: [param]);
 
             var mockClientProvider = new Mock<ClientProvider>(inputClient) { CallBase = true };
             _ = mockClientProvider.Object.Methods;

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/TestHelpers/MockHelpers.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
             var mockGeneratorContext = new Mock<GeneratorContext>(config!);
             var mockPluginInstance = new Mock<ClientModelPlugin>(mockGeneratorContext.Object) { CallBase = true };
             mockPluginInstance.SetupGet(p => p.TypeFactory).Returns(mockTypeFactory.Object);
-            mockPluginInstance.Setup(p => p.InputLibrary).Returns(mockInputLibrary.Object);
+            mockPluginInstance.Setup(p => p.InputNamespace).Returns(mockInputLibrary.Object.InputNamespace);
             if (clientResponseApi is not null)
             {
                 mockTypeFactory.Setup(p => p.ClientResponseApi).Returns(clientResponseApi);
@@ -135,7 +135,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
 
             if (createInputLibrary is not null)
             {
-                mockPluginInstance.Setup(p => p.InputLibrary).Returns(createInputLibrary);
+                mockPluginInstance.Setup(p => p.InputNamespace).Returns(createInputLibrary().InputNamespace);
             }
 
             var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(null)) { CallBase = true };

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/TestHelpers/MockHelpers.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
             Func<IReadOnlyList<InputEnumType>>? inputEnums = null,
             Func<IReadOnlyList<InputModelType>>? inputModels = null,
             Func<IReadOnlyList<InputClient>>? clients = null,
-            Func<InputLibrary>? createInputLibrary = null,
             Func<InputClient, ClientProvider>? createClientCore = null,
             string? configuration = null,
             ClientResponseApi? clientResponseApi = null,
@@ -131,11 +130,6 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests
             if (httpMessageApi is not null)
             {
                 mockTypeFactory.Setup(p => p.HttpMessageApi).Returns(httpMessageApi);
-            }
-
-            if (createInputLibrary is not null)
-            {
-                mockPluginInstance.Setup(p => p.InputNamespace).Returns(createInputLibrary().InputNamespace);
             }
 
             var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(null)) { CallBase = true };

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputLibrary.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputLibrary.cs
@@ -39,24 +39,5 @@ namespace Microsoft.Generator.CSharp.Input
             var json = File.ReadAllText(codeModelFile);
             return TypeSpecSerialization.Deserialize(json) ?? throw new InvalidOperationException($"Deserializing {codeModelFile} has failed.");
         }
-
-        private bool? _hasMultipartFormDataOperation;
-        public bool HasMultipartFormDataOperation => _hasMultipartFormDataOperation ??= GetHasMultipartFormDataOperation();
-
-        private bool GetHasMultipartFormDataOperation()
-        {
-            foreach (var client in InputNamespace.Clients)
-            {
-                foreach (var operation in client.Operations)
-                {
-                    if (operation.IsMultipartFormData)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputNamespace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/InputNamespace.cs
@@ -26,5 +26,24 @@ namespace Microsoft.Generator.CSharp.Input
         public IReadOnlyList<InputModelType> Models { get; init; }
         public IReadOnlyList<InputClient> Clients { get; init; }
         public InputAuth Auth { get; init; }
+
+        private bool? _hasMultipartFormDataOperation;
+        public bool HasMultipartFormDataOperation => _hasMultipartFormDataOperation ??= GetHasMultipartFormDataOperation();
+
+        private bool GetHasMultipartFormDataOperation()
+        {
+            foreach (var client in Clients)
+            {
+                foreach (var operation in client.Operations)
+                {
+                    if (operation.IsMultipartFormData)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CodeModelPlugin.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CodeModelPlugin.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Generator.CSharp
         public virtual SourceInputModel SourceInputModel => _sourceInputModel ?? throw new InvalidOperationException($"SourceInputModel has not been initialized yet");
         public virtual string LicenseString => string.Empty;
         public virtual OutputLibrary OutputLibrary { get; } = new();
-        public virtual InputLibrary InputLibrary => _inputLibrary.Value;
+        public virtual InputNamespace InputNamespace => _inputLibrary.Value.InputNamespace;
         public virtual TypeProviderWriter GetWriter(TypeProvider provider) => new(provider);
         public IReadOnlyList<MetadataReference> AdditionalMetadataReferences => _additionalMetadataReferences;
 

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputLibrary.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputLibrary.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Generator.CSharp
 
         private static TypeProvider[] BuildEnums()
         {
-            var input = CodeModelPlugin.Instance.InputLibrary.InputNamespace;
+            var input = CodeModelPlugin.Instance.InputNamespace;
             var enums = new List<TypeProvider>(input.Enums.Count);
             foreach (var inputEnum in input.Enums)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.Generator.CSharp
 
         private static TypeProvider[] BuildModels()
         {
-            var input = CodeModelPlugin.Instance.InputLibrary.InputNamespace;
+            var input = CodeModelPlugin.Instance.InputNamespace;
             var models = new List<TypeProvider>(input.Models.Count);
             foreach (var inputModel in input.Models)
             {

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelFactoryProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Generator.CSharp.Providers
 
         private readonly IEnumerable<InputModelType> _models;
 
-        public static ModelFactoryProvider FromInputLibrary() => new ModelFactoryProvider(CodeModelPlugin.Instance.InputLibrary.InputNamespace.Models);
+        public static ModelFactoryProvider FromInputLibrary() => new ModelFactoryProvider(CodeModelPlugin.Instance.InputNamespace.Models);
 
         private ModelFactoryProvider(IEnumerable<InputModelType> models)
         {

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/InputLibraryVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/InputLibraryVisitorTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Generator.CSharp.Tests
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private Mock<CodeModelPlugin> _mockPlugin;
         private Mock<LibraryVisitor> _mockVisitor;
-        private Mock<InputLibrary> _mockInputLibrary;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [SetUp]
@@ -24,8 +23,6 @@ namespace Microsoft.Generator.CSharp.Tests
         {
             _mockPlugin = MockHelpers.LoadMockPlugin();
             _mockVisitor = new Mock<LibraryVisitor> { CallBase = true };
-            _mockInputLibrary = new Mock<InputLibrary>();
-            _mockPlugin.Setup(p => p.InputNamespace).Returns(_mockInputLibrary.Object.InputNamespace);
         }
 
         [Test]
@@ -35,7 +32,7 @@ namespace Microsoft.Generator.CSharp.Tests
             var inputModelProperty = InputFactory.Property("prop1", InputPrimitiveType.Any, true, true);
             var inputModel = InputFactory.Model("foo", "internal", usage: InputModelTypeUsage.Input, properties: [inputModelProperty]);
 
-            _mockInputLibrary.Setup(l => l.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel]));
+            _mockPlugin.Setup(p => p.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel]));
 
             _mockVisitor.Object.Visit(_mockPlugin.Object.OutputLibrary);
 
@@ -51,7 +48,7 @@ namespace Microsoft.Generator.CSharp.Tests
             var inputModelProperty = InputFactory.Property("prop1", inputEnum, true, true);
             var inputModel = InputFactory.Model("foo", "internal", usage: InputModelTypeUsage.Input, properties: [inputModelProperty]);
 
-            _mockInputLibrary.Setup(l => l.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel]));
+            _mockPlugin.Setup(p => p.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel]));
 
             _mockVisitor.Object.Visit(_mockPlugin.Object.OutputLibrary);
 
@@ -70,7 +67,7 @@ namespace Microsoft.Generator.CSharp.Tests
 
             var inputModel2 = InputFactory.Model("Model2", "internal", usage: InputModelTypeUsage.Input, properties: [inputModel2Property]);
 
-            _mockInputLibrary.Setup(l => l.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel1, inputModel2]));
+            _mockPlugin.Setup(p => p.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel1, inputModel2]));
 
             var visitor = new PreVisitor();
             _mockPlugin.Object.AddVisitor(visitor);
@@ -87,7 +84,7 @@ namespace Microsoft.Generator.CSharp.Tests
 
             var inputModel2 = InputFactory.Model("Model2", "internal", usage: InputModelTypeUsage.Input, properties: [inputModel2Property]);
 
-            _mockInputLibrary.Setup(l => l.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel1, inputModel2]));
+            _mockPlugin.Setup(p => p.InputNamespace).Returns(InputFactory.Namespace("test library", models: [inputModel1, inputModel2]));
 
             var visitor = new PreVisitor(true);
             _mockPlugin.Object.AddVisitor(visitor);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/InputLibraryVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/InputLibraryVisitorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Generator.CSharp.Tests
             _mockPlugin = MockHelpers.LoadMockPlugin();
             _mockVisitor = new Mock<LibraryVisitor> { CallBase = true };
             _mockInputLibrary = new Mock<InputLibrary>();
-            _mockPlugin.Setup(p => p.InputLibrary).Returns(_mockInputLibrary.Object);
+            _mockPlugin.Setup(p => p.InputNamespace).Returns(_mockInputLibrary.Object.InputNamespace);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/TestHelpers/MockHelpers.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Generator.CSharp.Tests
                 models: inputModelTypes,
                 enums: inputEnumTypes));
 
-            mockPlugin.Setup(p => p.InputLibrary).Returns(mockInputLibrary.Object);
+            mockPlugin.Setup(p => p.InputNamespace).Returns(mockInputLibrary.Object.InputNamespace);
 
             mockPlugin.SetupGet(p => p.TypeFactory).Returns(mockTypeFactory.Object);
 


### PR DESCRIPTION
It seems like all usages of CodeModelPlugin.InputLibrary are about `IntputNamespace`.
https://github.com/microsoft/typespec/blob/a939c140980805dc66a9b6fef70be5647b1c9680/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/CodeModelPlugin.cs#L67

Should we expose `InputNamespace` instead?