### PR TITLE
openapi3.1 - add support for enums backed by multiple types

### DIFF
--- a/.chronus/changes/openapi31-type-array-enums-2024-10-26-15-27-28.md
+++ b/.chronus/changes/openapi31-type-array-enums-2024-10-26-15-27-28.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Add support for defining enums with multiple types in Open API 3.1

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -113,12 +113,10 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
       enumValues.add(member.value ?? member.name);
     }
 
-    if (enumTypes.size > 1) {
-      reportDiagnostic(program, { code: "enum-unique-type", target: en });
-    }
+    const enumTypesArray = [...enumTypes];
 
     const schema: OpenAPISchema3_1 = {
-      type: enumTypes.values().next().value!,
+      type: enumTypesArray.length === 1 ? enumTypesArray[0] : enumTypesArray,
       enum: [...enumValues],
     };
 

--- a/packages/openapi3/test/enums.test.ts
+++ b/packages/openapi3/test/enums.test.ts
@@ -1,24 +1,15 @@
 import { expectDiagnostics } from "@typespec/compiler/testing";
-import { strictEqual } from "assert";
-import { describe, it } from "vitest";
-import { diagnoseOpenApiFor, oapiForModel } from "./test-host.js";
+import { deepStrictEqual, strictEqual } from "assert";
+import { it } from "vitest";
+import { worksFor } from "./works-for.js";
 
-describe("openapi3: enums", () => {
+worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, oapiForModel }) => {
   it("throws diagnostics for empty enum definitions", async () => {
     const diagnostics = await diagnoseOpenApiFor(`enum PetType {}`);
 
     expectDiagnostics(diagnostics, {
       code: "@typespec/openapi3/empty-enum",
       message: "Empty enums are not supported for OpenAPI v3 - enums must have at least one value.",
-    });
-  });
-
-  it("throws diagnostics for enum with different types", async () => {
-    const diagnostics = await diagnoseOpenApiFor(`enum PetType {asString: "dog", asNumber: 1}`);
-
-    expectDiagnostics(diagnostics, {
-      code: "@typespec/openapi3/enum-unique-type",
-      message: "Enums are not supported unless all options are literals of the same type.",
     });
   });
 
@@ -33,5 +24,27 @@ describe("openapi3: enums", () => {
       `,
     );
     strictEqual(res.schemas.Foo.title, "FooEnum");
+  });
+});
+
+worksFor(["3.0.0"], ({ diagnoseOpenApiFor }) => {
+  it("throws diagnostics for enum with different types", async () => {
+    const diagnostics = await diagnoseOpenApiFor(`enum PetType {asString: "dog", asNumber: 1}`);
+
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi3/enum-unique-type",
+      message: "Enums are not supported unless all options are literals of the same type.",
+    });
+  });
+});
+
+worksFor(["3.1.0"], ({ oapiForModel }) => {
+  it("supports enum with different types", async () => {
+    const res = await oapiForModel("PetType", `enum PetType {asString: "dog", asNumber: 1}`);
+
+    deepStrictEqual(res.schemas.PetType, {
+      type: ["string", "number"],
+      enum: ["dog", 1],
+    });
   });
 });


### PR DESCRIPTION
Implements #5011 
The only place I found this made sense to emit a schema type as a list currently is with enums as mentioned in the linked issue.