### PR TITLE
[http-client-csharp] Add Flatten api to MethodBodyStatement

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Statements/MethodBodyStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Statements/MethodBodyStatement.cs
@@ -26,6 +26,29 @@ namespace Microsoft.Generator.CSharp.Statements
 
         public string ToDisplayString() => GetDebuggerDisplay();
 
+        public IEnumerable<MethodBodyStatement> Flatten()
+        {
+            Queue<MethodBodyStatement> queue = new();
+            queue.Enqueue(this);
+
+            while (queue.Count > 0)
+            {
+                MethodBodyStatement current = queue.Dequeue();
+
+                if (current is MethodBodyStatements statements)
+                {
+                    foreach (var subStatement in statements.Statements)
+                    {
+                        queue.Enqueue(subStatement);
+                    }
+                }
+                else
+                {
+                    yield return current;
+                }
+            }
+        }
+
         private string GetDebuggerDisplay()
         {
             using CodeWriter writer = new CodeWriter();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Statements/StatementTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/test/Statements/StatementTests.cs
@@ -488,5 +488,36 @@ namespace Microsoft.Generator.CSharp.Tests.Statements
             var test = writer.ToString(false);
             Assert.AreEqual(expectedResult, test);
         }
+
+        [Test]
+        public void TestFlatten()
+        {
+            var ifTrueStatement = new IfStatement(True) { Return(True) };
+            var ifFalseStatement = new IfStatement(False) { Return(False) };
+            var ifElseStatement = new IfElseStatement(True, new SingleLineCommentStatement("$hello"), new SingleLineCommentStatement("$world"));
+            MethodBodyStatement methodBodyStatements = new List<MethodBodyStatement>
+            {
+                ifTrueStatement,
+                ifElseStatement,
+                ifFalseStatement
+            };
+
+            var flattened = methodBodyStatements.Flatten().ToList();
+            Assert.AreEqual(3, flattened.Count);
+            Assert.AreEqual(ifTrueStatement, flattened[0]);
+            Assert.AreEqual(ifElseStatement, flattened[1]);
+            Assert.AreEqual(ifFalseStatement, flattened[2]);
+
+            // Test flattening a single statement
+            var singleStatementFlattened = ifTrueStatement.Flatten().ToList();
+            Assert.AreEqual(1, singleStatementFlattened.Count);
+
+            // flatten the body
+            var body = ifTrueStatement.Body.Flatten().ToList();
+            Assert.AreEqual(1, body.Count);
+            Assert.AreEqual(ifTrueStatement.Body.ToDisplayString(), body[0].ToDisplayString());
+        }
+
+
     }
 }


### PR DESCRIPTION
This PR adds a Flatten method to the MethodBodyStatement class to aid in implementing visitors and iterate through all the statements in a method body.

fixes: https://github.com/microsoft/typespec/issues/5017