### PR TITLE
http-client-java, add HttpLoggingPolicy to unbranded

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
@@ -27,6 +27,7 @@ import com.azure.core.http.MatchConditions;
 import com.azure.core.http.ProxyOptions;
 import com.azure.core.http.RequestConditions;
 import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
 import com.azure.core.http.policy.HttpPipelinePolicy;
 import com.azure.core.http.policy.KeyCredentialPolicy;
 import com.azure.core.http.policy.RedirectPolicy;
@@ -121,6 +122,8 @@ public class ClassType implements IType {
                 new ClassDetails(RetryPolicy.class, "io.clientcore.core.http.pipeline.HttpRetryPolicy"));
             put(RedirectPolicy.class,
                 new ClassDetails(RedirectPolicy.class, "io.clientcore.core.http.pipeline.HttpRedirectPolicy"));
+            put(HttpLoggingPolicy.class,
+                new ClassDetails(HttpLoggingPolicy.class, "io.clientcore.core.http.pipeline.HttpLoggingPolicy"));
             put(Configuration.class,
                 new ClassDetails(Configuration.class, "io.clientcore.core.util.configuration.Configuration"));
             put(HttpHeaders.class, new ClassDetails(HttpHeaders.class, "io.clientcore.core.models.Headers"));
@@ -486,6 +489,7 @@ public class ClassType implements IType {
 
     public static final ClassType RETRY_POLICY = getClassTypeBuilder(RetryPolicy.class).build();
     public static final ClassType REDIRECT_POLICY = getClassTypeBuilder(RedirectPolicy.class).build();
+    public static final ClassType HTTP_LOGGING_POLICY = getClassTypeBuilder(HttpLoggingPolicy.class).build();
 
     public static final ClassType RETRY_OPTIONS = getClassTypeBuilder(RetryOptions.class).build();
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ServiceClient.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ServiceClient.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.typespec.http.client.generator.core.model.clientmodel;
 
+import com.azure.core.http.policy.UserAgentPolicy;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
 import com.microsoft.typespec.http.client.generator.core.util.ClientModelUtil;
 import java.util.Collections;
@@ -361,9 +362,9 @@ public class ServiceClient {
     }
 
     protected void addHttpPolicyImports(Set<String> imports) {
+        ClassType.RETRY_POLICY.addImportsTo(imports, false);
         if (JavaSettings.getInstance().isBranded()) {
-            imports.add("com.azure.core.http.policy.RetryPolicy");
-            imports.add("com.azure.core.http.policy.UserAgentPolicy");
+            imports.add(UserAgentPolicy.class.getName());
         }
     }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceClientBuilderTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceClientBuilderTemplate.java
@@ -9,7 +9,6 @@ import com.azure.core.http.policy.AddHeadersFromContextPolicy;
 import com.azure.core.http.policy.AddHeadersPolicy;
 import com.azure.core.http.policy.AzureKeyCredentialPolicy;
 import com.azure.core.http.policy.BearerTokenAuthenticationPolicy;
-import com.azure.core.http.policy.HttpLoggingPolicy;
 import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RequestIdPolicy;
 import com.azure.core.util.CoreUtils;
@@ -523,7 +522,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
 
         imports.add(HttpPolicyProviders.class.getName());
         ClassType.HTTP_PIPELINE_POLICY.addImportsTo(imports, false);
-        imports.add(HttpLoggingPolicy.class.getName());
+        ClassType.HTTP_LOGGING_POLICY.addImportsTo(imports, false);
         imports.add(AddHeadersPolicy.class.getName());
         imports.add(RequestIdPolicy.class.getName());
         imports.add(AddHeadersFromContextPolicy.class.getName());

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/TemplateHelper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/TemplateHelper.java
@@ -76,6 +76,7 @@ public final class TemplateHelper {
                     + "\", keyCredential, " + prefixExpr + "));");
             });
         }
+        function.line("policies.add(new HttpLoggingPolicy(%s));", localHttpLogOptionsName);
         function.line("httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));");
         function.methodReturn("httpPipelineBuilder.build()");
     }


### PR DESCRIPTION
The reason we didn't have it before, is likely that this HttpLoggingPolicy class was not public in clientcore.