### PR TITLE
http-client-java, fix expandable enum `equals`

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
@@ -67,6 +67,7 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
             imports.add("java.util.ArrayList");
             imports.add("java.util.Objects");
             imports.add(ClassType.EXPANDABLE_ENUM.getFullName());
+            imports.add("java.util.function.Function");
             if (!settings.isStreamStyleSerialization()) {
                 imports.add("com.fasterxml.jackson.annotation.JsonCreator");
             }
@@ -84,6 +85,8 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
             javaFile.publicFinalClass(declaration, classBlock -> {
                 classBlock.privateStaticFinalVariable(
                     String.format("Map<%1$s, %2$s> VALUES = new ConcurrentHashMap<>()", pascalTypeName, enumName));
+                classBlock.privateStaticFinalVariable(
+                    String.format("Function<%1$s, %2$s> NEW_INSTANCE = %2$s::new", pascalTypeName, enumName));
 
                 for (ClientEnumValue enumValue : enumType.getValues()) {
                     String value = enumValue.getValue();
@@ -115,9 +118,7 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                 classBlock.publicStaticMethod(String.format("%1$s fromValue(%2$s value)", enumName, pascalTypeName),
                     function -> {
                         function.line("Objects.requireNonNull(value, \"'value' cannot be null.\");");
-                        function.line(enumName + " member = VALUES.get(value);");
-                        function.ifBlock("member != null", ifAction -> ifAction.line("return member;"));
-                        function.methodReturn("VALUES.computeIfAbsent(value, key -> new " + enumName + "(key))");
+                        function.methodReturn("VALUES.computeIfAbsent(value, NEW_INSTANCE)");
                     });
 
                 // values

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
@@ -150,10 +150,7 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                 addGeneratedAnnotation(classBlock);
                 classBlock.annotation("Override");
                 classBlock.method(JavaVisibility.Public, null, "boolean equals(Object obj)",
-                    function -> function.line(
-                        "if (this == obj) {\n" + "    return true;\n" + "}\n" + "if (!(obj instanceof %1$s)) {\n"
-                            + "    return false;\n" + "}\n" + "return Objects.equals(this.value, ((%1$s) obj).value);",
-                        enumName));
+                    function -> function.methodReturn("this == obj"));
 
                 // hashcode
                 addGeneratedAnnotation(classBlock);

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
@@ -150,7 +150,10 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                 addGeneratedAnnotation(classBlock);
                 classBlock.annotation("Override");
                 classBlock.method(JavaVisibility.Public, null, "boolean equals(Object obj)",
-                    function -> function.methodReturn("Objects.equals(this.value, obj)"));
+                    function -> function.line(
+                        "if (this == obj) {\n" + "    return true;\n" + "}\n" + "if (!(obj instanceof %1$s)) {\n"
+                            + "    return false;\n" + "}\n" + "return Objects.equals(this.value, ((%1$s) obj).value);",
+                        enumName));
 
                 // hashcode
                 addGeneratedAnnotation(classBlock);

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
@@ -76,13 +76,7 @@ public final class PriorityModel implements ExpandableEnum<Integer> {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof PriorityModel)) {
-            return false;
-        }
-        return Objects.equals(this.value, ((PriorityModel) obj).value);
+        return this == obj;
     }
 
     @Override

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
@@ -11,12 +11,15 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * Defines values for PriorityModel.
  */
 public final class PriorityModel implements ExpandableEnum<Integer> {
     private static final Map<Integer, PriorityModel> VALUES = new ConcurrentHashMap<>();
+
+    private static final Function<Integer, PriorityModel> NEW_INSTANCE = PriorityModel::new;
 
     /**
      * Static value 0 for PriorityModel.
@@ -43,11 +46,7 @@ public final class PriorityModel implements ExpandableEnum<Integer> {
     @JsonCreator
     public static PriorityModel fromValue(Integer value) {
         Objects.requireNonNull(value, "'value' cannot be null.");
-        PriorityModel member = VALUES.get(value);
-        if (member != null) {
-            return member;
-        }
-        return VALUES.computeIfAbsent(value, key -> new PriorityModel(key));
+        return VALUES.computeIfAbsent(value, NEW_INSTANCE);
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
@@ -76,7 +76,13 @@ public final class PriorityModel implements ExpandableEnum<Integer> {
 
     @Override
     public boolean equals(Object obj) {
-        return Objects.equals(this.value, obj);
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof PriorityModel)) {
+            return false;
+        }
+        return Objects.equals(this.value, ((PriorityModel) obj).value);
     }
 
     @Override

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
@@ -82,7 +82,13 @@ public final class OlympicRecordModel implements ExpandableEnum<Double> {
     @Generated
     @Override
     public boolean equals(Object obj) {
-        return Objects.equals(this.value, obj);
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof OlympicRecordModel)) {
+            return false;
+        }
+        return Objects.equals(this.value, ((OlympicRecordModel) obj).value);
     }
 
     @Generated

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
@@ -82,13 +82,7 @@ public final class OlympicRecordModel implements ExpandableEnum<Double> {
     @Generated
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof OlympicRecordModel)) {
-            return false;
-        }
-        return Objects.equals(this.value, ((OlympicRecordModel) obj).value);
+        return this == obj;
     }
 
     @Generated

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
@@ -11,12 +11,15 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * Defines values for OlympicRecordModel.
  */
 public final class OlympicRecordModel implements ExpandableEnum<Double> {
     private static final Map<Double, OlympicRecordModel> VALUES = new ConcurrentHashMap<>();
+
+    private static final Function<Double, OlympicRecordModel> NEW_INSTANCE = OlympicRecordModel::new;
 
     /**
      * Static value 9.58 for OlympicRecordModel.
@@ -45,11 +48,7 @@ public final class OlympicRecordModel implements ExpandableEnum<Double> {
     @Generated
     public static OlympicRecordModel fromValue(Double value) {
         Objects.requireNonNull(value, "'value' cannot be null.");
-        OlympicRecordModel member = VALUES.get(value);
-        if (member != null) {
-            return member;
-        }
-        return VALUES.computeIfAbsent(value, key -> new OlympicRecordModel(key));
+        return VALUES.computeIfAbsent(value, NEW_INSTANCE);
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
@@ -82,7 +82,13 @@ public final class PriorityModel implements ExpandableEnum<Integer> {
     @Generated
     @Override
     public boolean equals(Object obj) {
-        return Objects.equals(this.value, obj);
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof PriorityModel)) {
+            return false;
+        }
+        return Objects.equals(this.value, ((PriorityModel) obj).value);
     }
 
     @Generated

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
@@ -11,12 +11,15 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * Defines values for PriorityModel.
  */
 public final class PriorityModel implements ExpandableEnum<Integer> {
     private static final Map<Integer, PriorityModel> VALUES = new ConcurrentHashMap<>();
+
+    private static final Function<Integer, PriorityModel> NEW_INSTANCE = PriorityModel::new;
 
     /**
      * Static value 100 for PriorityModel.
@@ -45,11 +48,7 @@ public final class PriorityModel implements ExpandableEnum<Integer> {
     @Generated
     public static PriorityModel fromValue(Integer value) {
         Objects.requireNonNull(value, "'value' cannot be null.");
-        PriorityModel member = VALUES.get(value);
-        if (member != null) {
-            return member;
-        }
-        return VALUES.computeIfAbsent(value, key -> new PriorityModel(key));
+        return VALUES.computeIfAbsent(value, NEW_INSTANCE);
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
@@ -82,13 +82,7 @@ public final class PriorityModel implements ExpandableEnum<Integer> {
     @Generated
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof PriorityModel)) {
-            return false;
-        }
-        return Objects.equals(this.value, ((PriorityModel) obj).value);
+        return this == obj;
     }
 
     @Generated

--- a/packages/http-client-java/generator/http-client-generator-test/src/test/java/tsptest/enumservice/EnumTests.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/test/java/tsptest/enumservice/EnumTests.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 import tsptest.enumservice.implementation.EnumServiceClientImpl;
 import tsptest.enumservice.models.ColorModel;
 import tsptest.enumservice.models.Priority;
+import tsptest.enumservice.models.PriorityModel;
 
 public class EnumTests {
 
@@ -127,6 +128,15 @@ public class EnumTests {
         HttpRequest request = new HttpRequest(HttpMethod.POST, "http://endpoint/");
         getRequestCallback(requestOptionsArgumentCaptor.getValue()).accept(request);
         Assertions.assertEquals("colorArrayOpt=Green&colorArrayOpt=Red", request.getUrl().getQuery());
+    }
+
+    @Test
+    public void testExpandableEnum() {
+        Assertions.assertEquals(PriorityModel.HIGH, PriorityModel.fromValue(100));
+        Assertions.assertNotEquals(PriorityModel.HIGH, PriorityModel.LOW);
+        Assertions.assertNotEquals(PriorityModel.HIGH, PriorityModel.fromValue(200));
+
+        Assertions.assertEquals(100, PriorityModel.HIGH.getValue());
     }
 
     private static void verifyQuery(String query, String key, String value) {


### PR DESCRIPTION
Bug found in deserialization mock test: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4390469&view=logs&jobId=1ddb3322-d991-5251-324c-57ed6980c710&j=1ddb3322-d991-5251-324c-57ed6980c710&t=0da78e2d-17fd-5004-a494-748a34fd2ecc

Fluent lite packages will experience generation failure, thus already released packages should be good.
Premium packages are generated with `ExpandableStringEnum`, thus not affected as well.

Not sure about DPG packages. I've not yet seen any released packages with ExpandableEnum.