### PR TITLE
Update JS API parser to install from local feed

### DIFF
--- a/eng/emitters/scripts/Generate-APIView-CodeFile.ps1
+++ b/eng/emitters/scripts/Generate-APIView-CodeFile.ps1
@@ -1,7 +1,7 @@
 param (
   [Parameter(mandatory = $true)]
   $ArtifactPath,
-  $NpmDevopsFeedRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js@local/npm/registry/"
+  $NpmDevopsFeedRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js@Local/npm/registry/"
 )
 
 Set-StrictMode -Version 3

--- a/eng/emitters/scripts/Generate-APIView-CodeFile.ps1
+++ b/eng/emitters/scripts/Generate-APIView-CodeFile.ps1
@@ -1,7 +1,7 @@
 param (
   [Parameter(mandatory = $true)]
   $ArtifactPath,
-  $NpmDevopsFeedRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
+  $NpmDevopsFeedRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js@local/npm/registry/"
 )
 
 Set-StrictMode -Version 3


### PR DESCRIPTION
Install JS API parser from local feed to avoid checking upstream for latest version