### PR TITLE
Support non-kebab-case directories for cadl-ranch scenarios

### DIFF
--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Versioning/Removed/V1/VersioningRemovedV1Tests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Versioning/Removed/V1/VersioningRemovedV1Tests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Versioning.Removed.V1;
+using Versioning.Removed.V1.Models;
 
 namespace TestProjects.CadlRanch.Tests.Http.Versioning.Removed.V1
 {
@@ -39,5 +41,15 @@ namespace TestProjects.CadlRanch.Tests.Http.Versioning.Removed.V1
             var enumType = typeof(RemovedClientOptions.ServiceVersion);
             Assert.AreEqual(new string[] { "V1" }, enumType.GetEnumNames());
         }
+
+        [CadlRanchTest]
+        public Task Versioning_Removed_V3Model() => Test(async (host) =>
+        {
+            var model = new ModelV3("123", EnumV3.EnumMemberV1);
+            var response = await new RemovedClient(host).ModelV3Async(model);
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.AreEqual("123", response.Value.Id);
+            Assert.AreEqual(EnumV3.EnumMemberV1, response.Value.EnumProp);
+        });
     }
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
@@ -24,6 +24,12 @@ namespace TestProjects.CadlRanch.Tests
         {
             string clientCodeDirectory = GetGeneratedDirectory(test);
 
+            if (!Directory.Exists(clientCodeDirectory))
+            {
+                // Not all cadl-ranch scenarios use kebab-case directories, so try again without kebab-case.
+                clientCodeDirectory = GetGeneratedDirectory(test, false);
+            }
+
             var clientCsFile = GetClientCsFile(clientCodeDirectory);
 
             TestContext.Progress.WriteLine($"Checking if '{clientCsFile}' is a stubbed implementation.");
@@ -69,14 +75,14 @@ namespace TestProjects.CadlRanch.Tests
                 .FirstOrDefault();
         }
 
-        private static string GetGeneratedDirectory(Test test)
+        private static string GetGeneratedDirectory(Test test, bool kebabCaseDirectories = true)
         {
             var namespaceParts = test.FullName.Split('.').Skip(3);
             namespaceParts = namespaceParts.Take(namespaceParts.Count() - 2);
             var clientCodeDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestProjects", "CadlRanch");
             foreach (var part in namespaceParts)
             {
-                clientCodeDirectory = Path.Combine(clientCodeDirectory, FixName(part));
+                clientCodeDirectory = Path.Combine(clientCodeDirectory, kebabCaseDirectories ? FixName(part) : part);
             }
             return Path.Combine(clientCodeDirectory, "src", "Generated");
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/5287

Follow up to https://github.com/microsoft/typespec/pull/5273/. The directories defined in cadl-ranch spec for the versioning scenarios do not use kebab-case which led to our test attribute skipping the tests.

Also adds one missing scenario for versioning.