### PR TITLE
Fix to cadlranch attribute

### DIFF
--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
@@ -82,14 +82,19 @@ namespace TestProjects.CadlRanch.Tests
             var clientCodeDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestProjects", "CadlRanch");
             foreach (var part in namespaceParts)
             {
-                clientCodeDirectory = Path.Combine(clientCodeDirectory, kebabCaseDirectories ? FixName(part) : part);
+                clientCodeDirectory = Path.Combine(clientCodeDirectory, FixName(part, kebabCaseDirectories));
             }
             return Path.Combine(clientCodeDirectory, "src", "Generated");
         }
 
-        private static string FixName(string part)
+        private static string FixName(string part, bool kebabCaseDirectories)
         {
-            return ToKebabCase().Replace(part.StartsWith("_", StringComparison.Ordinal) ? part.Substring(1) : part, "-$1").ToLower();
+            if (kebabCaseDirectories)
+            {
+                return ToKebabCase().Replace(part.StartsWith("_", StringComparison.Ordinal) ? part.Substring(1) : part, "-$1").ToLower();
+            }
+            // Use camelCase
+            return part[0].ToString().ToLower() + part[1..];
         }
     }
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Infrastructure/CadlRanchTestAttribute.cs
@@ -91,10 +91,10 @@ namespace TestProjects.CadlRanch.Tests
         {
             if (kebabCaseDirectories)
             {
-                return ToKebabCase().Replace(part.StartsWith("_", StringComparison.Ordinal) ? part.Substring(1) : part, "-$1").ToLower();
+                return ToKebabCase().Replace(part.StartsWith("_", StringComparison.Ordinal) ? part.Substring(1) : part, "-$1").ToLowerInvariant();
             }
             // Use camelCase
-            return part[0].ToString().ToLower() + part[1..];
+            return char.ToLowerInvariant(part[0]) + part[1..];
         }
     }
 }


### PR DESCRIPTION
Linux filepaths are case-sensitive so updating to use the correct casing for the non kebab-case scenarios.