### PR TITLE
http-client-java, fix eclipse languageserver when tmp folder is corrupted

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -75,7 +75,8 @@ public class EclipseLanguageServerFacade {
             Process server = startServer(command, languageServerPath, logger);
             server.waitFor(1, TimeUnit.SECONDS);
             if (!server.isAlive() && pathToLanguageServerPlugin == null) {
-                logger.warn("Eclipse language server did not start correctly. The folder may be corrupted. Try re-download.");
+                logger.warn(
+                    "Eclipse language server did not start correctly. The folder may be corrupted. Try re-download.");
                 server = startServer(command, getLanguageServerDirectory(javaVersion, logger, true), logger);
             }
             this.server = server;

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -78,8 +78,8 @@ public class EclipseLanguageServerFacade {
             if (!server.isAlive()) {
                 if (pathToLanguageServerPlugin == null) {
                     // If user didn't specify language server path, we do a clean re-download.
-                    logger.warn(
-                        "Eclipse language server failed to start. The folder may be corrupted. Try re-download.");
+                    logger
+                        .warn("Eclipse language server failed to start. The folder may be corrupted. Try re-download.");
                     server = startServer(command, getLanguageServerDirectory(javaVersion, logger, true), logger);
                     if (!server.isAlive()) {
                         // if server failed to start anyway, throw with server output.

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -122,7 +122,7 @@ public class EclipseLanguageServerFacade {
 
         if (!Files.exists(languageServer) || forceReDownload) {
             Files.createDirectories(languageServer);
-            Path zipPath = languageServer.getParent().resolve("jdt-language-server.tar.gz");
+            Path zipPath = languageServerPath.resolve("jdt-language-server.tar.gz");
             Files.deleteIfExists(zipPath);
 
             logger.info("Downloading Eclipse JDT language server from {} to {}", downloadUrl, zipPath);

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import org.apache.tools.tar.TarEntry;
 import org.apache.tools.tar.TarInputStream;
@@ -33,7 +34,7 @@ public class EclipseLanguageServerFacade {
             int javaVersion = Runtime.version().feature();
 
             Path languageServerPath = (pathToLanguageServerPlugin == null)
-                ? getLanguageServerDirectory(javaVersion, logger)
+                ? getLanguageServerDirectory(javaVersion, logger, false)
                 : Paths.get(pathToLanguageServerPlugin).resolve("jdt-language-server");
 
             List<String> command = new ArrayList<>();
@@ -71,18 +72,31 @@ public class EclipseLanguageServerFacade {
                 command.add("./config_linux");
             }
 
-            logger.info("Starting Eclipse JDT language server at {}", languageServerPath);
-            server = new ProcessBuilder(command).redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .redirectInput(ProcessBuilder.Redirect.PIPE)
-                .redirectErrorStream(true)
-                .directory(languageServerPath.toFile())
-                .start();
+            Process server = startServer(command, languageServerPath, logger);
+            server.waitFor(1, TimeUnit.SECONDS);
+            if (!server.isAlive() && pathToLanguageServerPlugin == null) {
+                logger.warn("Eclipse language server did not start correctly. The folder may be corrupted. Try re-download.");
+                server = startServer(command, getLanguageServerDirectory(javaVersion, logger, true), logger);
+            }
+            this.server = server;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static Path getLanguageServerDirectory(int javaVersion, Logger logger) throws IOException {
+    private Process startServer(List<String> command, Path languageServerPath, Logger logger) throws IOException {
+        logger.info("Starting Eclipse JDT language server at {}", languageServerPath);
+        final Process server;
+        server = new ProcessBuilder(command).redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectInput(ProcessBuilder.Redirect.PIPE)
+            .redirectErrorStream(true)
+            .directory(languageServerPath.toFile())
+            .start();
+        return server;
+    }
+
+    private static Path getLanguageServerDirectory(int javaVersion, Logger logger, boolean forceReDownload)
+        throws IOException {
         Path tmp = Paths.get(System.getProperty("java.io.tmpdir"));
         Path autorestLanguageServer = tmp.resolve("autorest-java-language-server");
 
@@ -104,9 +118,12 @@ public class EclipseLanguageServerFacade {
         }
 
         Path languageServer = languageServerPath.resolve("jdt-language-server");
-        if (!Files.exists(languageServerPath) || !Files.exists(languageServer)) {
-            Files.createDirectories(languageServerPath);
-            Path zipPath = languageServerPath.resolve("jdt-language-server.tar.gz");
+
+        if (!Files.exists(languageServer) || forceReDownload) {
+            Files.createDirectories(languageServer);
+            Path zipPath = languageServer.getParent().resolve("jdt-language-server.tar.gz");
+            Files.deleteIfExists(zipPath);
+
             logger.info("Downloading Eclipse JDT language server from {} to {}", downloadUrl, zipPath);
             try (InputStream in = downloadUrl.openStream()) {
                 Files.copy(in, zipPath);
@@ -122,13 +139,15 @@ public class EclipseLanguageServerFacade {
     private static Path unzipLanguageServer(Path zipPath) throws IOException {
         try (TarInputStream tar = new TarInputStream(new GZIPInputStream(Files.newInputStream(zipPath)))) {
             Path languageServerDirectory = zipPath.getParent().resolve("jdt-language-server");
-            Files.createDirectory(languageServerDirectory);
             TarEntry entry;
             while ((entry = tar.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
                     Files.createDirectories(languageServerDirectory.resolve(entry.getName()));
                 } else {
-                    Files.copy(tar, languageServerDirectory.resolve(entry.getName()));
+                    Path entryPath = languageServerDirectory.resolve(entry.getName());
+                    // In case of corrupted folder, delete before create.
+                    Files.deleteIfExists(entryPath);
+                    Files.copy(tar, entryPath);
                 }
             }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -77,14 +77,17 @@ public class EclipseLanguageServerFacade {
             Process server = startServer(command, languageServerPath, logger);
             if (!server.isAlive()) {
                 if (pathToLanguageServerPlugin == null) {
+                    // If user didn't specify language server path, we do a clean re-download.
                     logger.warn(
                         "Eclipse language server failed to start. The folder may be corrupted. Try re-download.");
                     server = startServer(command, getLanguageServerDirectory(javaVersion, logger, true), logger);
                     if (!server.isAlive()) {
+                        // if server failed to start anyway, throw with server output.
                         throw new RuntimeException(String.format(
                             "Eclipse language server failed to start, error output:\n %s", readServerOutput(server)));
                     }
                 } else {
+                    // if user specify the language server path, we just throw with server output.
                     throw new RuntimeException(String.format(
                         "Eclipse language server failed to start, error output:\n %s", readServerOutput(server)));
                 }


### PR DESCRIPTION
### Situation
I somehow encountered a folder corruption situation that the tmp folder for language server is there, but with no Jar file. Language server didn't start correctly, but the exception is thrown only when JSON RPC to the server is performed.
<img width="1406" alt="Screenshot 2024-12-11 at 14 23 52" src="https://github.com/user-attachments/assets/1654fabc-bb71-4b81-aab7-b4c24b8afae3">


### This PR
- In case the language server did not start correctly, and user did not explicitly provide a language server path, force a re-download.
- If the server failed to start anyway, throw with the process output.

### Test
#### Normal first download
<img width="1372" alt="Screenshot 2024-12-09 at 20 12 06" src="https://github.com/user-attachments/assets/9126e436-cad2-4a03-9d7c-cb31d5bc4a95">


#### Normal downloaded
<img width="1251" alt="Screenshot 2024-12-09 at 20 09 22" src="https://github.com/user-attachments/assets/2deb6fb3-acef-4d4b-8365-8a6ebf3ab3f8">


#### Corrupted folder, we do a re-download
<img width="1306" alt="Screenshot 2024-12-09 at 20 08 35" src="https://github.com/user-attachments/assets/d8d56d6f-fd97-4b06-8327-08045cbadbff">

#### Server failed to start anyway, we throw with server output
<img width="1383" alt="Screenshot 2024-12-10 at 16 48 25" src="https://github.com/user-attachments/assets/36f56e7d-0b58-4820-8c6f-a33dc559c902">
