### PR TITLE
http-client-java, fix client accessor method parameter description

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplateBase.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplateBase.java
@@ -9,7 +9,6 @@ import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSe
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientEnumValue;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethod;
-import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethodParameter;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModel;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModelProperty;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.EnumType;
@@ -25,6 +24,7 @@ import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaJav
 import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaType;
 import com.microsoft.typespec.http.client.generator.core.util.ClientModelUtil;
 import com.microsoft.typespec.http.client.generator.core.util.CodeNamer;
+import com.microsoft.typespec.http.client.generator.core.util.MethodUtil;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -136,7 +136,7 @@ public abstract class ClientMethodTemplateBase implements IJavaTemplate<ClientMe
         }
 
         clientMethod.getParameters()
-            .forEach(p -> commentBlock.param(p.getName(), methodParameterDescriptionOrDefault(p)));
+            .forEach(p -> commentBlock.param(p.getName(), MethodUtil.methodParameterDescriptionOrDefault(p)));
         if (clientMethod.getProxyMethod() != null) {
             generateJavadocExceptions(clientMethod, commentBlock, false);
         }
@@ -351,14 +351,6 @@ public abstract class ClientMethodTemplateBase implements IJavaTemplate<ClientMe
             }
         }
         return description;
-    }
-
-    private static String methodParameterDescriptionOrDefault(ClientMethodParameter p) {
-        String doc = p.getDescription();
-        if (CoreUtils.isNullOrEmpty(doc)) {
-            doc = String.format("The %1$s parameter", p.getName());
-        }
-        return doc;
     }
 
     private static String appendOptionalOrRequiredAttribute(boolean isRequired, boolean isRequiredForCreate,

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceAsyncClientTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceAsyncClientTemplate.java
@@ -23,6 +23,7 @@ import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaCon
 import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaFile;
 import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaVisibility;
 import com.microsoft.typespec.http.client.generator.core.util.ClientModelUtil;
+import com.microsoft.typespec.http.client.generator.core.util.MethodUtil;
 import com.microsoft.typespec.http.client.generator.core.util.ModelNamer;
 import com.microsoft.typespec.http.client.generator.core.util.TemplateUtil;
 import java.util.HashSet;
@@ -241,7 +242,7 @@ public class ServiceAsyncClientTemplate implements IJavaTemplate<AsyncSyncClient
             classBlock.javadocComment(comment -> {
                 comment.description("Gets an instance of " + subClientClassName + " class.");
                 for (ClientMethodParameter property : methodParameters) {
-                    comment.param(property.getName(), property.getDescription());
+                    comment.param(property.getName(), MethodUtil.methodParameterDescriptionOrDefault(property));
                 }
                 comment.methodReturns("an instance of " + subClientClassName + "class");
             });

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceClientTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceClientTemplate.java
@@ -19,6 +19,7 @@ import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaVis
 import com.microsoft.typespec.http.client.generator.core.template.prototype.MethodTemplate;
 import com.microsoft.typespec.http.client.generator.core.util.ClientModelUtil;
 import com.microsoft.typespec.http.client.generator.core.util.CodeNamer;
+import com.microsoft.typespec.http.client.generator.core.util.MethodUtil;
 import com.microsoft.typespec.http.client.generator.core.util.ModelNamer;
 import com.microsoft.typespec.http.client.generator.core.util.TemplateUtil;
 import java.util.ArrayList;
@@ -386,7 +387,7 @@ public class ServiceClientTemplate implements IJavaTemplate<ServiceClient, JavaF
             classBlock.javadocComment(comment -> {
                 comment.description("Gets an instance of " + subClientName + " class.");
                 for (ClientMethodParameter parameter : methodParameters) {
-                    comment.param(parameter.getName(), parameter.getDescription());
+                    comment.param(parameter.getName(), MethodUtil.methodParameterDescriptionOrDefault(parameter));
                 }
                 comment.methodReturns("an instance of " + subClientName + "class");
             });

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/MethodUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/MethodUtil.java
@@ -23,6 +23,7 @@ import com.microsoft.typespec.http.client.generator.core.mapper.Mappers;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientEnumValue;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethod;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethodParameter;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.EnumType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.IType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ProxyMethod;
@@ -324,6 +325,20 @@ public class MethodUtil {
                     || Objects.equals(p.getName(), "maxPageSize")))
             .map(ProxyMethodParameter::getRequestParameterName)
             .findFirst();
+    }
+
+    /**
+     * Gets method parameter description, or a default description if not exists.
+     * 
+     * @param p the client method parameter
+     * @return the method parameter description
+     */
+    public static String methodParameterDescriptionOrDefault(ClientMethodParameter p) {
+        String doc = p.getDescription();
+        if (CoreUtils.isNullOrEmpty(doc)) {
+            doc = String.format("The %1$s parameter", p.getName());
+        }
+        return doc;
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/clientinitialization/ClientInitializationAsyncClient.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/clientinitialization/ClientInitializationAsyncClient.java
@@ -29,7 +29,7 @@ public final class ClientInitializationAsyncClient {
     /**
      * Gets an instance of SubAsyncClient class.
      * 
-     * @param name
+     * @param name The name parameter.
      * @return an instance of SubAsyncClientclass.
      */
     public SubAsyncClient getSubAsyncClient(String name) {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/clientinitialization/ClientInitializationClient.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/clientinitialization/ClientInitializationClient.java
@@ -29,7 +29,7 @@ public final class ClientInitializationClient {
     /**
      * Gets an instance of SubClient class.
      * 
-     * @param name
+     * @param name The name parameter.
      * @return an instance of SubClientclass.
      */
     public SubClient getSubClient(String name) {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/clientinitialization/implementation/ClientInitializationClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/clientinitialization/implementation/ClientInitializationClientImpl.java
@@ -95,7 +95,7 @@ public final class ClientInitializationClientImpl {
     /**
      * Gets an instance of SubClientImpl class.
      * 
-     * @param name
+     * @param name The name parameter.
      * @return an instance of SubClientImplclass.
      */
     public SubClientImpl getSubClient(String name) {


### PR DESCRIPTION
fix autorest CI: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4395471&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=0750e130-1e9a-5b8a-35b2-9986f25ac898

Similar to client method parameter, assign a default parameter description if not exists.