### PR TITLE
http-client-java, doc, require JDK 17

### DIFF
--- a/packages/http-client-java/README.md
+++ b/packages/http-client-java/README.md
@@ -6,7 +6,7 @@ This is a TypeSpec library that will emit a Java SDK from TypeSpec.
 
 Install [Node.js](https://nodejs.org/) 20 or above. (Verify by running `node --version`)
 
-Install [Java](https://docs.microsoft.com/java/openjdk/download) 11 or above. (Verify by running `java --version`)
+Install [Java](https://docs.microsoft.com/java/openjdk/download) 17 or above. (Verify by running `java --version`)
 
 Install [Maven](https://maven.apache.org/install.html). (Verify by running `mvn --version`)
 

--- a/packages/http-client-java/generator/README.md
+++ b/packages/http-client-java/generator/README.md
@@ -10,8 +10,8 @@ The **Microsoft Java client generator** tool generates client libraries for acce
 
 ## Prerequisites
 
-- [Java 11 or above](https://adoptium.net/temurin/releases/)
-- [Maven](https://maven.apache.org/download.cgi)
+- [Java 17 or above](https://docs.microsoft.com/java/openjdk/download)
+- [Maven](https://maven.apache.org/install.html)
 
 ## Build
 


### PR DESCRIPTION
clientcore now requires JDK 17.

Therefore since emitter requires JDK too, we'd better just ask user to install 17