### PR TITLE
[http-client-csharp] fix: enable cadl ranch coverage for srvdriven test

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Get-CadlRanch-Coverage.ps1
+++ b/packages/http-client-csharp/eng/scripts/Get-CadlRanch-Coverage.ps1
@@ -27,10 +27,6 @@ foreach ($directory in $directories) {
     $outputDir = $directory.FullName.Substring(0, $directory.FullName.IndexOf("src") - 1)
     $subPath = $outputDir.Substring($cadlRanchRoot.Length + 1)
 
-    if ($subPath.Contains($(Join-Path 'srv-driven' 'v1'))) {
-        continue
-    }
-
     Write-Host "Regenerating $subPath" -ForegroundColor Cyan
 
     $specFile = Join-Path $specsDirectory $subPath "client.tsp"

--- a/packages/http-client-csharp/eng/scripts/Test-CadlRanch.ps1
+++ b/packages/http-client-csharp/eng/scripts/Test-CadlRanch.ps1
@@ -67,6 +67,11 @@ foreach ($directory in $directories) {
         if ($subPath.Contains("v1")) {
             Generate-Srv-Driven ($(Join-Path $specsDirectory $subPath) | Split-Path) $($outputDir | Split-Path) -createOutputDirIfNotExist $false
         }
+        else {
+            continue;
+        }
+        # remove versioning from the test filter to ensure both versions are tested
+        $testFilter = $testFilter.Replace(".V1", "")
     }
     else {
         $command = Get-TspCommand $specFile $outputDir

--- a/packages/http-client-csharp/eng/scripts/Test-CadlRanch.ps1
+++ b/packages/http-client-csharp/eng/scripts/Test-CadlRanch.ps1
@@ -67,11 +67,6 @@ foreach ($directory in $directories) {
         if ($subPath.Contains("v1")) {
             Generate-Srv-Driven ($(Join-Path $specsDirectory $subPath) | Split-Path) $($outputDir | Split-Path) -createOutputDirIfNotExist $false
         }
-        else {
-            continue;
-        }
-        # remove versioning from the test filter to ensure both versions are tested
-        $testFilter = $testFilter.Replace(".V1", "")
     }
     else {
         $command = Get-TspCommand $specFile $outputDir

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Resiliency/SrvDriven/V1/SrvDrivenV1Tests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Resiliency/SrvDriven/V1/SrvDrivenV1Tests.cs
@@ -10,7 +10,7 @@ namespace TestProjects.CadlRanch.Tests.Http.Resiliency.SrvDriven.V1
     /// <summary>
     /// Contains tests for the service-driven resiliency V1 client.
     /// </summary>
-    public partial class SrvDrivenV2Tests : CadlRanchTestBase
+    public partial class SrvDrivenV1Tests : CadlRanchTestBase
     {
         private const string ServiceDeploymentV1 = "v1";
         private const string ServiceDeploymentV2 = "v2";


### PR DESCRIPTION
This PR fixes some issues in the cadl ranch scripts that were preventing the coverage to be calculated for the `resiliency/service-driven` client.