### PR TITLE
http-client-java, validate JDK and Maven

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -95,6 +95,7 @@ words:
   - itor
   - ivar
   - Jacoco
+  - javac
   - jdwp
   - jobject
   - Johan

--- a/packages/http-client-java/README.md
+++ b/packages/http-client-java/README.md
@@ -8,7 +8,7 @@ Install [Node.js](https://nodejs.org/) 20 or above. (Verify by running `node --v
 
 Install [Java](https://docs.microsoft.com/java/openjdk/download) 17 or above. (Verify by running `java --version`)
 
-Install [Maven](https://maven.apache.org/install.html). (Verify by running `mvn --version`)
+Install [Maven](https://maven.apache.org/download.cgi). (Verify by running `mvn --version`)
 
 ## Getting started
 

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -120,74 +120,78 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
   const program = context.program;
   await validateDependencies(program, true);
 
-  const options = context.options;
-  if (!options["flavor"]) {
-    if (options["package-dir"]?.toLocaleLowerCase().startsWith("azure")) {
-      // Azure package
-      options["flavor"] = "azure";
-    }
-  }
-  const builder = new CodeModelBuilder(program, context);
-  const codeModel = await builder.build();
-
-  if (!program.compilerOptions.noEmit && !program.hasError()) {
-    const __dirname = dirname(fileURLToPath(import.meta.url));
-    const moduleRoot = resolvePath(__dirname, "..", "..");
-
-    const outputPath = options["output-dir"] ?? context.emitterOutputDir;
-    options["output-dir"] = getNormalizedAbsolutePath(outputPath, undefined);
-
-    (options as any)["arm"] = codeModel.arm;
-
-    const codeModelFileName = resolvePath(outputPath, "./code-model.yaml");
-
-    await promises.mkdir(outputPath, { recursive: true }).catch((err) => {
-      if (err.code !== "EISDIR" && err.code !== "EEXIST") {
-        logError(program, `Failed to create output directory: ${outputPath}`);
-        return;
-      }
-    });
-
-    await program.host.writeFile(codeModelFileName, dump(codeModel));
-
-    program.trace("http-client-java", `Code model file written to ${codeModelFileName}`);
-
-    const emitterOptions = JSON.stringify(options);
-    program.trace("http-client-java", `Emitter options ${emitterOptions}`);
-
-    const jarFileName = resolvePath(
-      moduleRoot,
-      "generator/http-client-generator/target",
-      "emitter.jar",
-    );
-    program.trace("http-client-java", `Exec JAR ${jarFileName}`);
-
-    const javaArgs: string[] = [];
-    javaArgs.push(`-DemitterOptions=${emitterOptions}`);
-    if (options["dev-options"]?.debug) {
-      javaArgs.push("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005");
-    }
-    if (options["dev-options"]?.loglevel) {
-      javaArgs.push("-Dorg.slf4j.simpleLogger.defaultLogLevel=" + options["dev-options"]?.loglevel);
-    }
-    if (options["dev-options"]?.["java-temp-dir"]) {
-      javaArgs.push("-Dcodegen.java.temp.directory=" + options["dev-options"]?.["java-temp-dir"]);
-    }
-    javaArgs.push("-jar");
-    javaArgs.push(jarFileName);
-    javaArgs.push(codeModelFileName);
-    try {
-      await asyncSpawn("java", javaArgs);
-    } catch (error: any) {
-      if (error && "code" in error && error["code"] === "ENOENT") {
-        logError(program, "'java' is not on PATH. Please install JDK 11 or above.");
-      } else {
-        logError(program, error.message);
+  if (!program.hasError()) {
+    const options = context.options;
+    if (!options["flavor"]) {
+      if (options["package-dir"]?.toLocaleLowerCase().startsWith("azure")) {
+        // Azure package
+        options["flavor"] = "azure";
       }
     }
+    const builder = new CodeModelBuilder(program, context);
+    const codeModel = await builder.build();
 
-    if (!options["dev-options"]?.["generate-code-model"]) {
-      await program.host.rm(codeModelFileName);
+    if (!program.hasError() && !program.compilerOptions.noEmit) {
+      const __dirname = dirname(fileURLToPath(import.meta.url));
+      const moduleRoot = resolvePath(__dirname, "..", "..");
+
+      const outputPath = options["output-dir"] ?? context.emitterOutputDir;
+      options["output-dir"] = getNormalizedAbsolutePath(outputPath, undefined);
+
+      (options as any)["arm"] = codeModel.arm;
+
+      const codeModelFileName = resolvePath(outputPath, "./code-model.yaml");
+
+      await promises.mkdir(outputPath, { recursive: true }).catch((err) => {
+        if (err.code !== "EISDIR" && err.code !== "EEXIST") {
+          logError(program, `Failed to create output directory: ${outputPath}`);
+          return;
+        }
+      });
+
+      await program.host.writeFile(codeModelFileName, dump(codeModel));
+
+      program.trace("http-client-java", `Code model file written to ${codeModelFileName}`);
+
+      const emitterOptions = JSON.stringify(options);
+      program.trace("http-client-java", `Emitter options ${emitterOptions}`);
+
+      const jarFileName = resolvePath(
+        moduleRoot,
+        "generator/http-client-generator/target",
+        "emitter.jar",
+      );
+      program.trace("http-client-java", `Exec JAR ${jarFileName}`);
+
+      const javaArgs: string[] = [];
+      javaArgs.push(`-DemitterOptions=${emitterOptions}`);
+      if (options["dev-options"]?.debug) {
+        javaArgs.push("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005");
+      }
+      if (options["dev-options"]?.loglevel) {
+        javaArgs.push(
+          "-Dorg.slf4j.simpleLogger.defaultLogLevel=" + options["dev-options"]?.loglevel,
+        );
+      }
+      if (options["dev-options"]?.["java-temp-dir"]) {
+        javaArgs.push("-Dcodegen.java.temp.directory=" + options["dev-options"]?.["java-temp-dir"]);
+      }
+      javaArgs.push("-jar");
+      javaArgs.push(jarFileName);
+      javaArgs.push(codeModelFileName);
+      try {
+        await asyncSpawn("java", javaArgs);
+      } catch (error: any) {
+        if (error && "code" in error && error["code"] === "ENOENT") {
+          logError(program, "'java' is not on PATH. Please install JDK 11 or above.");
+        } else {
+          logError(program, error.message);
+        }
+      }
+
+      if (!options["dev-options"]?.["generate-code-model"]) {
+        await program.host.rm(codeModelFileName);
+      }
     }
   }
 }

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -10,7 +10,7 @@ import { dump } from "js-yaml";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { CodeModelBuilder } from "./code-model-builder.js";
-import { asyncSpawn, logError } from "./utils.js";
+import { logError, spawnAsync } from "./utils.js";
 import { JDK_NOT_FOUND_MESSAGE, validateDependencies } from "./validate.js";
 
 export interface EmitterOptions {
@@ -180,7 +180,7 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
       javaArgs.push(jarFileName);
       javaArgs.push(codeModelFileName);
       try {
-        await asyncSpawn("java", javaArgs);
+        await spawnAsync("java", javaArgs, { stdio: "inherit" });
       } catch (error: any) {
         if (error && "code" in error && error["code"] === "ENOENT") {
           logError(program, JDK_NOT_FOUND_MESSAGE);

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -11,7 +11,7 @@ import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { CodeModelBuilder } from "./code-model-builder.js";
 import { asyncSpawn, logError } from "./utils.js";
-import { validateDependencies } from "./validate.js";
+import { JDK_NOT_FOUND_MESSAGE, validateDependencies } from "./validate.js";
 
 export interface EmitterOptions {
   namespace?: string;
@@ -183,7 +183,7 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
         await asyncSpawn("java", javaArgs);
       } catch (error: any) {
         if (error && "code" in error && error["code"] === "ENOENT") {
-          logError(program, "'java' is not on PATH. Please install JDK 11 or above.");
+          logError(program, JDK_NOT_FOUND_MESSAGE);
         } else {
           logError(program, error.message);
         }

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -111,14 +111,14 @@ export const $lib = createTypeSpecLibrary({
   },
 });
 
-export function $onValidate(context: EmitContext<EmitterOptions>) {
+export async function $onValidate(context: EmitContext<EmitterOptions>) {
   const program = context.program;
-  validateDependencies(program, false);
+  await validateDependencies(program, false);
 }
 
 export async function $onEmit(context: EmitContext<EmitterOptions>) {
   const program = context.program;
-  validateDependencies(program, true);
+  await validateDependencies(program, true);
 
   const options = context.options;
   if (!options["flavor"]) {

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -111,11 +111,6 @@ export const $lib = createTypeSpecLibrary({
   },
 });
 
-export async function $onValidate(context: EmitContext<EmitterOptions>) {
-  const program = context.program;
-  await validateDependencies(program, false);
-}
-
 export async function $onEmit(context: EmitContext<EmitterOptions>) {
   const program = context.program;
   await validateDependencies(program, true);

--- a/packages/http-client-java/emitter/src/utils.ts
+++ b/packages/http-client-java/emitter/src/utils.ts
@@ -1,5 +1,5 @@
 import { NoTarget, Program, Type } from "@typespec/compiler";
-import { spawn } from "child_process";
+import { spawn, SpawnOptions } from "child_process";
 
 export function logError(program: Program, msg: string) {
   trace(program, msg);
@@ -70,9 +70,13 @@ export type SpawnReturns = {
   stderr: string;
 };
 
-export async function asyncSpawn(command: string, args: readonly string[]): Promise<SpawnReturns> {
+export async function spawnAsync(
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+): Promise<SpawnReturns> {
   return new Promise<SpawnReturns>((resolve, reject) => {
-    const childProcess = spawn(command, args, { stdio: "inherit" });
+    const childProcess = spawn(command, args, options);
 
     let error: Error | undefined = undefined;
 

--- a/packages/http-client-java/emitter/src/utils.ts
+++ b/packages/http-client-java/emitter/src/utils.ts
@@ -1,4 +1,5 @@
 import { NoTarget, Program, Type } from "@typespec/compiler";
+import { spawn } from "child_process";
 
 export function logError(program: Program, msg: string) {
   trace(program, msg);
@@ -62,4 +63,59 @@ export function stringArrayContainsIgnoreCase(stringList: string[], str: string)
 export function removeClientSuffix(clientName: string): string {
   const clientSuffix = "Client";
   return clientName.endsWith(clientSuffix) ? clientName.slice(0, -clientSuffix.length) : clientName;
+}
+
+export type SpawnReturns = {
+  stdout: string;
+  stderr: string;
+};
+
+export async function asyncSpawn(command: string, args: readonly string[]): Promise<SpawnReturns> {
+  return new Promise<SpawnReturns>((resolve, reject) => {
+    const childProcess = spawn(command, args, { stdio: "inherit" });
+
+    let error: Error | undefined = undefined;
+
+    // std
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    if (childProcess.stdout) {
+      childProcess.stdout.on("data", (data) => {
+        stdout.push(data.toString());
+      });
+    }
+    if (childProcess.stderr) {
+      childProcess.stderr.on("data", (data) => {
+        stderr.push(data.toString());
+      });
+    }
+
+    // failed to spawn the process
+    childProcess.on("error", (e) => {
+      error = e;
+    });
+
+    // process exits with error
+    childProcess.on("exit", (code, signal) => {
+      if (code !== 0) {
+        if (code) {
+          error = new Error(`${command} ended with code '${code}'.`);
+        } else {
+          error = new Error(`${command} terminated by signal '${signal}'.`);
+        }
+      }
+    });
+
+    // close and complete Promise
+    childProcess.on("close", () => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve({
+          stdout: stdout.join(""),
+          stderr: stderr.join(""),
+        });
+      }
+    });
+  });
 }

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -36,7 +36,7 @@ export async function validateDependencies(
 
   // Check Maven
   try {
-    await spawnAsync("mvn", ["-v"], { stdio: "pipe", shell: true });
+    await spawnAsync(process.platform === "win32" ? "mvn.cmd" : "mvn", ["-v"], { stdio: "pipe" });
   } catch (error: any) {
     let message = error.message;
     if (error && "code" in error && error["code"] === "ENOENT") {

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -35,12 +35,13 @@ export async function validateDependencies(
   }
 
   // Check Maven
-  const shell = (process.platform === 'win32');
+  // nodejs does not allow spawn of .cmd on win32
+  const shell = process.platform === "win32";
   try {
     await spawnAsync("mvn", ["-v"], { stdio: "pipe", shell: shell });
   } catch (error: any) {
     let message = error.message;
-    if (shell || (error && ("code" in error && error["code"] === "ENOENT"))) {
+    if (shell || (error && "code" in error && error["code"] === "ENOENT")) {
       message =
         "Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi";
     }

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -17,6 +17,7 @@ export async function validateDependencies(
         // the message is JDK 17, because clientcore depends on JDK 17
         // emitter only require JDK 11
         const message = `Java Development Kit (JDK) in PATH is version ${javaVersion}. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download`;
+        // eslint-disable-next-line no-console
         console.log("[ERROR] " + message);
         if (program && logDiagnostic) {
           logError(program, message);
@@ -28,6 +29,7 @@ export async function validateDependencies(
     if (error && "code" in error && error["code"] === "ENOENT") {
       message = JDK_NOT_FOUND_MESSAGE;
     }
+    // eslint-disable-next-line no-console
     console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
       logError(program, message);
@@ -45,6 +47,7 @@ export async function validateDependencies(
       message =
         "Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi";
     }
+    // eslint-disable-next-line no-console
     console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
       logError(program, message);

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -17,8 +17,8 @@ export async function validateDependencies(
         // the message is JDK 17, because clientcore depends on JDK 17
         // emitter only require JDK 11
         const message = `Java Development Kit (JDK) in PATH is version ${javaVersion}. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download`;
-        // eslint-disable-next-line no-console
-        console.log("[ERROR] " + message);
+        // // eslint-disable-next-line no-console
+        // console.log("[ERROR] " + message);
         if (program && logDiagnostic) {
           logError(program, message);
         }
@@ -29,8 +29,8 @@ export async function validateDependencies(
     if (error && "code" in error && error["code"] === "ENOENT") {
       message = JDK_NOT_FOUND_MESSAGE;
     }
-    // eslint-disable-next-line no-console
-    console.log("[ERROR] " + message);
+    // // eslint-disable-next-line no-console
+    // console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
       logError(program, message);
     }
@@ -47,8 +47,8 @@ export async function validateDependencies(
       message =
         "Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi";
     }
-    // eslint-disable-next-line no-console
-    console.log("[ERROR] " + message);
+    // // eslint-disable-next-line no-console
+    // console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
       logError(program, message);
     }

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -1,6 +1,9 @@
 import { Program } from "@typespec/compiler";
 import { asyncSpawn, logError } from "./utils.js";
 
+export const JDK_NOT_FOUND_MESSAGE =
+  "JDK Development Kit is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
+
 export async function validateDependencies(program: Program, logDiagnostic: boolean = false) {
   // Check JDK and version
   try {
@@ -8,10 +11,9 @@ export async function validateDependencies(program: Program, logDiagnostic: bool
   } catch (error: any) {
     let message = error.message;
     if (error && "code" in error && error["code"] === "ENOENT") {
-      message =
-        "JDK Development Kit is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
+      message = JDK_NOT_FOUND_MESSAGE;
     }
-    console.log(message);
+    console.log("[ERROR] " + message);
     if (logDiagnostic) {
       logError(program, message);
     }
@@ -26,7 +28,7 @@ export async function validateDependencies(program: Program, logDiagnostic: bool
       message =
         "JDK Development Kit is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
     }
-    console.log(message);
+    console.log("[ERROR] " + message);
     if (logDiagnostic) {
       logError(program, message);
     }

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -1,0 +1,34 @@
+import { Program } from "@typespec/compiler";
+import { asyncSpawn, logError } from "./utils.js";
+
+export async function validateDependencies(program: Program, logDiagnostic: boolean = false) {
+  // Check JDK and version
+  try {
+    await asyncSpawn("javac", ["-version"]);
+  } catch (error: any) {
+    let message = error.message;
+    if (error && "code" in error && error["code"] === "ENOENT") {
+      message =
+        "JDK Development Kit is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
+    }
+    console.log(message);
+    if (logDiagnostic) {
+      logError(program, message);
+    }
+  }
+
+  // Check Maven
+  try {
+    await asyncSpawn("mvn", ["-v"]);
+  } catch (error: any) {
+    let message = error.message;
+    if (error && "code" in error && error["code"] === "ENOENT") {
+      message =
+        "JDK Development Kit is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
+    }
+    console.log(message);
+    if (logDiagnostic) {
+      logError(program, message);
+    }
+  }
+}

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -35,11 +35,12 @@ export async function validateDependencies(
   }
 
   // Check Maven
+  const shell = (process.platform === 'win32');
   try {
-    await spawnAsync(process.platform === "win32" ? "mvn.cmd" : "mvn", ["-v"], { stdio: "pipe" });
+    await spawnAsync("mvn", ["-v"], { stdio: "pipe", shell: shell });
   } catch (error: any) {
     let message = error.message;
-    if (error && "code" in error && error["code"] === "ENOENT") {
+    if (shell || (error && ("code" in error && error["code"] === "ENOENT"))) {
       message =
         "Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi";
     }

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -26,7 +26,7 @@ export async function validateDependencies(program: Program, logDiagnostic: bool
     let message = error.message;
     if (error && "code" in error && error["code"] === "ENOENT") {
       message =
-        "JDK Development Kit is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
+        "Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi";
     }
     console.log("[ERROR] " + message);
     if (logDiagnostic) {

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -1,27 +1,42 @@
 import { Program } from "@typespec/compiler";
-import { asyncSpawn, logError } from "./utils.js";
+import { logError, spawnAsync } from "./utils.js";
 
 export const JDK_NOT_FOUND_MESSAGE =
-  "JDK Development Kit is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
+  "Java Development Kit (JDK) is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
 
-export async function validateDependencies(program: Program, logDiagnostic: boolean = false) {
+export async function validateDependencies(
+  program: Program | undefined,
+  logDiagnostic: boolean = false,
+) {
   // Check JDK and version
   try {
-    await asyncSpawn("javac", ["-version"]);
+    const result = await spawnAsync("javac", ["-version"], { stdio: "pipe" });
+    const javaVersion = findJavaVersion(result.stdout) ?? findJavaVersion(result.stderr);
+    if (javaVersion) {
+      if (javaVersion < 11) {
+        // the message is JDK 17, because clientcore depends on JDK 17
+        // emitter only require JDK 11
+        const message = `Java Development Kit (JDK) in PATH is version ${javaVersion}. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download`;
+        console.log("[ERROR] " + message);
+        if (program && logDiagnostic) {
+          logError(program, message);
+        }
+      }
+    }
   } catch (error: any) {
     let message = error.message;
     if (error && "code" in error && error["code"] === "ENOENT") {
       message = JDK_NOT_FOUND_MESSAGE;
     }
     console.log("[ERROR] " + message);
-    if (logDiagnostic) {
+    if (program && logDiagnostic) {
       logError(program, message);
     }
   }
 
   // Check Maven
   try {
-    await asyncSpawn("mvn", ["-v"]);
+    await spawnAsync("mvn", ["-v"], { stdio: "pipe", shell: true });
   } catch (error: any) {
     let message = error.message;
     if (error && "code" in error && error["code"] === "ENOENT") {
@@ -29,8 +44,23 @@ export async function validateDependencies(program: Program, logDiagnostic: bool
         "Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi";
     }
     console.log("[ERROR] " + message);
-    if (logDiagnostic) {
+    if (program && logDiagnostic) {
       logError(program, message);
     }
   }
+}
+
+function findJavaVersion(output: string): number | undefined {
+  const regex = /javac (\d+)\.(\d+)\..*/;
+  const matches = output.match(regex);
+  if (matches && matches.length > 2) {
+    if (matches[1] === "1") {
+      // "javac 1.8.0_422" -> 8
+      return +matches[2];
+    } else {
+      // "javac 21.0.3" -> 21
+      return +matches[1];
+    }
+  }
+  return undefined;
 }

--- a/packages/http-client-java/generator/README.md
+++ b/packages/http-client-java/generator/README.md
@@ -11,7 +11,7 @@ The **Microsoft Java client generator** tool generates client libraries for acce
 ## Prerequisites
 
 - [Java 17 or above](https://docs.microsoft.com/java/openjdk/download)
-- [Maven](https://maven.apache.org/install.html)
+- [Maven](https://maven.apache.org/download.cgi)
 
 ## Build
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/PomTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/PomTemplate.java
@@ -216,9 +216,9 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
         pluginsBlock.block("plugin", pluginBlock -> {
             pluginBlock.tag("groupId", "org.apache.maven.plugins");
             pluginBlock.tag("artifactId", "maven-compiler-plugin");
-            pluginBlock.tag("version", "3.10.1");
+            pluginBlock.tag("version", "3.13.0");
             pluginBlock.block("configuration", configurationBlock -> {
-                configurationBlock.tag("release", "11");
+                configurationBlock.tag("release", JavaSettings.getInstance().isBranded() ? "11" : "17");
             });
         });
 
@@ -226,7 +226,7 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
         pluginsBlock.block("plugin", pluginBlock -> {
             pluginBlock.tag("groupId", "org.apache.maven.plugins");
             pluginBlock.tag("artifactId", "maven-source-plugin");
-            pluginBlock.tag("version", "3.3.0");
+            pluginBlock.tag("version", "3.3.1");
             pluginBlock.block("executions", executionsBlock -> {
                 executionsBlock.block("execution", executionBlock -> {
                     executionBlock.tag("id", "attach-sources");


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/5365

run on no JDK/Maven

```
error http-client-java: Java Development Kit (JDK) is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download
error http-client-java: Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi

Found 2 errors.
```

fix https://github.com/microsoft/typespec/issues/5366

run on JDK version too old
```
error http-client-java: Java Development Kit (JDK) in PATH is version 8. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download

Found 1 error.
```

Currently validation only happen on `onEmit`.

I didn't add it to postinstall script, as this could be flagged as security warning.