### PR TITLE
http-client-java, default flavor=azure, if package is typespec-java

### DIFF
--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -203,6 +203,7 @@ export class CodeModelBuilder {
     const service = listServices(this.program)[0];
     if (!service) {
       this.logError("TypeSpec for HTTP must define a service.");
+      return;
     }
     this.serviceNamespace = service.type;
 
@@ -238,6 +239,10 @@ export class CodeModelBuilder {
   }
 
   public async build(): Promise<CodeModel> {
+    if (this.program.hasError()) {
+      return this.codeModel;
+    }
+
     this.sdkContext = await createSdkContext(this.emitterContext, "@typespec/http-client-java", {
       versioning: { previewStringRegex: /$/ },
     }); // include all versions and do the filter by ourselves
@@ -767,9 +772,7 @@ export class CodeModelBuilder {
    * Whether we support advanced versioning in non-breaking fashion.
    */
   private supportsAdvancedVersioning(): boolean {
-    return Boolean(
-      this.options["dev-options"] && this.options["dev-options"]["advanced-versioning"],
-    );
+    return Boolean(this.options["advanced-versioning"]);
   }
 
   private getOperationExample(

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -201,9 +201,12 @@ export class CodeModelBuilder {
     }
 
     const service = listServices(this.program)[0];
+    if (!service) {
+      this.logWarning("TypeSpec for HTTP client should define a service.");
+    }
     this.serviceNamespace = service?.type ?? this.program.getGlobalNamespaceType();
 
-    this.namespace = getNamespaceFullName(this.serviceNamespace) || "Azure.Client";
+    this.namespace = getNamespaceFullName(this.serviceNamespace) || "Client";
 
     const namespace1 = this.namespace;
     this.typeNameOptions = {

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -257,9 +257,8 @@ export class CodeModelBuilder {
 
     this.codeModel.language.java!.namespace = this.baseJavaNamespace;
 
-    // TODO: reportDiagnostics from TCGC temporary disabled
-    // issue https://github.com/Azure/typespec-azure/issues/1675
-    // this.program.reportDiagnostics(this.sdkContext.diagnostics);
+    // potential problem https://github.com/Azure/typespec-azure/issues/1675
+    this.program.reportDiagnostics(this.sdkContext.diagnostics);
 
     // auth
     // TODO: it is not very likely, but different client could have different auth

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -201,11 +201,7 @@ export class CodeModelBuilder {
     }
 
     const service = listServices(this.program)[0];
-    if (!service) {
-      this.logError("TypeSpec for HTTP must define a service.");
-      return;
-    }
-    this.serviceNamespace = service.type;
+    this.serviceNamespace = service?.type ?? this.program.getGlobalNamespaceType();
 
     this.namespace = getNamespaceFullName(this.serviceNamespace) || "Azure.Client";
 

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -767,7 +767,9 @@ export class CodeModelBuilder {
    * Whether we support advanced versioning in non-breaking fashion.
    */
   private supportsAdvancedVersioning(): boolean {
-    return Boolean(this.options["advanced-versioning"]);
+    return Boolean(
+      this.options["dev-options"] && this.options["dev-options"]["advanced-versioning"],
+    );
   }
 
   private getOperationExample(

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -118,8 +118,7 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
   if (!program.hasError()) {
     const options = context.options;
     if (!options["flavor"]) {
-      if (options["package-dir"]?.toLocaleLowerCase().startsWith("azure")) {
-        // Azure package
+      if ($lib.name === "@azure-tools/typespec-java") {
         options["flavor"] = "azure";
       }
     }

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -15,7 +15,6 @@ import { JDK_NOT_FOUND_MESSAGE, validateDependencies } from "./validate.js";
 
 export interface EmitterOptions {
   namespace?: string;
-  "output-dir"?: string;
   "package-dir"?: string;
 
   flavor?: string;
@@ -43,7 +42,6 @@ export interface EmitterOptions {
 
   "enable-subclient"?: boolean;
 
-  "advanced-versioning"?: boolean;
   "api-version"?: string;
   "service-version-exclude-preview"?: boolean;
 
@@ -51,18 +49,23 @@ export interface EmitterOptions {
 }
 
 export interface DevOptions {
+  "advanced-versioning"?: boolean;
   "generate-code-model"?: boolean;
   debug?: boolean;
   loglevel?: "off" | "debug" | "info" | "warn" | "error";
   "java-temp-dir"?: string; // working directory for java codegen, e.g. transformed code-model file
 }
 
+type CodeModelEmitterOptions = EmitterOptions & {
+  "output-dir": string;
+  arm?: boolean;
+};
+
 const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
   type: "object",
   additionalProperties: true,
   properties: {
     namespace: { type: "string", nullable: true },
-    "output-dir": { type: "string", nullable: true },
     "package-dir": { type: "string", nullable: true },
 
     flavor: { type: "string", nullable: true },
@@ -94,7 +97,6 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
 
     "enable-subclient": { type: "boolean", nullable: true, default: false },
 
-    "advanced-versioning": { type: "boolean", nullable: true, default: false },
     "api-version": { type: "string", nullable: true },
     "service-version-exclude-preview": { type: "boolean", nullable: true, default: false },
 
@@ -129,10 +131,13 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
       const __dirname = dirname(fileURLToPath(import.meta.url));
       const moduleRoot = resolvePath(__dirname, "..", "..");
 
-      const outputPath = options["output-dir"] ?? context.emitterOutputDir;
-      options["output-dir"] = getNormalizedAbsolutePath(outputPath, undefined);
+      const outputPath = context.emitterOutputDir;
+      (options as CodeModelEmitterOptions)["output-dir"] = getNormalizedAbsolutePath(
+        outputPath,
+        undefined,
+      );
 
-      (options as any)["arm"] = codeModel.arm;
+      (options as CodeModelEmitterOptions).arm = codeModel.arm;
 
       const codeModelFileName = resolvePath(outputPath, "./code-model.yaml");
 

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -42,6 +42,7 @@ export interface EmitterOptions {
 
   "enable-subclient"?: boolean;
 
+  "advanced-versioning"?: boolean;
   "api-version"?: string;
   "service-version-exclude-preview"?: boolean;
 
@@ -49,7 +50,6 @@ export interface EmitterOptions {
 }
 
 export interface DevOptions {
-  "advanced-versioning"?: boolean;
   "generate-code-model"?: boolean;
   debug?: boolean;
   loglevel?: "off" | "debug" | "info" | "warn" | "error";
@@ -97,6 +97,7 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
 
     "enable-subclient": { type: "boolean", nullable: true, default: false },
 
+    "advanced-versioning": { type: "boolean", nullable: true, default: false },
     "api-version": { type: "string", nullable: true },
     "service-version-exclude-preview": { type: "boolean", nullable: true, default: false },
 

--- a/packages/http-client-java/generator/http-client-generator-test/Generate.ps1
+++ b/packages/http-client-java/generator/http-client-generator-test/Generate.ps1
@@ -41,11 +41,11 @@ $generateScript = {
     # override namespace for "resiliency/srv-driven/old.tsp" (make it different to that from "main.tsp")
     $tspOptions += " --option ""@typespec/http-client-java.namespace=resiliency.servicedriven.v1"""
     # enable advanced versioning for resiliency test
-    $tspOptions += " --option ""@typespec/http-client-java.advanced-versioning=true"""
+    $tspOptions += " --option ""@typespec/http-client-java.dev-options.advanced-versioning=true"""
     $tspOptions += " --option ""@typespec/http-client-java.api-version=all"""
   } elseif ($tspFile -match "resiliency[\\/]srv-driven[\\/]main\.tsp") {
     # enable advanced versioning for resiliency test
-    $tspOptions += " --option ""@typespec/http-client-java.advanced-versioning=true"""
+    $tspOptions += " --option ""@typespec/http-client-java.dev-options.advanced-versioning=true"""
     $tspOptions += " --option ""@typespec/http-client-java.api-version=all"""
   } elseif ($tspFile -match "azure[\\/]resource-manager[\\/].*[\\/]main\.tsp") {
     # for mgmt, do not generate tests due to random mock values

--- a/packages/http-client-java/generator/http-client-generator-test/Generate.ps1
+++ b/packages/http-client-java/generator/http-client-generator-test/Generate.ps1
@@ -41,11 +41,11 @@ $generateScript = {
     # override namespace for "resiliency/srv-driven/old.tsp" (make it different to that from "main.tsp")
     $tspOptions += " --option ""@typespec/http-client-java.namespace=resiliency.servicedriven.v1"""
     # enable advanced versioning for resiliency test
-    $tspOptions += " --option ""@typespec/http-client-java.dev-options.advanced-versioning=true"""
+    $tspOptions += " --option ""@typespec/http-client-java.advanced-versioning=true"""
     $tspOptions += " --option ""@typespec/http-client-java.api-version=all"""
   } elseif ($tspFile -match "resiliency[\\/]srv-driven[\\/]main\.tsp") {
     # enable advanced versioning for resiliency test
-    $tspOptions += " --option ""@typespec/http-client-java.dev-options.advanced-versioning=true"""
+    $tspOptions += " --option ""@typespec/http-client-java.advanced-versioning=true"""
     $tspOptions += " --option ""@typespec/http-client-java.api-version=all"""
   } elseif ($tspFile -match "azure[\\/]resource-manager[\\/].*[\\/]main\.tsp") {
     # for mgmt, do not generate tests due to random mock values

--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@typespec/http-specs": "0.1.0-alpha.5",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.4",
-    "@typespec/http-client-java": "file:/../../typespec-http-client-java-0.1.4.tgz",
+    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.1.5.tgz",
     "@typespec/http-client-java-tests": "file:"
   },
   "overrides": {

--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typespec/http-client-java",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typespec/http-client-java",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-java",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
link https://github.com/microsoft/typespec/issues/5380

- default flavor depends on package
- remove a (deprecated) emitter options
- enable `reportDiagnostics` from TCGC diagnostics (we may get one error on https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-inference, I guess we can ignore that package for now)
- allow emitter runs on tsp without service -- this likely won't produce anything expected though (I've run it on tsp with only models, TCGC did not give me any model, even when I set access=public on them)