### PR TITLE
[@typespec/spec-dashboard] Release Spec Dashboard

### DIFF
--- a/eng/tsp-core/pipelines/dashboard-deploy.yml
+++ b/eng/tsp-core/pipelines/dashboard-deploy.yml
@@ -5,9 +5,6 @@ trigger:
       # For patch releases
       - release/*
 
-variables:
-  connectionString: $(AZ_SPEC_DASHBOARD_CONNECTION_STRING)
-
 extends:
   template: /eng/common/pipelines/templates/1es-redirect.yml
   parameters:
@@ -41,5 +38,5 @@ extends:
                   scriptLocation: "inlineScript"
                   inlineScript: |
                     echo "Uploading files to Azure Blob Storage..."
-                    az storage blob upload-batch --source packages/spec-dashboard/dist/ --destination '$web' --overwrite --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+                    az storage blob upload-batch --source packages/spec-dashboard/dist/ --destination '$web' --overwrite
                   displayName: "Upload files to Azure Blob Storage"


### PR DESCRIPTION
The new pipeline https://dev.azure.com/azure-sdk/internal/_build?definitionId=7395&_a=summary has been given access to the storage account through security group. So, it is not required for any connection string to be in the yml file. This PR removes this string. 

Please review and approve this PR. Thanks