### PR TITLE
Add support for json-schema decorators in open api emitter

### DIFF
--- a/.chronus/changes/openapi3-json-decorators-2024-11-18-14-22-8.md
+++ b/.chronus/changes/openapi3-json-decorators-2024-11-18-14-22-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Adds support for @typespec/json-schema decorators with Open API 3.0 and 3.1 emitters.

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -65,10 +65,14 @@
   "peerDependencies": {
     "@typespec/compiler": "workspace:~",
     "@typespec/http": "workspace:~",
+    "@typespec/json-schema": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/versioning": "workspace:~"
   },
   "peerDependenciesMeta": {
+    "@typespec/json-schema": {
+      "optional": true
+    },
     "@typespec/xml": {
       "optional": true
     }
@@ -78,6 +82,7 @@
     "@types/yargs": "~17.0.33",
     "@typespec/compiler": "workspace:~",
     "@typespec/http": "workspace:~",
+    "@typespec/json-schema": "workspace:~",
     "@typespec/library-linter": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/rest": "workspace:~",

--- a/packages/openapi3/src/json-schema.ts
+++ b/packages/openapi3/src/json-schema.ts
@@ -1,0 +1,9 @@
+export type JsonSchemaModule = typeof import("@typespec/json-schema");
+
+export async function resolveJsonSchemaModule(): Promise<JsonSchemaModule | undefined> {
+  try {
+    return await import("@typespec/json-schema");
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/openapi3/src/openapi-spec-mappings.ts
+++ b/packages/openapi3/src/openapi-spec-mappings.ts
@@ -2,6 +2,7 @@ import { EmitContext, Namespace, Program } from "@typespec/compiler";
 import { AssetEmitter } from "@typespec/compiler/emitter-framework";
 import { MetadataInfo } from "@typespec/http";
 import { getExternalDocs, resolveInfo } from "@typespec/openapi";
+import { JsonSchemaModule } from "./json-schema.js";
 import { OpenAPI3EmitterOptions, OpenAPIVersion } from "./lib.js";
 import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { createSchemaEmitter3_0 } from "./schema-emitter-3-0.js";
@@ -16,7 +17,7 @@ export type CreateSchemaEmitter = (props: {
   metadataInfo: MetadataInfo;
   visibilityUsage: VisibilityUsageTracker;
   options: ResolvedOpenAPI3EmitterOptions;
-  xmlModule: XmlModule | undefined;
+  optionalDependencies: { jsonSchemaModule?: JsonSchemaModule; xmlModule?: XmlModule };
 }) => AssetEmitter<OpenAPI3Schema | OpenAPISchema3_1, OpenAPI3EmitterOptions>;
 
 export interface OpenApiSpecSpecificProps {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -88,6 +88,7 @@ import { stringify } from "yaml";
 import { getRef } from "./decorators.js";
 import { applyEncoding } from "./encoding.js";
 import { getExampleOrExamples, OperationExamples, resolveOperationExamples } from "./examples.js";
+import { JsonSchemaModule, resolveJsonSchemaModule } from "./json-schema.js";
 import { createDiagnostic, FileType, OpenAPI3EmitterOptions, OpenAPIVersion } from "./lib.js";
 import { getOpenApiSpecProps } from "./openapi-spec-mappings.js";
 import { getOpenAPI3StatusCodes } from "./status-codes.js";
@@ -311,7 +312,7 @@ function createOAPIEmitter(
     service: Service,
     allHttpAuthentications: HttpAuth[],
     defaultAuth: AuthenticationReference,
-    xmlModule: XmlModule | undefined,
+    optionalDependencies: { jsonSchemaModule?: JsonSchemaModule; xmlModule?: XmlModule },
     version?: string,
   ) {
     diagnostics = createDiagnosticCollector();
@@ -333,7 +334,7 @@ function createOAPIEmitter(
       metadataInfo,
       visibilityUsage,
       options,
-      xmlModule,
+      optionalDependencies,
     });
 
     const securitySchemes = getOpenAPISecuritySchemes(allHttpAuthentications);
@@ -638,7 +639,14 @@ function createOAPIEmitter(
       const auth = (serviceAuth = resolveAuthentication(httpService));
 
       const xmlModule = await resolveXmlModule();
-      initializeEmitter(service, auth.schemes, auth.defaultAuth, xmlModule, version);
+      const jsonSchemaModule = await resolveJsonSchemaModule();
+      initializeEmitter(
+        service,
+        auth.schemes,
+        auth.defaultAuth,
+        { xmlModule, jsonSchemaModule },
+        version,
+      );
       reportIfNoRoutes(program, httpService.operations);
 
       for (const op of resolveOperations(httpService.operations)) {

--- a/packages/openapi3/src/schema-emitter-3-0.ts
+++ b/packages/openapi3/src/schema-emitter-3-0.ts
@@ -24,6 +24,7 @@ import {
 import { MetadataInfo } from "@typespec/http";
 import { shouldInline } from "@typespec/openapi";
 import { getOneOf } from "./decorators.js";
+import { JsonSchemaModule } from "./json-schema.js";
 import { OpenAPI3EmitterOptions, reportDiagnostic } from "./lib.js";
 import { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
 import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
@@ -37,11 +38,11 @@ function createWrappedSchemaEmitterClass(
   metadataInfo: MetadataInfo,
   visibilityUsage: VisibilityUsageTracker,
   options: ResolvedOpenAPI3EmitterOptions,
-  xmlModule: XmlModule | undefined,
+  optionalDependencies: { jsonSchemaModule?: JsonSchemaModule; xmlModule?: XmlModule },
 ): typeof TypeEmitter<Record<string, any>, OpenAPI3EmitterOptions> {
   return class extends OpenAPI3SchemaEmitter {
     constructor(emitter: AssetEmitter<Record<string, any>, OpenAPI3EmitterOptions>) {
-      super(emitter, metadataInfo, visibilityUsage, options, xmlModule);
+      super(emitter, metadataInfo, visibilityUsage, options, optionalDependencies);
     }
   };
 }
@@ -53,7 +54,7 @@ export const createSchemaEmitter3_0: CreateSchemaEmitter = ({ program, context, 
       rest.metadataInfo,
       rest.visibilityUsage,
       rest.options,
-      rest.xmlModule,
+      rest.optionalDependencies,
     ),
     context,
   );

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -26,6 +26,7 @@ import {
 import { MetadataInfo } from "@typespec/http";
 import { shouldInline } from "@typespec/openapi";
 import { getOneOf } from "./decorators.js";
+import { JsonSchemaModule } from "./json-schema.js";
 import { OpenAPI3EmitterOptions, reportDiagnostic } from "./lib.js";
 import { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
 import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
@@ -39,11 +40,11 @@ function createWrappedSchemaEmitterClass(
   metadataInfo: MetadataInfo,
   visibilityUsage: VisibilityUsageTracker,
   options: ResolvedOpenAPI3EmitterOptions,
-  xmlModule: XmlModule | undefined,
+  optionalDependencies: { jsonSchemaModule?: JsonSchemaModule; xmlModule?: XmlModule },
 ): typeof TypeEmitter<Record<string, any>, OpenAPI3EmitterOptions> {
   return class extends OpenAPI31SchemaEmitter {
     constructor(emitter: AssetEmitter<Record<string, any>, OpenAPI3EmitterOptions>) {
-      super(emitter, metadataInfo, visibilityUsage, options, xmlModule);
+      super(emitter, metadataInfo, visibilityUsage, options, optionalDependencies);
     }
   };
 }
@@ -55,7 +56,7 @@ export const createSchemaEmitter3_1: CreateSchemaEmitter = ({ program, context, 
       rest.metadataInfo,
       rest.visibilityUsage,
       rest.options,
-      rest.xmlModule,
+      rest.optionalDependencies,
     ),
     context,
   );

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -866,6 +866,33 @@ export type JsonSchema<AdditionalVocabularies extends {} = {}> = AdditionalVocab
   required?: Array<string>;
 
   /**
+   * Must be a string.
+   * If the schema instance is a string, this property defines that the string SHOULD be
+   * interpreted as encoded binary data and decoded using the encoding named by this property.
+   *
+   * @see https://json-schema.org/draft/2020-12/json-schema-validation#name-contentencoding
+   */
+  contentEncoding?: string;
+
+  /**
+   * If the schema instance is a string and "contentMediaType" is present, this property
+   * contains a schema which describes the structure of the string.
+   * This should be ignored if "contentMediaType" is not present.
+   *
+   * @see https://json-schema.org/draft/2020-12/json-schema-validation#name-contentschema
+   */
+  contentSchema?: Refable<JsonSchema<AdditionalVocabularies>>;
+
+  /**
+   * Must be a string.
+   * If the schema instance is a string, this property indicates the media type of the contents of the string.
+   * If "contentEncoding" is present, this property describes the decoded string.
+   *
+   * @see https://json-schema.org/draft/2020-12/json-schema-validation#name-contentmediatype
+   */
+  contentMediaType?: string;
+
+  /**
    * This attribute is a string that provides a short description of the instance property.
    *
    * @see https://json-schema.org/draft/2020-12/json-schema-validation#name-title-and-description

--- a/packages/openapi3/test/array.test.ts
+++ b/packages/openapi3/test/array.test.ts
@@ -150,6 +150,32 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel, openApiFor }) => {
     });
   });
 
+  it("can specify uniqueItems using @JsonSchema.uniqueItems decorator", async () => {
+    const res = await oapiForModel(
+      "Pets",
+      `
+      @uniqueItems
+      model Pets is Array<Pet>;
+      model Pet {
+        @uniqueItems
+        x: string[];
+      }
+      `,
+    );
+
+    deepStrictEqual(res.schemas.Pets, {
+      type: "array",
+      uniqueItems: true,
+      items: { $ref: "#/components/schemas/Pet" },
+    });
+
+    deepStrictEqual(res.schemas.Pet.properties.x, {
+      type: "array",
+      uniqueItems: true,
+      items: { type: "string" },
+    });
+  });
+
   it("can specify array defaults using tuple syntax", async () => {
     const res = await oapiForModel(
       "Pet",

--- a/packages/openapi3/test/scalar-constraints.test.ts
+++ b/packages/openapi3/test/scalar-constraints.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable vitest/no-identical-title */
-import { strictEqual } from "assert";
+import { deepStrictEqual, strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { worksFor } from "./works-for.js";
 
@@ -170,6 +170,46 @@ describe("string constraints", () => {
       );
 
       assertStringConstraints(schemas.schemas.Test);
+    });
+  });
+
+  worksFor(["3.1.0"], ({ oapiForModel }) => {
+    const jsonSchemaDecorators = `
+      @JsonSchema.contentEncoding("base64url")
+      @JsonSchema.contentMediaType("application/jwt")
+      @JsonSchema.contentSchema(JwtToken)
+    `;
+
+    function assertJsonSchemaStringConstraints(schema: any) {
+      strictEqual(schema.contentEncoding, "base64url");
+      strictEqual(schema.contentMediaType, "application/jwt");
+      deepStrictEqual(schema.contentSchema, { $ref: "#/components/schemas/JwtToken" });
+    }
+
+    it("on scalar declaration", async () => {
+      const schemas = await oapiForModel(
+        "Test",
+        `
+      ${jsonSchemaDecorators}
+      scalar Test extends string;
+      model JwtToken is Array<Record<string>>;
+    `,
+      );
+
+      assertJsonSchemaStringConstraints(schemas.schemas.Test);
+    });
+
+    it("on union declaration", async () => {
+      const schemas = await oapiForModel(
+        "Test",
+        `
+      ${jsonSchemaDecorators}
+      union Test {string, int32, null};
+      model JwtToken is Array<Record<string>>;
+    `,
+      );
+
+      assertJsonSchemaStringConstraints(schemas.schemas.Test);
     });
   });
 });

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -6,6 +6,7 @@ import {
   resolveVirtualPath,
 } from "@typespec/compiler/testing";
 import { HttpTestLibrary } from "@typespec/http/testing";
+import { JsonSchemaTestLibrary } from "@typespec/json-schema/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
@@ -19,6 +20,7 @@ export async function createOpenAPITestHost() {
   return createTestHost({
     libraries: [
       HttpTestLibrary,
+      JsonSchemaTestLibrary,
       RestTestLibrary,
       VersioningTestLibrary,
       XmlTestLibrary,
@@ -36,6 +38,7 @@ export async function createOpenAPITestRunner({
   const importAndUsings = `
   import "@typespec/http";
   import "@typespec/rest";
+  import "@typespec/json-schema";
   import "@typespec/openapi";
   import "@typespec/openapi3"; 
   import "@typespec/xml";
@@ -94,7 +97,7 @@ export async function openApiFor(
   const outPath = resolveVirtualPath("{version}.openapi.json");
   host.addTypeSpecFile(
     "./main.tsp",
-    `import "@typespec/http"; import "@typespec/rest"; import "@typespec/openapi"; import "@typespec/openapi3";import "@typespec/xml"; ${
+    `import "@typespec/http"; import "@typespec/json-schema"; import "@typespec/rest"; import "@typespec/openapi"; import "@typespec/openapi3";import "@typespec/xml"; ${
       versions ? `import "@typespec/versioning"; using TypeSpec.Versioning;` : ""
     }using TypeSpec.Rest;using TypeSpec.Http;using TypeSpec.OpenAPI;using TypeSpec.Xml;${code}`,
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 22.7.9
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       c8:
         specifier: ^10.1.2
         version: 10.1.2
@@ -67,7 +67,7 @@ importers:
         version: 56.0.1(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)(vitest@2.1.5)
+        version: 0.5.4(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -151,7 +151,7 @@ importers:
         version: link:../compiler
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -200,7 +200,7 @@ importers:
         version: 7.5.8
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -258,7 +258,7 @@ importers:
         version: 17.0.33
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -346,7 +346,7 @@ importers:
         version: link:../internal-build-utils
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -398,7 +398,7 @@ importers:
         version: 8.15.0
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -434,7 +434,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -504,7 +504,7 @@ importers:
         version: 4.3.3(vite@5.4.11(@types/node@22.7.9))
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -549,7 +549,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -598,7 +598,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -712,7 +712,7 @@ importers:
         version: 17.0.33
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -755,7 +755,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -788,7 +788,7 @@ importers:
         version: link:../compiler
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -816,7 +816,7 @@ importers:
         version: 22.7.9
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -858,7 +858,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -899,6 +899,9 @@ importers:
       '@typespec/http':
         specifier: workspace:~
         version: link:../http
+      '@typespec/json-schema':
+        specifier: workspace:~
+        version: link:../json-schema
       '@typespec/library-linter':
         specifier: workspace:~
         version: link:../library-linter
@@ -919,7 +922,7 @@ importers:
         version: link:../xml
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1161,7 +1164,7 @@ importers:
         version: 4.3.3(vite@5.4.11(@types/node@22.7.9))
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1237,7 +1240,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1298,7 +1301,7 @@ importers:
         version: 4.3.3(vite@5.4.11(@types/node@22.7.9))
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1343,7 +1346,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1413,7 +1416,7 @@ importers:
         version: link:../internal-build-utils
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1507,7 +1510,7 @@ importers:
         version: 17.0.33
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1729,7 +1732,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1762,7 +1765,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1830,7 +1833,7 @@ importers:
         version: link:../prettier-plugin-typespec
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1893,7 +1896,7 @@ importers:
         version: link:../internal-build-utils
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1941,7 +1944,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1974,7 +1977,7 @@ importers:
         version: link:../tspd
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -16371,7 +16374,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.5(vitest@2.1.5)':
+  '@vitest/coverage-v8@2.1.5(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -18550,7 +18553,7 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-vitest@0.5.4(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)(vitest@2.1.5):
+  eslint-plugin-vitest@0.5.4(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)(vitest@2.1.5(@types/node@22.7.9)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0)):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.15.0(jiti@1.21.6)


### PR DESCRIPTION
This PR updates the `@typespec/openapi3` emitter to read state from the `@typespec/json-schema` decorators.