### PR TITLE
Fix tsp-spector coverage breaking change

### DIFF
--- a/eng/emitters/pipelines/templates/steps/test-step.yml
+++ b/eng/emitters/pipelines/templates/steps/test-step.yml
@@ -74,5 +74,5 @@ steps:
           azureSubscription: "TypeSpec Storage"
           scriptType: "bash"
           scriptLocation: "inlineScript"
-          inlineScript: npx tsp-spector upload-coverage --coverageFile ./generator/artifacts/coverage/tsp-spector-coverage-${{ parameters.LanguageShortName }}-standard.json --generatorName ${{ coalesce(parameters.CadlRanchName, parameters.LanguageShortName) }} --storageAccountName typespec --generatorVersion $(node -p -e "require('./package.json').version") --generatorMode standard
+          inlineScript: npx tsp-spector upload-coverage --coverageFile ./generator/artifacts/coverage/tsp-spector-coverage-${{ parameters.LanguageShortName }}-standard.json --generatorName ${{ coalesce(parameters.CadlRanchName, parameters.LanguageShortName) }} --storageAccountName typespec --containerName coverages --generatorVersion $(node -p -e "require('./package.json').version") --generatorMode standard
           workingDirectory: $(selfRepositoryPath)${{ parameters.PackagePath }}


### PR DESCRIPTION
new tsp-spector now needs a required parameter to publish coverage report. Without this parameter, ci will fail with error
![image](https://github.com/user-attachments/assets/e6a6abb7-fd0c-4ed3-a998-0c4058e12828)
Checked it works in this ci: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4421855&view=results
