### PR TITLE
Do not start TypeSpec Language Server when there is no workspace opened

### DIFF
--- a/.chronus/changes/no-lsp-error-without-workspace-2024-11-19-18-43-58.md
+++ b/.chronus/changes/no-lsp-error-without-workspace-2024-11-19-18-43-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - typespec-vscode
+---
+
+Do not start TypeSpec Language Server when there is no workspace opened

--- a/packages/typespec-vscode/src/tsp-language-client.ts
+++ b/packages/typespec-vscode/src/tsp-language-client.ts
@@ -142,9 +142,10 @@ export class TspLanguageClient {
     }
   }
 
-  async start(showPopupWhenError: boolean): Promise<void> {
+  async start(): Promise<void> {
     try {
       if (this.client.needsStart()) {
+        // please be aware that this method may also popup error notification directly in vscode
         await this.client.start();
         logger.info("TypeSpec server started");
       } else {
@@ -162,13 +163,13 @@ export class TspLanguageClient {
             " - TypeSpec server path is configured with https://github.com/microsoft/typespec#installing-vs-code-extension.",
           ].join("\n"),
           [],
-          { showOutput: false, showPopup: showPopupWhenError },
+          { showOutput: false, showPopup: true },
         );
         logger.error("Error detail", [e]);
       } else {
         logger.error("Unexpected error when starting TypeSpec server", [e], {
           showOutput: false,
-          showPopup: showPopupWhenError,
+          showPopup: true,
         });
       }
     }


### PR DESCRIPTION
Do not start TypeSpec Language Server when there is no workspace opened in vscode (i.e. create TypeSpec project scenario) otherwise there may be error notification popup complaining LSP can't start properly which is confusing.