### PR TITLE
Added emitter support to init template

### DIFF
--- a/.chronus/changes/azhang_InitTemplateWithEmitterSupport-2024-11-19-14-44-8.md
+++ b/.chronus/changes/azhang_InitTemplateWithEmitterSupport-2024-11-19-14-44-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - typespec-vscode
+---
+
+Updated the init project template to include the new emitter definition

--- a/.chronus/changes/azhang_InitTemplateWithEmitterSupport-2024-11-19-9-37-2.md
+++ b/.chronus/changes/azhang_InitTemplateWithEmitterSupport-2024-11-19-9-37-2.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Added support for emitter selections for init template.

--- a/packages/compiler/src/init/init-template.ts
+++ b/packages/compiler/src/init/init-template.ts
@@ -34,6 +34,11 @@ export interface InitTemplate {
   libraries?: InitTemplateLibrary[];
 
   /**
+   * List of emitters to include
+   */
+  emitters?: Record<string, EmitterTemplate>;
+
+  /**
    * Config
    */
   config?: TypeSpecRawConfig;
@@ -53,6 +58,22 @@ export interface InitTemplate {
    * List of files to copy.
    */
   files?: InitTemplateFile[];
+}
+
+/**
+ * Describes emitter dependencies that will be added to the generated project.
+ */
+export interface EmitterTemplate {
+  /** Emitter Selection Description */
+  description?: string;
+  /** Whether emitter is selected by default in the list */
+  selected?: boolean;
+  /** Optional emitter Options to populate the tspconfig.yaml */
+  options?: any;
+  /** Optional message to display to the user post creation */
+  message?: string;
+  /** Optional specific emitter version. `latest` if not specified */
+  version?: string;
 }
 
 /**
@@ -98,6 +119,22 @@ export const InitTemplateSchema: JSONSchemaType<InitTemplate> = {
         oneOf: [{ type: "string" }, InitTemplateLibrarySpecSchema],
       },
       nullable: true,
+    },
+    emitters: {
+      type: "object",
+      nullable: true,
+      additionalProperties: {
+        type: "object",
+        properties: {
+          description: { type: "string", nullable: true },
+          selected: { type: "boolean", nullable: true },
+          options: {} as any,
+          message: { type: "string", nullable: true },
+          version: { type: "string", nullable: true },
+        },
+        required: [],
+      },
+      required: [],
     },
     skipCompilerPackage: { type: "boolean", nullable: true },
     config: { nullable: true, ...TypeSpecConfigJsonSchema },

--- a/packages/compiler/src/init/init.ts
+++ b/packages/compiler/src/init/init.ts
@@ -91,7 +91,7 @@ export async function initTypeSpecProject(
 
   if (Object.values(emitters).some((emitter) => emitter.message !== undefined)) {
     // eslint-disable-next-line no-console
-    console.log(pc.yellow("\nPlease review following messages from emitters:"));
+    console.log(pc.yellow("\nPlease review the following messages from emitters:"));
 
     for (const key of Object.keys(emitters)) {
       if (emitters[key].message) {

--- a/packages/typespec-vscode/src/vscode-cmd/create-tsp-project.ts
+++ b/packages/typespec-vscode/src/vscode-cmd/create-tsp-project.ts
@@ -162,6 +162,7 @@ export async function createTypeSpecProject(client: TspLanguageClient | undefine
         return;
       }
 
+      // TODO: add support for emitters picking
       const initTemplateConfig: InitProjectConfig = {
         template: info.template!,
         directory: selectedRootFolder,
@@ -171,6 +172,7 @@ export async function createTypeSpecProject(client: TspLanguageClient | undefine
         parameters: inputs ?? {},
         includeGitignore: includeGitignore,
         libraries: librariesToInclude,
+        emitters: {},
       };
       const initResult = await initProject(client, initTemplateConfig);
       if (!initResult) {


### PR DESCRIPTION
Init template now supports a list of emitters for user to choose from to be included in the project. 

Artifacts affected:
- `package.json` Emitters with optional package version are added
- `tspconfig.yaml` emitters with options are added to `emit` and `options` section. **Currently options do not support token replacement**
- optional messages are display after scaffolding for any additional environment setup instructions

Here is a sample template. We will evaluate whether to make it a built-in template:

```JSON
{
  "azure-core": {
    "title": "REST API with client or server project",
    "description": "Create a project representing a generic REST API with options to include client or server project",
    "compilerVersion": "0.63.0",
    "libraries": ["@typespec/http", "@typespec/rest", "@typespec/openapi3"],
    "config": {},
    "emitters": {
      "@typespec/openapi3": {
        "selected": true,
        "description": "Generate OpenAPI 3.0 or 3.1 specification",
        "options": {
          "emitter-output-dir": "{project-root}/openapi/"
        },
        "version": "0.49.0"
      },
      "@typespec/http-client-csharp": {
        "description": "Client: generate CSharp client",
        "options": {
          "emitter-output-dir": "{project-root}/client/csharp/generated"
        },
        "message": "Please ensure dotnet SDK has been installed. Download from https://dotnet.microsoft.com/download"
      },
      "@typespec/http-server-csharp": {
        "description": "Server: generate ASP.NET Core server",
        "options": {
          "emitter-output-dir": "{project-root}/servers/aspnet/generated"
        },
        "message": "Please ensure dotnet SDK has been installed. Download from https://dotnet.microsoft.com/download"
      }
    }
  }
}

```
