### PR TITLE
[python] Update dev_requirements.txt

### DIFF
--- a/packages/http-client-python/generator/dev_requirements.txt
+++ b/packages/http-client-python/generator/dev_requirements.txt
@@ -3,7 +3,6 @@ pyright==1.1.389
 pylint==3.2.7
 tox==4.16.0
 mypy==1.13.0
-azure-pylint-guidelines-checker==0.0.8
 colorama==0.4.6
 debugpy==1.8.2
 pytest==8.3.2


### PR DESCRIPTION
Remove useless dependency since it is declared in tox.ini: https://github.com/microsoft/typespec/blob/0e70f2e73070d92c8fd8c3ee913bb4f646e1862a/packages/http-client-python/generator/test/azure/tox.ini#L13