### PR TITLE
Fix OpenAPI YAML converts strings to boolean

### DIFF
--- a/.chronus/changes/wanl-fix-noway-yaml-2024-11-27-14-31-43.md
+++ b/.chronus/changes/wanl-fix-noway-yaml-2024-11-27-14-31-43.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/openapi3"
 ---
 
-Fix Problem of YAML 1.1 Treats Some Strings as Other Types of Values
+Fix: OpenAPI YAML converts strings to boolean

--- a/.chronus/changes/wanl-fix-noway-yaml-2024-11-27-14-31-43.md
+++ b/.chronus/changes/wanl-fix-noway-yaml-2024-11-27-14-31-43.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Fix Problem of YAML 1.1 Treats Some Strings as Other Types of Values

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1844,7 +1844,7 @@ function serializeDocument(root: OpenAPI3Document, fileType: FileType): string {
         singleQuote: true,
         aliasDuplicateObjects: false,
         lineWidth: 0,
-        schema: "yaml-1.1",
+        compat: "yaml-1.1",
       });
   }
 }

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1844,6 +1844,7 @@ function serializeDocument(root: OpenAPI3Document, fileType: FileType): string {
         singleQuote: true,
         aliasDuplicateObjects: false,
         lineWidth: 0,
+        schema: "yaml-1.1",
       });
   }
 }

--- a/packages/openapi3/test/emit-openapi.test.ts
+++ b/packages/openapi3/test/emit-openapi.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { emitOpenApiWithDiagnostics } from "./test-host.js";
 
 describe("Scalar formats of serialized document in YAML", () => {
-  it("should add single quote for y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF", async (c: TestCase) => {
+  it("should add single quote for y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF", async () => {
     const [_, __, content] = await emitOpenApiWithDiagnostics(`
       enum TestEnum {
         y: "y",

--- a/packages/openapi3/test/emit-openapi.test.ts
+++ b/packages/openapi3/test/emit-openapi.test.ts
@@ -1,14 +1,41 @@
 import { describe, expect, it } from "vitest";
 import { emitOpenApiWithDiagnostics } from "./test-host.js";
 
-interface TestCase {
-  content: string;
-  expected: string;
-  description: string;
-}
-
-function createExpectedContentForStringLiteral(expected: string) {
-  return `openapi: 3.0.0
+describe("Scalar formats of serialized document in YAML", () => {
+  it("should add single quote for y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF", async (c: TestCase) => {
+    const [_, __, content] = await emitOpenApiWithDiagnostics(`
+      enum TestEnum {
+        y: "y",
+        Y: "Y",
+        yes: "yes",
+        Yes: "Yes",
+        YES: "YES",
+        yEs: "yEs",
+        n: "n",
+        N: "N",
+        no: "no",
+        No: "No",
+        NO: "NO",
+        nO: "nO",
+        "true": "true",
+        True: "True",
+        TRUE: "TRUE",
+        tRUE: "tRUE",
+        "false": "false",
+        False: "False",
+        FALSE: "FALSE",
+        fALSE: "fALSE",
+        on: "on",
+        On: "On",
+        ON: "ON",
+        oN: "oN",
+        off: "off",
+        Off: "Off",
+        OFF: "OFF",
+        oFF: "oFF"
+      }
+      `);
+    expect(content).toBe(`openapi: 3.0.0
 info:
   title: (title)
   version: 0.0.0
@@ -16,126 +43,37 @@ tags: []
 paths: {}
 components:
   schemas:
-    Test:
-      type: object
-      required:
-        - test
-      properties:
-        test:
-          type: string
-          enum:
-            - ${expected}
-`;
-}
-
-function createExpectedContentForEnum(expected: string) {
-  return `openapi: 3.0.0
-info:
-  title: (title)
-  version: 0.0.0
-tags: []
-paths: {}
-components:
-  schemas:
-    Test:
+    TestEnum:
       type: string
       enum:
-        - ${expected}
-`;
-}
-
-function createTestCaseForStringLiteral(test: string, expected: string) {
-  return {
-    description: `string literal should output ${expected} in yaml file`,
-    content: `model Test {test: "${test}"}`,
-    expected: createExpectedContentForStringLiteral(`${expected}`),
-  };
-}
-
-function createTestCaseForEnum(test: string, expected: string) {
-  return {
-    description: `enum should output ${expected} in yaml file`,
-    content: `enum Test {test: "${test}"}`,
-    expected: createExpectedContentForEnum(`${expected}`),
-  };
-}
-
-const testCasesForStringLiteral: TestCase[] = [
-  createTestCaseForStringLiteral(`y`, `'y'`),
-  createTestCaseForStringLiteral(`Y`, `'Y'`),
-  createTestCaseForStringLiteral(`yes`, `'yes'`),
-  createTestCaseForStringLiteral(`Yes`, `'Yes'`),
-  createTestCaseForStringLiteral(`YES`, `'YES'`),
-  createTestCaseForStringLiteral(`yES`, `yES`),
-
-  createTestCaseForStringLiteral(`n`, `'n'`),
-  createTestCaseForStringLiteral(`N`, `'N'`),
-  createTestCaseForStringLiteral(`no`, `'no'`),
-  createTestCaseForStringLiteral(`No`, `'No'`),
-  createTestCaseForStringLiteral(`NO`, `'NO'`),
-  createTestCaseForStringLiteral(`nO`, `nO`),
-
-  createTestCaseForStringLiteral(`true`, `'true'`),
-  createTestCaseForStringLiteral(`True`, `'True'`),
-  createTestCaseForStringLiteral(`TRUE`, `'TRUE'`),
-  createTestCaseForStringLiteral(`tRUE`, `tRUE`),
-
-  createTestCaseForStringLiteral(`false`, `'false'`),
-  createTestCaseForStringLiteral(`False`, `'False'`),
-  createTestCaseForStringLiteral(`FALSE`, `'FALSE'`),
-  createTestCaseForStringLiteral(`fALSE`, `fALSE`),
-
-  createTestCaseForStringLiteral(`on`, `'on'`),
-  createTestCaseForStringLiteral(`On`, `'On'`),
-  createTestCaseForStringLiteral(`ON`, `'ON'`),
-  createTestCaseForStringLiteral(`oN`, `oN`),
-
-  createTestCaseForStringLiteral(`off`, `'off'`),
-  createTestCaseForStringLiteral(`Off`, `'Off'`),
-  createTestCaseForStringLiteral(`OFF`, `'OFF'`),
-  createTestCaseForStringLiteral(`oFF`, `oFF`),
-];
-
-const testCasesForEnum: TestCase[] = [
-  createTestCaseForEnum(`y`, `'y'`),
-  createTestCaseForEnum(`Y`, `'Y'`),
-  createTestCaseForEnum(`yes`, `'yes'`),
-  createTestCaseForEnum(`Yes`, `'Yes'`),
-  createTestCaseForEnum(`YES`, `'YES'`),
-  createTestCaseForEnum(`yES`, `yES`),
-
-  createTestCaseForEnum(`n`, `'n'`),
-  createTestCaseForEnum(`N`, `'N'`),
-  createTestCaseForEnum(`no`, `'no'`),
-  createTestCaseForEnum(`No`, `'No'`),
-  createTestCaseForEnum(`NO`, `'NO'`),
-  createTestCaseForEnum(`nO`, `nO`),
-
-  createTestCaseForEnum(`true`, `'true'`),
-  createTestCaseForEnum(`True`, `'True'`),
-  createTestCaseForEnum(`TRUE`, `'TRUE'`),
-  createTestCaseForEnum(`tRUE`, `tRUE`),
-
-  createTestCaseForEnum(`false`, `'false'`),
-  createTestCaseForEnum(`False`, `'False'`),
-  createTestCaseForEnum(`FALSE`, `'FALSE'`),
-  createTestCaseForEnum(`fALSE`, `fALSE`),
-
-  createTestCaseForEnum(`on`, `'on'`),
-  createTestCaseForEnum(`On`, `'On'`),
-  createTestCaseForEnum(`ON`, `'ON'`),
-  createTestCaseForEnum(`oN`, `oN`),
-
-  createTestCaseForEnum(`off`, `'off'`),
-  createTestCaseForEnum(`Off`, `'Off'`),
-  createTestCaseForEnum(`OFF`, `'OFF'`),
-  createTestCaseForEnum(`oFF`, `oFF`),
-];
-
-
-describe("Scalar formats of serialized document in YAML", () => {
-  it.each([...testCasesForEnum, ...testCasesForStringLiteral])("$description", async (c: TestCase) => {
-    const [_, __, content] = await emitOpenApiWithDiagnostics(c.content);
-    expect(content).toBe(c.expected);
+        - 'y'
+        - 'Y'
+        - 'yes'
+        - 'Yes'
+        - 'YES'
+        - yEs
+        - 'n'
+        - 'N'
+        - 'no'
+        - 'No'
+        - 'NO'
+        - nO
+        - 'true'
+        - 'True'
+        - 'TRUE'
+        - tRUE
+        - 'false'
+        - 'False'
+        - 'FALSE'
+        - fALSE
+        - 'on'
+        - 'On'
+        - 'ON'
+        - oN
+        - 'off'
+        - 'Off'
+        - 'OFF'
+        - oFF
+`);
   });
 });

--- a/packages/openapi3/test/emit-openapi.test.ts
+++ b/packages/openapi3/test/emit-openapi.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { emitOpenApiWithDiagnostics } from "./test-host.js";
+
+interface TestCase {
+  content: string;
+  expected: string;
+  description: string;
+}
+
+function createExpectedContentForStringLiteral(expected: string) {
+  return `openapi: 3.0.0
+info:
+  title: (title)
+  version: 0.0.0
+tags: []
+paths: {}
+components:
+  schemas:
+    Test:
+      type: object
+      required:
+        - test
+      properties:
+        test:
+          type: string
+          enum:
+            - ${expected}
+`;
+}
+
+function createExpectedContentForEnum(expected: string) {
+  return `openapi: 3.0.0
+info:
+  title: (title)
+  version: 0.0.0
+tags: []
+paths: {}
+components:
+  schemas:
+    Test:
+      type: string
+      enum:
+        - ${expected}
+`;
+}
+
+function createTestCaseForStringLiteral(test: string, expected: string) {
+  return {
+    description: `string literal should output ${expected} in yaml file`,
+    content: `model Test {test: "${test}"}`,
+    expected: createExpectedContentForStringLiteral(`${expected}`),
+  };
+}
+
+function createTestCaseForEnum(test: string, expected: string) {
+  return {
+    description: `enum should output ${expected} in yaml file`,
+    content: `enum Test {test: "${test}"}`,
+    expected: createExpectedContentForEnum(`${expected}`),
+  };
+}
+
+const testCasesForStringLiteral: TestCase[] = [
+  createTestCaseForStringLiteral(`y`, `'y'`),
+  createTestCaseForStringLiteral(`Y`, `'Y'`),
+  createTestCaseForStringLiteral(`yes`, `'yes'`),
+  createTestCaseForStringLiteral(`Yes`, `'Yes'`),
+  createTestCaseForStringLiteral(`YES`, `'YES'`),
+  createTestCaseForStringLiteral(`yES`, `yES`),
+
+  createTestCaseForStringLiteral(`n`, `'n'`),
+  createTestCaseForStringLiteral(`N`, `'N'`),
+  createTestCaseForStringLiteral(`no`, `'no'`),
+  createTestCaseForStringLiteral(`No`, `'No'`),
+  createTestCaseForStringLiteral(`NO`, `'NO'`),
+  createTestCaseForStringLiteral(`nO`, `nO`),
+
+  createTestCaseForStringLiteral(`true`, `'true'`),
+  createTestCaseForStringLiteral(`True`, `'True'`),
+  createTestCaseForStringLiteral(`TRUE`, `'TRUE'`),
+  createTestCaseForStringLiteral(`tRUE`, `tRUE`),
+
+  createTestCaseForStringLiteral(`false`, `'false'`),
+  createTestCaseForStringLiteral(`False`, `'False'`),
+  createTestCaseForStringLiteral(`FALSE`, `'FALSE'`),
+  createTestCaseForStringLiteral(`fALSE`, `fALSE`),
+
+  createTestCaseForStringLiteral(`on`, `'on'`),
+  createTestCaseForStringLiteral(`On`, `'On'`),
+  createTestCaseForStringLiteral(`ON`, `'ON'`),
+  createTestCaseForStringLiteral(`oN`, `oN`),
+
+  createTestCaseForStringLiteral(`off`, `'off'`),
+  createTestCaseForStringLiteral(`Off`, `'Off'`),
+  createTestCaseForStringLiteral(`OFF`, `'OFF'`),
+  createTestCaseForStringLiteral(`oFF`, `oFF`),
+];
+
+const testCasesForEnum: TestCase[] = [
+  createTestCaseForEnum(`y`, `'y'`),
+  createTestCaseForEnum(`Y`, `'Y'`),
+  createTestCaseForEnum(`yes`, `'yes'`),
+  createTestCaseForEnum(`Yes`, `'Yes'`),
+  createTestCaseForEnum(`YES`, `'YES'`),
+  createTestCaseForEnum(`yES`, `yES`),
+
+  createTestCaseForEnum(`n`, `'n'`),
+  createTestCaseForEnum(`N`, `'N'`),
+  createTestCaseForEnum(`no`, `'no'`),
+  createTestCaseForEnum(`No`, `'No'`),
+  createTestCaseForEnum(`NO`, `'NO'`),
+  createTestCaseForEnum(`nO`, `nO`),
+
+  createTestCaseForEnum(`true`, `'true'`),
+  createTestCaseForEnum(`True`, `'True'`),
+  createTestCaseForEnum(`TRUE`, `'TRUE'`),
+  createTestCaseForEnum(`tRUE`, `tRUE`),
+
+  createTestCaseForEnum(`false`, `'false'`),
+  createTestCaseForEnum(`False`, `'False'`),
+  createTestCaseForEnum(`FALSE`, `'FALSE'`),
+  createTestCaseForEnum(`fALSE`, `fALSE`),
+
+  createTestCaseForEnum(`on`, `'on'`),
+  createTestCaseForEnum(`On`, `'On'`),
+  createTestCaseForEnum(`ON`, `'ON'`),
+  createTestCaseForEnum(`oN`, `oN`),
+
+  createTestCaseForEnum(`off`, `'off'`),
+  createTestCaseForEnum(`Off`, `'Off'`),
+  createTestCaseForEnum(`OFF`, `'OFF'`),
+  createTestCaseForEnum(`oFF`, `oFF`),
+];
+
+
+describe("Scalar formats of serialized document in YAML", () => {
+  it.each([...testCasesForEnum, ...testCasesForStringLiteral])("$description", async (c: TestCase) => {
+    const [_, __, content] = await emitOpenApiWithDiagnostics(c.content);
+    expect(content).toBe(c.expected);
+  });
+});


### PR DESCRIPTION
Problem: yaml 1.1 treats some string as other types of value. Check out: https://perlpunk.github.io/yaml-test-schema/schemas.html
Fix: https://github.com/microsoft/typespec/issues/5377
Solution: make serialization compatible with YAML 1.1
Todo: test other types (in next PR).