### PR TITLE
refactor(http-client-csharp): improve error message of no root client

### DIFF
--- a/packages/http-client-csharp/emitter/src/lib/client-model-builder.ts
+++ b/packages/http-client-csharp/emitter/src/lib/client-model-builder.ts
@@ -11,6 +11,7 @@ import {
   SdkType,
   UsageFlags,
 } from "@azure-tools/typespec-client-generator-core";
+import { NoTarget } from "@typespec/compiler";
 import { NetEmitterOptions, resolveOptions } from "../options.js";
 import { CodeModel } from "../type/code-model.js";
 import { InputClient } from "../type/input-client.js";
@@ -20,6 +21,7 @@ import { InputEnumType, InputModelType, InputType } from "../type/input-type.js"
 import { RequestLocation } from "../type/request-location.js";
 import { SdkTypeMap } from "../type/sdk-type-map.js";
 import { fromSdkType } from "./converter.js";
+import { reportDiagnostic } from "./lib.js";
 import { Logger } from "./logger.js";
 import { navigateModels } from "./model.js";
 import { fromSdkServiceMethod, getParameterDefaultValue } from "./operation-converter.js";
@@ -38,17 +40,19 @@ export function createModel(sdkContext: SdkContext<NetEmitterOptions>): CodeMode
 
   const sdkApiVersionEnums = sdkPackage.enums.filter((e) => e.usage === UsageFlags.ApiVersionEnum);
 
+  const rootClients = sdkPackage.clients.filter((c) => c.initialization.access === "public");
+  if (rootClients.length === 0) {
+    reportDiagnostic(sdkContext.program, { code: "no-root-client", format: {}, target: NoTarget });
+    return {} as CodeModel;
+  }
+
   const rootApiVersions =
     sdkApiVersionEnums.length > 0
       ? sdkApiVersionEnums[0].values.map((v) => v.value as string).flat()
-      : getRootApiVersions(sdkPackage.clients);
+      : rootClients[0].apiVersions;
 
   const inputClients: InputClient[] = [];
-  fromSdkClients(
-    sdkPackage.clients.filter((c) => c.initialization.access === "public"),
-    inputClients,
-    [],
-  );
+  fromSdkClients(rootClients, inputClients, []);
 
   const clientModel: CodeModel = {
     Name: sdkPackage.rootNamespace,
@@ -175,14 +179,6 @@ export function createModel(sdkContext: SdkContext<NetEmitterOptions>): CodeMode
     }
     return parameters;
   }
-}
-
-function getRootApiVersions(clients: SdkClientType<SdkHttpOperation>[]): string[] {
-  // find any root client since they should have the same api versions
-  const oneRootClient = clients.find((c) => c.initialization.access === "public");
-  if (!oneRootClient) throw new Error("Root client not found");
-
-  return oneRootClient.apiVersions;
 }
 
 function getMethodUri(p: SdkEndpointParameter | undefined): string {

--- a/packages/http-client-csharp/emitter/src/lib/lib.ts
+++ b/packages/http-client-csharp/emitter/src/lib/lib.ts
@@ -37,6 +37,12 @@ const $lib = createTypeSpecLibrary({
         default: paramMessage`${"message"}`,
       },
     },
+    "no-root-client": {
+      severity: "error",
+      messages: {
+        default: "Cannot generate CSharp SDK since no public root client is defined in typespec file.",
+      },
+    },
   },
   emitter: {
     options: NetEmitterOptionsSchema,

--- a/packages/http-client-csharp/emitter/src/lib/lib.ts
+++ b/packages/http-client-csharp/emitter/src/lib/lib.ts
@@ -40,7 +40,8 @@ const $lib = createTypeSpecLibrary({
     "no-root-client": {
       severity: "error",
       messages: {
-        default: "Cannot generate CSharp SDK since no public root client is defined in typespec file.",
+        default:
+          "Cannot generate CSharp SDK since no public root client is defined in typespec file.",
       },
     },
   },


### PR DESCRIPTION
- add a `no-root-client` diagnostic error
- report diagnostic error instead of throwing exception when there is no root client

resolve #5363
