### PR TITLE
report nice error message when dotnet is not installed

### DIFF
--- a/packages/http-client-csharp/emitter/src/lib/lib.ts
+++ b/packages/http-client-csharp/emitter/src/lib/lib.ts
@@ -37,6 +37,12 @@ const $lib = createTypeSpecLibrary({
         default: paramMessage`${"message"}`,
       },
     },
+    "dependency-runtime-missing": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Dotnet is not found in PATH. Please install DotNet ${"dotnetMajorVersion"} or above. Dotnet can be downloaded from ${"downloadUrl"}"`,
+      },
+    },
   },
   emitter: {
     options: NetEmitterOptionsSchema,


### PR DESCRIPTION
Fix https://github.com/microsoft/typespec/issues/5364

- add `dependency-runtime-missing` diagnostic 
- When dotnet is not installed, the generation will fail, emitter report `dependency-runtime-missing` diagnostic error