### PR TITLE
use inspect instead of json.stringify when logging object

### DIFF
--- a/.chronus/changes/use-inspect-in-server-log-2025-0-3-15-44-52.md
+++ b/.chronus/changes/use-inspect-in-server-log-2025-0-3-15-44-52.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+
+Use inspect() instead of JSON.stringify() when logging object

--- a/packages/compiler/src/server/server.ts
+++ b/packages/compiler/src/server/server.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "fs/promises";
 import inspector from "inspector";
 import { join } from "path";
 import { fileURLToPath } from "url";
+import { inspect } from "util";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   ApplyWorkspaceEditParams,
@@ -50,8 +51,7 @@ function main() {
       let detail: string | undefined = undefined;
       let fullMessage = message;
       if (log.detail) {
-        detail =
-          typeof log.detail === "string" ? log.detail : JSON.stringify(log.detail, undefined, 2);
+        detail = typeof log.detail === "string" ? log.detail : inspect(log.detail);
         fullMessage = `${message}:\n${detail}`;
       }
 


### PR DESCRIPTION
use inspect instead of json.stringify when logging object