### PR TITLE
Expose CrossLanguageDefinitionId

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/ModelProvider.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Generator.CSharp.Providers
             }
         }
 
+        public string CrossLanguageDefinitionId => _inputModel.CrossLanguageDefinitionId;
         public bool IsUnknownDiscriminatorModel => _inputModel.IsUnknownDiscriminatorModel;
 
         public string? DiscriminatorValue => _inputModel.DiscriminatorValue;


### PR DESCRIPTION
Expose `CrossLanguageDefinitionId` to be able to replace types based on it.