### PR TITLE
Add missing multi-protocol file

### DIFF
--- a/packages/http-client-python/CONTRIBUTING.md
+++ b/packages/http-client-python/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To make the downstream PR, follow these steps:
    a. Click on the section that says `5 published; 1 consumed`, like in the above picture
    b. Follow `Published artifacts -> build_artifacts_python -> packages -> typespec-http-client-python-x.x.x.tgz`.
    c. Go to the right side, click the three dots, and click `Copy download url`.
-3. Create a PR in [autorest.python](https://github.com/Azure/autorest.python), updating the version of the `@typespec/http-client-python` in the `package.json` files to be the downloaded URL
+3. Create a _draft_ PR in [autorest.python](https://github.com/Azure/autorest.python), updating the version of the `@typespec/http-client-python` in the `package.json` files to be the downloaded URL
 4. Run `pnpm install`, and follow that repo's [CONTRIBUTING.md](https://github.com/Azure/autorest.python/blob/main/CONTRIBUTING.md) for your second PR
 5. Once the PR to [autorest.python](https://github.com/Azure/autorest.python) passes, you can merge and release the original PR
 6. When the change to `@typespec/http-client-python` has been released, update your [autorest.python](https://github.com/Azure/autorest.python) repo to use the released version of the `@typespec/http-client-python` package

--- a/website/src/pages/multi-protocol.md
+++ b/website/src/pages/multi-protocol.md
@@ -1,3 +1,7 @@
+---
+layout: ../layouts/content.astro
+---
+
 # Multi protocol
 
 TypeSpec is a protocol agnostic language. It could be used with many different protocols independently or together.

--- a/website/src/pages/multi-protocol.md
+++ b/website/src/pages/multi-protocol.md
@@ -1,0 +1,55 @@
+# Multi protocol
+
+TypeSpec is a protocol agnostic language. It could be used with many different protocols independently or together.
+
+## Examples
+
+### Protobuf service and emit a json schema for the models.
+
+In this example we have a protobuf service and we want to emit a json schema for the models which we can use later to validate the data in our service implementation.
+
+```tsp tryit="{"emit": ["@typespec/protobuf", "@typespec/json-schema"]}"
+import "@typespec/protobuf";
+import "@typespec/http";
+import "@typespec/json-schema";
+
+using TypeSpec.Protobuf;
+using TypeSpec.Http;
+
+@JsonSchema.jsonSchema
+@Protobuf.package({
+  name: "kiosk",
+})
+@TypeSpec.service
+namespace KioskExample;
+
+// models.tsp
+model Kiosk {
+  @field(1) id?: int32;
+  @field(2) name: string;
+  @field(3) size: ScreenSize;
+  @field(4) location: LatLng;
+  @field(5) create_time?: int32;
+}
+model ScreenSize {
+  @field(1) width: int32;
+  @field(2) height: int32;
+}
+
+model LatLng {
+  @field(1) lat: float64;
+  @field(2) lng: float64;
+}
+
+model ListResponse {
+  @field(1) kiosks: Kiosk[];
+}
+
+@Protobuf.service
+interface Kiosks {
+  @post createKiosk(...Kiosk): Kiosk;
+  @list listKiosks(): ListResponse;
+  @get getKiosk(@path @field(1) id: int32): Kiosk;
+  @delete deleteKiosk(@path @field(1) id: int32): void;
+}
+```


### PR DESCRIPTION
It was reported that the link for multi-protocol wasn't working: https://github.com/microsoft/typespec/issues/5454

After looking, the file is not present, looks like it got lost during migration, this is the original file: https://github.com/timotheeguerin/typespec/blob/663d057c08c496d0fb3a858c8a528e9900c05bde/packages/website/src/pages/multi-protocol.md

Adding the file again and verifying 