### PR TITLE
[core] Widen signature of isTemplateDeclaration/isTemplateDeclarationOrInstance

### DIFF
--- a/.chronus/changes/witemple-msft-widen-template-detect-sig-2025-0-8-11-34-58.md
+++ b/.chronus/changes/witemple-msft-widen-template-detect-sig-2025-0-8-11-34-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Widen type signature of `isTemplateDeclaration` and `isTemplateDeclarationOrInstance` to accept any type and assert the return type.

--- a/packages/compiler/src/core/type-utils.ts
+++ b/packages/compiler/src/core/type-utils.ts
@@ -120,7 +120,7 @@ export function isDeclaredType(type: Type): boolean {
  * Resolve if the type is a template type declaration(Non initialized template type).
  */
 export function isTemplateDeclaration(
-  type: TemplatedType,
+  type: Type,
 ): type is TemplatedType & { node: TemplateDeclarationNode } {
   if (type.node === undefined) {
     return false;
@@ -129,14 +129,16 @@ export function isTemplateDeclaration(
   return (
     node.templateParameters &&
     node.templateParameters.length > 0 &&
-    type.templateMapper === undefined
+    (type as TemplatedType).templateMapper === undefined
   );
 }
 
 /**
  * Resolve if the type was created from a template type or is a template type declaration.
  */
-export function isTemplateDeclarationOrInstance(type: TemplatedType): boolean {
+export function isTemplateDeclarationOrInstance(
+  type: Type,
+): type is TemplatedType & { node: TemplateDeclarationNode } {
   if (type.node === undefined) {
     return false;
   }


### PR DESCRIPTION
As described in #5447

This changes the signature of `isTemplateDeclaration` and `isTemplateDeclarationOrInstance` so that they accept any `Type` rather than just `TemplatedType`. This makes them consistent with `isTemplateInstance`.

`isTemplateDeclarationOrInstance` also gains a type guard to refine the input type when it returns true.