### PR TITLE
[HOTFIX] Release hotfix @path decorator do not accurately reflect the options parameters

### DIFF
--- a/.chronus/changes/fix-path-decorator-options-2025-0-8-11-34-19.md
+++ b/.chronus/changes/fix-path-decorator-options-2025-0-8-11-34-19.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@typespec/rest"
----
-
-In some scenarios, the options for the `@path` decorator do not accurately reflect the provided parameters, including the `#{allowReserved: true}` which is the `x-ms-skip-url-encoding` option. This change addresses and fixes this issue.

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @typespec/rest
 
+## 0.63.1
+
+### Bug Fixes
+
+- [#5535](https://github.com/microsoft/typespec/pull/5535) In some scenarios, the options for the `@path` decorator do not accurately reflect the provided parameters, including the `#{allowReserved: true}` which is the `x-ms-skip-url-encoding` option. This change addresses and fixes this issue.
+
+
 ## 0.63.0
 
 No changes, version bump only.

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/rest",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "author": "Microsoft Corporation",
   "description": "TypeSpec REST protocol binding",
   "homepage": "https://typespec.io",


### PR DESCRIPTION
Release hotfix: https://github.com/microsoft/typespec/pull/5535