### PR TITLE
[http-spec] remove unsupported pageable things

### DIFF
--- a/.chronus/changes/http_spec_pageable-2025-0-9-13-43-18.md
+++ b/.chronus/changes/http_spec_pageable-2025-0-9-13-43-18.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-specs"
+---
+
+remove unsupported pageable things

--- a/packages/http-specs/specs/payload/pageable/main.tsp
+++ b/packages/http-specs/specs/payload/pageable/main.tsp
@@ -30,9 +30,7 @@ namespace ServerDrivenPagination {
         { "id": "1", "name": "dog" },
         { "id": "2", "name": "cat" }
       ],
-      "links": {
-        "next": "http://[host]:[port]/payload/pageable/server-driven-pagination/link/nextPage"
-      }
+      "next": "http://[host]:[port]/payload/pageable/server-driven-pagination/link/nextPage"
     }
     ```
     2. Next page request:
@@ -52,11 +50,6 @@ namespace ServerDrivenPagination {
     @pageItems
     pets: Pet[];
 
-    links: {
-      @nextLink next?: url;
-      @prevLink prev?: url;
-      @firstLink first?: url;
-      @lastLink last?: url;
-    };
+    @nextLink next?: url;
   };
 }

--- a/packages/http-specs/specs/payload/pageable/mockapi.ts
+++ b/packages/http-specs/specs/payload/pageable/mockapi.ts
@@ -14,9 +14,7 @@ Scenarios.Payload_Pageable_ServerDrivenPagination_link = passOnSuccess([
           { id: "1", name: "dog" },
           { id: "2", name: "cat" },
         ],
-        links: {
-          next: "/payload/pageable/server-driven-pagination/link/nextPage",
-        },
+        next: "/payload/pageable/server-driven-pagination/link/nextPage",
       }),
     },
     handler: (req: MockRequest) => {
@@ -27,9 +25,7 @@ Scenarios.Payload_Pageable_ServerDrivenPagination_link = passOnSuccess([
             { id: "1", name: "dog" },
             { id: "2", name: "cat" },
           ],
-          links: {
-            next: `${req.baseUrl}/payload/pageable/server-driven-pagination/link/nextPage`,
-          },
+          next: `${req.baseUrl}/payload/pageable/server-driven-pagination/link/nextPage`,
         }),
       };
     },


### PR DESCRIPTION
currently, typespec core does not support nested `@nextLink`, and emitter does not support `@prevLink`, `@firstLink`, `@lastLink`. so remove it from test spec temporally. 