### PR TITLE
test(http-client-csharp): restore payload/media-type

### DIFF
--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Payload/MediaType/MediaTypeTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Payload/MediaType/MediaTypeTests.cs
@@ -17,7 +17,6 @@ namespace TestProjects.CadlRanch.Tests.Http.Payload.MediaType
         });
 
         [CadlRanchTest]
-        [Ignore("https://github.com/microsoft/typespec/issues/4208")]
         public Task GetAsText() => Test(async (host) =>
         {
             var response2 = await new MediaTypeClient(host, null).GetStringBodyClient().GetAsTextAsync();


### PR DESCRIPTION
Cadl-ranch test `media-type/string-body/getAsText` should not be blocked anymore, so we restore it

part of https://github.com/microsoft/typespec/issues/4208
