### PR TITLE
add support for binary types in open api 3.1

### DIFF
--- a/packages/openapi3/src/encoding.ts
+++ b/packages/openapi3/src/encoding.ts
@@ -7,7 +7,8 @@ import type { OpenAPI3Schema, OpenAPISchema3_1 } from "./types.js";
 export function applyEncoding(
   program: Program,
   typespecType: Scalar | ModelProperty,
-  target: OpenAPI3Schema,
+  target: OpenAPI3Schema | OpenAPISchema3_1,
+  getEncodedFieldName: (typespecType: Scalar | ModelProperty) => string,
   options: ResolvedOpenAPI3EmitterOptions,
 ): OpenAPI3Schema & OpenAPISchema3_1 {
   const encodeData = getEncode(program, typespecType);
@@ -16,8 +17,9 @@ export function applyEncoding(
     const newType = getSchemaForStdScalars(encodeData.type as any, options);
     newTarget.type = newType.type;
     // If the target already has a format it takes priority. (e.g. int32)
-    newTarget.format = mergeFormatAndEncoding(
-      newTarget.format,
+    const encodedFieldName = getEncodedFieldName(typespecType);
+    newTarget[encodedFieldName] = mergeFormatAndEncoding(
+      newTarget[encodedFieldName],
       encodeData.encoding,
       newType.format,
     );

--- a/packages/openapi3/src/openapi-helpers-3-0.ts
+++ b/packages/openapi3/src/openapi-helpers-3-0.ts
@@ -1,0 +1,25 @@
+import { applyEncoding as baseApplyEncoding } from "./encoding.js";
+import { OpenApiSpecSpecificProps } from "./openapi-spec-mappings.js";
+import { OpenAPI3Schema } from "./types.js";
+
+function getEncodingFieldName() {
+  // In Open API 3.0, format is always used for encoding.
+  return "format";
+}
+
+export const applyEncoding: OpenApiSpecSpecificProps["applyEncoding"] = (
+  program,
+  typespecType,
+  target,
+  options,
+) => {
+  return baseApplyEncoding(program, typespecType, target, getEncodingFieldName, options);
+};
+
+export const getRawBinarySchema = (): OpenAPI3Schema => {
+  return { type: "string", format: "binary" };
+};
+
+export const isRawBinarySchema = (schema: OpenAPI3Schema): boolean => {
+  return schema.type === "string" && schema.format === "binary";
+};

--- a/packages/openapi3/src/openapi-helpers-3-1.ts
+++ b/packages/openapi3/src/openapi-helpers-3-1.ts
@@ -1,0 +1,36 @@
+import { ModelProperty, Scalar } from "@typespec/compiler";
+import { applyEncoding as baseApplyEncoding } from "./encoding.js";
+import { OpenApiSpecSpecificProps } from "./openapi-spec-mappings.js";
+import { OpenAPISchema3_1 } from "./types.js";
+import { isScalarExtendsBytes } from "./util.js";
+
+function getEncodingFieldName(typespecType: Scalar | ModelProperty) {
+  // In Open API 3.1, `contentEncoding` is used for encoded binary data instead of `format`.
+  const typeIsBytes = isScalarExtendsBytes(
+    typespecType.kind === "ModelProperty" ? typespecType.type : typespecType,
+  );
+  if (typeIsBytes) {
+    return "contentEncoding";
+  }
+  return "format";
+}
+
+export const applyEncoding: OpenApiSpecSpecificProps["applyEncoding"] = (
+  program,
+  typespecType,
+  target,
+  options,
+) => {
+  return baseApplyEncoding(program, typespecType, target, getEncodingFieldName, options);
+};
+
+export const getRawBinarySchema = (contentType?: string): OpenAPISchema3_1 => {
+  if (contentType) {
+    return { contentMediaType: contentType };
+  }
+  return {};
+};
+
+export const isRawBinarySchema = (schema: OpenAPISchema3_1): boolean => {
+  return schema.type === undefined;
+};

--- a/packages/openapi3/src/openapi-spec-mappings.ts
+++ b/packages/openapi3/src/openapi-spec-mappings.ts
@@ -1,9 +1,19 @@
-import { EmitContext, Namespace, Program } from "@typespec/compiler";
+import { EmitContext, ModelProperty, Namespace, Program, Scalar } from "@typespec/compiler";
 import { AssetEmitter } from "@typespec/compiler/emitter-framework";
 import { MetadataInfo } from "@typespec/http";
 import { getExternalDocs, resolveInfo } from "@typespec/openapi";
 import { JsonSchemaModule } from "./json-schema.js";
 import { OpenAPI3EmitterOptions, OpenAPIVersion } from "./lib.js";
+import {
+  applyEncoding as applyEncoding3_0,
+  getRawBinarySchema as getRawBinarySchema3_0,
+  isRawBinarySchema as isRawBinarySchema3_0,
+} from "./openapi-helpers-3-0.js";
+import {
+  applyEncoding as applyEncoding3_1,
+  getRawBinarySchema as getRawBinarySchema3_1,
+  isRawBinarySchema as isRawBinarySchema3_1,
+} from "./openapi-helpers-3-1.js";
 import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { createSchemaEmitter3_0 } from "./schema-emitter-3-0.js";
 import { createSchemaEmitter3_1 } from "./schema-emitter-3-1.js";
@@ -21,6 +31,12 @@ export type CreateSchemaEmitter = (props: {
 }) => AssetEmitter<OpenAPI3Schema | OpenAPISchema3_1, OpenAPI3EmitterOptions>;
 
 export interface OpenApiSpecSpecificProps {
+  applyEncoding(
+    program: Program,
+    typespecType: Scalar | ModelProperty,
+    target: OpenAPI3Schema,
+    options: ResolvedOpenAPI3EmitterOptions,
+  ): OpenAPI3Schema & OpenAPISchema3_1;
   createRootDoc: (
     program: Program,
     serviceType: Namespace,
@@ -28,23 +44,36 @@ export interface OpenApiSpecSpecificProps {
   ) => SupportedOpenAPIDocuments;
 
   createSchemaEmitter: CreateSchemaEmitter;
+  /**
+   * Returns the binary description for an unencoded binary type
+   * @see https://spec.openapis.org/oas/v3.1.1.html#migrating-binary-descriptions-from-oas-3-0
+   */
+  getRawBinarySchema(contentType?: string): OpenAPI3Schema | OpenAPISchema3_1;
+
+  isRawBinarySchema(schema: OpenAPI3Schema | OpenAPISchema3_1): boolean;
 }
 
 export function getOpenApiSpecProps(specVersion: OpenAPIVersion): OpenApiSpecSpecificProps {
   switch (specVersion) {
     case "3.0.0":
       return {
+        applyEncoding: applyEncoding3_0,
         createRootDoc(program, serviceType, serviceVersion) {
           return createRoot(program, serviceType, specVersion, serviceVersion);
         },
         createSchemaEmitter: createSchemaEmitter3_0,
+        getRawBinarySchema: getRawBinarySchema3_0,
+        isRawBinarySchema: isRawBinarySchema3_0,
       };
     case "3.1.0":
       return {
+        applyEncoding: applyEncoding3_1,
         createRootDoc(program, serviceType, serviceVersion) {
           return createRoot(program, serviceType, specVersion, serviceVersion);
         },
         createSchemaEmitter: createSchemaEmitter3_1,
+        getRawBinarySchema: getRawBinarySchema3_1,
+        isRawBinarySchema: isRawBinarySchema3_1,
       };
   }
 }

--- a/packages/openapi3/src/schema-emitter-3-0.ts
+++ b/packages/openapi3/src/schema-emitter-3-0.ts
@@ -26,6 +26,7 @@ import { shouldInline } from "@typespec/openapi";
 import { getOneOf } from "./decorators.js";
 import { JsonSchemaModule } from "./json-schema.js";
 import { OpenAPI3EmitterOptions, reportDiagnostic } from "./lib.js";
+import { applyEncoding, getRawBinarySchema } from "./openapi-helpers-3-0.js";
 import { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
 import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { Builders, OpenAPI3SchemaEmitterBase } from "./schema-emitter.js";
@@ -97,6 +98,17 @@ export class OpenAPI3SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPI3Sch
     this.#applySchemaExamples(type, target);
   }
 
+  applyEncoding(
+    typespecType: Scalar | ModelProperty,
+    target: OpenAPI3Schema | Placeholder<OpenAPI3Schema>,
+  ): OpenAPI3Schema {
+    return applyEncoding(this.emitter.getProgram(), typespecType, target as any, this._options);
+  }
+
+  getRawBinarySchema(): OpenAPI3Schema {
+    return getRawBinarySchema();
+  }
+
   enumSchema(en: Enum): OpenAPI3Schema {
     const program = this.emitter.getProgram();
     if (en.members.size === 0) {
@@ -143,7 +155,7 @@ export class OpenAPI3SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPI3Sch
       }
 
       if (isMultipart && isBytesKeptRaw(program, variant.type)) {
-        schemaMembers.push({ schema: { type: "string", format: "binary" }, type: variant.type });
+        schemaMembers.push({ schema: this.getRawBinarySchema(), type: variant.type });
         continue;
       }
 

--- a/packages/openapi3/src/util.ts
+++ b/packages/openapi3/src/util.ts
@@ -133,6 +133,20 @@ export function includeDerivedModel(model: Model): boolean {
   );
 }
 
+export function isScalarExtendsBytes(type: Type): boolean {
+  if (type.kind !== "Scalar") {
+    return false;
+  }
+  let current: Scalar | undefined = type;
+  while (current) {
+    if (current.name === "bytes") {
+      return true;
+    }
+    current = current.baseScalar;
+  }
+  return false;
+}
+
 export function getDefaultValue(
   program: Program,
   defaultType: Value,

--- a/packages/openapi3/test/metadata.test.ts
+++ b/packages/openapi3/test/metadata.test.ts
@@ -1080,40 +1080,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
     });
   });
 
-  it("supports nested bodies", async () => {
-    const res = await openApiFor(
-      `
-      model Image {
-        @header contentType: "application/octet-stream";
-        @body body: bytes;
-      }
-      op doStuffWithBytes(data: Image): int32;
-      `,
-    );
-
-    const requestSchema =
-      res.paths["/"].post.requestBody.content["application/octet-stream"].schema;
-
-    deepStrictEqual(requestSchema, { format: "binary", type: "string" });
-  });
-
-  it("supports deeply nested bodies", async () => {
-    const res = await openApiFor(
-      `
-      model Image {
-        @header contentType: "application/octet-stream";
-        moreNesting: { @body body: bytes };
-      }
-      op doStuffWithBytes(data: Image): int32;
-      `,
-    );
-
-    const requestSchema =
-      res.paths["/"].post.requestBody.content["application/octet-stream"].schema;
-
-    deepStrictEqual(requestSchema, { format: "binary", type: "string" });
-  });
-
   it("don't create multiple scalars with different visibility if they are the same", async () => {
     const res = await openApiFor(`
       scalar uuid extends string;
@@ -1240,5 +1206,77 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
       },
       required: ["name"],
     });
+  });
+});
+
+worksFor(["3.0.0"], ({ openApiFor }) => {
+  it("supports nested bodies (binary payloads)", async () => {
+    const res = await openApiFor(
+      `
+      model Image {
+        @header contentType: "application/octet-stream";
+        @body body: bytes;
+      }
+      op doStuffWithBytes(data: Image): int32;
+      `,
+    );
+
+    const requestSchema =
+      res.paths["/"].post.requestBody.content["application/octet-stream"].schema;
+
+    deepStrictEqual(requestSchema, { format: "binary", type: "string" });
+  });
+
+  it("supports deeply nested bodies (binary payloads)", async () => {
+    const res = await openApiFor(
+      `
+      model Image {
+        @header contentType: "application/octet-stream";
+        moreNesting: { @body body: bytes };
+      }
+      op doStuffWithBytes(data: Image): int32;
+      `,
+    );
+
+    const requestSchema =
+      res.paths["/"].post.requestBody.content["application/octet-stream"].schema;
+
+    deepStrictEqual(requestSchema, { format: "binary", type: "string" });
+  });
+});
+
+worksFor(["3.1.0"], ({ openApiFor }) => {
+  it("supports nested bodies (unencoded binary payloads)", async () => {
+    const res = await openApiFor(
+      `
+      model Image {
+        @header contentType: "application/octet-stream";
+        @body body: bytes;
+      }
+      op doStuffWithBytes(data: Image): int32;
+      `,
+    );
+
+    const requestSchema =
+      res.paths["/"].post.requestBody.content["application/octet-stream"].schema;
+
+    deepStrictEqual(requestSchema, { contentMediaType: "application/octet-stream" });
+  });
+
+  it("supports deeply nested bodies (unencoded binary payloads)", async () => {
+    const res = await openApiFor(
+      `
+      model Image {
+        @header contentType: "application/octet-stream";
+        moreNesting: { @body body: bytes };
+      }
+      op doStuffWithBytes(data: Image): int32;
+      `,
+    );
+
+    const requestSchema =
+      res.paths["/"].post.requestBody.content["application/octet-stream"].schema;
+
+    deepStrictEqual(requestSchema, { contentMediaType: "application/octet-stream" });
   });
 });

--- a/packages/openapi3/test/multipart.test.ts
+++ b/packages/openapi3/test/multipart.test.ts
@@ -168,6 +168,7 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
       }
       `,
       );
+      expect(Object.keys(res.components.schemas).length).toBe(1);
       deepStrictEqual(res.components.schemas.FilePurpose, {
         type: "string",
         enum: ["one", "two"],
@@ -425,7 +426,7 @@ worksFor(["3.0.0"], ({ openApiFor }) => {
 
 worksFor(["3.1.0"], ({ openApiFor }) => {
   describe("Open API 3.1", () => {
-    // @see https://spec.openapis.org/oas/latest.html#encoding-content-type
+    // @see https://spec.openapis.org/oas/v3.1.1.html#encoding-content-type
     it("part of type `bytes` produce empty schema", async () => {
       const res = await openApiFor(
         `
@@ -444,7 +445,7 @@ worksFor(["3.1.0"], ({ openApiFor }) => {
       });
     });
 
-    it("part of type union `HttpPart<bytes | {content: bytes}>` produce `type: string, format: binary`", async () => {
+    it("part of type union `HttpPart<bytes | {content: bytes}>` produce `{}, type: string, contentEncoding: base64`", async () => {
       const res = await openApiFor(
         `
       op upload(@header contentType: "multipart/form-data", @multipartBody _: {profileImage: HttpPart<bytes | {content: bytes}>}): void;
@@ -481,7 +482,7 @@ worksFor(["3.1.0"], ({ openApiFor }) => {
       });
     });
 
-    it("part of type `bytes[]` produce `type: array, items: {type: string, format: binary}`", async () => {
+    it("part of type `bytes[]` produce `type: array, items: {}`", async () => {
       const res = await openApiFor(
         `
       op upload(@header contentType: "multipart/form-data",  @multipartBody _: { profileImage: HttpPart<bytes>[]}): void;
@@ -581,7 +582,7 @@ worksFor(["3.1.0"], ({ openApiFor }) => {
     });
 
     describe("legacy implicit form", () => {
-      it("part of type `bytes` produce `type: string, format: binary`", async () => {
+      it("part of type `bytes` produce `{}`", async () => {
         const res = await openApiFor(
           `
         op upload(@header contentType: "multipart/form-data", profileImage: bytes): void;
@@ -599,7 +600,7 @@ worksFor(["3.1.0"], ({ openApiFor }) => {
         });
       });
 
-      it("part of type union `bytes | {content: bytes}` produce `type: string, format: binary`", async () => {
+      it("part of type union `bytes | {content: bytes}` produce `{} | { content: {type: string, contentEncoding: 'base64' }`", async () => {
         const res = await openApiFor(
           `
         op upload(@header contentType: "multipart/form-data", profileImage: bytes | {content: bytes}): void;

--- a/packages/openapi3/test/multipart.test.ts
+++ b/packages/openapi3/test/multipart.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual } from "assert";
 import { describe, expect, it } from "vitest";
-import { OpenAPI3Encoding, OpenAPI3Schema } from "../src/types.js";
+import { OpenAPI3Encoding, OpenAPI3Schema, OpenAPISchema3_1 } from "../src/types.js";
 import { worksFor } from "./works-for.js";
 
 worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
@@ -15,85 +15,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
     deepStrictEqual(op.requestBody.content["multipart/form-data"], {
       schema: {
         $ref: "#/components/schemas/Form",
-      },
-    });
-  });
-
-  it("part of type `bytes` produce `type: string, format: binary`", async () => {
-    const res = await openApiFor(
-      `
-    op upload(@header contentType: "multipart/form-data", @multipartBody body: { profileImage: HttpPart<bytes> }): void;
-    `,
-    );
-    const op = res.paths["/"].post;
-    deepStrictEqual(op.requestBody.content["multipart/form-data"], {
-      schema: {
-        type: "object",
-        properties: {
-          profileImage: {
-            format: "binary",
-            type: "string",
-          },
-        },
-        required: ["profileImage"],
-      },
-    });
-  });
-
-  it("part of type union `HttpPart<bytes | {content: bytes}>` produce `type: string, format: binary`", async () => {
-    const res = await openApiFor(
-      `
-    op upload(@header contentType: "multipart/form-data", @multipartBody _: {profileImage: HttpPart<bytes | {content: bytes}>}): void;
-    `,
-    );
-    const op = res.paths["/"].post;
-    deepStrictEqual(op.requestBody.content["multipart/form-data"], {
-      schema: {
-        type: "object",
-        properties: {
-          profileImage: {
-            anyOf: [
-              {
-                type: "string",
-                format: "binary",
-              },
-              {
-                type: "object",
-                properties: {
-                  content: { type: "string", format: "byte" },
-                },
-                required: ["content"],
-              },
-            ],
-          },
-        },
-        required: ["profileImage"],
-      },
-      encoding: {
-        profileImage: {
-          contentType: "application/octet-stream, application/json",
-        },
-      },
-    });
-  });
-
-  it("part of type `bytes[]` produce `type: array, items: {type: string, format: binary}`", async () => {
-    const res = await openApiFor(
-      `
-    op upload(@header contentType: "multipart/form-data",  @multipartBody _: { profileImage: HttpPart<bytes>[]}): void;
-    `,
-    );
-    const op = res.paths["/"].post;
-    deepStrictEqual(op.requestBody.content["multipart/form-data"], {
-      schema: {
-        type: "object",
-        properties: {
-          profileImage: {
-            type: "array",
-            items: { type: "string", format: "binary" },
-          },
-        },
-        required: ["profileImage"],
       },
     });
   });
@@ -147,74 +68,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
     });
   });
 
-  it("bytes inside a json part will be treated as base64 encoded by default(same as for a json body)", async () => {
-    const res = await openApiFor(
-      `
-    op upload(@header contentType: "multipart/form-data", @multipartBody _: { address: HttpPart<{city: string, icon: bytes}> }): void;
-    `,
-    );
-    const op = res.paths["/"].post;
-    deepStrictEqual(
-      op.requestBody.content["multipart/form-data"].schema.properties.address.properties.icon,
-      {
-        type: "string",
-        format: "byte",
-      },
-    );
-  });
-
-  describe("part mapping", () => {
-    it.each([
-      [`string`, { type: "string" }],
-      [`bytes`, { type: "string", format: "binary" }],
-      [
-        `string[]`,
-        { type: "array", items: { type: "string" } },
-        { contentType: "application/json" },
-      ],
-      [
-        `bytes[]`,
-        { type: "array", items: { type: "string", format: "byte" } },
-        { contentType: "application/json" },
-      ],
-      [
-        `{@header contentType: "image/png", @body image: bytes}`,
-        { type: "string", format: "binary" },
-        { contentType: "image/png" },
-      ],
-      [`File`, { type: "string", format: "binary" }, { contentType: "*/*" }],
-      [
-        `{@header extra: string, @body body: string}`,
-        { type: "string" },
-        {
-          headers: {
-            extra: {
-              required: true,
-              schema: {
-                type: "string",
-              },
-            },
-          },
-        },
-      ],
-    ] satisfies [string, OpenAPI3Schema, OpenAPI3Encoding?][])(
-      `HttpPart<%s>`,
-      async (type: string, expectedSchema: OpenAPI3Schema, expectedEncoding?: OpenAPI3Encoding) => {
-        const res = await openApiFor(
-          `
-      op upload(@header contentType: "multipart/form-data", @multipartBody _: { part: HttpPart<${type}> }): void;
-      `,
-        );
-        const content = res.paths["/"].post.requestBody.content["multipart/form-data"];
-        expect(content.schema.properties.part).toEqual(expectedSchema);
-
-        if (expectedEncoding || content.encoding?.part) {
-          expect(content.encoding?.part).toEqual(expectedEncoding);
-        }
-      },
-    );
-  });
-
   describe("legacy implicit form", () => {
     it("add MultiPart suffix to model name", async () => {
       const res = await openApiFor(
@@ -227,59 +80,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
       deepStrictEqual(op.requestBody.content["multipart/form-data"], {
         schema: {
           $ref: "#/components/schemas/FormMultiPart",
-        },
-      });
-    });
-
-    it("part of type `bytes` produce `type: string, format: binary`", async () => {
-      const res = await openApiFor(
-        `
-      op upload(@header contentType: "multipart/form-data", profileImage: bytes): void;
-      `,
-      );
-      const op = res.paths["/"].post;
-      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
-        schema: {
-          type: "object",
-          properties: {
-            profileImage: {
-              format: "binary",
-              type: "string",
-            },
-          },
-          required: ["profileImage"],
-        },
-      });
-    });
-
-    it("part of type union `bytes | {content: bytes}` produce `type: string, format: binary`", async () => {
-      const res = await openApiFor(
-        `
-      op upload(@header contentType: "multipart/form-data", profileImage: bytes | {content: bytes}): void;
-      `,
-      );
-      const op = res.paths["/"].post;
-      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
-        schema: {
-          type: "object",
-          properties: {
-            profileImage: {
-              anyOf: [
-                {
-                  type: "string",
-                  format: "binary",
-                },
-                {
-                  type: "object",
-                  properties: {
-                    content: { type: "string", format: "byte" },
-                  },
-                  required: ["content"],
-                },
-              ],
-            },
-          },
-          required: ["profileImage"],
         },
       });
     });
@@ -298,27 +98,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
           properties: {
             profileImage: {
               $ref: "#/components/schemas/MyUnion",
-            },
-          },
-          required: ["profileImage"],
-        },
-      });
-    });
-
-    it("part of type `bytes[]` produce `type: array, items: {type: string, format: binary}`", async () => {
-      const res = await openApiFor(
-        `
-      op upload(@header contentType: "multipart/form-data", profileImage: bytes[]): void;
-      `,
-      );
-      const op = res.paths["/"].post;
-      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
-        schema: {
-          type: "object",
-          properties: {
-            profileImage: {
-              type: "array",
-              items: { type: "string", format: "binary" },
             },
           },
           required: ["profileImage"],
@@ -375,22 +154,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
       });
     });
 
-    it("bytes inside a json part will be treated as base64 encoded by default(same as for a json body)", async () => {
-      const res = await openApiFor(
-        `
-      op upload(@header contentType: "multipart/form-data", address: {city: string, icon: bytes}): void;
-      `,
-      );
-      const op = res.paths["/"].post;
-      deepStrictEqual(
-        op.requestBody.content["multipart/form-data"].schema.properties.address.properties.icon,
-        {
-          type: "string",
-          format: "byte",
-        },
-      );
-    });
-
     it("enum used in both a json payload and multipart part shouldn't create 2 models", async () => {
       const res = await openApiFor(
         `
@@ -408,6 +171,498 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
       deepStrictEqual(res.components.schemas.FilePurpose, {
         type: "string",
         enum: ["one", "two"],
+      });
+    });
+  });
+});
+
+worksFor(["3.0.0"], ({ openApiFor }) => {
+  describe("Open API 3.0", () => {
+    it("part of type `bytes` produce `type: string, format: binary`", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data", @multipartBody body: { profileImage: HttpPart<bytes> }): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+        schema: {
+          type: "object",
+          properties: {
+            profileImage: {
+              format: "binary",
+              type: "string",
+            },
+          },
+          required: ["profileImage"],
+        },
+      });
+    });
+
+    it("part of type union `HttpPart<bytes | {content: bytes}>` produce `type: string, format: binary`", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data", @multipartBody _: {profileImage: HttpPart<bytes | {content: bytes}>}): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+        schema: {
+          type: "object",
+          properties: {
+            profileImage: {
+              anyOf: [
+                {
+                  type: "string",
+                  format: "binary",
+                },
+                {
+                  type: "object",
+                  properties: {
+                    content: { type: "string", format: "byte" },
+                  },
+                  required: ["content"],
+                },
+              ],
+            },
+          },
+          required: ["profileImage"],
+        },
+        encoding: {
+          profileImage: {
+            contentType: "application/octet-stream, application/json",
+          },
+        },
+      });
+    });
+
+    it("part of type `bytes[]` produce `type: array, items: {type: string, format: binary}`", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data",  @multipartBody _: { profileImage: HttpPart<bytes>[]}): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+        schema: {
+          type: "object",
+          properties: {
+            profileImage: {
+              type: "array",
+              items: { type: "string", format: "binary" },
+            },
+          },
+          required: ["profileImage"],
+        },
+      });
+    });
+
+    it("bytes inside a json part will be treated as base64 encoded by default(same as for a json body)", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data", @multipartBody _: { address: HttpPart<{city: string, icon: bytes}> }): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(
+        op.requestBody.content["multipart/form-data"].schema.properties.address.properties.icon,
+        {
+          type: "string",
+          format: "byte",
+        },
+      );
+    });
+
+    describe("part mapping", () => {
+      it.each([
+        [`string`, { type: "string" }],
+        [`bytes`, { type: "string", format: "binary" }],
+        [
+          `string[]`,
+          { type: "array", items: { type: "string" } },
+          { contentType: "application/json" },
+        ],
+        [
+          `bytes[]`,
+          { type: "array", items: { type: "string", format: "byte" } },
+          { contentType: "application/json" },
+        ],
+        [
+          `{@header contentType: "image/png", @body image: bytes}`,
+          { type: "string", format: "binary" },
+          { contentType: "image/png" },
+        ],
+        [`File`, { type: "string", format: "binary" }, { contentType: "*/*" }],
+        [
+          `{@header extra: string, @body body: string}`,
+          { type: "string" },
+          {
+            headers: {
+              extra: {
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        ],
+      ] satisfies [string, OpenAPI3Schema, OpenAPI3Encoding?][])(
+        `HttpPart<%s>`,
+        async (
+          type: string,
+          expectedSchema: OpenAPI3Schema,
+          expectedEncoding?: OpenAPI3Encoding,
+        ) => {
+          const res = await openApiFor(
+            `
+        op upload(@header contentType: "multipart/form-data", @multipartBody _: { part: HttpPart<${type}> }): void;
+        `,
+          );
+          const content = res.paths["/"].post.requestBody.content["multipart/form-data"];
+          expect(content.schema.properties.part).toEqual(expectedSchema);
+
+          if (expectedEncoding || content.encoding?.part) {
+            expect(content.encoding?.part).toEqual(expectedEncoding);
+          }
+        },
+      );
+    });
+
+    describe("legacy implicit form", () => {
+      it("part of type `bytes` produce `type: string, format: binary`", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", profileImage: bytes): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+          schema: {
+            type: "object",
+            properties: {
+              profileImage: {
+                format: "binary",
+                type: "string",
+              },
+            },
+            required: ["profileImage"],
+          },
+        });
+      });
+
+      it("part of type union `bytes | {content: bytes}` produce `type: string, format: binary`", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", profileImage: bytes | {content: bytes}): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+          schema: {
+            type: "object",
+            properties: {
+              profileImage: {
+                anyOf: [
+                  {
+                    type: "string",
+                    format: "binary",
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      content: { type: "string", format: "byte" },
+                    },
+                    required: ["content"],
+                  },
+                ],
+              },
+            },
+            required: ["profileImage"],
+          },
+        });
+      });
+
+      it("part of type `bytes[]` produce `type: array, items: {type: string, format: binary}`", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", profileImage: bytes[]): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+          schema: {
+            type: "object",
+            properties: {
+              profileImage: {
+                type: "array",
+                items: { type: "string", format: "binary" },
+              },
+            },
+            required: ["profileImage"],
+          },
+        });
+      });
+
+      it("bytes inside a json part will be treated as base64 encoded by default(same as for a json body)", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", address: {city: string, icon: bytes}): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(
+          op.requestBody.content["multipart/form-data"].schema.properties.address.properties.icon,
+          {
+            type: "string",
+            format: "byte",
+          },
+        );
+      });
+    });
+  });
+});
+
+worksFor(["3.1.0"], ({ openApiFor }) => {
+  describe("Open API 3.1", () => {
+    // @see https://spec.openapis.org/oas/latest.html#encoding-content-type
+    it("part of type `bytes` produce empty schema", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data", @multipartBody body: { profileImage: HttpPart<bytes> }): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+        schema: {
+          type: "object",
+          properties: {
+            profileImage: {},
+          },
+          required: ["profileImage"],
+        },
+      });
+    });
+
+    it("part of type union `HttpPart<bytes | {content: bytes}>` produce `type: string, format: binary`", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data", @multipartBody _: {profileImage: HttpPart<bytes | {content: bytes}>}): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+        schema: {
+          type: "object",
+          properties: {
+            profileImage: {
+              anyOf: [
+                {},
+                {
+                  type: "object",
+                  properties: {
+                    content: {
+                      type: "string",
+                      contentEncoding: "base64",
+                    },
+                  },
+                  required: ["content"],
+                },
+              ],
+            },
+          },
+          required: ["profileImage"],
+        },
+        encoding: {
+          profileImage: {
+            contentType: "application/octet-stream, application/json",
+          },
+        },
+      });
+    });
+
+    it("part of type `bytes[]` produce `type: array, items: {type: string, format: binary}`", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data",  @multipartBody _: { profileImage: HttpPart<bytes>[]}): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+        schema: {
+          type: "object",
+          properties: {
+            profileImage: {
+              type: "array",
+              items: {},
+            },
+          },
+          required: ["profileImage"],
+        },
+      });
+    });
+
+    it("bytes inside a json part will be treated as base64 encoded by default(same as for a json body)", async () => {
+      const res = await openApiFor(
+        `
+      op upload(@header contentType: "multipart/form-data", @multipartBody _: { address: HttpPart<{city: string, icon: bytes}> }): void;
+      `,
+      );
+      const op = res.paths["/"].post;
+      deepStrictEqual(
+        op.requestBody.content["multipart/form-data"].schema.properties.address.properties.icon,
+        {
+          type: "string",
+          contentEncoding: "base64",
+        },
+      );
+    });
+
+    describe("part mapping", () => {
+      it.each([
+        [`string`, { type: "string" }],
+        [`bytes`, {}],
+        [
+          `string[]`,
+          { type: "array", items: { type: "string" } },
+          { contentType: "application/json" },
+        ],
+        [
+          `bytes[]`,
+          {
+            type: "array",
+            items: {
+              type: "string",
+              contentEncoding: "base64",
+            },
+          },
+          { contentType: "application/json" },
+        ],
+        [
+          `{@header contentType: "image/png", @body image: bytes}`,
+          {},
+          { contentType: "image/png" },
+        ],
+        [`File`, {}, { contentType: "*/*" }],
+        [
+          `{@header extra: string, @body body: string}`,
+          { type: "string" },
+          {
+            headers: {
+              extra: {
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        ],
+      ] satisfies [string, OpenAPISchema3_1, OpenAPI3Encoding?][])(
+        `HttpPart<%s>`,
+        async (
+          type: string,
+          expectedSchema: OpenAPI3Schema,
+          expectedEncoding?: OpenAPI3Encoding,
+        ) => {
+          const res = await openApiFor(
+            `
+        op upload(@header contentType: "multipart/form-data", @multipartBody _: { part: HttpPart<${type}> }): void;
+        `,
+          );
+          const content = res.paths["/"].post.requestBody.content["multipart/form-data"];
+          expect(content.schema.properties.part).toEqual(expectedSchema);
+
+          if (expectedEncoding || content.encoding?.part) {
+            expect(content.encoding?.part).toEqual(expectedEncoding);
+          }
+        },
+      );
+    });
+
+    describe("legacy implicit form", () => {
+      it("part of type `bytes` produce `type: string, format: binary`", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", profileImage: bytes): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+          schema: {
+            type: "object",
+            properties: {
+              profileImage: {},
+            },
+            required: ["profileImage"],
+          },
+        });
+      });
+
+      it("part of type union `bytes | {content: bytes}` produce `type: string, format: binary`", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", profileImage: bytes | {content: bytes}): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+          schema: {
+            type: "object",
+            properties: {
+              profileImage: {
+                anyOf: [
+                  {},
+                  {
+                    type: "object",
+                    properties: {
+                      content: { type: "string", contentEncoding: "base64" },
+                    },
+                    required: ["content"],
+                  },
+                ],
+              },
+            },
+            required: ["profileImage"],
+          },
+        });
+      });
+
+      it("part of type `bytes[]` produce `type: array, items: {}`", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", profileImage: bytes[]): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(op.requestBody.content["multipart/form-data"], {
+          schema: {
+            type: "object",
+            properties: {
+              profileImage: {
+                type: "array",
+                items: {},
+              },
+            },
+            required: ["profileImage"],
+          },
+        });
+      });
+
+      it("bytes inside a json part will be treated as base64 encoded by default(same as for a json body)", async () => {
+        const res = await openApiFor(
+          `
+        op upload(@header contentType: "multipart/form-data", address: {city: string, icon: bytes}): void;
+        `,
+        );
+        const op = res.paths["/"].post;
+        deepStrictEqual(
+          op.requestBody.content["multipart/form-data"].schema.properties.address.properties.icon,
+          {
+            type: "string",
+            contentEncoding: "base64",
+          },
+        );
       });
     });
   });

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -193,32 +193,6 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel, openApiFor, openapiWithOptions }) 
     strictEqual(res.components.parameters["PetId.name"].deprecated, undefined);
   });
 
-  describe("openapi3: request", () => {
-    describe("binary request", () => {
-      it("bytes request should default to application/json byte", async () => {
-        const res = await openApiFor(`
-        @post op read(@body body: bytes): {};
-      `);
-
-        const requestBody = res.paths["/"].post.requestBody;
-        ok(requestBody);
-        strictEqual(requestBody.content["application/json"].schema.type, "string");
-        strictEqual(requestBody.content["application/json"].schema.format, "byte");
-      });
-
-      it("bytes request should respect @header contentType and use binary format when not json or text", async () => {
-        const res = await openApiFor(`
-        @post op read(@header contentType: "image/png", @body body: bytes): {};
-      `);
-
-        const requestBody = res.paths["/"].post.requestBody;
-        ok(requestBody);
-        strictEqual(requestBody.content["image/png"].schema.type, "string");
-        strictEqual(requestBody.content["image/png"].schema.format, "binary");
-      });
-    });
-  });
-
   describe("openapi3: extension decorator", () => {
     it("adds an arbitrary extension to a model", async () => {
       const oapi = await openApiFor(`
@@ -347,6 +321,63 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel, openApiFor, openapiWithOptions }) 
       ok(oapi.paths["/"].get);
       strictEqual(oapi.paths["/"].get.responses["200"]["$ref"], "../common.json#/definitions/Foo");
       strictEqual(oapi.paths["/"].get.responses["201"]["$ref"], "https://example.com/example.yml");
+    });
+  });
+});
+
+worksFor(["3.0.0"], ({ openApiFor }) => {
+  describe("openapi 3.0: request", () => {
+    describe("binary request", () => {
+      it("bytes request should default to application/json byte", async () => {
+        const res = await openApiFor(`
+        @post op read(@body body: bytes): {};
+      `);
+
+        const requestBody = res.paths["/"].post.requestBody;
+        ok(requestBody);
+        strictEqual(requestBody.content["application/json"].schema.type, "string");
+        strictEqual(requestBody.content["application/json"].schema.format, "byte");
+      });
+
+      it("bytes request should respect @header contentType and use binary format when not json or text", async () => {
+        const res = await openApiFor(`
+        @post op read(@header contentType: "image/png", @body body: bytes): {};
+      `);
+
+        const requestBody = res.paths["/"].post.requestBody;
+        ok(requestBody);
+        strictEqual(requestBody.content["image/png"].schema.type, "string");
+        strictEqual(requestBody.content["image/png"].schema.format, "binary");
+      });
+    });
+  });
+});
+
+worksFor(["3.1.0"], ({ openApiFor }) => {
+  describe("openapi 3.1: request", () => {
+    describe("binary request", () => {
+      it("bytes request should default to application/json with base64 contentEncoding", async () => {
+        const res = await openApiFor(`
+        @post op read(@body body: bytes): {};
+      `);
+
+        const requestBody = res.paths["/"].post.requestBody;
+        ok(requestBody);
+        deepStrictEqual(requestBody.content["application/json"].schema, {
+          type: "string",
+          contentEncoding: "base64",
+        });
+      });
+
+      it("bytes request should respect @header contentType and use contentMediaType when not json or text", async () => {
+        const res = await openApiFor(`
+        @post op read(@header contentType: "image/png", @body body: bytes): {};
+      `);
+
+        const requestBody = res.paths["/"].post.requestBody;
+        ok(requestBody);
+        deepStrictEqual(requestBody.content["image/png"].schema, { contentMediaType: "image/png" });
+      });
     });
   });
 });

--- a/packages/openapi3/test/return-types.test.ts
+++ b/packages/openapi3/test/return-types.test.ts
@@ -560,56 +560,6 @@ worksFor(["3.0.0", "3.1.0"], ({ checkFor, openApiFor }) => {
     });
   });
 
-  describe("binary responses", () => {
-    it("bytes responses should default to application/json with byte format", async () => {
-      const res = await openApiFor(`
-        @get op read(): bytes;
-      `);
-
-      const response = res.paths["/"].get.responses["200"];
-      ok(response);
-      ok(response.content);
-      strictEqual(response.content["application/json"].schema.type, "string");
-      strictEqual(response.content["application/json"].schema.format, "byte");
-    });
-
-    it("@body body: bytes responses default to application/json with bytes format", async () => {
-      const res = await openApiFor(`
-        @get op read(): {@body body: bytes};
-      `);
-
-      const response = res.paths["/"].get.responses["200"];
-      ok(response);
-      ok(response.content);
-      strictEqual(response.content["application/json"].schema.type, "string");
-      strictEqual(response.content["application/json"].schema.format, "byte");
-    });
-
-    it("@header contentType text/plain should keep format to byte", async () => {
-      const res = await openApiFor(`
-        @get op read(): {@header contentType: "text/plain", @body body: bytes};
-      `);
-
-      const response = res.paths["/"].get.responses["200"];
-      ok(response);
-      ok(response.content);
-      strictEqual(response.content["text/plain"].schema.type, "string");
-      strictEqual(response.content["text/plain"].schema.format, "byte");
-    });
-
-    it("@header contentType not json or text should set format to binary", async () => {
-      const res = await openApiFor(`
-        @get op read(): {@header contentType: "image/png", @body body: bytes};
-      `);
-
-      const response = res.paths["/"].get.responses["200"];
-      ok(response);
-      ok(response.content);
-      strictEqual(response.content["image/png"].schema.type, "string");
-      strictEqual(response.content["image/png"].schema.format, "binary");
-    });
-  });
-
   describe("multiple responses", () => {
     it("handles multiple response types for the same status code", async () => {
       const res = await openApiFor(`
@@ -715,6 +665,115 @@ worksFor(["3.0.0", "3.1.0"], ({ checkFor, openApiFor }) => {
           description: "An unexpected error response.",
         },
       });
+    });
+  });
+});
+
+worksFor(["3.0.0"], ({ openApiFor }) => {
+  describe("open api 3.0.0 binary responses", () => {
+    it("bytes responses should default to application/json with byte format", async () => {
+      const res = await openApiFor(`
+        @get op read(): bytes;
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      strictEqual(response.content["application/json"].schema.type, "string");
+      strictEqual(response.content["application/json"].schema.format, "byte");
+    });
+
+    it("@body body: bytes responses default to application/json with bytes format", async () => {
+      const res = await openApiFor(`
+        @get op read(): {@body body: bytes};
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      strictEqual(response.content["application/json"].schema.type, "string");
+      strictEqual(response.content["application/json"].schema.format, "byte");
+    });
+
+    it("@header contentType text/plain should keep format to byte", async () => {
+      const res = await openApiFor(`
+        @get op read(): {@header contentType: "text/plain", @body body: bytes};
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      strictEqual(response.content["text/plain"].schema.type, "string");
+      strictEqual(response.content["text/plain"].schema.format, "byte");
+    });
+
+    it("@header contentType not json or text should set format to binary", async () => {
+      const res = await openApiFor(`
+        @get op read(): {@header contentType: "image/png", @body body: bytes};
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      strictEqual(response.content["image/png"].schema.type, "string");
+      strictEqual(response.content["image/png"].schema.format, "binary");
+    });
+  });
+});
+
+worksFor(["3.1.0"], ({ openApiFor }) => {
+  describe("open api 3.1.0 binary responses", () => {
+    it("bytes responses should default to application/json with base64 contentEncoding", async () => {
+      const res = await openApiFor(`
+        @get op read(): bytes;
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      deepStrictEqual(response.content["application/json"].schema, {
+        type: "string",
+        contentEncoding: "base64",
+      });
+    });
+
+    it("@body body: bytes responses default to application/json with base64 contentEncoding", async () => {
+      const res = await openApiFor(`
+        @get op read(): {@body body: bytes};
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      deepStrictEqual(response.content["application/json"].schema, {
+        type: "string",
+        contentEncoding: "base64",
+      });
+    });
+
+    it("@header contentType text/plain should set contentEncoding to base64", async () => {
+      const res = await openApiFor(`
+        @get op read(): {@header contentType: "text/plain", @body body: bytes};
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      deepStrictEqual(response.content["text/plain"].schema, {
+        type: "string",
+        contentEncoding: "base64",
+      });
+    });
+
+    it("@header contentType not json or text should set contentMediaType", async () => {
+      const res = await openApiFor(`
+        @get op read(): {@header contentType: "image/png", @body body: bytes};
+      `);
+
+      const response = res.paths["/"].get.responses["200"];
+      ok(response);
+      ok(response.content);
+      deepStrictEqual(response.content["image/png"].schema, { contentMediaType: "image/png" });
     });
   });
 });


### PR DESCRIPTION
Fixes #5507 

This PR updates the Open API 3.1 schema to support binary types.

The linked issue includes more details on the required changes (and Open API 3.1 spec) but here's a quick summary:

## Binary types

Open API supports 2 types of binary data: raw (unencoded) binary, and encoded binary.

In Open API 3.0, binary data is described using the `string` type with `format: binary` indicating raw binary data, and `format: byte` indicating encoded binary data (defaulted to base64 encoding).

In Open API 3.1, binary data is represented with an empty schema - `{}` for raw binary data, and uses the `string` type with `contentEncoding: base64` to represent encoded binary data (note that the actual value of contentEncoding can be anything).
Additionally, `contentMediaType` can be set on both raw and encoded binary data schemas, though this value will be ignored if `encoding` fields are present (common for multipart) or if it matches the requestBody content type.

This PR preserves the behavior where `@encode` can be used to indicate the content encoding. For Open API 3.0, it updates the encoded binary schema's `format` field. In Open API 3.1, it will update the encoded binary schema's `contentEncoding` field.