### PR TITLE
fix(http-client-csharp): wrong `text/plain` result conversion determination logic

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
                     return response.Content().ToObjectFromJson(responseBodyType);
                 }
             }
-            if (responseBodyType.Equals(typeof(string)) && Operation.RequestMediaTypes?.Contains("text/plain") == true)
+            if (responseBodyType.Equals(typeof(string)) && Operation.Responses.Any(r => r.IsErrorResponse is false && r.ContentTypes.Contains("text/plain")))
             {
                 return response.Content().InvokeToString();
             }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Payload/MediaType/MediaTypeTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch.Tests/Http/Payload/MediaType/MediaTypeTests.cs
@@ -17,7 +17,6 @@ namespace TestProjects.CadlRanch.Tests.Http.Payload.MediaType
         });
 
         [CadlRanchTest]
-        [Ignore("https://github.com/microsoft/typespec/issues/4208")]
         public Task GetAsText() => Test(async (host) =>
         {
             var response2 = await new MediaTypeClient(host, null).GetStringBodyClient().GetAsTextAsync();


### PR DESCRIPTION
We're using `Operation.RequestMediaType` to help determine the result conversion statement, which is apparently wrong.

This commit includes:
- use `Operation.Responses.ContentTypes` to determine the result conversion statment for `string` return type
- enable a previously disabled cadl ranch test `Payload/MediaType/getAsText`

part of https://github.com/microsoft/typespec/issues/4208
