### PR TITLE
Some small adjustment in the vscode UX when creating TypeSpec project

### DIFF
--- a/.chronus/changes/scaffolding-wording-2025-0-9-19-12-18.md
+++ b/.chronus/changes/scaffolding-wording-2025-0-9-19-12-18.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - typespec-vscode
+---
+
+Some small adjustment in the vscode UX when creating TypeSpec project

--- a/packages/typespec-vscode/src/vscode-cmd/create-tsp-project.ts
+++ b/packages/typespec-vscode/src/vscode-cmd/create-tsp-project.ts
@@ -698,7 +698,7 @@ async function CheckCompilerAndStartLSPClient(folder: string): Promise<Result<Ts
     const igcArgs: InstallGlobalCliCommandArgs = {
       confirm: true,
       confirmTitle: TITLE,
-      confirmPlaceholder: "Install Type Compiler CLI.",
+      confirmPlaceholder: "Install TypeSpec Compiler CLI.",
       silentMode: true,
     };
     const result = await vscode.commands.executeCommand<Result<void>>(

--- a/packages/typespec-vscode/src/vscode-cmd/install-tsp-compiler.ts
+++ b/packages/typespec-vscode/src/vscode-cmd/install-tsp-compiler.ts
@@ -36,7 +36,6 @@ export async function installCompilerGlobally(
       if (event.item === yes) {
         vscode.env.openExternal(vscode.Uri.parse(detailLink));
       }
-      confirmPicker.hide();
     });
     const p = new Promise<QuickPickItem[] | undefined>((resolve) => {
       confirmPicker.onDidAccept(() => {


### PR DESCRIPTION
Some small adjustment in the vscode UX when creating TypeSpec project
1. refine some wording
2. not close quickpick when user opens external link