### PR TITLE
[python] use generic type of 'token credential' in docstring

### DIFF
--- a/packages/http-client-python/generator/pygen/codegen/models/credential_types.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/credential_types.py
@@ -155,7 +155,7 @@ class TokenCredentialType(CredentialType[Union[BearerTokenCredentialPolicyType, 
 
     @property
     def type_description(self) -> str:
-        return "TokenCredential"
+        return "token credential"
 
     @property
     def credentials_subfolder(self) -> str:


### PR DESCRIPTION
fixes #5503