### PR TITLE
feat(compiler): Bring back the `Map<K, V>` type

### DIFF
--- a/.chronus/changes/feat-bring-back-map-type-2025-0-12-21-27-56.md
+++ b/.chronus/changes/feat-bring-back-map-type-2025-0-12-21-27-56.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Bring back the `Map<K, V>` type to intrinsics

--- a/packages/compiler/lib/intrinsics.tsp
+++ b/packages/compiler/lib/intrinsics.tsp
@@ -184,8 +184,16 @@ scalar boolean;
 model Array<Element> {}
 
 /**
- * @dev Model with string properties where all the properties have type `Property`
+ * @dev Model with string properties where all the properties have type `Element`
  * @template Element The type of the properties
  */
 @indexer(string, Element)
 model Record<Element> {}
+
+/**
+ * @dev Model with string properties where all the keys have type `Key` and all the properties have type `Element`
+ * @template Key     The type of the keys
+ * @template Element The type of the properties
+ */
+@indexer(Key, Element)
+model Map<Key extends string, Element>  {}

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -280,7 +280,7 @@ export type NeverIndexer = {
 };
 
 export type ModelIndexer = {
-  readonly key: Scalar;
+  readonly key: Enum | Scalar | Union;
   readonly value: Type;
 };
 

--- a/packages/compiler/src/lib/intrinsic/decorators.ts
+++ b/packages/compiler/src/lib/intrinsic/decorators.ts
@@ -1,12 +1,19 @@
 import { DocTarget, setDocData } from "../../core/intrinsic-type-state.js";
 import type { Program } from "../../core/program.js";
-import type { DecoratorContext, ModelIndexer, Scalar, Type } from "../../core/types.js";
+import type {
+  DecoratorContext,
+  Enum,
+  ModelIndexer,
+  Scalar,
+  Type,
+  Union,
+} from "../../core/types.js";
 
 const indexTypeKey = Symbol.for(`TypeSpec.index`);
 export const indexerDecorator = (
   context: DecoratorContext,
   target: Type,
-  key: Scalar,
+  key: Enum | Scalar | Union,
   value: Type,
 ) => {
   const indexer: ModelIndexer = { key, value };

--- a/packages/compiler/test/stdlib.test.ts
+++ b/packages/compiler/test/stdlib.test.ts
@@ -20,6 +20,7 @@ const intrinsicTypes = [
   "decimal",
   "Array<string>",
   "Record<string>",
+  "Map<string, integer>",
   "string[]",
 ];
 

--- a/packages/openapi3/test/additional-properties.test.ts
+++ b/packages/openapi3/test/additional-properties.test.ts
@@ -3,78 +3,161 @@ import { describe, it } from "vitest";
 import { oapiForModel } from "./test-host.js";
 
 describe("openapi3: Additional properties", () => {
-  describe("extends Record<T>", () => {
-    it("doesn't set additionalProperties on model itself", async () => {
-      const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet.additionalProperties, undefined);
-    });
-
-    it("links to an allOf of the Record<unknown> schema", async () => {
-      const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet.allOf, [{ type: "object", additionalProperties: {} }]);
-    });
-
-    it("include model properties", async () => {
-      const res = await oapiForModel("Pet", `model Pet extends Record<unknown> { name: string };`);
-      deepStrictEqual(res.schemas.Pet.properties, {
-        name: { type: "string" },
+  describe("Record<T>", () => {
+    describe("extends Record<T>", () => {
+      it("doesn't set additionalProperties on model itself", async () => {
+        const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {};`);
+        deepStrictEqual(res.schemas.Pet.additionalProperties, undefined);
       });
-    });
-  });
 
-  describe("is Record<T>", () => {
-    it("set additionalProperties on model itself", async () => {
-      const res = await oapiForModel("Pet", `model Pet is Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet.additionalProperties, {});
-    });
+      it("links to an allOf of the Record<unknown> schema", async () => {
+        const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {};`);
+        deepStrictEqual(res.schemas.Pet.allOf, [{ type: "object", additionalProperties: {} }]);
+      });
 
-    it("set additional properties type", async () => {
-      const res = await oapiForModel("Pet", `model Pet is Record<string> {};`);
-      deepStrictEqual(res.schemas.Pet.additionalProperties, {
-        type: "string",
+      it("include model properties", async () => {
+        const res = await oapiForModel(
+          "Pet",
+          `model Pet extends Record<unknown> { name: string };`,
+        );
+        deepStrictEqual(res.schemas.Pet.properties, {
+          name: { type: "string" },
+        });
       });
     });
 
-    it("include model properties", async () => {
-      const res = await oapiForModel("Pet", `model Pet is Record<unknown> { name: string };`);
-      deepStrictEqual(res.schemas.Pet.properties, {
-        name: { type: "string" },
+    describe("is Record<T>", () => {
+      it("set additionalProperties on model itself", async () => {
+        const res = await oapiForModel("Pet", `model Pet is Record<unknown> {};`);
+        deepStrictEqual(res.schemas.Pet.additionalProperties, {});
+      });
+
+      it("set additional properties type", async () => {
+        const res = await oapiForModel("Pet", `model Pet is Record<string> {};`);
+        deepStrictEqual(res.schemas.Pet.additionalProperties, {
+          type: "string",
+        });
+      });
+
+      it("include model properties", async () => {
+        const res = await oapiForModel("Pet", `model Pet is Record<unknown> { name: string };`);
+        deepStrictEqual(res.schemas.Pet.properties, {
+          name: { type: "string" },
+        });
       });
     });
-  });
 
-  describe("referencing Record<T>", () => {
-    it("add additionalProperties inline for property of type Record<unknown>", async () => {
+    describe("referencing Record<T>", () => {
+      it("add additionalProperties inline for property of type Record<unknown>", async () => {
+        const res = await oapiForModel(
+          "Pet",
+          `
+        model Pet { details: Record<unknown> };
+        `,
+        );
+
+        ok(res.isRef);
+        ok(res.schemas.Pet, "expected definition named Pet");
+        deepStrictEqual(res.schemas.Pet.properties.details, {
+          type: "object",
+          additionalProperties: {},
+        });
+      });
+    });
+
+    it("set additionalProperties if model extends Record with leaf type", async () => {
       const res = await oapiForModel(
         "Pet",
         `
-        model Pet { details: Record<unknown> };
+      @doc("value")
+      scalar Value;
+      model Pet is Record<Value> {};
+      `,
+      );
+
+      ok(res.isRef);
+      ok(res.schemas.Pet, "expected definition named Pet");
+      deepStrictEqual(res.schemas.Pet.additionalProperties, {
+        $ref: "#/components/schemas/Value",
+      });
+    });
+  });
+
+  describe("Map<K, V>", () => {
+    describe("extends Map<K, V>", () => {
+      it("doesn't set additionalProperties on model itself", async () => {
+        const res = await oapiForModel("Pet", `model Pet extends Map<string, unknown> {};`);
+        deepStrictEqual(res.schemas.Pet.additionalProperties, undefined);
+      });
+
+      it("links to an allOf of the Map<string, unknown> schema", async () => {
+        const res = await oapiForModel("Pet", `model Pet extends Map<string, unknown> {};`);
+        deepStrictEqual(res.schemas.Pet.allOf, [{ type: "object", additionalProperties: {} }]);
+      });
+
+      it("include model properties", async () => {
+        const res = await oapiForModel(
+          "Pet",
+          `model Pet extends Map<string, unknown> { name: string };`,
+        );
+        deepStrictEqual(res.schemas.Pet.properties, {
+          name: { type: "string" },
+        });
+      });
+    });
+
+    describe("is Map<K, V>", () => {
+      it("set additionalProperties on model itself", async () => {
+        const res = await oapiForModel("Pet", `model Pet is Map<string, unknown> {};`);
+        deepStrictEqual(res.schemas.Pet.additionalProperties, {});
+      });
+
+      it("set additional properties type", async () => {
+        const res = await oapiForModel("Pet", `model Pet is Map<string, string> {};`);
+        deepStrictEqual(res.schemas.Pet.additionalProperties, {
+          type: "string",
+        });
+      });
+
+      it("include model properties", async () => {
+        const res = await oapiForModel(
+          "Pet",
+          `model Pet is Map<string, unknown> { name: string };`,
+        );
+        deepStrictEqual(res.schemas.Pet.properties, {
+          name: { type: "string" },
+        });
+      });
+    });
+
+    describe("referencing Map<K, V>", () => {
+      it("add additionalProperties inline for property of type Map<string, unknown>", async () => {
+        const res = await oapiForModel("Pet", `model Pet { details: Map<string, unknown> };`);
+
+        ok(res.isRef);
+        ok(res.schemas.Pet, "expected definition named Pet");
+        deepStrictEqual(res.schemas.Pet.properties.details, {
+          type: "object",
+          additionalProperties: {},
+        });
+      });
+    });
+
+    it("set additionalProperties if model extends Map with leaf type", async () => {
+      const res = await oapiForModel(
+        "Pet",
+        `
+        @doc("value")
+        scalar Value;
+        model Pet is Map<string, Value> {};
         `,
       );
 
       ok(res.isRef);
       ok(res.schemas.Pet, "expected definition named Pet");
-      deepStrictEqual(res.schemas.Pet.properties.details, {
-        type: "object",
-        additionalProperties: {},
+      deepStrictEqual(res.schemas.Pet.additionalProperties, {
+        $ref: "#/components/schemas/Value",
       });
-    });
-  });
-
-  it("set additionalProperties if model extends Record with leaf type", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      @doc("value")
-      scalar Value;
-      model Pet is Record<Value> {};
-      `,
-    );
-
-    ok(res.isRef);
-    ok(res.schemas.Pet, "expected definition named Pet");
-    deepStrictEqual(res.schemas.Pet.additionalProperties, {
-      $ref: "#/components/schemas/Value",
     });
   });
 });

--- a/website/src/content/docs/docs/standard-library/built-in-data-types.md
+++ b/website/src/content/docs/docs/standard-library/built-in-data-types.md
@@ -122,6 +122,24 @@ model ExampleOptions
 | title? | [`string`](#string) | The title of the example |
 | description? | [`string`](#string) | Description of the example |
 
+### `Map` {#Map}
+
+
+
+```typespec
+model Map<Key, Element>
+```
+
+#### Template Parameters
+| Name | Description |
+|------|-------------|
+| Key | The type of the keys |
+| Element | The type of the properties |
+
+
+#### Properties
+None
+
 ### `object` {#object}
 :::caution
 **Deprecated**: object is deprecated. Please use {} for an empty model, `Record<unknown>` for a record with unknown property types, `unknown[]` for an array.


### PR DESCRIPTION
Related Issue: https://github.com/microsoft/typespec/issues/2842

I was wondering how to emit `propertyNames` keyword of a object schema from TypeSpec. Then I found #2842. After looked up https://github.com/microsoft/typespec/issues/2842#issuecomment-1995183325, #571, and #1537, I noticed the previously there was the `Map<K, V>` type. (I couldn't catch exactly why it has been removed)

Because of lacking the key type of `Record<T>`, we cannot inject some custom types as the keys of the object. As @timotheeguerin suggested, bringing back the Map type should be the start point for adding `propertyNames` support.

As the current main branch of TypeSpec doesn't support OpenAPI 3.1 yet, I postponed to add emitting support of `propertyNames` keyword. Once this pull request got merged, I will prepare it, targeting the `openapi3.1` branch.