### PR TITLE
http-client-java, prepare release 0.1.6

### DIFF
--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -12,7 +12,11 @@ import { fileURLToPath } from "url";
 import { CodeModelBuilder } from "./code-model-builder.js";
 import { CodeModel } from "./common/code-model.js";
 import { logError, spawnAsync, SpawnError } from "./utils.js";
-import { JDK_NOT_FOUND_MESSAGE, validateDependencies } from "./validate.js";
+import {
+  CODE_RUNTIME_DEPENDENCY,
+  JDK_NOT_FOUND_MESSAGE,
+  validateDependencies,
+} from "./validate.js";
 
 export interface EmitterOptions {
   namespace?: string;
@@ -193,7 +197,7 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
         program.trace("http-client-java", `Code generation log: ${result.stdout}`);
       } catch (error: any) {
         if (error && "code" in error && error["code"] === "ENOENT") {
-          logError(program, JDK_NOT_FOUND_MESSAGE, "invalid-runtime-dependency");
+          logError(program, JDK_NOT_FOUND_MESSAGE, CODE_RUNTIME_DEPENDENCY);
         } else {
           logError(
             program,

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -193,7 +193,7 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
         program.trace("http-client-java", `Code generation log: ${result.stdout}`);
       } catch (error: any) {
         if (error && "code" in error && error["code"] === "ENOENT") {
-          logError(program, JDK_NOT_FOUND_MESSAGE);
+          logError(program, JDK_NOT_FOUND_MESSAGE, "invalid-runtime-dependency");
         } else {
           logError(
             program,

--- a/packages/http-client-java/emitter/src/utils.ts
+++ b/packages/http-client-java/emitter/src/utils.ts
@@ -1,18 +1,18 @@
 import { NoTarget, Program, Type } from "@typespec/compiler";
 import { spawn, SpawnOptions } from "child_process";
 
-export function logError(program: Program, msg: string) {
+export function logError(program: Program, msg: string, code: string = "http-client-java") {
   program.reportDiagnostic({
-    code: "http-client-java",
+    code: code,
     severity: "error",
     message: msg,
     target: NoTarget,
   });
 }
 
-export function logWarning(program: Program, msg: string) {
+export function logWarning(program: Program, msg: string, code: string = "http-client-java") {
   program.reportDiagnostic({
-    code: "http-client-java",
+    code: code,
     severity: "warning",
     message: msg,
     target: NoTarget,

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -24,7 +24,7 @@ export async function validateDependencies(
         // // eslint-disable-next-line no-console
         // console.log("[ERROR] " + message);
         if (program && logDiagnostic) {
-          logError(program, message);
+          logError(program, message, "invalid-runtime-dependency");
         }
       }
     }
@@ -36,7 +36,7 @@ export async function validateDependencies(
     // // eslint-disable-next-line no-console
     // console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
-      logError(program, message);
+      logError(program, message, "invalid-runtime-dependency");
     }
   }
 
@@ -60,7 +60,7 @@ export async function validateDependencies(
     // // eslint-disable-next-line no-console
     // console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
-      logError(program, message);
+      logError(program, message, "invalid-runtime-dependency");
     }
   }
 }

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -3,6 +3,7 @@ import { logError, spawnAsync, trace } from "./utils.js";
 
 export const JDK_NOT_FOUND_MESSAGE =
   "Java Development Kit (JDK) is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download";
+export const CODE_RUNTIME_DEPENDENCY = "invalid-runtime-dependency";
 
 export async function validateDependencies(
   program: Program | undefined,
@@ -24,7 +25,7 @@ export async function validateDependencies(
         // // eslint-disable-next-line no-console
         // console.log("[ERROR] " + message);
         if (program && logDiagnostic) {
-          logError(program, message, "invalid-runtime-dependency");
+          logError(program, message, CODE_RUNTIME_DEPENDENCY);
         }
       }
     }
@@ -36,7 +37,7 @@ export async function validateDependencies(
     // // eslint-disable-next-line no-console
     // console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
-      logError(program, message, "invalid-runtime-dependency");
+      logError(program, message, CODE_RUNTIME_DEPENDENCY);
     }
   }
 
@@ -60,7 +61,7 @@ export async function validateDependencies(
     // // eslint-disable-next-line no-console
     // console.log("[ERROR] " + message);
     if (program && logDiagnostic) {
-      logError(program, message, "invalid-runtime-dependency");
+      logError(program, message, CODE_RUNTIME_DEPENDENCY);
     }
   }
 }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@typespec/http-specs": "0.1.0-alpha.5",
-    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.1.5.tgz",
+    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.1.6.tgz",
     "@typespec/http-client-java-tests": "file:"
   },
   "overrides": {

--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@typespec/http-specs": "0.1.0-alpha.5",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.4",
-    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.1.5.tgz",
+    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.1.6.tgz",
     "@typespec/http-client-java-tests": "file:"
   },
   "overrides": {

--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typespec/http-client-java",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typespec/http-client-java",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",
@@ -20,22 +20,22 @@
         "@azure-tools/typespec-azure-resource-manager": "0.49.0",
         "@azure-tools/typespec-azure-rulesets": "0.49.0",
         "@azure-tools/typespec-client-generator-core": "0.49.1",
-        "@microsoft/api-extractor": "^7.48.0",
-        "@microsoft/api-extractor-model": "^7.30.0",
+        "@microsoft/api-extractor": "^7.49.1",
+        "@microsoft/api-extractor-model": "^7.30.2",
         "@types/js-yaml": "~4.0.9",
-        "@types/lodash": "~4.17.13",
-        "@types/node": "~22.10.1",
+        "@types/lodash": "~4.17.14",
+        "@types/node": "~22.10.6",
         "@typespec/compiler": "0.63.0",
         "@typespec/http": "0.63.0",
         "@typespec/openapi": "0.63.0",
-        "@typespec/rest": "0.63.0",
+        "@typespec/rest": "0.63.1",
         "@typespec/spector": "0.1.0-alpha.5",
         "@typespec/versioning": "0.63.0",
         "@vitest/coverage-v8": "^2.1.8",
         "@vitest/ui": "^2.1.8",
         "c8": "~10.1.3",
         "rimraf": "~6.0.1",
-        "typescript": "~5.7.2",
+        "typescript": "~5.7.3",
         "vitest": "^2.1.8"
       },
       "engines": {
@@ -1173,40 +1173,40 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.48.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.48.0.tgz",
-      "integrity": "sha512-FMFgPjoilMUWeZXqYRlJ3gCVRhB7WU/HN88n8OLqEsmsG4zBdX/KQdtJfhq95LQTQ++zfu0Em1LLb73NqRCLYQ==",
+      "version": "7.49.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.49.1.tgz",
+      "integrity": "sha512-jRTR/XbQF2kb+dYn8hfYSicOGA99+Fo00GrsdMwdfE3eIgLtKdH6Qa2M3wZV9S2XmbgCaGX1OdPtYctbfu5jQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.30.0",
+        "@microsoft/api-extractor-model": "7.30.2",
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.10.0",
+        "@rushstack/node-core-library": "5.10.2",
         "@rushstack/rig-package": "0.5.3",
-        "@rushstack/terminal": "0.14.3",
-        "@rushstack/ts-command-line": "4.23.1",
+        "@rushstack/terminal": "0.14.5",
+        "@rushstack/ts-command-line": "4.23.3",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
         "semver": "~7.5.4",
         "source-map": "~0.6.1",
-        "typescript": "5.4.2"
+        "typescript": "5.7.2"
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.0.tgz",
-      "integrity": "sha512-26/LJZBrsWDKAkOWRiQbdVgcfd1F3nyJnAiJzsAgpouPk7LtOIj7PK9aJtBaw/pUXrkotEg27RrT+Jm/q0bbug==",
+      "version": "7.30.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.2.tgz",
+      "integrity": "sha512-3/t2F+WhkJgBzSNwlkTIL0tBgUoBqDqL66pT+nh2mPbM0NIDGVGtpqbGWPgHIzn/mn7kGS/Ep8D8po58e8UUIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.10.0"
+        "@rushstack/node-core-library": "5.10.2"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
@@ -1259,10 +1259,11 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1607,9 +1608,9 @@
       ]
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.10.0.tgz",
-      "integrity": "sha512-2pPLCuS/3x7DCd7liZkqOewGM0OzLyCacdvOe8j6Yrx9LkETGnxul1t7603bIaB8nUAooORcct9fFDOQMbWAgw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.10.2.tgz",
+      "integrity": "sha512-xOF/2gVJZTfjTxbo4BDj9RtQq/HFnrrKdtem4JkyRLnwsRz2UDTg8gA1/et10fBx5RxmZD9bYVGST69W8ME5OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1688,13 +1689,13 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.3.tgz",
-      "integrity": "sha512-csXbZsAdab/v8DbU1sz7WC2aNaKArcdS/FPmXMOXEj/JBBZMvDK0+1b4Qao0kkG0ciB1Qe86/Mb68GjH6/TnMw==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.5.tgz",
+      "integrity": "sha512-TEOpNwwmsZVrkp0omnuTUTGZRJKTr6n6m4OITiNjkqzLAkcazVpwR1SOtBg6uzpkIBLgrcNHETqI8rbw3uiUfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.10.0",
+        "@rushstack/node-core-library": "5.10.2",
         "supports-color": "~8.1.1"
       },
       "peerDependencies": {
@@ -1733,13 +1734,13 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.1.tgz",
-      "integrity": "sha512-40jTmYoiu/xlIpkkRsVfENtBq4CW3R4azbL0Vmda+fMwHWqss6wwf/Cy/UJmMqIzpfYc2OTnjYP1ZLD3CmyeCA==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.3.tgz",
+      "integrity": "sha512-HazKL8fv4HMQMzrKJCrOrhyBPPdzk7iajUXgsASwjQ8ROo1cmgyqxt/k9+SdmrNLGE1zATgRqMUH3s/6smbRMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.14.3",
+        "@rushstack/terminal": "0.14.5",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -1793,16 +1794,16 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
+      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1897,9 +1898,9 @@
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.63.0.tgz",
-      "integrity": "sha512-HftzMjSDHAYX+ILE9C6pFS4oAq7oBHMCtpA8QgSFPDF4V5a8l1k2K8c4x1B+7yl+GkREmIdtpc6S0xZm2G7hXg==",
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.63.1.tgz",
+      "integrity": "sha512-RQbTM+HGjCaNIWC0v72m5ulnuvLjuRigb7pH4QeRCvFtGPHos+WBv5SImkGrbYx3353OGR8dIi7lWe7aNwiDcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6190,9 +6191,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-java",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"
@@ -65,21 +65,21 @@
     "@azure-tools/typespec-azure-rulesets": "0.49.0",
     "@azure-tools/typespec-client-generator-core": "0.49.1",
     "@typespec/spector": "0.1.0-alpha.5",
-    "@microsoft/api-extractor": "^7.48.0",
-    "@microsoft/api-extractor-model": "^7.30.0",
+    "@microsoft/api-extractor": "^7.49.1",
+    "@microsoft/api-extractor-model": "^7.30.2",
     "@types/js-yaml": "~4.0.9",
-    "@types/lodash": "~4.17.13",
-    "@types/node": "~22.10.1",
+    "@types/lodash": "~4.17.14",
+    "@types/node": "~22.10.6",
     "@typespec/compiler": "0.63.0",
     "@typespec/http": "0.63.0",
     "@typespec/openapi": "0.63.0",
-    "@typespec/rest": "0.63.0",
+    "@typespec/rest": "0.63.1",
     "@typespec/versioning": "0.63.0",
     "@vitest/coverage-v8": "^2.1.8",
     "@vitest/ui": "^2.1.8",
     "c8": "~10.1.3",
     "rimraf": "~6.0.1",
-    "typescript": "~5.7.2",
+    "typescript": "~5.7.3",
     "vitest": "^2.1.8"
   }
 }


### PR DESCRIPTION
Use code="invalid-runtime-dependency" if cannot find JDK or Maven, as this is what .NET plan to use (it could change).

![image](https://github.com/user-attachments/assets/fb29e758-310d-4de5-89ce-f15e4321b164)
