### PR TITLE
Support Emitter section in init-template when creating TypeSpec project in vscode

### DIFF
--- a/.chronus/changes/scaffolding-emitter-2025-0-14-11-30-33.md
+++ b/.chronus/changes/scaffolding-emitter-2025-0-14-11-30-33.md
@@ -1,0 +1,8 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+  - typespec-vscode
+---
+
+Support Emitters section in Init Template when creating TypeSpec project in vscode

--- a/packages/compiler/src/server/types.ts
+++ b/packages/compiler/src/server/types.ts
@@ -39,7 +39,7 @@ import {
 import { TextDocument, TextEdit } from "vscode-languageserver-textdocument";
 import type { CompilerHost, Program, SourceFile, TypeSpecScriptNode } from "../core/index.js";
 import { LoadedCoreTemplates } from "../init/core-templates.js";
-import { InitTemplate, InitTemplateLibrarySpec } from "../init/init-template.js";
+import { EmitterTemplate, InitTemplate, InitTemplateLibrarySpec } from "../init/init-template.js";
 import { ScaffoldingConfig } from "../init/scaffold.js";
 
 export type ServerLogLevel = "trace" | "debug" | "info" | "warning" | "error";
@@ -172,3 +172,4 @@ export interface InitProjectContext {
 export type InitProjectConfig = ScaffoldingConfig;
 export type InitProjectTemplate = InitTemplate;
 export type InitProjectTemplateLibrarySpec = InitTemplateLibrarySpec;
+export type InitProjectTemplateEmitterTemplate = EmitterTemplate;

--- a/packages/typespec-vscode/src/extension-state-manager.ts
+++ b/packages/typespec-vscode/src/extension-state-manager.ts
@@ -1,0 +1,61 @@
+import { LogLevel } from "rollup";
+import vscode from "vscode";
+import { normalizePath } from "./path-utils.js";
+
+export interface StartUpMessage {
+  /**
+   * the message to show in the popup notification
+   */
+  popupMessage: string;
+  /**
+   * the detail logged to the Output window
+   */
+  detail: string;
+  /**
+   * the level used to show notification and log
+   */
+  level: LogLevel;
+}
+
+/** manage data stored in vscode extension's state (ExtensionContext.globalState/workspaceState) */
+export class ExtensionStateManager {
+  constructor(private vscodeContext: vscode.ExtensionContext) {}
+
+  private getValue<T>(key: string, defaultValue: T, isGlobal: boolean): T {
+    return isGlobal
+      ? this.vscodeContext.globalState.get(key, defaultValue)
+      : this.vscodeContext.workspaceState.get(key, defaultValue);
+  }
+
+  /**
+   *
+   * @param key
+   * @param value must be JSON stringifyable, set to undefined to delete the key
+   * @param isGlobal
+   */
+  private setValue<T>(key: string, value: T | undefined, isGlobal: boolean) {
+    isGlobal
+      ? this.vscodeContext.globalState.update(key, value)
+      : this.vscodeContext.workspaceState.update(key, value);
+  }
+
+  private getStartUpMessageKey(workspaceFolder: string) {
+    const ON_START_UP_MESSAGE_KEY_PREFIX = "onStartUpMessage-";
+    const path = normalizePath(workspaceFolder);
+    return `${ON_START_UP_MESSAGE_KEY_PREFIX}${path}`;
+  }
+
+  saveStartUpMessage(msg: StartUpMessage, workspaceFolder: string) {
+    const key = this.getStartUpMessageKey(workspaceFolder);
+    this.setValue(key, msg, true);
+  }
+  loadStartUpMessage(workspaceFolder: string): StartUpMessage | undefined {
+    const key = this.getStartUpMessageKey(workspaceFolder);
+    const value = this.getValue<StartUpMessage | undefined>(key, undefined, true);
+    return value;
+  }
+  cleanUpStartUpMessage(workspaceFolder: string) {
+    const key = this.getStartUpMessageKey(workspaceFolder);
+    this.setValue(key, undefined, true);
+  }
+}

--- a/packages/typespec-vscode/src/extension.ts
+++ b/packages/typespec-vscode/src/extension.ts
@@ -1,7 +1,8 @@
 import vscode, { commands, ExtensionContext, TabInputText } from "vscode";
 import { State } from "vscode-languageclient";
 import { createCodeActionProvider } from "./code-action-provider.js";
-import { ExtensionLogListener } from "./log/extension-log-listener.js";
+import { ExtensionStateManager } from "./extension-state-manager.js";
+import { ExtensionLogListener, getPopupAction } from "./log/extension-log-listener.js";
 import logger from "./log/logger.js";
 import { TypeSpecLogOutputChannel } from "./log/typespec-log-output-channel.js";
 import { createTaskProvider } from "./task-provider.js";
@@ -12,6 +13,7 @@ import {
   RestartServerCommandArgs,
   SettingName,
 } from "./types.js";
+import { isWhitespaceStringOrUndefined } from "./utils.js";
 import { createTypeSpecProject } from "./vscode-cmd/create-tsp-project.js";
 import { installCompilerGlobally } from "./vscode-cmd/install-tsp-compiler.js";
 
@@ -24,6 +26,8 @@ const outputChannel = new TypeSpecLogOutputChannel("TypeSpec");
 logger.registerLogListener("extension-log", new ExtensionLogListener(outputChannel));
 
 export async function activate(context: ExtensionContext) {
+  const stateManager = new ExtensionStateManager(context);
+
   context.subscriptions.push(createTaskProvider());
 
   context.subscriptions.push(createCodeActionProvider());
@@ -84,7 +88,7 @@ export async function activate(context: ExtensionContext) {
 
   context.subscriptions.push(
     commands.registerCommand(CommandName.CreateProject, async () => {
-      await createTypeSpecProject(client);
+      await createTypeSpecProject(client, stateManager);
     }),
   );
 
@@ -128,7 +132,7 @@ export async function activate(context: ExtensionContext) {
         return t.input.uri.fsPath.endsWith(".tsp");
       }) >= 0
   ) {
-    return await vscode.window.withProgress(
+    await vscode.window.withProgress(
       {
         title: "Launching TypeSpec language service...",
         location: vscode.ProgressLocation.Notification,
@@ -140,6 +144,7 @@ export async function activate(context: ExtensionContext) {
   } else {
     logger.info("No workspace opened, Skip starting TypeSpec language service.");
   }
+  showStartUpMessages(stateManager);
 }
 
 export async function deactivate() {
@@ -153,4 +158,36 @@ async function recreateLSPClient(context: ExtensionContext) {
   await oldClient?.stop();
   await client.start();
   return client;
+}
+
+function showStartUpMessages(stateManager: ExtensionStateManager) {
+  vscode.workspace.workspaceFolders?.forEach((workspaceFolder) => {
+    const msg = stateManager.loadStartUpMessage(workspaceFolder.uri.fsPath);
+    if (msg) {
+      logger.log("debug", "Start up message found for folder: " + workspaceFolder.uri.fsPath);
+      if (isWhitespaceStringOrUndefined(msg.detail)) {
+        logger.log(msg.level, msg.popupMessage, [], {
+          showPopup: true,
+        });
+      } else {
+        const SHOW_DETAIL = "View Details in Output";
+        const popupAction = getPopupAction(msg.level);
+        if (popupAction) {
+          popupAction(msg.popupMessage, SHOW_DETAIL).then((action) => {
+            if (action === SHOW_DETAIL) {
+              outputChannel.show(true);
+            }
+            // log the start up message to Output no matter user clicked the button or not
+            // and there are many logs coming when starting the extension, so
+            // log the message when the popup is clicked (or disappearing) to make sure these logs are shown at the end of the Output window to catch
+            // user's attention.
+            logger.log(msg.level, msg.popupMessage + "\n", [msg.detail]);
+          });
+        }
+      }
+    } else {
+      logger.log("debug", "No start up message found for folder: " + workspaceFolder.uri.fsPath);
+    }
+    stateManager.cleanUpStartUpMessage(workspaceFolder.uri.fsPath);
+  });
 }


### PR DESCRIPTION
Support Emitter section in init-template when creating TypeSpec project in vscode

fixes: #5426 