### PR TITLE
[CSharp Server Emitter] Fix 204 return in controller

### DIFF
--- a/.chronus/changes/fix-csharp-server-noresponse-2025-0-15-10-37-0.md
+++ b/.chronus/changes/fix-csharp-server-noresponse-2025-0-15-10-37-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Fixes controller generation with incorrect return when NoContent is in the spec

--- a/packages/http-server-csharp/src/interfaces.ts
+++ b/packages/http-server-csharp/src/interfaces.ts
@@ -7,12 +7,19 @@ import {
   Scope,
   SourceFile,
 } from "@typespec/compiler/emitter-framework";
+import { HttpStatusCodeRange } from "@typespec/http";
 
 export const HelperNamespace: string = "TypeSpec.Helpers.JsonConverters";
 
 export interface CSharpTypeMetadata {
   name: string;
   namespace?: string;
+}
+
+export interface ResponseInfo {
+  statusCode: number | HttpStatusCodeRange | "*";
+  csharpStatusCode: string;
+  resultType: CSharpType;
 }
 
 export class CSharpType implements CSharpTypeMetadata {

--- a/packages/http-server-csharp/src/service.ts
+++ b/packages/http-server-csharp/src/service.ts
@@ -674,7 +674,7 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
         ]);
       }
       const responseInfo = this.#getOperationResponse(httpOperation);
-      const status: ResponseInfo["statusCode"] = responseInfo?.statusCode ?? 200;
+      const status = responseInfo?.statusCode ?? 200;
       const response: CSharpType =
         responseInfo?.resultType ??
         new CSharpType({


### PR DESCRIPTION
Issue: 
C# server emitter incorrectly emits the return statement for 204 no content operations. Instead of 204 with no body it emits `return Ok()` which ends up with a 200 response with no body which doesn't match the spec.

Fix:
Use the http status code instead of the C# status code when testing for 204

Repro:

```ts
it("Produces NoContent result", async () => {
  await compileAndValidateMultiple(
    runner,
    `
      @error
  model NotFoundErrorResponse {
     @statusCode statusCode: 404;
     code: "not-found";
  }
model ApiError {
  /** A machine readable error code */
  code: string;

  /** A human readable message */
  message: string;
}
    /**
 * Something is wrong with you.
 */
model Standard4XXResponse extends ApiError {
  @minValue(400)
  @maxValue(499)
  @statusCode
  statusCode: int32;
}

/**
 * Something is wrong with me.
 */
model Standard5XXResponse extends ApiError {
  @minValue(500)
  @maxValue(599)
  @statusCode
  statusCode: int32;
}

model FileAttachmentMultipartRequest {
  contents: HttpPart<File>;
}

    alias WithStandardErrors<T> = T | Standard4XXResponse | Standard5XXResponse;

    @post
    op createFileAttachment(
      @header contentType: "multipart/form-data",
      @path itemId: int32,
      @multipartBody body: FileAttachmentMultipartRequest,
    ): WithStandardErrors<NoContentResponse | NotFoundErrorResponse>;
    `,
    [["ContosoOperationsControllerBase.cs", ["return NoContent()"]]],
  );
```