### PR TITLE
Export and use utility functions from `lib/utils`

### DIFF
--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -100,7 +100,7 @@ import {
 } from "../core/types.js";
 import { useStateMap, useStateSet } from "../utils/index.js";
 import { setKey } from "./key.js";
-import { createStateSymbol } from "./utils.js";
+import { createStateSymbol, filterModelPropertiesInPlace } from "./utils.js";
 
 export { $encodedName, resolveEncodedName } from "./encoded-names.js";
 export { serializeValueAsJson } from "./examples.js";
@@ -810,17 +810,6 @@ function validateEncodeData(context: DecoratorContext, target: Type, encodeData:
 }
 
 export { getEncode };
-
-export function filterModelPropertiesInPlace(
-  model: Model,
-  filter: (prop: ModelProperty) => boolean,
-) {
-  for (const [key, prop] of model.properties) {
-    if (!filter(prop)) {
-      model.properties.delete(key);
-    }
-  }
-}
 
 // -- @withOptionalProperties decorator ---------------------
 

--- a/packages/compiler/src/utils/index.ts
+++ b/packages/compiler/src/utils/index.ts
@@ -3,5 +3,5 @@
 // Be explicit about what get exported so we don't export utils that are not meant to be public.
 // ---------------------------------------
 export { DuplicateTracker } from "./duplicate-tracker.js";
-export { Queue, TwoLevelMap, createRekeyableMap, deepClone, deepEquals } from "./misc.js";
+export { Queue, TwoLevelMap, createRekeyableMap, deepClone, deepEquals, mutate } from "./misc.js";
 export { useStateMap, useStateSet } from "./state-accessor.js";


### PR DESCRIPTION
Export `createStateSymbol` from `lib/utils`, and export all of utils in `@typespec/compiler` so they can be used by other packages.

Additionally, replace duplicate definitions of `utils` functions in `@typespec/compiler` with imports from `utils`.