### PR TITLE
Skip empty clients

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/ClientProvider.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         private Lazy<IReadOnlyList<FieldProvider>> _additionalClientFields;
 
         private Lazy<ParameterProvider?> ClientOptionsParameter { get; }
+        internal IReadOnlyList<ClientProvider> SubClients => _subClients.Value;
 
         // for mocking
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
@@ -98,8 +98,33 @@ namespace Microsoft.Generator.CSharp.ClientModel
                 }
             }
 
-            ClientCache[inputClient] = client;
-            return client;
+            var result = client is not null && IsValidClient(inputClient, client) ? client : null;
+            ClientCache[inputClient] = result;
+            return result;
+        }
+
+        private bool IsValidClient(InputClient inputClient, ClientProvider client)
+        {
+            // client is not valid if it has no operations, sub-client methods, or custom code methods
+            if (inputClient.Operations.Count > 0)
+            {
+                return true;
+            }
+
+            foreach (var subclient in client.SubClients)
+            {
+                if (subclient.Methods.Count > 0)
+                {
+                    return true;
+                }
+            }
+
+            if (client.CustomCodeView?.Methods.Count > 0)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         protected virtual ClientProvider? CreateClientCore(InputClient inputClient) => new ClientProvider(inputClient);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/ScmTypeFactory.cs
@@ -98,30 +98,26 @@ namespace Microsoft.Generator.CSharp.ClientModel
                 }
             }
 
-            var result = client is not null && IsValidClient(inputClient, client) ? client : null;
+            var result = client is not null && IsValidClient(client) ? client : null;
             ClientCache[inputClient] = result;
             return result;
         }
 
-        private bool IsValidClient(InputClient inputClient, ClientProvider client)
+        private bool IsValidClient(ClientProvider client)
         {
-            // client is not valid if it has no operations, sub-client methods, or custom code methods
-            if (inputClient.Operations.Count > 0)
+            // client is valid if it has methods or custom code has methods
+            if (client.Methods.Count > 0 || client.CustomCodeView?.Methods.Count > 0)
             {
                 return true;
             }
 
+            // client is valid if any of its subclients have methods or custom code has methods
             foreach (var subclient in client.SubClients)
             {
-                if (subclient.Methods.Count > 0)
+                if (subclient.Methods.Count > 0 || subclient.CustomCodeView?.Methods.Count > 0)
                 {
                     return true;
                 }
-            }
-
-            if (client.CustomCodeView?.Methods.Count > 0)
-            {
-                return true;
             }
 
             return false;

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
 {
     public class ClientProviderCustomizationTests
     {
+        private const string TestClientName = "TestClient";
+
         [Test]
         public async Task CanAddMethod()
         {
@@ -43,6 +45,33 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
             Assert.AreEqual(customMethods[0].Signature.Parameters.Count, 2);
             Assert.IsNull(customMethods[0].BodyExpression);
             Assert.AreEqual(string.Empty, customMethods[0].BodyStatements!.ToDisplayString());
+        }
+
+        [Test]
+        public async Task ShouldGenerateEmptyClientWithCustomMethods()
+        {
+            var client = InputFactory.Client(TestClientName);
+            var plugin = await MockHelpers.LoadMockPluginAsync(
+                clients: () => [client],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var clientProvider = plugin.Object.OutputLibrary.TypeProviders.SingleOrDefault(t => t is ClientProvider && t.Name == TestClientName);
+            Assert.IsNotNull(clientProvider);
+        }
+
+        [Test]
+        public async Task GenerateSubClientWithCustomMethods()
+        {
+            var inputOperation = InputFactory.Operation("HelloAgain", parameters:
+            [
+                InputFactory.Parameter("p1", InputFactory.Array(InputPrimitiveType.String))
+            ]);
+            var client = InputFactory.Client(TestClientName);
+            var subClient = InputFactory.Client($"Sub{TestClientName}", [inputOperation], [], client.Name);
+            var plugin = await MockHelpers.LoadMockPluginAsync(
+                clients: () => [client, subClient],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var clientProvider = plugin.Object.OutputLibrary.TypeProviders.SingleOrDefault(t => t is ClientProvider && t.Name == TestClientName);
+            Assert.IsNotNull(clientProvider);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
                 InputFactory.Parameter("p1", InputFactory.Array(InputPrimitiveType.String))
             ]);
             var inputClient = InputFactory.Client("TestClient", operations: [inputOperation]);
-            InputClient subClient = InputFactory.Client("custom", [], [], inputClient.Name);
+            InputClient subClient = InputFactory.Client("custom", [inputOperation], [], inputClient.Name);
             var plugin = await MockHelpers.LoadMockPluginAsync(
                 clients: () => [inputClient, subClient],
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
@@ -14,11 +14,15 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
     public class ClientProviderSubClientTests
     {
         private const string TestClientName = "TestClient";
-        private static readonly InputClient _animalClient = new("animal", string.Empty, "AnimalClient description", [], [], TestClientName);
-        private static readonly InputClient _dogClient = new("dog", string.Empty, "DogClient description", [], [], _animalClient.Name);
-        private static readonly InputClient _catClient = new("cat", string.Empty, "CatClient description", [], [], _animalClient.Name);
-        private static readonly InputClient _hawkClient = new("hawkClient", string.Empty, "HawkClient description", [], [], _animalClient.Name);
-        private static readonly InputClient _huskyClient = new("husky", string.Empty, "HuskyClient description", [], [], _dogClient.Name);
+        private static readonly InputOperation _inputOperation = InputFactory.Operation("HelloAgain", parameters:
+        [
+            InputFactory.Parameter("p1", InputFactory.Array(InputPrimitiveType.String))
+        ]);
+        private static readonly InputClient _animalClient = new("animal", string.Empty, "AnimalClient description", [_inputOperation], [], TestClientName);
+        private static readonly InputClient _dogClient = new("dog", string.Empty, "DogClient description", [_inputOperation], [], _animalClient.Name);
+        private static readonly InputClient _catClient = new("cat", string.Empty, "CatClient description", [_inputOperation], [], _animalClient.Name);
+        private static readonly InputClient _hawkClient = new("hawkClient", string.Empty, "HawkClient description", [_inputOperation], [], _animalClient.Name);
+        private static readonly InputClient _huskyClient = new("husky", string.Empty, "HuskyClient description", [_inputOperation], [], _dogClient.Name);
 
         [SetUp]
         public void SetUp()

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
         }
 
         [Test]
-        public void TestEmptyClient()
+        public void ShouldSkipEmptyClient()
         {
             var client = InputFactory.Client(TestClientName);
             var plugin = MockHelpers.LoadMockPlugin(clients: () => [client]);
@@ -80,7 +80,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
         }
 
         [Test]
-        public void TestNonEmptySubClient()
+        public void ShouldGenerateClientWithNonEmptySubClient()
         {
             var inputOperation = InputFactory.Operation("HelloAgain", parameters:
             [
@@ -98,7 +98,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
         }
 
         [Test]
-        public void TestEmptySubClient()
+        public void ShouldSkipClientWithEmptySubClient()
         {
             var client = InputFactory.Client(TestClientName);
             var subClient = InputFactory.Client($"Sub{TestClientName}", [], [], client.Name);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/GenerateSubClientWithCustomMethods/GenerateSubClientWithCustomMethods.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/GenerateSubClientWithCustomMethods/GenerateSubClientWithCustomMethods.cs
@@ -1,0 +1,22 @@
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sample
+{
+    /// <summary></summary>
+    public partial class SubTestClient
+    {
+        public virtual ClientResult NewMethod(BinaryContent content, RequestOptions options)
+        {
+            Argument.AssertNotNull(content, nameof(content));
+
+            using PipelineMessage message = CreateRequest(content, options);
+            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/ShouldGenerateEmptyClientWithCustomMethods/ShouldGenerateEmptyClientWithCustomMethods.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/ShouldGenerateEmptyClientWithCustomMethods/ShouldGenerateEmptyClientWithCustomMethods.cs
@@ -1,0 +1,22 @@
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sample
+{
+    /// <summary></summary>
+    public partial class TestClient
+    {
+        public virtual ClientResult NewMethod(BinaryContent content, RequestOptions options)
+        {
+            Argument.AssertNotNull(content, nameof(content));
+
+            using PipelineMessage message = CreateRequest(content, options);
+            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/RestClientProviders/RestClientProviderCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/RestClientProviders/RestClientProviderCustomizationTests.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Generator.CSharp.ClientModel.Providers;
+using Microsoft.Generator.CSharp.Input;
 using Microsoft.Generator.CSharp.Primitives;
 using Microsoft.Generator.CSharp.Tests.Common;
 using NUnit.Framework;
@@ -16,7 +17,11 @@ namespace Microsoft.Generator.CSharp.ClientModel.Tests.Providers.ClientProviders
         [Test]
         public async Task CanChangeClientNamespace()
         {
-            var inputClient = InputFactory.Client("TestClient");
+            var inputOperation = InputFactory.Operation("HelloAgain", parameters:
+            [
+                InputFactory.Parameter("p1", InputFactory.Array(InputPrimitiveType.String))
+            ]);
+            var inputClient = InputFactory.Client("TestClient", [inputOperation]);
             var plugin = await MockHelpers.LoadMockPluginAsync(
                 clients: () => [inputClient],
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/RestClientProviders/TestData/RestClientProviderCustomizationTests/CanChangeClientNamespace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/test/Providers/RestClientProviders/TestData/RestClientProviderCustomizationTests/CanChangeClientNamespace.cs
@@ -2,10 +2,31 @@
 
 #nullable disable
 
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using Sample;
+
 namespace Sample.Custom
 {
     /// <summary></summary>
     public partial class TestClient
     {
+        private static global::System.ClientModel.Primitives.PipelineMessageClassifier _pipelineMessageClassifier200;
+
+        private static global::System.ClientModel.Primitives.PipelineMessageClassifier PipelineMessageClassifier200 => _pipelineMessageClassifier200 = global::System.ClientModel.Primitives.PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
+
+        internal global::System.ClientModel.Primitives.PipelineMessage CreateHelloAgainRequest(global::System.ClientModel.BinaryContent content, global::System.ClientModel.Primitives.RequestOptions options)
+        {
+            global::System.ClientModel.Primitives.PipelineMessage message = Pipeline.CreateMessage();
+            message.ResponseClassifier = PipelineMessageClassifier200;
+            global::System.ClientModel.Primitives.PipelineRequest request = message.Request;
+            request.Method = "GET";
+            global::Sample.ClientUriBuilder uri = new global::Sample.ClientUriBuilder();
+            uri.Reset(_endpoint);
+            request.Uri = uri.ToUri();
+            request.Content = content;
+            message.Apply(options);
+            return message;
+        }
     }
 }


### PR DESCRIPTION
Based on the e2e experiment in https://github.com/microsoft/typespec/pull/5651, the user can implement an empty client in TypeSpec and MGC still generates it.
So, this is not a specific case for Azure plugin only, and then we should skip the empty client generation in MGC as a general behavior.

The criteria of an empty client:
- There is no methods within clientProvider and its custom code
- There is no methods in the corresponding sub-clients and its custom code

Resolves https://github.com/microsoft/typespec/issues/5624