### PR TITLE
Add "constant" to DurationKnownEncoding

### DIFF
--- a/packages/compiler/lib/std/decorators.tsp
+++ b/packages/compiler/lib/std/decorators.tsp
@@ -451,6 +451,11 @@ enum DurationKnownEncoding {
    * Encode to integer or float
    */
   seconds: "seconds",
+
+  /**
+   * Encode for duration-constant
+   */
+  constant: "constant",
 }
 
 /**


### PR DESCRIPTION
It starts from https://github.com/Azure/typespec-azure/issues/1901. To represent "x-ms-format": "duration-constant", we are expecting something like

```
model Test {
  @encode(DurationKnownEncoding.constant)
  input: duration;
}
```

What's more, we might need to change in  TypeSpec-Azure to emit `"x-ms-format": "duration-constant"` in the swagger.