### PR TITLE
Promote `state-accessor` functions from experimental to supported

### DIFF
--- a/.chronus/changes/promote-state-accessor-2025-0-23-9-50-42.md
+++ b/.chronus/changes/promote-state-accessor-2025-0-23-9-50-42.md
@@ -1,0 +1,12 @@
+---
+changeKind: deprecation
+packages:
+  - "@typespec/compiler"
+  - "@typespec/events"
+  - "@typespec/json-schema"
+  - "@typespec/openapi"
+  - "@typespec/sse"
+  - "@typespec/streams"
+---
+
+Deprecate `unsafe_useStateMap` and `unsafe_useStateSet`, export `useStateMap` and `useStateSet`

--- a/packages/compiler/src/core/visibility/core.ts
+++ b/packages/compiler/src/core/visibility/core.ts
@@ -29,7 +29,7 @@ import {
 } from "./lifecycle.js";
 
 import type { VisibilityFilter as GeneratedVisibilityFilter } from "../../../generated-defs/TypeSpec.js";
-import { useStateMap, useStateSet } from "../../lib/utils.js";
+import { useStateMap, useStateSet } from "../../utils/index.js";
 
 export { GeneratedVisibilityFilter };
 
@@ -38,13 +38,17 @@ export { GeneratedVisibilityFilter };
  */
 type VisibilityModifiers = Map<Enum, Set<EnumMember>>;
 
+function createStateSymbol(name: string) {
+  return Symbol.for(`TypeSpec.${name}`);
+}
+
 /**
  * The global visibility store.
  *
  * This store is used to track the visibility modifiers
  */
 const [getVisibilityStore, setVisibilityStore] = useStateMap<ModelProperty, VisibilityModifiers>(
-  "visibilityStore",
+  createStateSymbol("visibilityStore"),
 );
 
 /**
@@ -99,13 +103,13 @@ function getOrInitializeActiveModifierSetForClass(
 const VISIBILITY_PROGRAM_SEALS = new WeakSet<Program>();
 
 const [isVisibilitySealedForProperty, sealVisibilityForProperty] = useStateSet<ModelProperty>(
-  "propertyVisibilitySealed",
+  createStateSymbol("propertyVisibilitySealed"),
 );
 
 const [getSealedVisibilityClasses, setSealedVisibilityClasses] = useStateMap<
   ModelProperty,
   Set<Enum>
->("sealedVisibilityClasses");
+>(createStateSymbol("sealedVisibilityClasses"));
 
 /**
  * Seals visibility modifiers for a property in a given visibility class.
@@ -133,7 +137,7 @@ function sealVisibilityModifiersForClass(
  * Stores the default modifier set for a given visibility class.
  */
 const [getDefaultModifiers, setDefaultModifiers] = useStateMap<Enum, Set<EnumMember>>(
-  "defaultVisibilityModifiers",
+  createStateSymbol("defaultVisibilityModifiers"),
 );
 
 /**
@@ -205,7 +209,7 @@ function groupModifiersByVisibilityClass(modifiers: EnumMember[]): Map<Enum, Set
 // #region Legacy Visibility API
 
 const [getLegacyVisibility, setLegacyVisibilityModifiers, getLegacyVisibilityStateMap] =
-  useStateMap<ModelProperty, string[]>("legacyVisibility");
+  useStateMap<ModelProperty, string[]>(createStateSymbol("legacyVisibility"));
 
 export { getLegacyVisibility };
 

--- a/packages/compiler/src/experimental/index.ts
+++ b/packages/compiler/src/experimental/index.ts
@@ -1,5 +1,7 @@
 export {
   MutableType as unsafe_MutableType,
+  mutateSubgraph as unsafe_mutateSubgraph,
+  mutateSubgraphWithNamespace as unsafe_mutateSubgraphWithNamespace,
   Mutator as unsafe_Mutator,
   MutatorFilterFn as unsafe_MutatorFilterFn,
   MutatorFlow as unsafe_MutatorFlow,
@@ -7,8 +9,13 @@ export {
   MutatorRecord as unsafe_MutatorRecord,
   MutatorReplaceFn as unsafe_MutatorReplaceFn,
   MutatorWithNamespace as unsafe_MutatorWithNamespace,
-  mutateSubgraph as unsafe_mutateSubgraph,
-  mutateSubgraphWithNamespace as unsafe_mutateSubgraphWithNamespace,
 } from "./mutators.js";
 export { Realm as unsafe_Realm } from "./realm.js";
 export { $ as unsafe_$ } from "./typekit/index.js";
+
+import { useStateMap, useStateSet } from "../utils/state-accessor.js";
+
+/** @deprecated use `useStateMap` from `@typespec/compiler/utils` instead */
+export const unsafe_useStateMap = useStateMap;
+/** @deprecated use `useStateSet` from `@typespec/compiler/utils` instead */
+export const unsafe_useStateSet = useStateSet;

--- a/packages/compiler/src/experimental/index.ts
+++ b/packages/compiler/src/experimental/index.ts
@@ -11,5 +11,4 @@ export {
   mutateSubgraphWithNamespace as unsafe_mutateSubgraphWithNamespace,
 } from "./mutators.js";
 export { Realm as unsafe_Realm } from "./realm.js";
-export { unsafe_useStateMap, unsafe_useStateSet } from "./state-accessor.js";
 export { $ as unsafe_$ } from "./typekit/index.js";

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -99,7 +99,7 @@ import {
   Value,
 } from "../core/types.js";
 import { setKey } from "./key.js";
-import { useStateMap, useStateSet } from "./utils.js";
+import { useStateMap, useStateSet } from "../utils/index.js";
 
 export { $encodedName, resolveEncodedName } from "./encoded-names.js";
 export { serializeValueAsJson } from "./examples.js";
@@ -121,11 +121,11 @@ function replaceTemplatedStringFromProperties(formatString: string, sourceObject
   });
 }
 
-export function createStateSymbol(name: string) {
+function createStateSymbol(name: string) {
   return Symbol.for(`TypeSpec.${name}`);
 }
 
-const [getSummary, setSummary] = useStateMap<Type, string>("summary");
+const [getSummary, setSummary] = useStateMap<Type, string>(createStateSymbol("summary"));
 /**
  * @summary attaches a documentation string. It is typically used to give a short, single-line
  * description, and can be used in combination with or instead of @doc.
@@ -326,7 +326,7 @@ function validateTargetingAString(
 
 // -- @error decorator ----------------------
 
-const [getErrorState, setErrorState] = useStateSet<Model>("error");
+const [getErrorState, setErrorState] = useStateSet<Model>(createStateSymbol("error"));
 /**
  * `@error` decorator marks a model as an error type.
  *  Any derived models (using extends) will also be seen as error types.
@@ -355,7 +355,7 @@ export function isErrorModel(program: Program, target: Type): boolean {
 
 // -- @format decorator ---------------------
 
-const [getFormat, setFormat] = useStateMap<Type, string>("format");
+const [getFormat, setFormat] = useStateMap<Type, string>(createStateSymbol("format"));
 
 /**
  * `@format` - specify the data format hint for a string type
@@ -395,7 +395,7 @@ export const $format: FormatDecorator = (
 export { getFormat };
 
 // -- @pattern decorator ---------------------
-const [getPatternData, setPatternData] = useStateMap<Type, PatternData>("patternValues");
+const [getPatternData, setPatternData] = useStateMap<Type, PatternData>(createStateSymbol("patternValues"));
 
 export interface PatternData {
   readonly pattern: string;
@@ -656,7 +656,7 @@ export const $maxValueExclusive: MaxValueExclusiveDecorator = (
 };
 // -- @secret decorator ---------------------
 
-const [isSecret, markSecret] = useStateSet("secretTypes");
+const [isSecret, markSecret] = useStateSet(createStateSymbol("secretTypes"));
 
 /**
  * Mark a string as a secret value that should be treated carefully to avoid exposure
@@ -690,7 +690,7 @@ export interface EncodeData {
   type: Scalar;
 }
 
-const [getEncode, setEncodeData] = useStateMap<Scalar | ModelProperty, EncodeData>("encode");
+const [getEncode, setEncodeData] = useStateMap<Scalar | ModelProperty, EncodeData>(createStateSymbol("encode"));
 export const $encode: EncodeDecorator = (
   context: DecoratorContext,
   target: Scalar | ModelProperty,
@@ -893,7 +893,7 @@ export const $withoutDefaultValues: WithoutDefaultValuesDecorator = (
 
 // -- @tag decorator ---------------------
 
-const [getTagsState, setTags] = useStateMap<Type, string[]>("tagProperties");
+const [getTagsState, setTags] = useStateMap<Type, string[]>(createStateSymbol("tagProperties"));
 
 // Set a tag on an operation, interface, or namespace.  There can be multiple tags on an
 // operation, interface, or namespace.
@@ -943,7 +943,7 @@ export function getAllTags(
 
 // -- @friendlyName decorator ---------------------
 
-const [getFriendlyName, setFriendlyName] = useStateMap<Type, string>("friendlyNames");
+const [getFriendlyName, setFriendlyName] = useStateMap<Type, string>(createStateSymbol("friendlyNames"));
 export const $friendlyName: FriendlyNameDecorator = (
   context: DecoratorContext,
   target: Type,
@@ -981,7 +981,7 @@ export const $friendlyName: FriendlyNameDecorator = (
 
 export { getFriendlyName };
 
-const [getKnownValues, setKnownValues] = useStateMap<Type, Enum>("knownValues");
+const [getKnownValues, setKnownValues] = useStateMap<Type, Enum>(createStateSymbol("knownValues"));
 
 /**
  * `@knownValues` marks a string type with an enum that contains all known values
@@ -1100,9 +1100,9 @@ export function getDeprecated(program: Program, type: Type): string | undefined 
   return getDeprecationDetails(program, type)?.message;
 }
 
-const [getOverloads, setOverloads] = useStateMap<Operation, Operation[]>("overloadedByKey");
+const [getOverloads, setOverloads] = useStateMap<Operation, Operation[]>(createStateSymbol("overloadedByKey"));
 const [getOverloadedOperation, setOverloadBase] = useStateMap<Operation, Operation>(
-  "overloadsOperation",
+  createStateSymbol("overloadsOperation"),
 );
 
 /**
@@ -1293,7 +1293,7 @@ export interface OpExample extends ExampleOptions {
 const [getExamplesState, setExamples] = useStateMap<
   Model | Scalar | Enum | Union | ModelProperty | UnionVariant,
   Example[]
->("examples");
+>(createStateSymbol("examples"));
 export const $example: ExampleDecorator = (
   context: DecoratorContext,
   target: Model | Scalar | Enum | Union | ModelProperty | UnionVariant,
@@ -1334,7 +1334,7 @@ export function getExamples(
   return getExamplesState(program, target) ?? [];
 }
 
-const [getOpExamplesState, setOpExamples] = useStateMap<Operation, OpExample[]>("opExamples");
+const [getOpExamplesState, setOpExamples] = useStateMap<Operation, OpExample[]>(createStateSymbol("opExamples"));
 export const $opExample: OpExampleDecorator = (
   context: DecoratorContext,
   target: Operation,

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -98,8 +98,8 @@ import {
   UnionVariant,
   Value,
 } from "../core/types.js";
-import { setKey } from "./key.js";
 import { useStateMap, useStateSet } from "../utils/index.js";
+import { setKey } from "./key.js";
 
 export { $encodedName, resolveEncodedName } from "./encoded-names.js";
 export { serializeValueAsJson } from "./examples.js";
@@ -395,7 +395,9 @@ export const $format: FormatDecorator = (
 export { getFormat };
 
 // -- @pattern decorator ---------------------
-const [getPatternData, setPatternData] = useStateMap<Type, PatternData>(createStateSymbol("patternValues"));
+const [getPatternData, setPatternData] = useStateMap<Type, PatternData>(
+  createStateSymbol("patternValues"),
+);
 
 export interface PatternData {
   readonly pattern: string;
@@ -690,7 +692,9 @@ export interface EncodeData {
   type: Scalar;
 }
 
-const [getEncode, setEncodeData] = useStateMap<Scalar | ModelProperty, EncodeData>(createStateSymbol("encode"));
+const [getEncode, setEncodeData] = useStateMap<Scalar | ModelProperty, EncodeData>(
+  createStateSymbol("encode"),
+);
 export const $encode: EncodeDecorator = (
   context: DecoratorContext,
   target: Scalar | ModelProperty,
@@ -943,7 +947,9 @@ export function getAllTags(
 
 // -- @friendlyName decorator ---------------------
 
-const [getFriendlyName, setFriendlyName] = useStateMap<Type, string>(createStateSymbol("friendlyNames"));
+const [getFriendlyName, setFriendlyName] = useStateMap<Type, string>(
+  createStateSymbol("friendlyNames"),
+);
 export const $friendlyName: FriendlyNameDecorator = (
   context: DecoratorContext,
   target: Type,
@@ -1100,7 +1106,9 @@ export function getDeprecated(program: Program, type: Type): string | undefined 
   return getDeprecationDetails(program, type)?.message;
 }
 
-const [getOverloads, setOverloads] = useStateMap<Operation, Operation[]>(createStateSymbol("overloadedByKey"));
+const [getOverloads, setOverloads] = useStateMap<Operation, Operation[]>(
+  createStateSymbol("overloadedByKey"),
+);
 const [getOverloadedOperation, setOverloadBase] = useStateMap<Operation, Operation>(
   createStateSymbol("overloadsOperation"),
 );
@@ -1334,7 +1342,9 @@ export function getExamples(
   return getExamplesState(program, target) ?? [];
 }
 
-const [getOpExamplesState, setOpExamples] = useStateMap<Operation, OpExample[]>(createStateSymbol("opExamples"));
+const [getOpExamplesState, setOpExamples] = useStateMap<Operation, OpExample[]>(
+  createStateSymbol("opExamples"),
+);
 export const $opExample: OpExampleDecorator = (
   context: DecoratorContext,
   target: Operation,

--- a/packages/compiler/src/lib/encoded-names.ts
+++ b/packages/compiler/src/lib/encoded-names.ts
@@ -2,13 +2,16 @@ import { reportDiagnostic } from "../core/messages.js";
 import { parseMimeType } from "../core/mime-type.js";
 import type { Program } from "../core/program.js";
 import type { DecoratorContext, Enum, Model, Type, Union } from "../core/types.js";
-import { DuplicateTracker } from "../utils/index.js";
-import { useStateMap } from "./utils.js";
+import { DuplicateTracker, useStateMap } from "../utils/index.js";
+
+function createStateSymbol(name: string) {
+  return Symbol.for(`TypeSpec.${name}`);
+}
 
 const [getEncodedNamesMap, setEncodedNamesMap, getEncodedNamesStateMap] = useStateMap<
   Type,
   Map<string, string>
->("encodedName");
+>(createStateSymbol("encodedName"));
 
 export function $encodedName(
   context: DecoratorContext,

--- a/packages/compiler/src/lib/key.ts
+++ b/packages/compiler/src/lib/key.ts
@@ -1,8 +1,12 @@
 import { Program } from "../core/index.js";
 import { ModelProperty, Type } from "../core/types.js";
-import { useStateMap } from "./utils.js";
+import { useStateMap } from "../utils/index.js";
 
-const [getKey, setKey] = useStateMap<Type, string>("key");
+function createStateSymbol(name: string) {
+  return Symbol.for(`TypeSpec.${name}`);
+}
+
+const [getKey, setKey] = useStateMap<Type, string>(createStateSymbol("key"));
 
 export function isKey(program: Program, property: ModelProperty) {
   return getKey(program, property) !== undefined;

--- a/packages/compiler/src/lib/paging.ts
+++ b/packages/compiler/src/lib/paging.ts
@@ -26,9 +26,8 @@ import type {
   Operation,
   Type,
 } from "../core/types.js";
-import { DuplicateTracker } from "../utils/duplicate-tracker.js";
+import { DuplicateTracker, useStateSet } from "../utils/index.js";
 import { isNumericType, isStringType } from "./decorators.js";
-import { useStateSet } from "./utils.js";
 
 export const [
   /**
@@ -342,11 +341,15 @@ function validatePagingOperation(program: Program, op: Operation) {
   program.reportDiagnostics(diagnostics);
 }
 
+function createStateSymbol(name: string) {
+  return Symbol.for(`TypeSpec.${name}`);
+}
+
 function createMarkerDecorator<T extends DecoratorFunction>(
   key: string,
   validate?: (...args: Parameters<T>) => boolean,
 ) {
-  const [isLink, markLink] = useStateSet<Parameters<T>[1]>(key);
+  const [isLink, markLink] = useStateSet<Parameters<T>[1]>(createStateSymbol(key));
   const decorator = (...args: Parameters<T>) => {
     if (validate && !validate(...args)) {
       return;

--- a/packages/compiler/src/lib/service.ts
+++ b/packages/compiler/src/lib/service.ts
@@ -4,7 +4,7 @@ import { Type, getTypeName, reportDeprecated } from "../core/index.js";
 import { reportDiagnostic } from "../core/messages.js";
 import type { Program } from "../core/program.js";
 import { DecoratorContext, Namespace } from "../core/types.js";
-import { useStateMap } from "./utils.js";
+import { useStateMap } from "../utils/index.js";
 
 export interface ServiceDetails {
   title?: string;

--- a/packages/compiler/src/lib/utils.ts
+++ b/packages/compiler/src/lib/utils.ts
@@ -1,17 +1,4 @@
-import type { Model, ModelProperty, Type } from "../core/types.js";
-import { unsafe_useStateMap, unsafe_useStateSet } from "../experimental/state-accessor.js";
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
-}
-
-export function useStateMap<K extends Type, V>(key: string | symbol) {
-  return unsafe_useStateMap<K, V>(typeof key === "string" ? createStateSymbol(key) : key);
-}
-
-export function useStateSet<K extends Type>(key: string | symbol) {
-  return unsafe_useStateSet<K>(typeof key === "string" ? createStateSymbol(key) : key);
-}
+import type { Model, ModelProperty } from "../core/types.js";
 
 /**
  * Filters the properties of a model by removing them from the model instance if

--- a/packages/compiler/src/lib/visibility.ts
+++ b/packages/compiler/src/lib/visibility.ts
@@ -51,9 +51,14 @@ import {
 } from "../core/visibility/lifecycle.js";
 import { isMutableType, mutateSubgraph, Mutator, MutatorFlow } from "../experimental/mutators.js";
 import { isKey } from "./key.js";
-import { filterModelPropertiesInPlace, useStateMap } from "./utils.js";
+import { filterModelPropertiesInPlace } from "./utils.js";
+import { useStateMap } from "../utils/index.js";
 
 // #region Legacy Visibility Utilities
+
+function createStateSymbol(name: string) {
+  return Symbol.for(`TypeSpec.${name}`);
+}
 
 /**
  * Takes a list of visibilities that possibly include both legacy visibility
@@ -136,7 +141,7 @@ interface OperationVisibilityConfig {
 const [getOperationVisibilityConfigRaw, setOperationVisibilityConfigRaw] = useStateMap<
   Operation,
   OperationVisibilityConfig
->("operationVisibilityConfig");
+>(createStateSymbol("operationVisibilityConfig"));
 
 function getOperationVisibilityConfig(
   program: Program,

--- a/packages/compiler/src/lib/visibility.ts
+++ b/packages/compiler/src/lib/visibility.ts
@@ -50,9 +50,9 @@ import {
   normalizeVisibilityToLegacyLifecycleString,
 } from "../core/visibility/lifecycle.js";
 import { isMutableType, mutateSubgraph, Mutator, MutatorFlow } from "../experimental/mutators.js";
+import { useStateMap } from "../utils/index.js";
 import { isKey } from "./key.js";
 import { filterModelPropertiesInPlace } from "./utils.js";
-import { useStateMap } from "../utils/index.js";
 
 // #region Legacy Visibility Utilities
 

--- a/packages/compiler/src/utils/index.ts
+++ b/packages/compiler/src/utils/index.ts
@@ -3,5 +3,5 @@
 // Be explicit about what get exported so we don't export utils that are not meant to be public.
 // ---------------------------------------
 export { DuplicateTracker } from "./duplicate-tracker.js";
-export { useStateMap, useStateSet } from "./state-accessor.js";
 export { Queue, TwoLevelMap, createRekeyableMap, deepClone, deepEquals } from "./misc.js";
+export { useStateMap, useStateSet } from "./state-accessor.js";

--- a/packages/compiler/src/utils/index.ts
+++ b/packages/compiler/src/utils/index.ts
@@ -3,4 +3,5 @@
 // Be explicit about what get exported so we don't export utils that are not meant to be public.
 // ---------------------------------------
 export { DuplicateTracker } from "./duplicate-tracker.js";
+export { useStateMap, useStateSet } from "./state-accessor.js";
 export { Queue, TwoLevelMap, createRekeyableMap, deepClone, deepEquals } from "./misc.js";

--- a/packages/compiler/src/utils/state-accessor.ts
+++ b/packages/compiler/src/utils/state-accessor.ts
@@ -18,9 +18,7 @@ export function useStateMap<K extends Type, V>(
 type StateSetGetter<K extends Type> = (program: Program, type: K) => boolean;
 type StateSetSetter<K extends Type> = (program: Program, type: K) => void;
 
-export function useStateSet<K extends Type>(
-  key: symbol,
-): [StateSetGetter<K>, StateSetSetter<K>] {
+export function useStateSet<K extends Type>(key: symbol): [StateSetGetter<K>, StateSetSetter<K>] {
   const getter = (program: Program, target: K) => program.stateSet(key).has(target);
   const setter = (program: Program, target: K) => program.stateSet(key).add(target);
 

--- a/packages/compiler/src/utils/state-accessor.ts
+++ b/packages/compiler/src/utils/state-accessor.ts
@@ -5,8 +5,7 @@ type StateMapGetter<K extends Type, V> = (program: Program, type: K) => V | unde
 type StateMapSetter<K extends Type, V> = (program: Program, type: K, value: V) => void;
 type StateMapMapGetter<K extends Type, V> = (program: Program) => Map<K, V>;
 
-/** @experimental */
-export function unsafe_useStateMap<K extends Type, V>(
+export function useStateMap<K extends Type, V>(
   key: symbol,
 ): [StateMapGetter<K, V>, StateMapSetter<K, V>, StateMapMapGetter<K, V>] {
   const getter = (program: Program, target: K) => program.stateMap(key).get(target);
@@ -19,8 +18,7 @@ export function unsafe_useStateMap<K extends Type, V>(
 type StateSetGetter<K extends Type> = (program: Program, type: K) => boolean;
 type StateSetSetter<K extends Type> = (program: Program, type: K) => void;
 
-/** @experimental */
-export function unsafe_useStateSet<K extends Type>(
+export function useStateSet<K extends Type>(
   key: symbol,
 ): [StateSetGetter<K>, StateSetSetter<K>] {
   const getter = (program: Program, target: K) => program.stateSet(key).has(target);

--- a/packages/events/src/decorators.ts
+++ b/packages/events/src/decorators.ts
@@ -1,11 +1,11 @@
 import { type ModelProperty, type Union, type UnionVariant } from "@typespec/compiler";
+import { useStateMap, useStateSet } from "@typespec/compiler/utils";
 import type {
   ContentTypeDecorator,
   DataDecorator,
   EventsDecorator,
 } from "../generated-defs/TypeSpec.Events.js";
 import { EventsStateKeys } from "./lib.js";
-import { useStateMap, useStateSet } from "@typespec/compiler/utils";
 
 const [isEvents, setEvents] = useStateSet<Union>(EventsStateKeys.events);
 

--- a/packages/events/src/decorators.ts
+++ b/packages/events/src/decorators.ts
@@ -1,13 +1,13 @@
 import { type ModelProperty, type Union, type UnionVariant } from "@typespec/compiler";
-import { unsafe_useStateMap, unsafe_useStateSet } from "@typespec/compiler/experimental";
 import type {
   ContentTypeDecorator,
   DataDecorator,
   EventsDecorator,
 } from "../generated-defs/TypeSpec.Events.js";
 import { EventsStateKeys } from "./lib.js";
+import { useStateMap, useStateSet } from "@typespec/compiler/utils";
 
-const [isEvents, setEvents] = unsafe_useStateSet<Union>(EventsStateKeys.events);
+const [isEvents, setEvents] = useStateSet<Union>(EventsStateKeys.events);
 
 export const $eventsDecorator: EventsDecorator = (context, target) => {
   setEvents(context.program, target);
@@ -15,7 +15,7 @@ export const $eventsDecorator: EventsDecorator = (context, target) => {
 
 export { isEvents };
 
-const [getContentType, setContentType] = unsafe_useStateMap<ModelProperty | UnionVariant, string>(
+const [getContentType, setContentType] = useStateMap<ModelProperty | UnionVariant, string>(
   EventsStateKeys.contentType,
 );
 
@@ -25,7 +25,7 @@ export const $contentTypeDecorator: ContentTypeDecorator = (context, target, con
 
 export { getContentType };
 
-const [isEventData, setEventData] = unsafe_useStateSet<ModelProperty>(EventsStateKeys.data);
+const [isEventData, setEventData] = useStateSet<ModelProperty>(EventsStateKeys.data);
 
 export const $dataDecorator: DataDecorator = (context, target) => {
   setEventData(context.program, target);

--- a/packages/json-schema/src/decorators.ts
+++ b/packages/json-schema/src/decorators.ts
@@ -12,6 +12,7 @@ import {
   typespecTypeToJson,
   type Union,
 } from "@typespec/compiler";
+import { useStateMap, useStateSet } from "@typespec/compiler/utils";
 import type { ValidatesRawJsonDecorator } from "../generated-defs/TypeSpec.JsonSchema.Private.js";
 import type {
   ContainsDecorator,
@@ -32,7 +33,6 @@ import type {
 } from "../generated-defs/TypeSpec.JsonSchema.js";
 import { JsonSchemaStateKeys } from "./lib.js";
 import { createDataDecorator } from "./utils.js";
-import { useStateMap, useStateSet } from "@typespec/compiler/utils";
 
 /**
  * TypeSpec Types that can create a json schmea declaration
@@ -247,10 +247,9 @@ export interface ExtensionRecord {
   value: Type | unknown;
 }
 
-const [getExtensionsInternal, _, getExtensionsStateMap] = useStateMap<
-  Type,
-  ExtensionRecord[]
->(JsonSchemaStateKeys["JsonSchema.extension"]);
+const [getExtensionsInternal, _, getExtensionsStateMap] = useStateMap<Type, ExtensionRecord[]>(
+  JsonSchemaStateKeys["JsonSchema.extension"],
+);
 /** {@inheritdoc ExtensionDecorator} */
 export const $extension: ExtensionDecorator = (
   context: DecoratorContext,

--- a/packages/json-schema/src/decorators.ts
+++ b/packages/json-schema/src/decorators.ts
@@ -12,7 +12,6 @@ import {
   typespecTypeToJson,
   type Union,
 } from "@typespec/compiler";
-import { unsafe_useStateMap, unsafe_useStateSet } from "@typespec/compiler/experimental";
 import type { ValidatesRawJsonDecorator } from "../generated-defs/TypeSpec.JsonSchema.Private.js";
 import type {
   ContainsDecorator,
@@ -33,6 +32,7 @@ import type {
 } from "../generated-defs/TypeSpec.JsonSchema.js";
 import { JsonSchemaStateKeys } from "./lib.js";
 import { createDataDecorator } from "./utils.js";
+import { useStateMap, useStateSet } from "@typespec/compiler/utils";
 
 /**
  * TypeSpec Types that can create a json schmea declaration
@@ -43,7 +43,7 @@ export const [
   /** Check if the given type is annotated with `@jsonSchema`  */
   getJsonSchema,
   markJsonSchema,
-] = unsafe_useStateSet(JsonSchemaStateKeys.JsonSchema);
+] = useStateSet(JsonSchemaStateKeys.JsonSchema);
 /** {@inheritdoc JsonSchemaDecorator} */
 export const $jsonSchema: JsonSchemaDecorator = (
   context: DecoratorContext,
@@ -135,7 +135,7 @@ export const [
   /** Check if given type is annotated with `@oneOf` decorator */
   isOneOf,
   markOneOf,
-] = unsafe_useStateSet(JsonSchemaStateKeys["JsonSchema.oneOf"]);
+] = useStateSet(JsonSchemaStateKeys["JsonSchema.oneOf"]);
 
 /** {@inheritdoc OneOfDecorator} */
 export const $oneOf: OneOfDecorator = (context: DecoratorContext, target: Type) => {
@@ -170,7 +170,7 @@ export const [
   /** Check if the given array is annotated with `@uniqueItems` decorator */
   getUniqueItems,
   setUniqueItems,
-] = unsafe_useStateMap(JsonSchemaStateKeys["JsonSchema.uniqueItems"]);
+] = useStateMap(JsonSchemaStateKeys["JsonSchema.uniqueItems"]);
 /** {@inheritdoc UniqueItemsDecorator} */
 export const $uniqueItems: UniqueItemsDecorator = (context: DecoratorContext, target: Type) =>
   setUniqueItems(context.program, target, true);
@@ -226,7 +226,7 @@ export const [
   /** Get prefix items set with `@prefixItems` decorator */
   getPrefixItems,
   setPrefixItems,
-] = unsafe_useStateMap<Type, Tuple>(JsonSchemaStateKeys["JsonSchema.prefixItems"]);
+] = useStateMap<Type, Tuple>(JsonSchemaStateKeys["JsonSchema.prefixItems"]);
 
 /** {@inheritdoc PrefixItemsDecorator} */
 export const $prefixItems: PrefixItemsDecorator = (
@@ -247,7 +247,7 @@ export interface ExtensionRecord {
   value: Type | unknown;
 }
 
-const [getExtensionsInternal, _, getExtensionsStateMap] = unsafe_useStateMap<
+const [getExtensionsInternal, _, getExtensionsStateMap] = useStateMap<
   Type,
   ExtensionRecord[]
 >(JsonSchemaStateKeys["JsonSchema.extension"]);

--- a/packages/json-schema/src/utils.ts
+++ b/packages/json-schema/src/utils.ts
@@ -1,11 +1,11 @@
 import type { DecoratorFunction, Type } from "@typespec/compiler";
-import { unsafe_useStateMap } from "@typespec/compiler/experimental";
+import { useStateMap } from "@typespec/compiler/utils";
 
 export function createDataDecorator<
   T extends DecoratorFunction,
   Target extends Type = Parameters<T>[1],
 >(key: symbol, validate?: (...args: Parameters<T>) => boolean) {
-  const [getData, setData] = unsafe_useStateMap<Target, Parameters<T>[2]>(key);
+  const [getData, setData] = useStateMap<Target, Parameters<T>[2]>(key);
   const decorator = (...args: Parameters<T>) => {
     if (validate && !validate(...args)) {
       return;

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -12,7 +12,7 @@ import {
   typespecTypeToJson,
   TypeSpecValue,
 } from "@typespec/compiler";
-import { unsafe_useStateMap } from "@typespec/compiler/experimental";
+import { useStateMap } from "@typespec/compiler/utils";
 import { setStatusCode } from "@typespec/http";
 import {
   DefaultResponseDecorator,
@@ -243,7 +243,7 @@ function omitUndefined<T extends Record<string, unknown>>(data: T): T {
 }
 
 /** Get TagsMetadata set with `@tagMetadata` decorator */
-const [getTagsMetadata, setTagsMetadata] = unsafe_useStateMap<
+const [getTagsMetadata, setTagsMetadata] = useStateMap<
   Type,
   { [name: string]: TagMetadata }
 >(OpenAPIKeys.tagsMetadata);

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -243,10 +243,9 @@ function omitUndefined<T extends Record<string, unknown>>(data: T): T {
 }
 
 /** Get TagsMetadata set with `@tagMetadata` decorator */
-const [getTagsMetadata, setTagsMetadata] = useStateMap<
-  Type,
-  { [name: string]: TagMetadata }
->(OpenAPIKeys.tagsMetadata);
+const [getTagsMetadata, setTagsMetadata] = useStateMap<Type, { [name: string]: TagMetadata }>(
+  OpenAPIKeys.tagsMetadata,
+);
 
 /**
  * Decorator to add metadata to a tag associated with a namespace.

--- a/packages/sse/src/decorators.ts
+++ b/packages/sse/src/decorators.ts
@@ -1,9 +1,9 @@
 import type { UnionVariant } from "@typespec/compiler";
-import { unsafe_useStateSet } from "@typespec/compiler/experimental";
+import { useStateSet } from "@typespec/compiler/utils";
 import type { TerminalEventDecorator } from "../generated-defs/TypeSpec.SSE.js";
 import { SSEStateKeys } from "./lib.js";
 
-const [isTerminalEvent, setTerminalEvent] = unsafe_useStateSet<UnionVariant>(
+const [isTerminalEvent, setTerminalEvent] = useStateSet<UnionVariant>(
   SSEStateKeys.terminalEvent,
 );
 

--- a/packages/sse/src/decorators.ts
+++ b/packages/sse/src/decorators.ts
@@ -3,9 +3,7 @@ import { useStateSet } from "@typespec/compiler/utils";
 import type { TerminalEventDecorator } from "../generated-defs/TypeSpec.SSE.js";
 import { SSEStateKeys } from "./lib.js";
 
-const [isTerminalEvent, setTerminalEvent] = useStateSet<UnionVariant>(
-  SSEStateKeys.terminalEvent,
-);
+const [isTerminalEvent, setTerminalEvent] = useStateSet<UnionVariant>(SSEStateKeys.terminalEvent);
 
 export const $terminalEventDecorator: TerminalEventDecorator = (context, target) => {
   setTerminalEvent(context.program, target);

--- a/packages/streams/src/decorators.ts
+++ b/packages/streams/src/decorators.ts
@@ -1,9 +1,9 @@
 import type { Model, Program, Type } from "@typespec/compiler";
-import { unsafe_useStateMap } from "@typespec/compiler/experimental";
+import { useStateMap } from "@typespec/compiler/utils";
 import type { StreamOfDecorator } from "../generated-defs/TypeSpec.Streams.js";
 import { StreamStateKeys } from "./lib.js";
 
-const [getStreamOf, setStreamOf] = unsafe_useStateMap<Model, Type>(StreamStateKeys.streamOf);
+const [getStreamOf, setStreamOf] = useStateMap<Model, Type>(StreamStateKeys.streamOf);
 
 export const $streamOfDecorator: StreamOfDecorator = (context, target, type) => {
   setStreamOf(context.program, target, type);


### PR DESCRIPTION
These reusable state accessors were added in 3eed29834600d02c6a1ab3dd039188edf0fb2951 under the `experimental` namespace. They are now considered ready to be promoted out to the `@typespec/compiler` package exports (and to have their `unsafe_` prefixes removed).

In this commit, we move `state-accessor` into `utils` and add it to the module index so that its functions can be imported from `@typespec/compiler/utils`.

For usages inside `@typespec/compiler`, we are replacing the wrapper functions in `lib/utils` with direct imports of the newly-exposed accessor functions. Because the wrapper functions previously created a symbol with the `TypeSpec.` prefix when given a string, we preserve this behavior by introducing the simple `createStateSymbol` function in files that previously used the wrapper functions.

 `createStateSymbol` could be trivially refactored into a shared utility function rather than duplicated, but here we are simply following the pattern already established where there are already several copies of this function. Indeed, while one of these was exported in 050139d2e272bb0b1f4d02010276a554c0b4ddc4, that export was never used.