### PR TITLE
Migrate CADL Ranch Docs to Spector

### DIFF
--- a/packages/spector/docs/decorators.md
+++ b/packages/spector/docs/decorators.md
@@ -1,0 +1,24 @@
+## Spector decorators
+
+### `@scenarioService`
+
+Decorator setting up the boilerplate for specs service namespace. Will automatically set:
+
+- `@service{title: '<namespace>', value: '1.0.0'}` using the namespace as a value
+- `@server` to `localhost:3000`
+- `@route` using the parameter passed.
+
+Usage:
+
+```cadl
+@scenarioSpec("/my-spec")
+namespace MySpec;
+```
+
+### `@scenario`
+
+Mark an operation, interface or namespace as a scenario. Optionally can provide the name of the scenario.
+
+### `@scenarioDoc`
+
+Specify how to implement this scenario. Value is markdown. Differ from @doc which describe the scenario to the end user.

--- a/packages/spector/docs/decorators.md
+++ b/packages/spector/docs/decorators.md
@@ -10,7 +10,7 @@ Decorator setting up the boilerplate for specs service namespace. Will automatic
 
 Usage:
 
-```cadl
+```tsp
 @scenarioSpec("/my-spec")
 namespace MySpec;
 ```

--- a/packages/spector/docs/using-spector.md
+++ b/packages/spector/docs/using-spector.md
@@ -1,0 +1,99 @@
+# Using spector
+
+Install `spector` CLI globally or as a local dependency:
+
+- **Globally**: run `npm install -g @typespec/spector`. You can then use `tsp-spector` as a CLI tool.
+- **Locally**: run `npm install @typespec/spector` which should add the dependency to package.json. You can then use `tsp-spector` with `npx tsp-spector`.
+
+**NOTE** With local install you'll need to prefix `tsp-spector` with `npx`(unless commands are written directly as npm scripts)
+
+## Test against scenarios
+
+### Spector Config
+
+Spector supports a config file where you can configure scenarios that are not supported by your generator.
+
+Create a `spector-config.yaml` file.
+
+```yaml
+# List of unsupported scenarios
+unsupportedScenarios:
+  - Foo_Bar
+```
+
+### Run mock api server
+
+```bash
+# Minimal
+tsp-spector serve ./path/to/scenarios
+
+# Change the port
+tsp-spector serve ./path/to/scenarios --port 1234
+
+# Specify where the coverage file should go
+tsp-spector serve ./path/to/scenarios --coverageFile ./path/to/spector-coverage.json
+```
+
+Alternative to start in background
+
+```bash
+tsp-spector server start ./path/to/scenarios # Takes the same arguments as serve
+```
+
+### Stop running server
+
+```bash
+tsp-spector server stop # Stop at the default port
+tsp-spector server stop --port  1234 # If started the server at another port
+```
+
+### Validate and merge coverage
+
+```bash
+# Minimal
+tsp-spector check-coverage ./path/to/scenarios
+
+# Path to tsp-spector config file for generator
+tsp-spector check-coverage ./path/to/scenarios --configFile ./spector-config.yaml
+
+# In case where there was multiple serve instance each creating their own coverage file
+tsp-spector check-coverage ./path/to/scenarios --coverageFiles ./path/to/*-coverage.json --coverageFiles ./other/to/*-coverage.json
+
+# Specify where the merged coverage file should go
+tsp-spector check-coverage ./path/to/scenarios --mergedCoverageFile ./path/to/spector-final-coverage.json
+```
+
+### Upload coverage
+
+Upload the coverage. Upload from the `main` branch. DO NOT upload on PR this WILL override the latest index.
+
+```bash
+# Minimal
+tsp-spector upload-coverage --generatorName typescript --version=0.1.0
+
+# Specify Coverage file
+tsp-spector upload-coverage --generatorName typescript --version=0.1.0  --coverageFile ./path/to/spector-final-coverage.json
+```
+
+Options:
+
+- `--storageAccountName`: Name of the storage account to publish coverage. Use `typespec` for Spector/Azure Spector dashboard.
+- `--generatorName`: Name of the generator. Must be one of `"@typespec/http-client-python", "@typespec/http-client-csharp", "@azure-tools/typespec-ts-rlc", "@azure-tools/typespec-ts-modular", "@typespec/http-client-java"`.
+- `--generatorVersion`: Version of the generator
+- `--coverageFile`: Path to the coverage file
+
+#### Upload in azure devops
+
+**This is applicable in the azure-sdk/internal ado project only.**
+
+Add the following step
+
+```yaml
+- task: AzureCLI@2
+  displayName: Upload scenario manifest
+  inputs:
+    azureSubscription: "Typespec Storage"
+    scriptType: "bash"
+    scriptLocation: "inlineScript"
+    inlineScript: `tsp-spector upload-coverage --storageAccountName typespec --containerName coverages --generatorMode standard  ... FILL options fitting your generator here as described above...`
+```

--- a/packages/spector/docs/writing-mock-apis.md
+++ b/packages/spector/docs/writing-mock-apis.md
@@ -1,0 +1,116 @@
+# Writing mock apis
+
+1. Create a `mockapi.ts` file next to the `main.tsp` of the scenario
+2. Create and export a variable called `Scenarios` with a `Record<string, ScenarioMockApi>` type
+3. For each of the scenario assign a new property to the `Scenarios` variable. The value use one of the following:
+   - `passOnSuccess`: This will take one or multiple routes and will only pass teh scenario if all the routes gets called with a 2xx success code.
+
+## Example
+
+```ts
+import { passOnSuccess, mockapi } from "@typespec/spec-api";
+import { ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Hello_world = passOnSuccess(
+  mockapi.get("/hello/world", () => {
+    return {
+      status: 200,
+      body: {
+        contentType: "application/json",
+        rawContent: `"Hello World!"`,
+      },
+    };
+  }),
+);
+```
+
+## How to build response
+
+Return the response object. [See type](../../spec-api/src/types.ts)
+
+```ts
+// Minimum requirement is the status code.
+return {
+  status: 200,
+};
+```
+
+### Return a body
+
+```ts
+// Return json
+return {
+  status: 200,
+  body: json({ foo: 123 }),
+};
+
+// Return raw content
+return {
+  status: 200,
+  body: {
+    contentType: "application/text",
+    rawContent: "foobar",
+  },
+};
+```
+
+### Return headers
+
+```ts
+// Return json
+return {
+  status: 200,
+  headers: {
+      MyHeader: "value-1"
+      MyHeaderOther: req.headers.MyRequestHeader
+  }
+};
+
+```
+
+## How to validate the request:
+
+All built-in validation tools can be accessed using `req.expect.`
+
+### Validate the body
+
+- With `req.expect.bodyEquals`
+
+This will do a deep equals of the body to make sure it match.
+
+```ts
+app.post("/example", "Example", (req) => {
+  req.bodyEquals({ foo: "123", bar: "456" });
+});
+```
+
+- With `req.expect.rawBodyEquals`
+
+This will compare the raw body sent.
+
+```ts
+app.post("/example", "Example", (req) => {
+  req.rawBodyEquals('"foo"');
+});
+```
+
+### Custom validation
+
+You can do any kind of validation accessing the `req: MockRequest` object and deciding to return a different response in some cases.
+You can also always `throw` a `ValidationError`
+
+Example:
+
+```ts
+app.post("/example", "Example", (req) => {
+  if (req.headers.MyCustomHeader.startsWith("x-foo")) {
+    throw new ValidationError(
+      "MyCustomHeader shouldn't start with x-foo",
+      null,
+      req.headers.MyCustomHeader,
+    );
+  }
+});
+```

--- a/packages/spector/docs/writing-scenario-spec.md
+++ b/packages/spector/docs/writing-scenario-spec.md
@@ -1,0 +1,49 @@
+## Defining scenario
+
+The goal of the testserver is to define scenarios that needs to be supported in client generators. This means to have a meaningful coverage we need scenarios to:
+
+- have a specific behavior that is meant to be tested
+  - ❌ DO NOT use the same scenario for testing multiple things.
+- have a meaningful name that can be used in a compatibility table to see what a given generator support(e.g. `get_string`)
+- a description of what the scenario is validating(e.g. `"Support passing a simple string as JSON"`)
+- have a good description on what the client is expecting to generate/receive/send(e.g `Validate that this operation returns a JSON string that match "abc"`)
+  - ✅ DO describe how to validate that this scenario is working from the client point of view
+
+When naming scenario always think about what would it look like in the [compatibility table](#compatibility-table) and would that name be meaningful to someone looking to see what is supported.
+
+```cadl
+import "@typespec/spector";
+
+@scenarioService("/strings")
+namespace String;
+
+@scenario("get_string")
+@doc("Support passing a simple string as JSON")
+@scenarioDoc("In this scenario the Client should expect a string matching 'abc' to be returned.")
+@get
+@route("/simple")
+op returnString(): string;
+```
+
+Decorators that should be provided in this test library `@typespec/spector`:
+
+- `@scenario`: Specify that this operation, interface or namespace is a scenario. Optionally take a scenario name otherwise default to the namespace name + operation/interface name
+- `@scenarioDoc`: Specify how to implement this scenario. Differ from `@doc` which describe the scenario to the end user.
+- `@supportedBy`: Specify if something is supported only by some kind of SDK. Option: `arm`, `dpg`. By default everything.
+
+## Compatibility table
+
+With all this information, a detailed compatibility table should be able to be produced by compiling each one of the scenarios and extracting the cases. Providing something like
+
+| Scenario                     | CSharp | Python | Go  | Java | TS/JS |
+| ---------------------------- | ------ | ------ | --- | ---- | ----- |
+| Vanilla                      |
+| `get_string`                 | ✅     | ✅     | ✅  | ✅   | ✅    |
+| `put_string`                 | ✅     | ✅     | ✅  | ✅   | ✅    |
+| Azure                        |
+| `pageable_nextLink`          | ✅     | ✅     | ✅  | ✅   | ✅    |
+| `pageable_continuationToken` | ❌     | ✅     | ✅  | ✅   | ✅    |
+
+## Writing the mock api
+
+Each scenario should be accompanied by a mock api. See [writing a mock api docs](./writing-mock-apis.md)


### PR DESCRIPTION
Migrated https://github.com/Azure/cadl-ranch/tree/main/docs to the current repository under spector package. Changed package-names and command names to migrated values.

Please review and approve it. 