### PR TITLE
[python] Fix for scenario that output folder is different with namespace

### DIFF
--- a/packages/http-client-python/CHANGELOG.md
+++ b/packages/http-client-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @typespec/http-client-python
 
+## 0.6.8
+
+### Bug Fixes
+
+- Fix for scenario that output folder is different with namespace
+
 ## 0.6.7
 
 ### Bug Fixes

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -479,7 +479,12 @@ class JinjaSerializer(ReaderAndWriter):
             else Path(".")
         )
 
+    def exec_path_for_test_sample(self, namespace: str) -> Path:
+        return self.exec_path_compensation / Path(*namespace.split("."))
+
     def exec_path(self, namespace: str) -> Path:
+        if self.code_model.options["no_namespace_folders"]:
+            return Path(".")
         return self.exec_path_compensation / Path(*namespace.split("."))
 
     @property
@@ -492,7 +497,7 @@ class JinjaSerializer(ReaderAndWriter):
         return Path("")
 
     def _serialize_and_write_sample(self, env: Environment, namespace: str):
-        out_path = self.exec_path(namespace) / Path("generated_samples")
+        out_path = self.exec_path_for_test_sample(namespace) / Path("generated_samples")
         for client in self.code_model.clients:
             for op_group in client.operation_groups:
                 for operation in op_group.operations:
@@ -526,7 +531,7 @@ class JinjaSerializer(ReaderAndWriter):
 
     def _serialize_and_write_test(self, env: Environment, namespace: str):
         self.code_model.for_test = True
-        out_path = self.exec_path(namespace) / Path("generated_tests")
+        out_path = self.exec_path_for_test_sample(namespace) / Path("generated_tests")
         general_serializer = TestGeneralSerializer(code_model=self.code_model, env=env)
         self.write_file(out_path / "conftest.py", general_serializer.serialize_conftest())
         if not self.code_model.options["azure_arm"]:

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -483,7 +483,7 @@ class JinjaSerializer(ReaderAndWriter):
         return self.exec_path_compensation / Path(*namespace.split("."))
 
     def exec_path(self, namespace: str) -> Path:
-        if self.code_model.options["no_namespace_folders"]:
+        if self.code_model.options["no_namespace_folders"] and not self.code_model.options["multiapi"]:
             return Path(".")
         return self.exec_path_compensation / Path(*namespace.split("."))
 


### PR DESCRIPTION
We shall keep compatibility for scenario that output folder is different with namespace (e.g. [azure-communication-callautomation](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/communication/azure-communication-callautomation/swagger/SWAGGER.md) has additional `_generated` in output folder which is not in namespace)