### PR TITLE
http-client-java, do not generate overload, when sync-method=none

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
@@ -784,7 +784,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .groupedParameterRequired(false)
             .methodVisibility(methodVisibility);
 
-        methods.add(builder.build());
+        if (settings.getSyncMethods() != SyncMethodsGeneration.NONE) {
+            methods.add(builder.build());
+        }
 
         // Generate an overload with all parameters, optionally include context.
         builder.methodVisibility(visibilityFunction.methodVisibility(true, defaultOverloadType, true));
@@ -806,10 +808,14 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .groupedParameterRequired(false)
             .methodVisibility(visibilityFunction.methodVisibility(false, defaultOverloadType, false));
 
-        methods.add(builder.build());
+        if (settings.getSyncMethods() != SyncMethodsGeneration.NONE) {
+            // generate the overload, if "sync-methods != NONE"
 
-        // overload for versioning
-        createOverloadForVersioning(isProtocolMethod, methods, builder, parameters);
+            methods.add(builder.build());
+
+            // overload for versioning
+            createOverloadForVersioning(isProtocolMethod, methods, builder, parameters);
+        }
 
         if (generateClientMethodWithOnlyRequiredParameters) {
             methods.add(builder.onlyRequiredParameters(true)


### PR DESCRIPTION
bug fix for https://github.com/Azure/autorest.java/pull/3016#discussion_r1928100820