### PR TITLE
[python] Fix output folder of models when output folder is different with namespace in configuration

### DIFF
--- a/.chronus/changes/fix-namespace-new-2025-0-24-16-11-9.md
+++ b/.chronus/changes/fix-namespace-new-2025-0-24-16-11-9.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix output folder of models when output folder is different with namespace in configuration

--- a/packages/http-client-python/CHANGELOG.md
+++ b/packages/http-client-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @typespec/http-client-python
 
+## 0.6.9
+
+### Bug Fixes
+
+- Fix output folder of models when output folder is different with namespace in configuration
+
 ## 0.6.8
 
 ### Bug Fixes

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -238,7 +238,7 @@ class JinjaSerializer(ReaderAndWriter):
         self, env: Environment, namespace: str, models: List[ModelType], enums: List[EnumType]
     ) -> None:
         # Write the models folder
-        models_path = self.exec_path(namespace + ".models")
+        models_path = self.exec_path(namespace) / "models"
         serializer = DpgModelSerializer if self.code_model.options["models_mode"] == "dpg" else MsrestModelSerializer
         if self.code_model.has_non_json_models(models):
             self.write_file(

--- a/packages/http-client-python/package-lock.json
+++ b/packages/http-client-python/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typespec/http-client-python",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://typespec.io",


### PR DESCRIPTION
Supplementation for https://github.com/microsoft/typespec/pull/5711. The issue is not covered by test case since test case doesn't contain `models`. Here is updated test case to cover this issue: https://github.com/Azure/autorest.python/pull/3030/files#diff-5fa7ea68bc2d31e09e995e5f522a9e4f58572767f393937a1cf6baf35fa16664