### PR TITLE
Expose output dir

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Configuration.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Configuration.cs
@@ -150,7 +150,10 @@ namespace Microsoft.Generator.CSharp
         /// <summary> Gets the namespace for the models. </summary>
         public string ModelNamespace { get; }
 
-        internal string OutputDirectory { get; }
+        /// <summary>
+        /// Gets the root output directory for the generated library.
+        /// </summary>
+        public string OutputDirectory { get; }
 
         internal static UnreferencedTypesHandlingOption UnreferencedTypesHandling { get; private set; } = UnreferencedTypesHandlingOption.RemoveOrInternalize;
 


### PR DESCRIPTION
Need this to finish https://github.com/Azure/azure-sdk-for-net/issues/47071.

As a follow up to comments left here https://github.com/Azure/azure-sdk-for-net/pull/47936#discussion_r1929119141 I realized that each csproj we write in Local or CadlRanch can have a different path so the hard coded relative path we did here https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp/generator/Azure.Generator/src/Primitives/NewAzureProjectScaffolding.cs#L35 won't work and we need to fix that todo.