### PR TITLE
Make `createStateSymbol` a common utility function for `@typespec/compiler`

### DIFF
--- a/.chronus/changes/steverice-createStateSymbol-util-2025-0-25-10-46-13.md
+++ b/.chronus/changes/steverice-createStateSymbol-util-2025-0-25-10-46-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+
+Make `createStateSymbol` a common utility function for `@typespec/compiler`

--- a/packages/compiler/src/core/deprecation.ts
+++ b/packages/compiler/src/core/deprecation.ts
@@ -1,9 +1,6 @@
+import { createStateSymbol } from "../lib/utils.js";
 import type { Program } from "./program.js";
 import { BaseNode, Node, SyntaxKind, Type } from "./types.js";
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
-}
 
 const deprecatedKey = createStateSymbol("deprecated");
 

--- a/packages/compiler/src/core/intrinsic-type-state.ts
+++ b/packages/compiler/src/core/intrinsic-type-state.ts
@@ -1,13 +1,10 @@
 // Contains all intrinsic data setter or getter
 // Anything that the TypeSpec check might should be here.
 
+import { createStateSymbol } from "../lib/utils.js";
 import type { Model, Type, Union } from "./index.js";
 import type { Numeric } from "./numeric.js";
 import type { Program } from "./program.js";
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
-}
 
 const stateKeys = {
   minValues: createStateSymbol("minValues"),

--- a/packages/compiler/src/core/visibility/core.ts
+++ b/packages/compiler/src/core/visibility/core.ts
@@ -29,6 +29,7 @@ import {
 } from "./lifecycle.js";
 
 import type { VisibilityFilter as GeneratedVisibilityFilter } from "../../../generated-defs/TypeSpec.js";
+import { createStateSymbol } from "../../lib/utils.js";
 import { useStateMap, useStateSet } from "../../utils/index.js";
 
 export { GeneratedVisibilityFilter };
@@ -37,10 +38,6 @@ export { GeneratedVisibilityFilter };
  * A set of active visibility modifiers per visibility class.
  */
 type VisibilityModifiers = Map<Enum, Set<EnumMember>>;
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
-}
 
 /**
  * The global visibility store.

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -100,6 +100,7 @@ import {
 } from "../core/types.js";
 import { useStateMap, useStateSet } from "../utils/index.js";
 import { setKey } from "./key.js";
+import { createStateSymbol } from "./utils.js";
 
 export { $encodedName, resolveEncodedName } from "./encoded-names.js";
 export { serializeValueAsJson } from "./examples.js";
@@ -119,10 +120,6 @@ function replaceTemplatedStringFromProperties(formatString: string, sourceObject
   return formatString.replace(/{(\w+)}/g, (_, propName) => {
     return (sourceObject as any)[propName];
   });
-}
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
 }
 
 const [getSummary, setSummary] = useStateMap<Type, string>(createStateSymbol("summary"));

--- a/packages/compiler/src/lib/encoded-names.ts
+++ b/packages/compiler/src/lib/encoded-names.ts
@@ -3,10 +3,7 @@ import { parseMimeType } from "../core/mime-type.js";
 import type { Program } from "../core/program.js";
 import type { DecoratorContext, Enum, Model, Type, Union } from "../core/types.js";
 import { DuplicateTracker, useStateMap } from "../utils/index.js";
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
-}
+import { createStateSymbol } from "./utils.js";
 
 const [getEncodedNamesMap, setEncodedNamesMap, getEncodedNamesStateMap] = useStateMap<
   Type,

--- a/packages/compiler/src/lib/key.ts
+++ b/packages/compiler/src/lib/key.ts
@@ -1,10 +1,7 @@
 import { Program } from "../core/index.js";
 import { ModelProperty, Type } from "../core/types.js";
 import { useStateMap } from "../utils/index.js";
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
-}
+import { createStateSymbol } from "./utils.js";
 
 const [getKey, setKey] = useStateMap<Type, string>(createStateSymbol("key"));
 

--- a/packages/compiler/src/lib/paging.ts
+++ b/packages/compiler/src/lib/paging.ts
@@ -26,6 +26,7 @@ import type {
   Operation,
   Type,
 } from "../core/types.js";
+import { createStateSymbol } from "../lib/utils.js";
 import { DuplicateTracker, useStateSet } from "../utils/index.js";
 import { isNumericType, isStringType } from "./decorators.js";
 
@@ -339,10 +340,6 @@ function getPagingProperty(
 function validatePagingOperation(program: Program, op: Operation) {
   const [_, diagnostics] = getPagingOperation(program, op);
   program.reportDiagnostics(diagnostics);
-}
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
 }
 
 function createMarkerDecorator<T extends DecoratorFunction>(

--- a/packages/compiler/src/lib/utils.ts
+++ b/packages/compiler/src/lib/utils.ts
@@ -17,3 +17,11 @@ export function filterModelPropertiesInPlace(
     }
   }
 }
+
+/**
+ * Creates a unique symbol for storing state on objects
+ * @param name The name/description of the state
+ */
+export function createStateSymbol(name: string): symbol {
+  return Symbol.for(`TypeSpec.${name}`);
+}

--- a/packages/compiler/src/lib/visibility.ts
+++ b/packages/compiler/src/lib/visibility.ts
@@ -52,13 +52,9 @@ import {
 import { isMutableType, mutateSubgraph, Mutator, MutatorFlow } from "../experimental/mutators.js";
 import { useStateMap } from "../utils/index.js";
 import { isKey } from "./key.js";
-import { filterModelPropertiesInPlace } from "./utils.js";
+import { createStateSymbol, filterModelPropertiesInPlace } from "./utils.js";
 
 // #region Legacy Visibility Utilities
-
-function createStateSymbol(name: string) {
-  return Symbol.for(`TypeSpec.${name}`);
-}
 
 /**
  * Takes a list of visibilities that possibly include both legacy visibility


### PR DESCRIPTION
This commit addresses a suggestion from c788082e18a833aa764e5108d110090bdced8988 to refactor `createStateSymbol` into a shared utility function. This is not meant for use outside of `@typespec/compiler`, but rather an internal utility.