### PR TITLE
Add example to the vscode setting "initTemplatesUrls"

### DIFF
--- a/.chronus/changes/refine-config-description-2025-0-26-14-13-27.md
+++ b/.chronus/changes/refine-config-description-2025-0-26-14-13-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - typespec-vscode
+---
+
+Add example to the vscode setting "initTemplatesUrls"

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -77,7 +77,7 @@
           "typespec.initTemplatesUrls": {
             "type": "array",
             "default": [],
-            "description": "List of URLs to fetch templates from when creating a new project.",
+            "description": "List of URLs to fetch templates from when creating a new project.\n\nExample:\n\"typespec.initTemplatesUrls\": [{\n\"name\": \"displayName\",\n\"url\": \"https://urlToTheFileContainsTemplates\"\n}],",
             "scope": "machine-overridable",
             "items": {
               "type": "object",


### PR DESCRIPTION
From user feedback, it's not easy to figure out how to use the setting "initTemplatesUrls". The doc in changelog and intellisense in json is not that visible. So add example to the vscode setting page for "initTemplatesUrls" so that user can understand how to configure it easily.