### PR TITLE
Export `mutate` from `@typespec/compiler/utils`

### DIFF
--- a/.chronus/changes/steverice-export-mutate-2025-0-26-1-2-47.md
+++ b/.chronus/changes/steverice-export-mutate-2025-0-26-1-2-47.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Export `mutate` from `@typespec/compiler/utils`

--- a/packages/compiler/src/utils/index.ts
+++ b/packages/compiler/src/utils/index.ts
@@ -3,5 +3,5 @@
 // Be explicit about what get exported so we don't export utils that are not meant to be public.
 // ---------------------------------------
 export { DuplicateTracker } from "./duplicate-tracker.js";
-export { Queue, TwoLevelMap, createRekeyableMap, deepClone, deepEquals } from "./misc.js";
+export { Queue, TwoLevelMap, createRekeyableMap, deepClone, deepEquals, mutate } from "./misc.js";
 export { useStateMap, useStateSet } from "./state-accessor.js";


### PR DESCRIPTION
This is a generic function that's useful for dealing with some of the immutable types used within TypeSpec.