### PR TITLE
[http-client-csharp] remove unused emitter options

### DIFF
--- a/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/packages/http-client-csharp/emitter/src/emitter.ts
@@ -74,7 +74,7 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
       process.exit(1);
     }
     const tspNamespace = root.Name; // this is the top-level namespace defined in the typespec file, which is actually always different from the namespace of the SDK
-    // await program.host.writeFile(outPath, prettierOutput(JSON.stringify(root, null, 2)));
+
     if (root) {
       const generatedFolder = resolvePath(outputFolder, "src", "Generated");
 
@@ -93,37 +93,8 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
         "output-folder": ".",
         namespace: namespace,
         "library-name": options["library-name"] ?? namespace,
-        "single-top-level-client": options["single-top-level-client"],
         "unreferenced-types-handling": options["unreferenced-types-handling"],
-        "keep-non-overloadable-protocol-signature":
-          options["keep-non-overloadable-protocol-signature"],
         "model-namespace": options["model-namespace"],
-        "models-to-treat-empty-string-as-null": options["models-to-treat-empty-string-as-null"],
-        "intrinsic-types-to-treat-empty-string-as-null": options[
-          "models-to-treat-empty-string-as-null"
-        ]
-          ? options["additional-intrinsic-types-to-treat-empty-string-as-null"].concat(
-              ["Uri", "Guid", "ResourceIdentifier", "DateTimeOffset"].filter(
-                (item) =>
-                  options["additional-intrinsic-types-to-treat-empty-string-as-null"].indexOf(
-                    item,
-                  ) < 0,
-              ),
-            )
-          : undefined,
-        "methods-to-keep-client-default-value": options["methods-to-keep-client-default-value"],
-        "head-as-boolean": options["head-as-boolean"],
-        "deserialize-null-collection-as-null-value":
-          options["deserialize-null-collection-as-null-value"],
-        flavor: options["flavor"],
-        //only emit these if they are not the default values
-        "generate-sample-project":
-          options["generate-sample-project"] === true
-            ? undefined
-            : options["generate-sample-project"],
-        "generate-test-project":
-          options["generate-test-project"] === false ? undefined : options["generate-test-project"],
-        "use-model-reader-writer": options["use-model-reader-writer"] ?? true,
         "disable-xml-docs":
           options["disable-xml-docs"] === false ? undefined : options["disable-xml-docs"],
       };
@@ -142,9 +113,6 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
         Logger.getInstance().info(`Checking if ${csProjFile} exists`);
         const newProjectOption =
           options["new-project"] || !checkFile(csProjFile) ? "--new-project" : "";
-        const existingProjectOption = options["existing-project-folder"]
-          ? `--existing-project-folder ${options["existing-project-folder"]}`
-          : "";
         const debugFlag = (options.debug ?? false) ? "--debug" : "";
 
         const emitterPath = options["emitter-extension-path"] ?? import.meta.url;
@@ -153,7 +121,7 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
           projectRoot + "/dist/generator/Microsoft.Generator.CSharp.dll",
         );
 
-        const command = `dotnet --roll-forward Major ${generatorPath} ${outputFolder} -p ${options["plugin-name"]}${constructCommandArg(newProjectOption)}${constructCommandArg(existingProjectOption)}${constructCommandArg(debugFlag)}`;
+        const command = `dotnet --roll-forward Major ${generatorPath} ${outputFolder} -p ${options["plugin-name"]}${constructCommandArg(newProjectOption)}${constructCommandArg(debugFlag)}`;
         Logger.getInstance().info(command);
 
         try {
@@ -167,7 +135,6 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
               "-p",
               options["plugin-name"],
               newProjectOption,
-              existingProjectOption,
               debugFlag,
             ],
             { stdio: "inherit" },

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -9,27 +9,14 @@ export interface NetEmitterOptions extends SdkEmitterOptions {
   logFile?: string;
   namespace: string;
   "library-name": string;
-  "single-top-level-client"?: boolean;
   skipSDKGeneration?: boolean;
   "unreferenced-types-handling"?: "removeOrInternalize" | "internalize" | "keepAll";
   "new-project"?: boolean;
   "clear-output-folder"?: boolean;
   "save-inputs"?: boolean;
   "model-namespace"?: boolean;
-  "existing-project-folder"?: string;
-  "keep-non-overloadable-protocol-signature"?: boolean;
   debug?: boolean;
-  "models-to-treat-empty-string-as-null"?: string[];
-  "additional-intrinsic-types-to-treat-empty-string-as-null"?: string[];
-  "methods-to-keep-client-default-value"?: string[];
-  "deserialize-null-collection-as-null-value"?: boolean;
   logLevel?: LoggerLevel;
-  "package-dir"?: string;
-  "head-as-boolean"?: boolean;
-  flavor?: string;
-  "generate-sample-project"?: boolean;
-  "generate-test-project"?: boolean;
-  "use-model-reader-writer"?: boolean;
   "disable-xml-docs"?: boolean;
   "plugin-name"?: string;
   "emitter-extension-path"?: string;
@@ -47,7 +34,6 @@ export const NetEmitterOptionsSchema: JSONSchemaType<NetEmitterOptions> = {
     logFile: { type: "string", nullable: true },
     namespace: { type: "string" },
     "library-name": { type: "string" },
-    "single-top-level-client": { type: "boolean", nullable: true },
     skipSDKGeneration: { type: "boolean", default: false, nullable: true },
     "unreferenced-types-handling": {
       type: "string",
@@ -62,50 +48,12 @@ export const NetEmitterOptionsSchema: JSONSchemaType<NetEmitterOptions> = {
     "generate-convenience-methods": { type: "boolean", nullable: true },
     "flatten-union-as-enum": { type: "boolean", nullable: true },
     "package-name": { type: "string", nullable: true },
-    "existing-project-folder": { type: "string", nullable: true },
-    "keep-non-overloadable-protocol-signature": {
-      type: "boolean",
-      nullable: true,
-    },
     debug: { type: "boolean", nullable: true },
-    "models-to-treat-empty-string-as-null": {
-      type: "array",
-      nullable: true,
-      items: { type: "string" },
-    },
-    "additional-intrinsic-types-to-treat-empty-string-as-null": {
-      type: "array",
-      nullable: true,
-      items: { type: "string" },
-    },
-    "methods-to-keep-client-default-value": {
-      type: "array",
-      nullable: true,
-      items: { type: "string" },
-    },
-    "deserialize-null-collection-as-null-value": {
-      type: "boolean",
-      nullable: true,
-    },
     logLevel: {
       type: "string",
       enum: [LoggerLevel.INFO, LoggerLevel.DEBUG, LoggerLevel.VERBOSE],
       nullable: true,
     },
-    "package-dir": { type: "string", nullable: true },
-    "head-as-boolean": { type: "boolean", nullable: true },
-    flavor: { type: "string", nullable: true },
-    "generate-sample-project": {
-      type: "boolean",
-      nullable: true,
-      default: true,
-    },
-    "generate-test-project": {
-      type: "boolean",
-      nullable: true,
-      default: false,
-    },
-    "use-model-reader-writer": { type: "boolean", nullable: true },
     "disable-xml-docs": { type: "boolean", nullable: true },
     "plugin-name": { type: "string", nullable: true },
     "emitter-extension-path": { type: "string", nullable: true },
@@ -125,13 +73,7 @@ export const defaultOptions = {
   "generate-convenience-methods": true,
   "package-name": undefined,
   debug: undefined,
-  "models-to-treat-empty-string-as-null": undefined,
-  "additional-intrinsic-types-to-treat-empty-string-as-null": [],
-  "methods-to-keep-client-default-value": undefined,
-  "deserialize-null-collection-as-null-value": undefined,
   logLevel: LoggerLevel.INFO,
-  flavor: undefined,
-  "generate-test-project": false,
   "plugin-name": "ClientModelPlugin",
   "emitter-extension-path": undefined,
 };

--- a/packages/http-client-csharp/emitter/src/type/configuration.ts
+++ b/packages/http-client-csharp/emitter/src/type/configuration.ts
@@ -5,19 +5,7 @@ export interface Configuration {
   "output-folder": string;
   namespace: string;
   "library-name": string | null;
-  flavor?: string;
-  "single-top-level-client"?: boolean;
   "unreferenced-types-handling"?: "removeOrInternalize" | "internalize" | "keepAll";
   "model-namespace"?: boolean;
-  "models-to-treat-empty-string-as-null"?: string[];
-  "additional-intrinsic-types-to-treat-empty-string-as-null"?: string[];
-  "methods-to-keep-client-default-value"?: string[];
-  "keep-non-overloadable-protocol-signature"?: boolean;
-  "intrinsic-types-to-treat-empty-string-as-null"?: string[];
-  "head-as-boolean"?: boolean;
-  "deserialize-null-collection-as-null-value"?: boolean;
-  "generate-sample-project"?: boolean;
-  "generate-test-project"?: boolean;
-  "use-model-reader-writer"?: boolean;
   "disable-xml-docs"?: boolean;
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Configuration.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Configuration.cs
@@ -44,9 +44,6 @@ namespace Microsoft.Generator.CSharp
             string outputPath,
             Dictionary<string, BinaryData> additionalConfigOptions,
             bool clearOutputFolder,
-            bool generateModelFactory,
-            bool generateSampleProject,
-            bool generateTestProject,
             string libraryName,
             bool useModelNamespace,
             string libraryNamespace,
@@ -56,9 +53,6 @@ namespace Microsoft.Generator.CSharp
             OutputDirectory = outputPath;
             AdditionalConfigOptions = additionalConfigOptions;
             ClearOutputFolder = clearOutputFolder;
-            GenerateModelFactory = generateModelFactory;
-            GenerateSampleProject = generateSampleProject;
-            GenerateTestProject = generateTestProject;
             LibraryName = libraryName;
             UseModelNamespace = useModelNamespace;
             RootNamespace = GetCleanNameSpace(libraryNamespace);
@@ -129,9 +123,6 @@ namespace Microsoft.Generator.CSharp
         private static class Options
         {
             public const string ClearOutputFolder = "clear-output-folder";
-            public const string GenerateModelFactory = "generate-model-factory";
-            public const string GenerateSampleProject = "generate-sample-project";
-            public const string GenerateTestProject = "generate-test-project";
             public const string LibraryName = "library-name";
             public const string Namespace = "namespace";
             public const string UseModelNamespace = "use-model-namespace";
@@ -220,9 +211,6 @@ namespace Microsoft.Generator.CSharp
                 Path.GetFullPath(outputPath),
                 ParseAdditionalConfigOptions(root),
                 ReadOption(root, Options.ClearOutputFolder),
-                ReadOption(root, Options.GenerateModelFactory),
-                ReadOption(root, Options.GenerateSampleProject),
-                ReadOption(root, Options.GenerateTestProject),
                 ReadRequiredStringOption(root, Options.LibraryName),
                 ReadOption(root, Options.UseModelNamespace),
                 ReadRequiredStringOption(root, Options.Namespace),
@@ -236,10 +224,7 @@ namespace Microsoft.Generator.CSharp
         private static readonly Dictionary<string, bool> _defaultBoolOptionValues = new()
         {
             { Options.UseModelNamespace, true },
-            { Options.GenerateModelFactory, true },
-            { Options.GenerateSampleProject, true },
             { Options.ClearOutputFolder, true },
-            { Options.GenerateTestProject, false },
             { Options.DisableXmlDocs, false },
         };
 
@@ -249,9 +234,6 @@ namespace Microsoft.Generator.CSharp
         private static readonly HashSet<string> _knownOptions = new()
         {
             Options.ClearOutputFolder,
-            Options.GenerateModelFactory,
-            Options.GenerateSampleProject,
-            Options.GenerateTestProject,
             Options.LibraryName,
             Options.UseModelNamespace,
             Options.Namespace,

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/api-key/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/api-key/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Authentication.ApiKey",
-  "library-name": "Authentication.ApiKey",
-  "use-model-reader-writer": true
+  "library-name": "Authentication.ApiKey"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/http/custom/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/http/custom/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Authentication.Http.Custom",
-  "library-name": "Authentication.Http.Custom",
-  "use-model-reader-writer": true
+  "library-name": "Authentication.Http.Custom"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/oauth2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/oauth2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Authentication.OAuth2",
-  "library-name": "Authentication.OAuth2",
-  "use-model-reader-writer": true
+  "library-name": "Authentication.OAuth2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/union/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/authentication/union/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Authentication.Union",
-  "library-name": "Authentication.Union",
-  "use-model-reader-writer": true
+  "library-name": "Authentication.Union"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/naming/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/naming/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Client.Naming",
-  "library-name": "Client.Naming",
-  "use-model-reader-writer": true
+  "library-name": "Client.Naming"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/client-operation-group/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/client-operation-group/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Client.Structure.Service",
-  "library-name": "Client.Structure.Service",
-  "use-model-reader-writer": true
+  "library-name": "Client.Structure.Service"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/default/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/default/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Client.Structure.Service.Default",
-  "library-name": "Client.Structure.Service.Default",
-  "use-model-reader-writer": true
+  "library-name": "Client.Structure.Service.Default"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/multi-client/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/multi-client/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Client.Structure.Service.Multi.Client",
-  "library-name": "Client.Structure.Service.Multi.Client",
-  "use-model-reader-writer": true
+  "library-name": "Client.Structure.Service.Multi.Client"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/renamed-operation/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/renamed-operation/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Client.Structure.Service.Renamed.Operation",
-  "library-name": "Client.Structure.Service.Renamed.Operation",
-  "use-model-reader-writer": true
+  "library-name": "Client.Structure.Service.Renamed.Operation"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/two-operation-group/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/client/structure/two-operation-group/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Client.Structure.Service.TwoOperationGroup",
-  "library-name": "Client.Structure.Service.TwoOperationGroup",
-  "use-model-reader-writer": true
+  "library-name": "Client.Structure.Service.TwoOperationGroup"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/bytes/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/bytes/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Encode.Bytes",
-  "library-name": "Encode.Bytes",
-  "use-model-reader-writer": true
+  "library-name": "Encode.Bytes"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/datetime/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/datetime/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Encode.Datetime",
-  "library-name": "Encode.Datetime",
-  "use-model-reader-writer": true
+  "library-name": "Encode.Datetime"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/duration/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/duration/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Encode.Duration",
-  "library-name": "Encode.Duration",
-  "use-model-reader-writer": true
+  "library-name": "Encode.Duration"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/numeric/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/encode/numeric/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Encode.Numeric",
-  "library-name": "Encode.Numeric",
-  "use-model-reader-writer": true
+  "library-name": "Encode.Numeric"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/basic/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/basic/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Parameters.Basic",
-  "library-name": "Parameters.Basic",
-  "use-model-reader-writer": true
+  "library-name": "Parameters.Basic"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/body-optionality/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/body-optionality/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Parameters.BodyOptionality",
-  "library-name": "Parameters.BodyOptionality",
-  "use-model-reader-writer": true
+  "library-name": "Parameters.BodyOptionality"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/collection-format/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/collection-format/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Parameters.CollectionFormat",
-  "library-name": "Parameters.CollectionFormat",
-  "use-model-reader-writer": true
+  "library-name": "Parameters.CollectionFormat"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/spread/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/parameters/spread/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Parameters.Spread",
-  "library-name": "Parameters.Spread",
-  "use-model-reader-writer": true
+  "library-name": "Parameters.Spread"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/content-negotiation/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/content-negotiation/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Payload.ContentNegotiation",
-  "library-name": "Payload.ContentNegotiation",
-  "use-model-reader-writer": true
+  "library-name": "Payload.ContentNegotiation"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/json-merge-patch/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/json-merge-patch/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Payload.JsonMergePatch",
-  "library-name": "Payload.JsonMergePatch",
-  "use-model-reader-writer": true
+  "library-name": "Payload.JsonMergePatch"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/media-type/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/media-type/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Payload.MediaType",
-  "library-name": "Payload.MediaType",
-  "use-model-reader-writer": true
+  "library-name": "Payload.MediaType"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/multipart/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/payload/multipart/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Payload.MultiPart",
-  "library-name": "Payload.MultiPart",
-  "use-model-reader-writer": true
+  "library-name": "Payload.MultiPart"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/resiliency/srv-driven/v1/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/resiliency/srv-driven/v1/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Resiliency.SrvDriven.V1",
-  "library-name": "Resiliency.SrvDriven.V1",
-  "use-model-reader-writer": true
+  "library-name": "Resiliency.SrvDriven.V1"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/resiliency/srv-driven/v2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/resiliency/srv-driven/v2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Resiliency.SrvDriven.V2",
-  "library-name": "Resiliency.SrvDriven.V2",
-  "use-model-reader-writer": true
+  "library-name": "Resiliency.SrvDriven.V2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/routes/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/routes/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Routes",
-  "library-name": "Routes",
-  "use-model-reader-writer": true
+  "library-name": "Routes"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/serialization/encoded-name/json/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/serialization/encoded-name/json/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Serialization.EncodedName.Json",
-  "library-name": "Serialization.EncodedName.Json",
-  "use-model-reader-writer": true
+  "library-name": "Serialization.EncodedName.Json"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/endpoint/not-defined/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/endpoint/not-defined/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Server.Endpoint.NotDefined",
-  "library-name": "Server.Endpoint.NotDefined",
-  "use-model-reader-writer": true
+  "library-name": "Server.Endpoint.NotDefined"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/path/multiple/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/path/multiple/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Server.Path.Multiple",
-  "library-name": "Server.Path.Multiple",
-  "use-model-reader-writer": true
+  "library-name": "Server.Path.Multiple"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/path/single/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/path/single/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Server.Path.Single",
-  "library-name": "Server.Path.Single",
-  "use-model-reader-writer": true
+  "library-name": "Server.Path.Single"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/versions/not-versioned/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/versions/not-versioned/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Server.Versions.NotVersioned",
-  "library-name": "Server.Versions.NotVersioned",
-  "use-model-reader-writer": true
+  "library-name": "Server.Versions.NotVersioned"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/versions/versioned/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/server/versions/versioned/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Server.Versions.Versioned",
-  "library-name": "Server.Versions.Versioned",
-  "use-model-reader-writer": true
+  "library-name": "Server.Versions.Versioned"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/special-headers/conditional-request/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/special-headers/conditional-request/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "SpecialHeaders.ConditionalRequest",
-  "library-name": "SpecialHeaders.ConditionalRequest",
-  "use-model-reader-writer": true
+  "library-name": "SpecialHeaders.ConditionalRequest"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/special-headers/repeatability/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/special-headers/repeatability/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "SpecialHeaders.Repeatability",
-  "library-name": "SpecialHeaders.Repeatability",
-  "use-model-reader-writer": true
+  "library-name": "SpecialHeaders.Repeatability"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/special-words/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/special-words/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "SpecialWords",
-  "library-name": "SpecialWords",
-  "use-model-reader-writer": true
+  "library-name": "SpecialWords"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/array/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/array/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Array",
-  "library-name": "Type.Array",
-  "use-model-reader-writer": true
+  "library-name": "Type.Array"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/dictionary/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/dictionary/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Dictionary",
-  "library-name": "Type.Dictionary",
-  "use-model-reader-writer": true
+  "library-name": "Type.Dictionary"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/enum/extensible/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/enum/extensible/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Enum.Extensible",
-  "library-name": "Type.Enum.Extensible",
-  "use-model-reader-writer": true
+  "library-name": "Type.Enum.Extensible"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/enum/fixed/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/enum/fixed/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Enum.Fixed",
-  "library-name": "Type.Enum.Fixed",
-  "use-model-reader-writer": true
+  "library-name": "Type.Enum.Fixed"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/empty/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/empty/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Empty",
-  "library-name": "Type.Model.Empty",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Empty"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/enum-discriminator/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/enum-discriminator/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Inheritance.EnumDiscriminator",
-  "library-name": "Type.Model.Inheritance.EnumDiscriminator",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Inheritance.EnumDiscriminator"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/nested-discriminator/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/nested-discriminator/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Inheritance.NestedDiscriminator",
-  "library-name": "Type.Model.Inheritance.NestedDiscriminator",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Inheritance.NestedDiscriminator"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/not-discriminated/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/not-discriminated/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Inheritance.NotDiscriminated",
-  "library-name": "Type.Model.Inheritance.NotDiscriminated",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Inheritance.NotDiscriminated"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/recursive/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/recursive/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Inheritance.Recursive",
-  "library-name": "Type.Model.Inheritance.Recursive",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Inheritance.Recursive"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/single-discriminator/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/inheritance/single-discriminator/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Inheritance.SingleDiscriminator",
-  "library-name": "Type.Model.Inheritance.SingleDiscriminator",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Inheritance.SingleDiscriminator"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/usage/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/usage/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Usage",
-  "library-name": "Type.Model.Usage",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Usage"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/visibility/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/model/visibility/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Model.Visibility",
-  "library-name": "Type.Model.Visibility",
-  "use-model-reader-writer": true
+  "library-name": "Type.Model.Visibility"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/additional-properties/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/additional-properties/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Property.AdditionalProperties",
-  "library-name": "Type.Property.AdditionalProperties",
-  "use-model-reader-writer": true
+  "library-name": "Type.Property.AdditionalProperties"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/nullable/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/nullable/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Property.Nullable",
-  "library-name": "Type.Property.Nullable",
-  "use-model-reader-writer": true
+  "library-name": "Type.Property.Nullable"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/optionality/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/optionality/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Property.Optional",
-  "library-name": "Type.Property.Optional",
-  "use-model-reader-writer": true
+  "library-name": "Type.Property.Optional"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/value-types/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/property/value-types/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Property.ValueTypes",
-  "library-name": "Type.Property.ValueTypes",
-  "use-model-reader-writer": true
+  "library-name": "Type.Property.ValueTypes"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/scalar/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/scalar/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Scalar",
-  "library-name": "Type.Scalar",
-  "use-model-reader-writer": true
+  "library-name": "Type.Scalar"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/union/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/type/union/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Type.Union",
-  "library-name": "Type.Union",
-  "use-model-reader-writer": true
+  "library-name": "Type.Union"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/added/v1/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/added/v1/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.Added.V1",
-  "library-name": "Versioning.Added.V1",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.Added.V1"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/added/v2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/added/v2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.Added.V2",
-  "library-name": "Versioning.Added.V2",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.Added.V2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/madeOptional/v1/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/madeOptional/v1/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.MadeOptional.V1",
-  "library-name": "Versioning.MadeOptional.V1",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.MadeOptional.V1"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/madeOptional/v2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/madeOptional/v2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.MadeOptional.V2",
-  "library-name": "Versioning.MadeOptional.V2",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.MadeOptional.V2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/removed/v1/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/removed/v1/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.Removed.V1",
-  "library-name": "Versioning.Removed.V1",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.Removed.V1"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/removed/v2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/removed/v2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.Removed.V2",
-  "library-name": "Versioning.Removed.V2",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.Removed.V2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/removed/v2Preview/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/removed/v2Preview/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.Removed.V2Preview",
-  "library-name": "Versioning.Removed.V2Preview",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.Removed.V2Preview"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/renamedFrom/v1/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/renamedFrom/v1/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.RenamedFrom.V1",
-  "library-name": "Versioning.RenamedFrom.V1",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.RenamedFrom.V1"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/renamedFrom/v2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/renamedFrom/v2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.RenamedFrom.V2",
-  "library-name": "Versioning.RenamedFrom.V2",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.RenamedFrom.V2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/returnTypeChangedFrom/v1/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/returnTypeChangedFrom/v1/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.ReturnTypeChangedFrom.V1",
-  "library-name": "Versioning.ReturnTypeChangedFrom.V1",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.ReturnTypeChangedFrom.V1"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/returnTypeChangedFrom/v2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/returnTypeChangedFrom/v2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.ReturnTypeChangedFrom.V2",
-  "library-name": "Versioning.ReturnTypeChangedFrom.V2",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.ReturnTypeChangedFrom.V2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/typeChangedFrom/v1/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/typeChangedFrom/v1/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.TypeChangedFrom.V1",
-  "library-name": "Versioning.TypeChangedFrom.V1",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.TypeChangedFrom.V1"
 }

--- a/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/typeChangedFrom/v2/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/CadlRanch/http/versioning/typeChangedFrom/v2/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "Versioning.TypeChangedFrom.V2",
-  "library-name": "Versioning.TypeChangedFrom.V2",
-  "use-model-reader-writer": true
+  "library-name": "Versioning.TypeChangedFrom.V2"
 }

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/Configuration.json
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/Configuration.json
@@ -1,6 +1,5 @@
 {
   "output-folder": ".",
   "namespace": "UnbrandedTypeSpec",
-  "library-name": "UnbrandedTypeSpec",
-  "use-model-reader-writer": true
+  "library-name": "UnbrandedTypeSpec"
 }


### PR DESCRIPTION
fixes: https://github.com/microsoft/typespec/issues/5746

Follow up autorest PR to migrate the removed options: https://github.com/Azure/autorest.csharp/pull/5227