### PR TITLE
Fix JS doc not generated since typedoc 0.27.0 upgrade

### DIFF
--- a/packages/tspd/src/ref-doc/api-docs.ts
+++ b/packages/tspd/src/ref-doc/api-docs.ts
@@ -1,7 +1,7 @@
 import { joinPaths } from "@typespec/compiler";
 import { writeFile } from "fs/promises";
 import { Application, PageEvent, Reflection, ReflectionKind } from "typedoc";
-import { PluginOptions, load } from "typedoc-plugin-markdown";
+import { PluginOptions } from "typedoc-plugin-markdown";
 import { stringify } from "yaml";
 export async function generateJsApiDocs(libraryPath: string, outputDir: string) {
   const markdownPluginOptions: Partial<PluginOptions> = {
@@ -19,11 +19,12 @@ export async function generateJsApiDocs(libraryPath: string, outputDir: string) 
   const app = await Application.bootstrapWithPlugins({
     entryPoints: [joinPaths(libraryPath, "src/index.ts")],
     tsconfig: joinPaths(libraryPath, "tsconfig.json"),
+    plugin: ["typedoc-plugin-markdown"],
     entryPointStrategy: "resolve",
   });
 
   loadRenderer(app);
-  load(app);
+  // load(app);
 
   setOptions(app, {
     name: "JS API",
@@ -31,6 +32,7 @@ export async function generateJsApiDocs(libraryPath: string, outputDir: string) 
     readme: "none",
     hideGenerator: true,
     disableSources: true,
+    out: outputDir,
     ...markdownPluginOptions,
   });
 
@@ -41,7 +43,7 @@ export async function generateJsApiDocs(libraryPath: string, outputDir: string) 
     return;
   }
 
-  await app.generateDocs(project, outputDir);
+  await app.generateOutputs(project);
 
   await writeFile(
     joinPaths(outputDir, "_category_.json"),

--- a/packages/tspd/src/ref-doc/api-docs.ts
+++ b/packages/tspd/src/ref-doc/api-docs.ts
@@ -1,7 +1,7 @@
 import { joinPaths } from "@typespec/compiler";
 import { writeFile } from "fs/promises";
 import { Application, PageEvent, Reflection, ReflectionKind } from "typedoc";
-import { PluginOptions } from "typedoc-plugin-markdown";
+import { PluginOptions, load } from "typedoc-plugin-markdown";
 import { stringify } from "yaml";
 export async function generateJsApiDocs(libraryPath: string, outputDir: string) {
   const markdownPluginOptions: Partial<PluginOptions> = {
@@ -19,12 +19,11 @@ export async function generateJsApiDocs(libraryPath: string, outputDir: string) 
   const app = await Application.bootstrapWithPlugins({
     entryPoints: [joinPaths(libraryPath, "src/index.ts")],
     tsconfig: joinPaths(libraryPath, "tsconfig.json"),
-    plugin: ["typedoc-plugin-markdown"],
     entryPointStrategy: "resolve",
   });
 
   loadRenderer(app);
-  // load(app);
+  load(app);
 
   setOptions(app, {
     name: "JS API",


### PR DESCRIPTION
typedoc changed their api so it was generting the html not the markdown files