### PR TITLE
`tsp init` to automatically run `tsp install`

### DIFF
--- a/.chronus/changes/tspInitUpdate-2025-0-31-9-41-10.md
+++ b/.chronus/changes/tspInitUpdate-2025-0-31-9-41-10.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+`tsp init` will not automatically run `tsp install` if a `package.json` file is created.

--- a/packages/compiler/src/init/scaffold.ts
+++ b/packages/compiler/src/init/scaffold.ts
@@ -97,7 +97,7 @@ export async function scaffoldNewProject(host: CompilerHost, config: Scaffolding
   await writeFiles(host, config);
 }
 
-function isFileSkipGeneration(fileName: string, files: InitTemplateFile[]): boolean {
+export function isFileSkipGeneration(fileName: string, files: InitTemplateFile[]): boolean {
   for (const file of files) {
     if (file.destination === fileName) {
       return file.skipGeneration ?? false;


### PR DESCRIPTION
Close #5766.

Per discussion from https://github.com/microsoft/typespec/pull/5796 and Teams, this PR:

- automatically runs `tsp install` as part of `tsp init` if the template created a `package.json` file
- skips running or mentioning `tsp install` if `package.json` is not created
- does NOT provide a flag for opt in/out
- does NOT provide a confirmation dialogue