### PR TITLE
Pass `tracer` to `SourceLoader` to fix tracing

### DIFF
--- a/.chronus/changes/steverice-source-loader-tracer-2025-1-1-14-9-29.md
+++ b/.chronus/changes/steverice-source-loader-tracer-2025-1-1-14-9-29.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix tracing in `SourceLoader`

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -315,6 +315,7 @@ export async function compile(
   async function loadSources(entrypoint: string) {
     const sourceLoader = await createSourceLoader(host, {
       parseOptions: options.parseOptions,
+      tracer,
       getCachedScript: (file) =>
         oldProgram?.sourceFiles.get(file.path) ?? host.parseCache?.get(file),
     });


### PR DESCRIPTION
The `SourceLoader` emits traces under the `"import-resolution"` namespace.
During the refactor in d2ac9958422db48acd818340c6b8ae069da0cf41, we stopped passing the `tracer` to the `SourceLoader` so those traces weren't happening.

This appear to be a bug, as `LoadSourceOptions` has a field for `tracer`.