### PR TITLE
Upgrade corepack to fix key integrity issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,14 @@
 # --------------------------------
 #  Build compiler
 # --------------------------------
-FROM mcr.microsoft.com/mirror/docker/library/node:18-alpine as builder
+FROM mcr.microsoft.com/mirror/docker/library/node:18-alpine AS builder
 
 RUN apk add --no-cache git
 COPY . /app
 
 WORKDIR /app
 ENV TYPESPEC_SKIP_VS_BUILD=1
-RUN corepack enable && corepack prepare
+RUN npm install -g corepack@latest && corepack enable && corepack prepare
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter "@typespec/compiler..." run build
 


### PR DESCRIPTION
This should fix the issue
```
Cannot find matching keyid: {"signatures":[{"sig":"MEQCIHGqHbvc2zImUPEPFpT4grh6rMYslel+lAjFArx8+RUdAiBfnJA+bgmUvO5Lctfkq+46KKDQdx/8RhLPge3pA+EdHA==","keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"}],"keys":[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}]}
```

when running docker builds. See https://github.com/pnpm/pnpm/issues/9014#issuecomment-2618565344 for more context.

On my machine, I've run `docker build -f ./docker/Dockerfile .` before and after this change. Before I get the integrity error, after everything works again.