### PR TITLE
Allow specifying the name for an authorization type with `id`

### DIFF
--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -642,7 +642,7 @@ function extractHttpAuthentication(
   return [
     {
       ...auth,
-      id: modelType.name || result.type,
+      ...{ id: auth.id || modelType.name || result.type },
       ...(description && { description }),
     },
     diagnostics,

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -867,6 +867,31 @@ describe("http: decorators", () => {
       });
     });
 
+    it("can specify custom name using id", async () => {
+      const { Foo } = (await runner.compile(`
+        @doc("My basic auth with a custom name")
+        model MyAuth extends BasicAuth { id: "YourAuth"; };
+        @useAuth(MyAuth)
+        @test namespace Foo {}
+      `)) as { Foo: Namespace };
+
+      expect(getAuthentication(runner.program, Foo)).toEqual({
+        options: [
+          {
+            schemes: [
+              {
+                id: "YourAuth",
+                description: "My basic auth with a custom name",
+                type: "http",
+                scheme: "basic",
+                model: expect.objectContaining({ kind: "Model" }),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
     it("can specify BearerAuth", async () => {
       const { Foo } = (await runner.compile(`
         @useAuth(BearerAuth)


### PR DESCRIPTION
Emitters like OpenAPI3 need to provide a name for each of the listed `securitySchemes` in a schema. Currently, that name comes from the name of the model that defines the authentication.