### PR TITLE
Add all inherited model properties to JSON data

### DIFF
--- a/.chronus/changes/steverice-json-data-inheritance-2025-1-2-22-21-58.md
+++ b/.chronus/changes/steverice-json-data-inheritance-2025-1-2-22-21-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@typespec/compiler"
+---
+
+Add all inherited model properties to JSON data

--- a/packages/compiler/src/core/decorator-utils.ts
+++ b/packages/compiler/src/core/decorator-utils.ts
@@ -1,3 +1,4 @@
+import { walkPropertiesInherited } from "./checker.js";
 import { compilerAssert, ignoreDiagnostics } from "./diagnostics.js";
 import { getTypeName } from "./helpers/type-name-utils.js";
 import { createDiagnostic, reportDiagnostic } from "./messages.js";
@@ -404,15 +405,15 @@ function typespecTypeToJsonInternal(
     }
     case "Model": {
       const result: Record<string, any> = {};
-      for (const [name, type] of typespecType.properties.entries()) {
-        const [item, diagnostics] = typespecTypeToJsonInternal(type.type, target, [
+      for (const property of walkPropertiesInherited(typespecType)) {
+        const [item, diagnostics] = typespecTypeToJsonInternal(property.type, target, [
           ...path,
-          name.toString(),
+          property.name.toString(),
         ]);
         if (diagnostics.length > 0) {
           return [undefined, diagnostics];
         }
-        result[name] = item;
+        result[property.name] = item;
       }
       return [result, []];
     }

--- a/packages/compiler/test/decorator-utils.test.ts
+++ b/packages/compiler/test/decorator-utils.test.ts
@@ -101,13 +101,25 @@ describe("compiler: decorator utils", () => {
       strictEqual(diagnostics.length, 0);
     });
 
-    it("can a nested model", async () => {
+    it("can convert a nested model", async () => {
       const [data, diagnostics] = await convertDecoratorDataToJson(`
         @jsonData({string: "string", nested: {foo: "bar"}, bool: true})
         model Foo {}
       `);
 
       deepStrictEqual(data, { string: "string", nested: { foo: "bar" }, bool: true });
+      strictEqual(diagnostics.length, 0);
+    });
+
+    it("can convert a named model with inherited properties", async () => {
+      const [data, diagnostics] = await convertDecoratorDataToJson(`
+        model Parent {number: 123}
+        model Child extends Parent {string: "child", bool: true}
+        @jsonData(Child)
+        model Foo {}
+      `);
+
+      deepStrictEqual(data, { string: "child", number: 123, bool: true });
       strictEqual(diagnostics.length, 0);
     });
 


### PR DESCRIPTION
When using `typespecTypeToJson` with a model type, only the properties implemented directly on that model are included.

Now we use `walkPropertiesInherited` to include all inherited properties as well.

This is technically a breaking change; specs that provide models with inherited properties to decorators using `typeSpecToJson` will now see those properties added to the output. The decorators affected by this are:
- `@useAuth` (from `http`)
- `@extension` (both `json-schema` and `openapi`)
- `@info` (from `openapi`)