### PR TITLE
Fix sample command of changing output-dir

### DIFF
--- a/website/src/content/docs/docs/handbook/configuration/configuration.mdx
+++ b/website/src/content/docs/docs/handbook/configuration/configuration.mdx
@@ -441,7 +441,7 @@ You can change the compiler's `output-dir` with `--output-dir` or by setting tha
 To change a specific emitter's output directory, you can set the `emitter-output-dir` option for that emitter:
 
 ```bash
---option "@typespec/openapi3.output-dir={project-root}/openapispec"
+--option "@typespec/openapi3.emitter-output-dir={project-root}/openapispec"
 ```
 
 {/* prettier-ignore */}


### PR DESCRIPTION
I tried `openapi3.output-dir`, but the following error occured.

> tspconfig.yaml:one:1 - error invalid-schema: Schema violation: must NOT have additional properties (/)
>   additionalProperty: output-dir

Changed sample command to the right one as described just above in the same page.