### PR TITLE
Add extension methods of FieldProvider to avoid explicit casting

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Snippets/Snippet.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Snippets/Snippet.cs
@@ -22,8 +22,10 @@ namespace Microsoft.Generator.CSharp.Snippets
         public static ScopedApi<T> As<T>(this FieldProvider field) => ((ValueExpression)field).As<T>();
 
         public static ValueExpression NullConditional(this ParameterProvider parameter) => new NullConditionalExpression(parameter);
+        public static ValueExpression NullConditional(this FieldProvider field) => new NullConditionalExpression(field);
 
         public static ValueExpression NullCoalesce(this ParameterProvider parameter, ValueExpression value) => new BinaryOperatorExpression("??", parameter, value);
+        public static ValueExpression NullCoalesce(this FieldProvider field, ValueExpression value) => new BinaryOperatorExpression("??", field, value);
         public static ValueExpression PositionalReference(this ParameterProvider parameter, ValueExpression value)
             => new PositionalParameterReferenceExpression(parameter.Name, value);
 


### PR DESCRIPTION
There are usages of `FieldProvider.NullConditional()` and `FieldProvider.NullCoalesce` in [Azure plugin PR](https://github.com/Azure/azure-sdk-for-net/pull/48108/files#diff-3d43cbed0759c14bceedcc880bd23c13689a62d2dd7f9ebcdfb87213d3947e75).
Add extension methods to avoid explicit casting.