### PR TITLE
Fix: StringTemplate type not supported in typespecValueToJson

### DIFF
--- a/.chronus/changes/fix-handle-typeof-string-template-json-2025-1-10-23-8-49.md
+++ b/.chronus/changes/fix-handle-typeof-string-template-json-2025-1-10-23-8-49.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix: StringTemplate type not supported in typespecValueToJson

--- a/packages/compiler/src/core/decorator-utils.ts
+++ b/packages/compiler/src/core/decorator-utils.ts
@@ -417,6 +417,12 @@ function typespecTypeToJsonInternal(
       }
       return [result, []];
     }
+    case "StringTemplate":
+      if (typespecType.stringValue) {
+        return [typespecType.stringValue, []];
+      }
+    // By design
+    // eslint-disable-next-line no-fallthrough
     default:
       const diagnostic =
         path.length === 0


### PR DESCRIPTION
This should work as long as the template has a string representation.

fix [#5391](https://github.com/microsoft/typespec/issues/5391)