### PR TITLE
Fix: Infinite loop in language server due to not caching indeterminate entities

### DIFF
--- a/.chronus/changes/fix-infinite-loop-diagnostic-2025-1-10-23-29-7.md
+++ b/.chronus/changes/fix-infinite-loop-diagnostic-2025-1-10-23-29-7.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix: Infinite loop in language server due to not caching indeterminate entities in templates

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -399,6 +399,7 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
   }
 
   let evalContext: EvalContext | undefined = undefined;
+  const indeterminateEntities = new WeakMap<Type, IndeterminateEntity>();
 
   const checker: Checker = {
     getTypeForNode,
@@ -3390,10 +3391,17 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
   }
 
   function createIndeterminateEntity(type: IndeterminateEntity["type"]): IndeterminateEntity {
-    return {
+    const existing = indeterminateEntities.get(type);
+    if (existing) {
+      return existing;
+    }
+    const entity: IndeterminateEntity = {
       entityKind: "Indeterminate",
       type,
     };
+
+    indeterminateEntities.set(type, entity);
+    return entity;
   }
   function stringifyTypeForTemplate(type: Type): string | undefined {
     switch (type.kind) {
@@ -3448,24 +3456,15 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
   }
 
   function checkStringLiteral(str: StringLiteralNode): IndeterminateEntity {
-    return {
-      entityKind: "Indeterminate",
-      type: getLiteralType(str),
-    };
+    return createIndeterminateEntity(getLiteralType(str));
   }
 
   function checkNumericLiteral(num: NumericLiteralNode): IndeterminateEntity {
-    return {
-      entityKind: "Indeterminate",
-      type: getLiteralType(num),
-    };
+    return createIndeterminateEntity(getLiteralType(num));
   }
 
   function checkBooleanLiteral(bool: BooleanLiteralNode): IndeterminateEntity {
-    return {
-      entityKind: "Indeterminate",
-      type: getLiteralType(bool),
-    };
+    return createIndeterminateEntity(getLiteralType(bool));
   }
 
   function checkProgram() {

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -368,6 +368,7 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
   const neverType = createType({ kind: "Intrinsic", name: "never" } as const);
   const unknownType = createType({ kind: "Intrinsic", name: "unknown" } as const);
   const nullType = createType({ kind: "Intrinsic", name: "null" } as const);
+  const indeterminateEntities = new WeakMap<Type, IndeterminateEntity>();
 
   const projectionsByTypeKind = new Map<Type["kind"], ProjectionStatementNode[]>([
     ["Model", []],
@@ -399,7 +400,6 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
   }
 
   let evalContext: EvalContext | undefined = undefined;
-  const indeterminateEntities = new WeakMap<Type, IndeterminateEntity>();
 
   const checker: Checker = {
     getTypeForNode,

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -338,6 +338,7 @@ const TypeInstantiationMap = class
 
 export function createChecker(program: Program, resolver: NameResolver): Checker {
   const stdTypes: Partial<StdTypes> = {};
+  const indeterminateEntities = new WeakMap<Type, IndeterminateEntity>();
   const docFromCommentForSym = new Map<Sym, string>();
   const referenceSymCache = new WeakMap<
     TypeReferenceNode | MemberExpressionNode | IdentifierNode,
@@ -368,7 +369,6 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
   const neverType = createType({ kind: "Intrinsic", name: "never" } as const);
   const unknownType = createType({ kind: "Intrinsic", name: "unknown" } as const);
   const nullType = createType({ kind: "Intrinsic", name: "null" } as const);
-  const indeterminateEntities = new WeakMap<Type, IndeterminateEntity>();
 
   const projectionsByTypeKind = new Map<Type["kind"], ProjectionStatementNode[]>([
     ["Model", []],

--- a/packages/compiler/test/checker/templates.test.ts
+++ b/packages/compiler/test/checker/templates.test.ts
@@ -10,6 +10,7 @@ import {
   createTestRunner,
   expectDiagnosticEmpty,
   expectDiagnostics,
+  expectTypeEquals,
   extractCursor,
   extractSquiggles,
 } from "../../src/testing/index.js";
@@ -127,6 +128,22 @@ describe("compiler: templates", () => {
 
     const diagnostics = await testHost.diagnose("main.tsp");
     expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("cache indeterminate types", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+        model Template<T> {t: T}
+        @test model Test {
+          a: Template<"a">;
+          b: Template<"a">;
+        }
+      `,
+    );
+
+    const { Test } = (await testHost.compile("main.tsp")) as { Test: Model };
+    expectTypeEquals(Test.properties.get("a")!.type, Test.properties.get("b")!.type);
   });
 
   it("allows default template parameters that are models", async () => {


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/2964
The problem is everytime we created an indeterminate entity we created a new object instead of caching it from the type. This meant everytime we needed to reinstantiate the template it would create 2 separate instances.
This caused an inifinite loop in the LSP as it would call getTypeForNode for diagnostics

This should also solve some duplicate type issue we might have encountered.