### PR TITLE
OpenAPI/JsonSchema - use unevaluatedProperties instead of additionalProperties and support setting to false

### DIFF
--- a/.chronus/changes/schemas-unevaluated-props-2025-1-11-14-31-24.md
+++ b/.chronus/changes/schemas-unevaluated-props-2025-1-11-14-31-24.md
@@ -1,0 +1,8 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/json-schema"
+  - "@typespec/openapi3"
+---
+
+Updates JsonSchema and Open API 3.1 emitters to use unevaluatedProperties instead of additionalProperties, and updates Open API 3 emitters to match JsonSchema behavior of treating Record<never> as setting "additionalProperties: { not: {} }"

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -96,7 +96,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
     }
 
     if (model.indexer) {
-      schema.set("additionalProperties", this.emitter.emitTypeReference(model.indexer.value));
+      schema.set("unevaluatedProperties", this.emitter.emitTypeReference(model.indexer.value));
     }
 
     this.#applyConstraints(model, schema);
@@ -111,7 +111,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
     });
 
     if (model.indexer) {
-      schema.set("additionalProperties", this.emitter.emitTypeReference(model.indexer.value));
+      schema.set("unevaluatedProperties", this.emitter.emitTypeReference(model.indexer.value));
     }
 
     return schema;

--- a/packages/json-schema/test/extension.test.ts
+++ b/packages/json-schema/test/extension.test.ts
@@ -72,7 +72,7 @@ it("handles types", async () => {
   assert.deepStrictEqual(Foo["x-named-model"], { $ref: "Thing.json" });
   assert.deepStrictEqual(Foo["x-model-template"], { $ref: "CollectionThing.json" });
   assert.deepStrictEqual(Foo["x-record"], {
-    additionalProperties: {
+    unevaluatedProperties: {
       properties: {
         name: {
           type: "string",

--- a/packages/json-schema/test/models.test.ts
+++ b/packages/json-schema/test/models.test.ts
@@ -148,8 +148,8 @@ describe("emitting models", () => {
     );
 
     assert.deepStrictEqual(schemas["ExtendsRecord.json"].allOf[0], { $ref: "RecordString.json" });
-    assert.deepStrictEqual(schemas["RecordString.json"].additionalProperties, { type: "string" });
-    assert.deepStrictEqual(schemas["IsRecord.json"].additionalProperties, {
+    assert.deepStrictEqual(schemas["RecordString.json"].unevaluatedProperties, { type: "string" });
+    assert.deepStrictEqual(schemas["IsRecord.json"].unevaluatedProperties, {
       type: "object",
       properties: {
         x: {
@@ -181,10 +181,10 @@ describe("emitting models", () => {
       { emitAllRefs: true },
     );
 
-    assert.deepStrictEqual(schemas["RecordNever.json"].additionalProperties, { not: {} });
-    assert.deepStrictEqual(schemas["RecordUnknown.json"].additionalProperties, {});
-    assert.deepStrictEqual(schemas["RecordVoid.json"].additionalProperties, { not: {} });
-    assert.deepStrictEqual(schemas["RecordNull.json"].additionalProperties, { type: "null" });
+    assert.deepStrictEqual(schemas["RecordNever.json"].unevaluatedProperties, { not: {} });
+    assert.deepStrictEqual(schemas["RecordUnknown.json"].unevaluatedProperties, {});
+    assert.deepStrictEqual(schemas["RecordVoid.json"].unevaluatedProperties, { not: {} });
+    assert.deepStrictEqual(schemas["RecordNull.json"].unevaluatedProperties, { type: "null" });
   });
 
   it("handles instantiations of literal types", async () => {
@@ -198,15 +198,15 @@ describe("emitting models", () => {
       `,
       { emitAllRefs: true },
     );
-    assert.deepStrictEqual(schemas["Test.json"].properties.string.additionalProperties, {
+    assert.deepStrictEqual(schemas["Test.json"].properties.string.unevaluatedProperties, {
       type: "string",
       const: "hi",
     });
-    assert.deepStrictEqual(schemas["Test.json"].properties.number.additionalProperties, {
+    assert.deepStrictEqual(schemas["Test.json"].properties.number.unevaluatedProperties, {
       type: "number",
       const: 1.2,
     });
-    assert.deepStrictEqual(schemas["Test.json"].properties.boolean.additionalProperties, {
+    assert.deepStrictEqual(schemas["Test.json"].properties.boolean.unevaluatedProperties, {
       type: "boolean",
       const: true,
     });
@@ -227,7 +227,7 @@ describe("emitting models", () => {
       { emitAllRefs: true },
     );
 
-    assert.deepStrictEqual(schemas["Test.json"].properties.union.additionalProperties, {
+    assert.deepStrictEqual(schemas["Test.json"].properties.union.unevaluatedProperties, {
       anyOf: [
         {
           type: "integer",
@@ -242,7 +242,7 @@ describe("emitting models", () => {
       ],
     });
 
-    assert.deepStrictEqual(schemas["Test.json"].properties.intersection.additionalProperties, {
+    assert.deepStrictEqual(schemas["Test.json"].properties.intersection.unevaluatedProperties, {
       type: "object",
       properties: {
         x: {
@@ -260,11 +260,11 @@ describe("emitting models", () => {
     });
 
     assert.deepStrictEqual(
-      schemas["Test.json"].properties.unspeakableInstantiation.additionalProperties,
+      schemas["Test.json"].properties.unspeakableInstantiation.unevaluatedProperties,
       {
         type: "object",
         properties: {},
-        additionalProperties: {
+        unevaluatedProperties: {
           type: "object",
           properties: {
             x: {
@@ -282,7 +282,7 @@ describe("emitting models", () => {
         },
       },
     );
-    assert.deepStrictEqual(schemas["RecordRecordInt32.json"].additionalProperties, {
+    assert.deepStrictEqual(schemas["RecordRecordInt32.json"].unevaluatedProperties, {
       $ref: "RecordInt32.json",
     });
   });

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -147,6 +147,12 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
     return applyEncoding(this.emitter.getProgram(), typespecType, target as any, this._options);
   }
 
+  applyModelIndexer(schema: ObjectBuilder<any>, model: Model): void {
+    if (model.indexer) {
+      schema.set("unevaluatedProperties", this.emitter.emitTypeReference(model.indexer.value));
+    }
+  }
+
   getRawBinarySchema(): OpenAPISchema3_1 {
     return getRawBinarySchema();
   }

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -6,6 +6,7 @@ import {
   getMinValueExclusive,
   IntrinsicScalarName,
   IntrinsicType,
+  isNeverType,
   Model,
   ModelProperty,
   Program,
@@ -148,9 +149,13 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
   }
 
   applyModelIndexer(schema: ObjectBuilder<any>, model: Model): void {
-    if (model.indexer) {
-      schema.set("unevaluatedProperties", this.emitter.emitTypeReference(model.indexer.value));
-    }
+    if (!model.indexer) return;
+    const indexerType = model.indexer.value;
+
+    const unevaluatedPropertiesSchema = isNeverType(indexerType)
+      ? { not: {} }
+      : this.emitter.emitTypeReference(indexerType);
+    schema.set("unevaluatedProperties", unevaluatedPropertiesSchema);
   }
 
   getRawBinarySchema(): OpenAPISchema3_1 {

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -155,6 +155,12 @@ export class OpenAPI3SchemaEmitterBase<
     }
   }
 
+  applyModelIndexer(schema: ObjectBuilder<any>, model: Model): void {
+    if (model.indexer) {
+      schema.set("additionalProperties", this.emitter.emitTypeReference(model.indexer.value));
+    }
+  }
+
   modelDeclaration(model: Model, _: string): EmitterOutput<object> {
     const program = this.emitter.getProgram();
     const visibility = this.#getVisibilityContext();
@@ -164,9 +170,7 @@ export class OpenAPI3SchemaEmitterBase<
       properties: this.emitter.emitModelProperties(model),
     });
 
-    if (model.indexer) {
-      schema.set("additionalProperties", this.emitter.emitTypeReference(model.indexer.value));
-    }
+    this.applyModelIndexer(schema, model);
 
     const derivedModels = model.derivedModels.filter(includeDerivedModel);
     // getSchemaOrRef on all children to push them into components.schemas
@@ -224,9 +228,7 @@ export class OpenAPI3SchemaEmitterBase<
       required: this.#requiredModelProperties(model, this.#getVisibilityContext()),
     });
 
-    if (model.indexer) {
-      schema.set("additionalProperties", this.emitter.emitTypeReference(model.indexer.value));
-    }
+    this.applyModelIndexer(schema, model);
 
     return schema;
   }

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -1013,6 +1013,15 @@ export type JsonSchema<AdditionalVocabularies extends {} = {}> = AdditionalVocab
   additionalProperties?: boolean | Refable<JsonSchema<AdditionalVocabularies>>;
 
   /**
+   * Indicates that additional unlisted properties can exist in this schema.
+   * This differs from additionalProperties in that it is aware of any in-place applicators.
+   * This includes being aware of properties defined in sibling `allOf` sub-schemas.
+   *
+   * @see https://json-schema.org/draft/2020-12/json-schema-core#name-unevaluatedproperties
+   */
+  unevaluatedProperties?: boolean | Refable<JsonSchema<AdditionalVocabularies>>;
+
+  /**
    * Property is readonly.
    */
   readOnly?: boolean;

--- a/packages/openapi3/test/additional-properties.test.ts
+++ b/packages/openapi3/test/additional-properties.test.ts
@@ -2,16 +2,16 @@ import { deepStrictEqual, ok } from "assert";
 import { describe, it } from "vitest";
 import { worksFor } from "./works-for.js";
 
-worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
+worksFor(["3.0.0", "3.1.0"], ({ oapiForModel, objectSchemaIndexer }) => {
   describe("extends Record<T>", () => {
-    it("doesn't set additionalProperties on model itself", async () => {
+    it(`doesn't set ${objectSchemaIndexer} on model itself`, async () => {
       const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet.additionalProperties, undefined);
+      deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], undefined);
     });
 
     it("links to an allOf of the Record<unknown> schema", async () => {
       const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet.allOf, [{ type: "object", additionalProperties: {} }]);
+      deepStrictEqual(res.schemas.Pet.allOf, [{ type: "object", [objectSchemaIndexer]: {} }]);
     });
 
     it("include model properties", async () => {
@@ -23,14 +23,14 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
   });
 
   describe("is Record<T>", () => {
-    it("set additionalProperties on model itself", async () => {
+    it(`set ${objectSchemaIndexer} on model itself`, async () => {
       const res = await oapiForModel("Pet", `model Pet is Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet.additionalProperties, {});
+      deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], {});
     });
 
     it("set additional properties type", async () => {
       const res = await oapiForModel("Pet", `model Pet is Record<string> {};`);
-      deepStrictEqual(res.schemas.Pet.additionalProperties, {
+      deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], {
         type: "string",
       });
     });
@@ -44,7 +44,7 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
   });
 
   describe("referencing Record<T>", () => {
-    it("add additionalProperties inline for property of type Record<unknown>", async () => {
+    it(`add ${objectSchemaIndexer} inline for property of type Record<unknown>`, async () => {
       const res = await oapiForModel(
         "Pet",
         `
@@ -56,12 +56,12 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
       ok(res.schemas.Pet, "expected definition named Pet");
       deepStrictEqual(res.schemas.Pet.properties.details, {
         type: "object",
-        additionalProperties: {},
+        [objectSchemaIndexer]: {},
       });
     });
   });
 
-  it("set additionalProperties if model extends Record with leaf type", async () => {
+  it(`set ${objectSchemaIndexer} if model extends Record with leaf type`, async () => {
     const res = await oapiForModel(
       "Pet",
       `
@@ -73,7 +73,7 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
 
     ok(res.isRef);
     ok(res.schemas.Pet, "expected definition named Pet");
-    deepStrictEqual(res.schemas.Pet.additionalProperties, {
+    deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], {
       $ref: "#/components/schemas/Value",
     });
   });

--- a/packages/openapi3/test/nullable-properties.test.ts
+++ b/packages/openapi3/test/nullable-properties.test.ts
@@ -132,7 +132,7 @@ worksFor(["3.1.0"], ({ oapiForModel, openApiFor }) => {
     it("keep nullable Record<T> inline", async () => {
       await expectInCircularReference("Record<Test>", {
         anyOf: [
-          { type: "object", additionalProperties: { $ref: "#/components/schemas/Test" } },
+          { type: "object", unevaluatedProperties: { $ref: "#/components/schemas/Test" } },
           { type: "null" },
         ],
       });

--- a/packages/openapi3/test/record.test.ts
+++ b/packages/openapi3/test/record.test.ts
@@ -2,7 +2,7 @@ import { deepStrictEqual, ok } from "assert";
 import { it } from "vitest";
 import { worksFor } from "./works-for.js";
 
-worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
+worksFor(["3.0.0", "3.1.0"], ({ oapiForModel, objectSchemaIndexer }) => {
   it("defines record inline", async () => {
     const res = await oapiForModel(
       "Pet",
@@ -15,7 +15,7 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
     ok(res.schemas.Pet, "expected definition named Pet");
     deepStrictEqual(res.schemas.Pet.properties.foodScores, {
       type: "object",
-      additionalProperties: { type: "integer", format: "int32" },
+      [objectSchemaIndexer]: { type: "integer", format: "int32" },
     });
   });
 
@@ -33,11 +33,11 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
     ok(res.schemas.Pet, "expected definition named Pet");
     deepStrictEqual(res.schemas.FoodScores, {
       type: "object",
-      additionalProperties: { type: "integer", format: "int32" },
+      [objectSchemaIndexer]: { type: "integer", format: "int32" },
     });
   });
 
-  it("specify additionalProperties when `...Record<T>`", async () => {
+  it(`specify ${objectSchemaIndexer} when "...Record<T>"`, async () => {
     const res = await oapiForModel(
       "Person",
       `
@@ -48,12 +48,12 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
     deepStrictEqual(res.schemas.Person, {
       type: "object",
       properties: { age: { type: "integer", format: "int32" } },
-      additionalProperties: { type: "string" },
+      [objectSchemaIndexer]: { type: "string" },
       required: ["age"],
     });
   });
 
-  it("specify additionalProperties of anyOf when multiple `...Record<T>`", async () => {
+  it(`specify ${objectSchemaIndexer} of anyOf when multiple "...Record<T>"`, async () => {
     const res = await oapiForModel(
       "Person",
       `
@@ -64,7 +64,7 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel }) => {
     deepStrictEqual(res.schemas.Person, {
       type: "object",
       properties: { age: { type: "integer", format: "int32" } },
-      additionalProperties: { anyOf: [{ type: "string" }, { type: "boolean" }] },
+      [objectSchemaIndexer]: { anyOf: [{ type: "string" }, { type: "boolean" }] },
       required: ["age"],
     });
   });

--- a/packages/openapi3/test/return-types.test.ts
+++ b/packages/openapi3/test/return-types.test.ts
@@ -3,7 +3,7 @@ import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
 import { worksFor } from "./works-for.js";
 
-worksFor(["3.0.0", "3.1.0"], ({ checkFor, openApiFor }) => {
+worksFor(["3.0.0", "3.1.0"], ({ checkFor, openApiFor, objectSchemaIndexer }) => {
   it("model used with @body and without shouldn't conflict if it contains no metadata", async () => {
     const res = await openApiFor(
       `
@@ -293,7 +293,7 @@ worksFor(["3.0.0", "3.1.0"], ({ checkFor, openApiFor }) => {
     );
   });
 
-  it("produce additionalProperties schema if response is Record<T>", async () => {
+  it(`produce ${objectSchemaIndexer} schema if response is Record<T>`, async () => {
     const res = await openApiFor(
       `
       @get op test(): Record<string>;
@@ -306,7 +306,7 @@ worksFor(["3.0.0", "3.1.0"], ({ checkFor, openApiFor }) => {
       "application/json": {
         schema: {
           type: "object",
-          additionalProperties: {
+          [objectSchemaIndexer]: {
             type: "string",
           },
         },

--- a/packages/openapi3/test/works-for.ts
+++ b/packages/openapi3/test/works-for.ts
@@ -14,6 +14,8 @@ export const OpenAPISpecHelpers: Record<OpenAPIVersion, SpecHelper> = {
   "3.1.0": createSpecHelpers("3.1.0"),
 };
 
+export type ObjectSchemaIndexer = "additionalProperties" | "unevaluatedProperties";
+
 export type SpecHelper = {
   version: OpenAPIVersion;
   oapiForModel: typeof oapiForModel;
@@ -22,6 +24,7 @@ export type SpecHelper = {
   checkFor: typeof checkFor;
   diagnoseOpenApiFor: typeof diagnoseOpenApiFor;
   emitOpenApiWithDiagnostics: typeof emitOpenApiWithDiagnostics;
+  objectSchemaIndexer: ObjectSchemaIndexer;
 };
 
 export type WorksForCb = (specHelpers: SpecHelper) => void;
@@ -42,6 +45,7 @@ function createSpecHelpers(version: OpenAPIVersion): SpecHelper {
     emitOpenApiWithDiagnostics: (
       ...[code, options]: Parameters<typeof emitOpenApiWithDiagnostics>
     ) => emitOpenApiWithDiagnostics(code, { ...options, "openapi-versions": [version] }),
+    objectSchemaIndexer: version === "3.0.0" ? "additionalProperties" : "unevaluatedProperties",
   };
 }
 


### PR DESCRIPTION
Related to #3549 

This PR does a couple things:

### Json Schema and Open API 3.1 use unevaluatedProperties instead of additionalProperties

`unevaluatedProperties` is similar to `additionalProperties` in that it can specify what extra properties are allowed on an object. One key difference from additionalProperties though is that it evaluates properties after any in-place applicators. Practically speaking, this means that it will take into account any properties defined in `allOf` subschemas when validating an object instance, whereas additionalProperties only takes into account properties defined in its containing schema.

This is particularly useful when trying to set `additionalProperties` to false on a schema that has sub-schemas.

#### Risks

Functionally, I don't believe this is a breaking change. Where this _might_ cause problems though is if someone is doing their own processing of the Json Schema or Open API 3.1 output to add `additionalProperties: false` if that field isn't present, since those would now be called `unevaluatedProperties`. 

### Open API 3 - support Record<never> for additionalProperties: { not: {} }

This change brings the Open API 3 (3.0 and 3.1) emitter in line with the Json Schema emitter, which already supports treating `Record<never>` as `additionalProperties: { not: {} }`. `{ not: {} }` is equivalent to the boolean `false` for schemas, so this is the same as supporting `additionalProperties: false`.

_Note_: For Open API 3.1 output, `unevaluatedProperties` is emitted instead of `additionalProperties`.

For Open API 3.0 output that still relies on `additionalProperties`, there's some additional handling of `model extends` so that any properties that exist on a base model, but not the derived model, are redeclared as `propertyName: {}` in the derived model. Without this, if the base model contains any properties that aren't in the derived model, and the derived model spreads `Record<never>`, that emitted schema will never pass validation on an input.

#### Example
```tsp
model Widget {
  id: string;
  ...Record<never>;
}
```
```json
{
  "type": "object",
  "required": [ "id" ],
  "properties": { "id": { "type": "string" } },
  "unevaluatedProperties": { "not": {} }
}
```

### Followups
A separate PR will be created to add an emitter option to JsonSchema/OpenAPI emitters to automatically set `additionalProperties: { not: {} }` on at least leaf schemas.
