### PR TITLE
http-client-java, update clientcore to beta.3

### DIFF
--- a/.chronus/changes/http-client-java_update-clientcore-2025-1-13-13-43-59.md
+++ b/.chronus/changes/http-client-java_update-clientcore-2025-1-13-13-43-59.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-java"
+---
+
+Support clientcore 1.0.0-beta.3

--- a/packages/http-client-java/CONTRIBUTING.md
+++ b/packages/http-client-java/CONTRIBUTING.md
@@ -68,3 +68,9 @@ Before creating pull request, the code is required to be well-formatted.
 
 Run `npm run format` in "packages/http-client-java" folder.
 It formats TypeScript code as well as Java code.
+
+## Add Change Description
+
+A change description is required to pass CI of your pull request.
+
+Run `pnpm chronus add` in repository root to add change description.

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/pom.xml
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.clientcore</groupId>
       <artifactId>core</artifactId>
-      <version>1.0.0-beta.2</version>
+      <version>1.0.0-beta.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/apikey/ApiKeyClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/apikey/ApiKeyClientBuilder.java
@@ -7,7 +7,7 @@ import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.credential.KeyCredential;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -92,15 +92,15 @@ public final class ApiKeyClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public ApiKeyClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public ApiKeyClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -235,7 +235,9 @@ public final class ApiKeyClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
@@ -244,7 +246,7 @@ public final class ApiKeyClientBuilder
         if (keyCredential != null) {
             policies.add(new KeyCredentialPolicy("x-ms-api-key", keyCredential, null));
         }
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/http/custom/CustomClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/http/custom/CustomClientBuilder.java
@@ -7,7 +7,7 @@ import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.credential.KeyCredential;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -92,15 +92,15 @@ public final class CustomClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public CustomClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public CustomClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -235,7 +235,9 @@ public final class CustomClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
@@ -244,7 +246,7 @@ public final class CustomClientBuilder
         if (keyCredential != null) {
             policies.add(new KeyCredentialPolicy("authorization", keyCredential, "SharedAccessKey"));
         }
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/oauth2/OAuth2ClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/oauth2/OAuth2ClientBuilder.java
@@ -7,7 +7,7 @@ import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.credential.KeyCredential;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -92,15 +92,15 @@ public final class OAuth2ClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public OAuth2ClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public OAuth2ClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -235,7 +235,9 @@ public final class OAuth2ClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
@@ -244,7 +246,7 @@ public final class OAuth2ClientBuilder
         if (keyCredential != null) {
             policies.add(new KeyCredentialPolicy("authorization", keyCredential, "Bearer"));
         }
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/union/UnionClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/authentication/union/UnionClientBuilder.java
@@ -7,7 +7,7 @@ import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.credential.KeyCredential;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -91,15 +91,15 @@ public final class UnionClientBuilder implements HttpTrait<UnionClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public UnionClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public UnionClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -234,7 +234,9 @@ public final class UnionClientBuilder implements HttpTrait<UnionClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
@@ -243,7 +245,7 @@ public final class UnionClientBuilder implements HttpTrait<UnionClientBuilder>, 
         if (keyCredential != null) {
             policies.add(new KeyCredentialPolicy("authorization", keyCredential, "Bearer"));
         }
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/encode/duration/DurationClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/encode/duration/DurationClientBuilder.java
@@ -6,7 +6,7 @@ import encode.duration.implementation.DurationClientImpl;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class DurationClientBuilder implements HttpTrait<DurationClientBuil
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public DurationClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public DurationClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class DurationClientBuilder implements HttpTrait<DurationClientBuil
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/encode/numeric/NumericClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/encode/numeric/NumericClientBuilder.java
@@ -6,7 +6,7 @@ import encode.numeric.implementation.NumericClientImpl;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class NumericClientBuilder implements HttpTrait<NumericClientBuilde
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public NumericClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public NumericClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class NumericClientBuilder implements HttpTrait<NumericClientBuilde
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/basic/BasicClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/basic/BasicClientBuilder.java
@@ -5,7 +5,7 @@ package parameters.basic;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class BasicClientBuilder implements HttpTrait<BasicClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public BasicClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public BasicClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class BasicClientBuilder implements HttpTrait<BasicClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/bodyoptionality/BodyOptionalityClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/bodyoptionality/BodyOptionalityClientBuilder.java
@@ -5,7 +5,7 @@ package parameters.bodyoptionality;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class BodyOptionalityClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public BodyOptionalityClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public BodyOptionalityClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class BodyOptionalityClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/collectionformat/CollectionFormatClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/collectionformat/CollectionFormatClientBuilder.java
@@ -5,7 +5,7 @@ package parameters.collectionformat;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class CollectionFormatClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public CollectionFormatClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public CollectionFormatClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class CollectionFormatClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/spread/SpreadClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/parameters/spread/SpreadClientBuilder.java
@@ -5,7 +5,7 @@ package parameters.spread;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class SpreadClientBuilder implements HttpTrait<SpreadClientBuilder>
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public SpreadClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public SpreadClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class SpreadClientBuilder implements HttpTrait<SpreadClientBuilder>
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/contentnegotiation/ContentNegotiationClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/contentnegotiation/ContentNegotiationClientBuilder.java
@@ -5,7 +5,7 @@ package payload.contentnegotiation;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class ContentNegotiationClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public ContentNegotiationClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public ContentNegotiationClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class ContentNegotiationClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/jsonmergepatch/JsonMergePatchClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/jsonmergepatch/JsonMergePatchClientBuilder.java
@@ -5,7 +5,7 @@ package payload.jsonmergepatch;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class JsonMergePatchClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public JsonMergePatchClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public JsonMergePatchClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class JsonMergePatchClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/mediatype/MediaTypeClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/mediatype/MediaTypeClientBuilder.java
@@ -5,7 +5,7 @@ package payload.mediatype;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class MediaTypeClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public MediaTypeClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public MediaTypeClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +216,15 @@ public final class MediaTypeClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/multipart/MultiPartClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/multipart/MultiPartClientBuilder.java
@@ -5,7 +5,7 @@ package payload.multipart;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -94,15 +94,15 @@ public final class MultiPartClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public MultiPartClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public MultiPartClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -221,13 +221,15 @@ public final class MultiPartClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/pageable/PageableClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/payload/pageable/PageableClientBuilder.java
@@ -5,7 +5,7 @@ package payload.pageable;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class PageableClientBuilder implements HttpTrait<PageableClientBuil
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public PageableClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public PageableClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class PageableClientBuilder implements HttpTrait<PageableClientBuil
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/response/statuscoderange/StatusCodeRangeClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/response/statuscoderange/StatusCodeRangeClientBuilder.java
@@ -5,7 +5,7 @@ package response.statuscoderange;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class StatusCodeRangeClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public StatusCodeRangeClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public StatusCodeRangeClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class StatusCodeRangeClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/routes/RoutesClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/routes/RoutesClientBuilder.java
@@ -5,7 +5,7 @@ package routes;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -106,15 +106,15 @@ public final class RoutesClientBuilder implements HttpTrait<RoutesClientBuilder>
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public RoutesClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public RoutesClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -233,13 +233,15 @@ public final class RoutesClientBuilder implements HttpTrait<RoutesClientBuilder>
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/serialization/encodedname/json/JsonClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/serialization/encodedname/json/JsonClientBuilder.java
@@ -5,7 +5,7 @@ package serialization.encodedname.json;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class JsonClientBuilder implements HttpTrait<JsonClientBuilder>, Pr
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public JsonClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public JsonClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class JsonClientBuilder implements HttpTrait<JsonClientBuilder>, Pr
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/endpoint/notdefined/NotDefinedClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/endpoint/notdefined/NotDefinedClientBuilder.java
@@ -5,7 +5,7 @@ package server.endpoint.notdefined;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class NotDefinedClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public NotDefinedClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public NotDefinedClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +216,15 @@ public final class NotDefinedClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/path/multiple/MultipleClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/path/multiple/MultipleClientBuilder.java
@@ -5,7 +5,7 @@ package server.path.multiple;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class MultipleClientBuilder implements HttpTrait<MultipleClientBuil
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public MultipleClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public MultipleClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -235,13 +235,15 @@ public final class MultipleClientBuilder implements HttpTrait<MultipleClientBuil
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/path/single/SingleClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/path/single/SingleClientBuilder.java
@@ -5,7 +5,7 @@ package server.path.single;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class SingleClientBuilder implements HttpTrait<SingleClientBuilder>
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public SingleClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public SingleClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class SingleClientBuilder implements HttpTrait<SingleClientBuilder>
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/versions/notversioned/NotVersionedClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/versions/notversioned/NotVersionedClientBuilder.java
@@ -5,7 +5,7 @@ package server.versions.notversioned;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class NotVersionedClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public NotVersionedClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public NotVersionedClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +216,15 @@ public final class NotVersionedClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/versions/versioned/VersionedClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/server/versions/versioned/VersionedClientBuilder.java
@@ -5,7 +5,7 @@ package server.versions.versioned;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class VersionedClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public VersionedClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public VersionedClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -236,13 +236,15 @@ public final class VersionedClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/specialwords/SpecialWordsClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/specialwords/SpecialWordsClientBuilder.java
@@ -5,7 +5,7 @@ package specialwords;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -94,15 +94,15 @@ public final class SpecialWordsClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public SpecialWordsClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public SpecialWordsClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -221,13 +221,15 @@ public final class SpecialWordsClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/array/ArrayClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/array/ArrayClientBuilder.java
@@ -5,7 +5,7 @@ package type.array;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -103,15 +103,15 @@ public final class ArrayClientBuilder implements HttpTrait<ArrayClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public ArrayClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public ArrayClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -230,13 +230,15 @@ public final class ArrayClientBuilder implements HttpTrait<ArrayClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/dictionary/DictionaryClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/dictionary/DictionaryClientBuilder.java
@@ -5,7 +5,7 @@ package type.dictionary;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -101,15 +101,15 @@ public final class DictionaryClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public DictionaryClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public DictionaryClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -228,13 +228,15 @@ public final class DictionaryClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/enums/extensible/ExtensibleClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/enums/extensible/ExtensibleClientBuilder.java
@@ -5,7 +5,7 @@ package type.enums.extensible;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class ExtensibleClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public ExtensibleClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public ExtensibleClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +216,15 @@ public final class ExtensibleClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/enums/fixed/FixedClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/enums/fixed/FixedClientBuilder.java
@@ -5,7 +5,7 @@ package type.enums.fixed;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class FixedClientBuilder implements HttpTrait<FixedClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public FixedClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public FixedClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class FixedClientBuilder implements HttpTrait<FixedClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/empty/EmptyClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/empty/EmptyClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.empty;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class EmptyClientBuilder implements HttpTrait<EmptyClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public EmptyClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public EmptyClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class EmptyClientBuilder implements HttpTrait<EmptyClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/enumdiscriminator/EnumDiscriminatorClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/enumdiscriminator/EnumDiscriminatorClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.inheritance.enumdiscriminator;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class EnumDiscriminatorClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public EnumDiscriminatorClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public EnumDiscriminatorClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class EnumDiscriminatorClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/nesteddiscriminator/NestedDiscriminatorClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/nesteddiscriminator/NestedDiscriminatorClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.inheritance.nesteddiscriminator;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class NestedDiscriminatorClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public NestedDiscriminatorClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public NestedDiscriminatorClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class NestedDiscriminatorClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/notdiscriminated/NotDiscriminatedClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/notdiscriminated/NotDiscriminatedClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.inheritance.notdiscriminated;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class NotDiscriminatedClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public NotDiscriminatedClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public NotDiscriminatedClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class NotDiscriminatedClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/recursive/RecursiveClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/recursive/RecursiveClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.inheritance.recursive;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class RecursiveClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public RecursiveClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public RecursiveClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +216,15 @@ public final class RecursiveClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/singlediscriminator/SingleDiscriminatorClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/singlediscriminator/SingleDiscriminatorClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.inheritance.singlediscriminator;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class SingleDiscriminatorClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public SingleDiscriminatorClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public SingleDiscriminatorClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +217,15 @@ public final class SingleDiscriminatorClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/usage/UsageClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/usage/UsageClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.usage;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class UsageClientBuilder implements HttpTrait<UsageClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public UsageClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public UsageClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -215,13 +215,15 @@ public final class UsageClientBuilder implements HttpTrait<UsageClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/visibility/VisibilityClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/visibility/VisibilityClientBuilder.java
@@ -5,7 +5,7 @@ package type.model.visibility;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class VisibilityClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public VisibilityClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public VisibilityClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -216,13 +216,15 @@ public final class VisibilityClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/additionalproperties/AdditionalPropertiesClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/additionalproperties/AdditionalPropertiesClientBuilder.java
@@ -5,7 +5,7 @@ package type.property.additionalproperties;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -122,15 +122,16 @@ public final class AdditionalPropertiesClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public AdditionalPropertiesClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public AdditionalPropertiesClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -249,13 +250,15 @@ public final class AdditionalPropertiesClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/nullable/NullableClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/nullable/NullableClientBuilder.java
@@ -5,7 +5,7 @@ package type.property.nullable;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -96,15 +96,15 @@ public final class NullableClientBuilder implements HttpTrait<NullableClientBuil
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public NullableClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public NullableClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -223,13 +223,15 @@ public final class NullableClientBuilder implements HttpTrait<NullableClientBuil
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/optional/OptionalClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/optional/OptionalClientBuilder.java
@@ -5,7 +5,7 @@ package type.property.optional;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -105,15 +105,15 @@ public final class OptionalClientBuilder implements HttpTrait<OptionalClientBuil
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public OptionalClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public OptionalClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -232,13 +232,15 @@ public final class OptionalClientBuilder implements HttpTrait<OptionalClientBuil
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/valuetypes/ValueTypesClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/valuetypes/ValueTypesClientBuilder.java
@@ -5,7 +5,7 @@ package type.property.valuetypes;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -119,15 +119,15 @@ public final class ValueTypesClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public ValueTypesClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public ValueTypesClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -246,13 +246,15 @@ public final class ValueTypesClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/scalar/ScalarClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/scalar/ScalarClientBuilder.java
@@ -5,7 +5,7 @@ package type.scalar;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -96,15 +96,15 @@ public final class ScalarClientBuilder implements HttpTrait<ScalarClientBuilder>
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public ScalarClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public ScalarClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -223,13 +223,15 @@ public final class ScalarClientBuilder implements HttpTrait<ScalarClientBuilder>
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/union/UnionClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/union/UnionClientBuilder.java
@@ -5,7 +5,7 @@ package type.union;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -99,15 +99,15 @@ public final class UnionClientBuilder implements HttpTrait<UnionClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public UnionClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public UnionClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -226,13 +226,15 @@ public final class UnionClientBuilder implements HttpTrait<UnionClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/added/AddedClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/added/AddedClientBuilder.java
@@ -5,7 +5,7 @@ package versioning.added;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class AddedClientBuilder implements HttpTrait<AddedClientBuilder>, 
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public AddedClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public AddedClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -254,13 +254,15 @@ public final class AddedClientBuilder implements HttpTrait<AddedClientBuilder>, 
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/madeoptional/MadeOptionalClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/madeoptional/MadeOptionalClientBuilder.java
@@ -5,7 +5,7 @@ package versioning.madeoptional;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class MadeOptionalClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public MadeOptionalClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public MadeOptionalClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -256,13 +256,15 @@ public final class MadeOptionalClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/removed/RemovedClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/removed/RemovedClientBuilder.java
@@ -5,7 +5,7 @@ package versioning.removed;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -88,15 +88,15 @@ public final class RemovedClientBuilder implements HttpTrait<RemovedClientBuilde
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public RemovedClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public RemovedClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -255,13 +255,15 @@ public final class RemovedClientBuilder implements HttpTrait<RemovedClientBuilde
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/renamedfrom/RenamedFromClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/renamedfrom/RenamedFromClientBuilder.java
@@ -5,7 +5,7 @@ package versioning.renamedfrom;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,15 @@ public final class RenamedFromClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public RenamedFromClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public RenamedFromClientBuilder httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -256,13 +256,15 @@ public final class RenamedFromClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/returntypechangedfrom/ReturnTypeChangedFromClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/returntypechangedfrom/ReturnTypeChangedFromClientBuilder.java
@@ -5,7 +5,7 @@ package versioning.returntypechangedfrom;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class ReturnTypeChangedFromClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public ReturnTypeChangedFromClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public ReturnTypeChangedFromClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -256,13 +257,15 @@ public final class ReturnTypeChangedFromClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/typechangedfrom/TypeChangedFromClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/versioning/typechangedfrom/TypeChangedFromClientBuilder.java
@@ -5,7 +5,7 @@ package versioning.typechangedfrom;
 import io.clientcore.core.annotation.Metadata;
 import io.clientcore.core.annotation.ServiceClientBuilder;
 import io.clientcore.core.http.client.HttpClient;
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import io.clientcore.core.http.models.HttpRedirectOptions;
 import io.clientcore.core.http.models.HttpRetryOptions;
 import io.clientcore.core.http.models.ProxyOptions;
@@ -89,15 +89,16 @@ public final class TypeChangedFromClientBuilder
      * The logging configuration for HTTP requests and responses.
      */
     @Metadata(generated = true)
-    private HttpLogOptions httpLogOptions;
+    private HttpInstrumentationOptions httpInstrumentationOptions;
 
     /**
      * {@inheritDoc}.
      */
     @Metadata(generated = true)
     @Override
-    public TypeChangedFromClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
-        this.httpLogOptions = httpLogOptions;
+    public TypeChangedFromClientBuilder
+        httpInstrumentationOptions(HttpInstrumentationOptions httpInstrumentationOptions) {
+        this.httpInstrumentationOptions = httpInstrumentationOptions;
         return this;
     }
 
@@ -256,13 +257,15 @@ public final class TypeChangedFromClientBuilder
     private HttpPipeline createHttpPipeline() {
         Configuration buildConfiguration
             = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
-        HttpLogOptions localHttpLogOptions = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;
+        HttpInstrumentationOptions localHttpInstrumentationOptions = this.httpInstrumentationOptions == null
+            ? new HttpInstrumentationOptions()
+            : this.httpInstrumentationOptions;
         HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();
         List<HttpPipelinePolicy> policies = new ArrayList<>();
         policies.add(redirectOptions == null ? new HttpRedirectPolicy() : new HttpRedirectPolicy(redirectOptions));
         policies.add(retryOptions == null ? new HttpRetryPolicy() : new HttpRetryPolicy(retryOptions));
         this.pipelinePolicies.stream().forEach(p -> policies.add(p));
-        policies.add(new HttpInstrumentationPolicy(null, localHttpLogOptions));
+        policies.add(new HttpInstrumentationPolicy(localHttpInstrumentationOptions));
         httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));
         return httpPipelineBuilder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/parameters/bodyoptionality/BodyTests.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/parameters/bodyoptionality/BodyTests.java
@@ -4,7 +4,6 @@
 package parameters.bodyoptionality;
 
 import io.clientcore.core.http.models.HttpHeaderName;
-import io.clientcore.core.http.models.HttpLogOptions;
 import io.clientcore.core.http.models.HttpRequest;
 import io.clientcore.core.http.models.Response;
 import io.clientcore.core.http.pipeline.HttpPipelineNextPolicy;
@@ -17,9 +16,7 @@ public class BodyTests {
     private final ContentTypeValidationPolicy validationPolicy = new ContentTypeValidationPolicy();
     private final BodyOptionalityClient client = new BodyOptionalityClientBuilder().buildClient();
     private final OptionalExplicitClient optionalClient
-        = new BodyOptionalityClientBuilder().addHttpPipelinePolicy(validationPolicy)
-            .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogOptions.HttpLogDetailLevel.BODY_AND_HEADERS))
-            .buildOptionalExplicitClient();
+        = new BodyOptionalityClientBuilder().addHttpPipelinePolicy(validationPolicy).buildOptionalExplicitClient();
 
     private final static class ContentTypeValidationPolicy implements HttpPipelinePolicy {
         private boolean contentTypeHeaderExists;

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/payload/contentnegotiation/SharedRouteTests.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/payload/contentnegotiation/SharedRouteTests.java
@@ -3,7 +3,6 @@
 
 package payload.contentnegotiation;
 
-import io.clientcore.core.http.models.HttpLogOptions;
 import io.clientcore.core.util.binarydata.BinaryData;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,9 +12,7 @@ import payload.contentnegotiation.differentbody.PngImageAsJson;
 public class SharedRouteTests {
 
     private final SameBodyClient client1 = new ContentNegotiationClientBuilder().buildSameBodyClient();
-    private final DifferentBodyClient client2 = new ContentNegotiationClientBuilder()
-        .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogOptions.HttpLogDetailLevel.BODY_AND_HEADERS))
-        .buildDifferentBodyClient();
+    private final DifferentBodyClient client2 = new ContentNegotiationClientBuilder().buildDifferentBodyClient();
 
     @Test
     public void testContentNegotiation() {

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/routes/RouteTests.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/routes/RouteTests.java
@@ -3,7 +3,7 @@
 
 package routes;
 
-import io.clientcore.core.http.models.HttpLogOptions;
+import io.clientcore.core.http.models.HttpInstrumentationOptions;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -78,7 +78,8 @@ public class RouteTests {
     @Test
     public void buildQueryParametersQueryContinuationExplode() {
         var client = new RoutesClientBuilder()
-            .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogOptions.HttpLogDetailLevel.BODY_AND_HEADERS)
+            .httpInstrumentationOptions(new HttpInstrumentationOptions()
+                .setHttpLogLevel(HttpInstrumentationOptions.HttpLogDetailLevel.BODY_AND_HEADERS)
                 .setAllowedQueryParamNames(Set.of("fixed", "param")))
             .buildQueryParametersQueryContinuationExplodeClient();
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
@@ -113,7 +113,7 @@ public class ClassType implements IType {
             put(Context.class, new ClassDetails(Context.class, "io.clientcore.core.util.Context"));
             put(HttpClient.class, new ClassDetails(HttpClient.class, "io.clientcore.core.http.client.HttpClient"));
             put(HttpLogOptions.class,
-                new ClassDetails(HttpLogOptions.class, "io.clientcore.core.http.models.HttpLogOptions"));
+                new ClassDetails(HttpLogOptions.class, "io.clientcore.core.http.models.HttpInstrumentationOptions"));
             put(HttpPipelinePolicy.class,
                 new ClassDetails(HttpPipelinePolicy.class, "io.clientcore.core.http.pipeline.HttpPipelinePolicy"));
             put(KeyCredentialPolicy.class,

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
@@ -122,8 +122,8 @@ public class ClassType implements IType {
                 new ClassDetails(RetryPolicy.class, "io.clientcore.core.http.pipeline.HttpRetryPolicy"));
             put(RedirectPolicy.class,
                 new ClassDetails(RedirectPolicy.class, "io.clientcore.core.http.pipeline.HttpRedirectPolicy"));
-            put(HttpLoggingPolicy.class,
-                new ClassDetails(HttpLoggingPolicy.class, "io.clientcore.core.http.pipeline.HttpLoggingPolicy"));
+            put(HttpLoggingPolicy.class, new ClassDetails(HttpLoggingPolicy.class,
+                "io.clientcore.core.http.pipeline.HttpInstrumentationPolicy"));
             put(Configuration.class,
                 new ClassDetails(Configuration.class, "io.clientcore.core.util.configuration.Configuration"));
             put(HttpHeaders.class, new ClassDetails(HttpHeaders.class, "io.clientcore.core.models.Headers"));
@@ -500,12 +500,6 @@ public class ClassType implements IType {
     public static final ClassType RETRY_POLICY = getClassTypeBuilder(RetryPolicy.class).build();
     public static final ClassType REDIRECT_POLICY = getClassTypeBuilder(RedirectPolicy.class).build();
     public static final ClassType HTTP_LOGGING_POLICY = getClassTypeBuilder(HttpLoggingPolicy.class).build();
-
-    // clientcore
-    public static final ClassType HTTP_INSTRUMENTATION_POLICY
-        = new ClassType.Builder(false).packageName("io.clientcore.core.http.pipeline")
-            .name("HttpInstrumentationPolicy")
-            .build();
 
     public static final ClassType RETRY_OPTIONS = getClassTypeBuilder(RetryOptions.class).build();
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientBuilderTrait.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientBuilderTrait.java
@@ -12,6 +12,7 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.core.util.logging.LogLevel;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
 import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaBlock;
+import com.microsoft.typespec.http.client.generator.core.util.CodeNamer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -143,15 +144,17 @@ public class ClientBuilderTrait {
         httpClientBuilderTraitMethods.add(httpClientMethod);
 
         // httpLogOptions
+        String httpLogTraitMethodAndParameterName = CodeNamer.toCamelCase(ClassType.HTTP_LOG_OPTIONS.getName());
         ServiceClientProperty httpLogOptionsProperty
             = new ServiceClientProperty("The logging configuration for HTTP " + "requests and responses.",
-                ClassType.HTTP_LOG_OPTIONS, "httpLogOptions", false, null);
+                ClassType.HTTP_LOG_OPTIONS, httpLogTraitMethodAndParameterName, false, null);
         Consumer<JavaBlock> httpLogOptionsMethodImpl = function -> {
-            function.line(String.format("this.%1$s = %2$s;", "httpLogOptions", "httpLogOptions"));
+            function.line(String.format("this.%1$s = %1$s;", httpLogTraitMethodAndParameterName));
             function.methodReturn("this");
         };
-        ClientBuilderTraitMethod httpLogOptionsMethod = createTraitMethod("httpLogOptions", "httpLogOptions",
-            ClassType.HTTP_LOG_OPTIONS, httpLogOptionsProperty, "{@inheritDoc}", httpLogOptionsMethodImpl);
+        ClientBuilderTraitMethod httpLogOptionsMethod
+            = createTraitMethod(httpLogTraitMethodAndParameterName, httpLogTraitMethodAndParameterName,
+                ClassType.HTTP_LOG_OPTIONS, httpLogOptionsProperty, "{@inheritDoc}", httpLogOptionsMethodImpl);
         importPackages.add(ClassType.HTTP_LOG_OPTIONS.getFullName());
 
         httpClientBuilderTraitMethods.add(httpLogOptionsMethod);

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/projectmodel/Project.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/projectmodel/Project.java
@@ -63,7 +63,7 @@ public class Project {
         AZURE_IDENTITY("com.azure", "azure-identity", "1.15.1"),
         AZURE_CORE_EXPERIMENTAL("com.azure", "azure-core-experimental", "1.0.0-beta.57"),
 
-        CLIENTCORE("io.clientcore", "core", "1.0.0-beta.2");
+        CLIENTCORE("io.clientcore", "core", "1.0.0-beta.3");
 
         private final String groupId;
         private final String artifactId;

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceClientBuilderTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ServiceClientBuilderTemplate.java
@@ -523,7 +523,6 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
         imports.add(HttpPolicyProviders.class.getName());
         ClassType.HTTP_PIPELINE_POLICY.addImportsTo(imports, false);
         ClassType.HTTP_LOGGING_POLICY.addImportsTo(imports, false);
-        ClassType.HTTP_INSTRUMENTATION_POLICY.addImportsTo(imports, false);
         imports.add(AddHeadersPolicy.class.getName());
         imports.add(RequestIdPolicy.class.getName());
         imports.add(AddHeadersFromContextPolicy.class.getName());

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/TemplateHelper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/TemplateHelper.java
@@ -55,10 +55,10 @@ public final class TemplateHelper {
         SecurityInfo securityInfo, PipelinePolicyDetails pipelinePolicyDetails, JavaBlock function) {
         function.line("Configuration buildConfiguration = (configuration == null) ? Configuration"
             + ".getGlobalConfiguration() : configuration;");
-        String localHttpLogOptionsName = "local" + CodeNamer.toPascalCase("httpLogOptions");
+        String localHttpInstrumentationOptionsName = "local" + CodeNamer.toPascalCase("httpInstrumentationOptions");
         function.line(String.format(
-            "HttpLogOptions %s = this.httpLogOptions == null ? new HttpLogOptions() : this.httpLogOptions;",
-            localHttpLogOptionsName));
+            "HttpInstrumentationOptions %s = this.httpInstrumentationOptions == null ? new HttpInstrumentationOptions() : this.httpInstrumentationOptions;",
+            localHttpInstrumentationOptionsName));
 
         function.line("HttpPipelineBuilder httpPipelineBuilder = new HttpPipelineBuilder();");
         function.line("List<HttpPipelinePolicy> policies = new ArrayList<>();");
@@ -76,7 +76,7 @@ public final class TemplateHelper {
                     + "\", keyCredential, " + prefixExpr + "));");
             });
         }
-        function.line("policies.add(new HttpInstrumentationPolicy(null, %s));", localHttpLogOptionsName);
+        function.line("policies.add(new HttpInstrumentationPolicy(%s));", localHttpInstrumentationOptionsName);
         function.line("httpPipelineBuilder.policies(policies.toArray(new HttpPipelinePolicy[0]));");
         function.methodReturn("httpPipelineBuilder.build()");
     }


### PR DESCRIPTION
The difference of clientcore is replacing `HttpLogOptions` with `HttpInstrumentationOptions` (and its related `HttpTrait` class)

It seems we now need to add change description to http-client-java lib too
https://github.com/microsoft/typespec/pull/5974/commits/e1b63b329334782820f6b188d044bb0fa463816a

I didn't lower the requirement on Java8/11, as at this runtime they would require http-okhttp3 lib and that lib is not yet released https://central.sonatype.com/artifact/io.clientcore/http-okhttp3