### PR TITLE
[openapi3/json-schema] add `seal-object-schemas` emitter option

### DIFF
--- a/.chronus/changes/oa3-jschema-uneval-default-2025-1-12-16-59-46.md
+++ b/.chronus/changes/oa3-jschema-uneval-default-2025-1-12-16-59-46.md
@@ -1,0 +1,8 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/json-schema"
+  - "@typespec/openapi3"
+---
+
+Adds `seal-object-schemas` emitter option to automatically set additionalProperties/unevaluatedProperties to `{ not: {} }` wherever possible

--- a/packages/json-schema/README.md
+++ b/packages/json-schema/README.md
@@ -86,6 +86,14 @@ When true, emit all model declarations to JSON Schema without requiring the @jso
 
 When true, emit all references as json schema files, even if the referenced type does not have the `@jsonSchema` decorator or is not within a namespace with the `@jsonSchema` decorator.
 
+### `seal-object-schemas`
+
+**Type:** `boolean`
+
+If true, then for models emitted as object schemas we default `unevaluatedProperties` to `{ not: {} }`,
+if not explicitly specified elsewhere.
+Default: `false`
+
 ## Decorators
 
 ### TypeSpec.JsonSchema

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -76,11 +76,25 @@ import {
   isOneOf,
 } from "./index.js";
 import { type JSONSchemaEmitterOptions, reportDiagnostic } from "./lib.js";
+import { includeDerivedModel } from "./utils.js";
 
 /** @internal */
 export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSchemaEmitterOptions> {
   #idDuplicateTracker = new DuplicateTracker<string, DiagnosticTarget>();
   #typeForSourceFile = new Map<SourceFile<any>, JsonSchemaDeclaration>();
+
+  #applyModelIndexer(schema: ObjectBuilder<unknown>, model: Model) {
+    if (model.indexer) {
+      schema.set("unevaluatedProperties", this.emitter.emitTypeReference(model.indexer.value));
+      return;
+    }
+    if (!this.emitter.getOptions()["seal-object-schemas"]) return;
+
+    const derivedModels = model.derivedModels.filter(includeDerivedModel);
+    if (!derivedModels.length) {
+      schema.set("unevaluatedProperties", { not: {} });
+    }
+  }
 
   modelDeclaration(model: Model, name: string): EmitterOutput<object> {
     const schema = this.#initializeSchema(model, name, {
@@ -95,9 +109,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
       schema.set("allOf", allOf);
     }
 
-    if (model.indexer) {
-      schema.set("unevaluatedProperties", this.emitter.emitTypeReference(model.indexer.value));
-    }
+    this.#applyModelIndexer(schema, model);
 
     this.#applyConstraints(model, schema);
     return this.#createDeclaration(model, name, schema);
@@ -110,9 +122,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
       required: this.#requiredModelProperties(model),
     });
 
-    if (model.indexer) {
-      schema.set("unevaluatedProperties", this.emitter.emitTypeReference(model.indexer.value));
-    }
+    this.#applyModelIndexer(schema, model);
 
     return schema;
   }

--- a/packages/json-schema/src/lib.ts
+++ b/packages/json-schema/src/lib.ts
@@ -55,6 +55,13 @@ export interface JSONSchemaEmitterOptions {
    * with the `@jsonSchema` decorator.
    */
   emitAllRefs?: boolean;
+
+  /**
+   * If true, then for models emitted as object schemas we default `unevaluatedProperties` to `{ not: {} }`,
+   * if not explicitly specified elsewhere.
+   * @defaultValue false
+   */
+  "seal-object-schemas"?: boolean;
 }
 
 /**
@@ -96,6 +103,16 @@ export const EmitterOptionsSchema: JSONSchemaType<JSONSchemaEmitterOptions> = {
       nullable: true,
       description:
         "When true, emit all references as json schema files, even if the referenced type does not have the `@jsonSchema` decorator or is not within a namespace with the `@jsonSchema` decorator.",
+    },
+    "seal-object-schemas": {
+      type: "boolean",
+      nullable: true,
+      default: false,
+      description: [
+        "If true, then for models emitted as object schemas we default `unevaluatedProperties` to `{ not: {} }`,",
+        "if not explicitly specified elsewhere.",
+        "Default: `false`",
+      ].join("\n"),
     },
   },
   required: [],

--- a/packages/json-schema/src/utils.ts
+++ b/packages/json-schema/src/utils.ts
@@ -1,4 +1,9 @@
-import type { DecoratorFunction, Type } from "@typespec/compiler";
+import {
+  isTemplateDeclaration,
+  type DecoratorFunction,
+  type Model,
+  type Type,
+} from "@typespec/compiler";
 import { useStateMap } from "@typespec/compiler/utils";
 
 export function createDataDecorator<
@@ -14,4 +19,13 @@ export function createDataDecorator<
     setData(context.program, target, value);
   };
   return [getData, setData, decorator as T] as const;
+}
+
+export function includeDerivedModel(model: Model): boolean {
+  return (
+    !isTemplateDeclaration(model) &&
+    (model.templateMapper?.args === undefined ||
+      model.templateMapper.args?.length === 0 ||
+      model.derivedModels.length > 0)
+  );
 }

--- a/packages/openapi3/README.md
+++ b/packages/openapi3/README.md
@@ -109,6 +109,14 @@ How to handle safeint type. Options are:
 
 Default: `int64`
 
+### `seal-object-schemas`
+
+**Type:** `boolean`
+
+If true, then for models emitted as object schemas we default `additionalProperties` to false for
+OpenAPI 3.0, and `unevaluatedProperties` to false for OpenAPI 3.1, if not explicitly specified elsewhere.
+Default: `false`
+
 ## Decorators
 
 ### TypeSpec.OpenAPI

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -73,6 +73,13 @@ export interface OpenAPI3EmitterOptions {
    * @default "int64"
    */
   "safeint-strategy"?: "double-int" | "int64";
+
+  /**
+   * If true, then for models emitted as object schemas we default `additionalProperties` to false for
+   * OpenAPI 3.0, and `unevaluatedProperties` to false for OpenAPI 3.1, if not explicitly specified elsewhere.
+   * @default false
+   */
+  "seal-object-schemas"?: boolean;
 }
 
 const EmitterOptionsSchema: JSONSchemaType<OpenAPI3EmitterOptions> = {
@@ -159,6 +166,16 @@ const EmitterOptionsSchema: JSONSchemaType<OpenAPI3EmitterOptions> = {
         " - `int64`: Will produce `type: integer, format: int64`",
         "",
         "Default: `int64`",
+      ].join("\n"),
+    },
+    "seal-object-schemas": {
+      type: "boolean",
+      nullable: true,
+      default: false,
+      description: [
+        "If true, then for models emitted as object schemas we default `additionalProperties` to false for",
+        "OpenAPI 3.0, and `unevaluatedProperties` to false for OpenAPI 3.1, if not explicitly specified elsewhere.",
+        "Default: `false`",
       ].join("\n"),
     },
   },

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -131,6 +131,7 @@ const defaultOptions = {
   "omit-unreachable-types": false,
   "include-x-typespec-name": "never",
   "safeint-strategy": "int64",
+  "seal-object-schemas": false,
 } as const;
 
 export async function $onEmit(context: EmitContext<OpenAPI3EmitterOptions>) {
@@ -213,6 +214,7 @@ export function resolveOptions(
     safeintStrategy: resolvedOptions["safeint-strategy"],
     outputFile: resolvePath(context.emitterOutputDir, specDir, outputFile),
     openapiVersions,
+    sealObjectSchemas: resolvedOptions["seal-object-schemas"],
   };
 }
 
@@ -224,6 +226,7 @@ export interface ResolvedOpenAPI3EmitterOptions {
   omitUnreachableTypes: boolean;
   includeXTypeSpecName: "inline-only" | "never";
   safeintStrategy: "double-int" | "int64";
+  sealObjectSchemas: boolean;
 }
 
 function createOAPIEmitter(

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -6,7 +6,6 @@ import {
   getMinValueExclusive,
   IntrinsicScalarName,
   IntrinsicType,
-  isNeverType,
   Model,
   ModelProperty,
   Program,
@@ -149,12 +148,12 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
   }
 
   applyModelIndexer(schema: ObjectBuilder<any>, model: Model): void {
-    if (!model.indexer) return;
-    const indexerType = model.indexer.value;
+    const shouldSeal = this.shouldSealSchema(model);
+    if (!shouldSeal && !model.indexer) return;
 
-    const unevaluatedPropertiesSchema = isNeverType(indexerType)
+    const unevaluatedPropertiesSchema = shouldSeal
       ? { not: {} }
-      : this.emitter.emitTypeReference(indexerType);
+      : this.emitter.emitTypeReference(model.indexer!.value);
     schema.set("unevaluatedProperties", unevaluatedPropertiesSchema);
   }
 

--- a/website/src/content/docs/docs/emitters/json-schema/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/json-schema/reference/emitter.md
@@ -61,3 +61,11 @@ When true, emit all model declarations to JSON Schema without requiring the @jso
 **Type:** `boolean`
 
 When true, emit all references as json schema files, even if the referenced type does not have the `@jsonSchema` decorator or is not within a namespace with the `@jsonSchema` decorator.
+
+### `seal-object-schemas`
+
+**Type:** `boolean`
+
+If true, then for models emitted as object schemas we default `unevaluatedProperties` to `{ not: {} }`,
+if not explicitly specified elsewhere.
+Default: `false`

--- a/website/src/content/docs/docs/emitters/openapi3/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/openapi3/reference/emitter.md
@@ -102,3 +102,11 @@ How to handle safeint type. Options are:
 - `int64`: Will produce `type: integer, format: int64`
 
 Default: `int64`
+
+### `seal-object-schemas`
+
+**Type:** `boolean`
+
+If true, then for models emitted as object schemas we default `additionalProperties` to false for
+OpenAPI 3.0, and `unevaluatedProperties` to false for OpenAPI 3.1, if not explicitly specified elsewhere.
+Default: `false`


### PR DESCRIPTION
This adds an emitter option to the Open API 3 and Json Schema emitters to automatically set `additionalProperties: { not: {} }` and `unevaluatedProperties: { not: {} }` for object schemas.

- This doesn't ovewrite the existing field if the field would already be present (e.g. the field is already set to a different schema)
- The only applies to lead models. This means that when you have `model A extends B`, `A` would automatically have this field set, but `B` would not. This is because doing so would in most cases break validation for the derived model.

I'm open to changing the name of the option if we want to make it clearer that this only applies to leaf models. Since there are tradeoffs with sealing base models there might be value in adding a future `seal-object-schemas-strategy` option that defaults to `leaves-only` but lets us support things like 'copy-base-models' 