### PR TITLE
Add new labels P0 and P1

### DIFF
--- a/eng/common/config/labels.ts
+++ b/eng/common/config/labels.ts
@@ -218,6 +218,14 @@ export default defineConfig({
           color: "0969da",
           description: "Good candidate for MQ",
         },
+        P0: {
+          color: "1d76db",
+          description: "Priority level 0",
+        },
+        P1: {
+          color: "26EA9E",
+          description: "Priority level 1",
+        },
       },
     },
   },


### PR DESCRIPTION
Labels check is failing validation because P0 and P1 were recently added. Tracking these new labels.

@markcowl, @allenjzhang do we want to keep these new labels or remove them? It looks like priority is not commonly tracked by labels in the repo?