### PR TITLE
Add back import typespec menu

### DIFF
--- a/.chronus/changes/add-back-import-typespec-menu-2025-1-14-13-40-53.md
+++ b/.chronus/changes/add-back-import-typespec-menu-2025-1-14-13-40-53.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - typespec-vscode
+---
+
+Add "Import TypeSpec from OpenApi3" menu item into explorer context menu

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -115,16 +115,20 @@
     "menus": {
       "explorer/context": [
         {
+          "command": "typespec.importFromOpenApi3",
+          "group": "typespec@2"
+        },
+        {
           "command": "typespec.generateCode",
           "when": "explorerResourceIsFolder || resourceLangId == typespec",
-          "group": "code_generation"
+          "group": "typespec@1"
         }
       ],
       "editor/context": [
         {
           "command": "typespec.generateCode",
           "when": "resourceLangId == typespec",
-          "group": "code_generation"
+          "group": "typespec@1"
         }
       ]
     },


### PR DESCRIPTION
The "Import TypeSpec from OpenApi3" was removed by PR #5890 by mistake, so add it back.