### PR TITLE
expandableenum, add back equals override

### DIFF
--- a/.chronus/changes/expandableenum_equals-2025-1-17-3-23-41.md
+++ b/.chronus/changes/expandableenum_equals-2025-1-17-3-23-41.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+ExpandableEnum, add back `equals()` override

--- a/.chronus/changes/expandableenum_equals-2025-1-17-3-23-41.md
+++ b/.chronus/changes/expandableenum_equals-2025-1-17-3-23-41.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@typespec/http-client-java"
----
-
-ExpandableEnum, add back `equals()` override

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/enums/extensible/DaysOfWeekExtensibleEnum.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/enums/extensible/DaysOfWeekExtensibleEnum.java
@@ -148,6 +148,12 @@ public final class DaysOfWeekExtensibleEnum
 
     @Metadata(generated = true)
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Metadata(generated = true)
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/enumdiscriminator/DogKind.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/model/inheritance/enumdiscriminator/DogKind.java
@@ -111,6 +111,12 @@ public final class DogKind implements ExpandableEnum<String>, JsonSerializable<D
 
     @Metadata(generated = true)
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Metadata(generated = true)
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/valuetypes/ExtendedEnum.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/valuetypes/ExtendedEnum.java
@@ -111,6 +111,12 @@ public final class ExtendedEnum implements ExpandableEnum<String>, JsonSerializa
 
     @Metadata(generated = true)
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Metadata(generated = true)
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/valuetypes/InnerEnum.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/property/valuetypes/InnerEnum.java
@@ -117,6 +117,12 @@ public final class InnerEnum implements ExpandableEnum<String>, JsonSerializable
 
     @Metadata(generated = true)
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Metadata(generated = true)
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/union/GetResponseProp3.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/union/GetResponseProp3.java
@@ -117,6 +117,12 @@ public final class GetResponseProp3 implements ExpandableEnum<String>, JsonSeria
 
     @Metadata(generated = true)
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Metadata(generated = true)
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/union/StringExtensibleNamedUnion.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/java/type/union/StringExtensibleNamedUnion.java
@@ -118,6 +118,12 @@ public final class StringExtensibleNamedUnion
 
     @Metadata(generated = true)
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Metadata(generated = true)
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
@@ -349,7 +349,7 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
             addGeneratedAnnotation(classBlock);
             classBlock.annotation("Override");
             classBlock.method(JavaVisibility.Public, null, "boolean equals(Object obj)",
-              function -> function.methodReturn("this == obj"));
+                function -> function.methodReturn("this == obj"));
 
             // hashcode
             addGeneratedAnnotation(classBlock);

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/EnumTemplate.java
@@ -343,6 +343,14 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
             classBlock.method(JavaVisibility.Public, null, "String toString()",
                 function -> function.methodReturn("Objects.toString(this.value)"));
 
+            // equals
+            // checkstyle needs both equals() and hashcode() override, so even if its implementation is identical to
+            // Object's equals(), we still need it
+            addGeneratedAnnotation(classBlock);
+            classBlock.annotation("Override");
+            classBlock.method(JavaVisibility.Public, null, "boolean equals(Object obj)",
+              function -> function.methodReturn("this == obj"));
+
             // hashcode
             addGeneratedAnnotation(classBlock);
             classBlock.annotation("Override");

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/PriorityModel.java
@@ -77,6 +77,11 @@ public final class PriorityModel implements ExpandableEnum<Integer> {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Priority.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Priority.java
@@ -109,6 +109,11 @@ public final class Priority implements ExpandableEnum<Integer>, JsonSerializable
     }
 
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/OlympicRecordModel.java
@@ -119,6 +119,12 @@ public final class OlympicRecordModel implements ExpandableEnum<Double>, JsonSer
 
     @Generated
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Generated
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/enumservice/models/PriorityModel.java
@@ -119,6 +119,12 @@ public final class PriorityModel implements ExpandableEnum<Integer>, JsonSeriali
 
     @Generated
     @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Generated
+    @Override
     public int hashCode() {
         return Objects.hashCode(this.value);
     }


### PR DESCRIPTION
- SDK checkstyle enforces that `equals` and `hashcode` be overridden together, not one of them.
- autorest fluent pipeline failed for this: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4565552&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=738c417a-4a48-5620-b571-4f9e77e0bfd2&l=101
- autorest CI passed: https://github.com/Azure/autorest.java/pull/3027