### PR TITLE
Fix/skip val op example too

### DIFF
--- a/.chronus/changes/fix-skip-val-op-example-too-2025-1-18-17-48-42.md
+++ b/.chronus/changes/fix-skip-val-op-example-too-2025-1-18-17-48-42.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix validation issue in `@opExample` when using versioning/mutators

--- a/packages/compiler/src/lib/decorators.ts
+++ b/packages/compiler/src/lib/decorators.ts
@@ -1347,7 +1347,7 @@ export const $opExample: OpExampleDecorator = (
   const returnType = rawExampleConfig.properties.get("returnType")?.value;
 
   // skip validation in projections
-  if (target.projectionBase === undefined) {
+  if (target.projectionBase === undefined && Realm.realmForType.get(target) === undefined) {
     if (
       parameters &&
       !checkExampleValid(


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/5999

PR #6003 only fixed `@example` but `@opExample` had the same issue