### PR TITLE
http-client-java, when codegen error, trace the stderr too

### DIFF
--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -122,7 +122,8 @@ export async function $onEmit(context: EmitContext<EmitterOptions>) {
             target: NoTarget,
           });
           if (error instanceof SpawnError) {
-            trace(program, `Code generation error: ${error.stdout}`);
+            trace(program, `Code generation log: ${error.stdout}`);
+            trace(program, `Code generation error: ${error.stderr}`);
           }
         }
       }


### PR DESCRIPTION
I forgot to trace stderr. For error in postprocess/customization, the error log is on stderr.