### PR TITLE
updates openapi `@extension` to support value types, and removes starts with `x-` extension name constraint

### DIFF
--- a/.chronus/changes/align-openapi-jsonschema-extensions-2025-1-19-23-20-52.md
+++ b/.chronus/changes/align-openapi-jsonschema-extensions-2025-1-19-23-20-52.md
@@ -1,0 +1,11 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi"
+---
+
+Updates the `@extension` decorator with 3 changes:
+
+1. Removes the extension name starts with `x-` constraint.
+1. Adds support for passing in values to emit raw data.
+1. Adds a deprecation warning for passing in types. Passed in types will emit Open API schemas in a future release.

--- a/.chronus/changes/align-openapi-jsonschema-extensions-2025-1-19-23-20-52.md
+++ b/.chronus/changes/align-openapi-jsonschema-extensions-2025-1-19-23-20-52.md
@@ -9,3 +9,14 @@ Updates the `@extension` decorator with 3 changes:
 1. Removes the extension name starts with `x-` constraint.
 1. Adds support for passing in values to emit raw data.
 1. Adds a deprecation warning for passing in types. Passed in types will emit Open API schemas in a future release.
+
+Scalar literals (e.g. string, boolean, number values) are automatically treated as values.
+Model or tuple expression usage needs to be converted to values to retain current behavior in future releases.
+
+```diff lang="tsp"
+-@extension("x-obj", { foo: true })
++@extension("x-obj", #{ foo: true })
+-@extension("x-tuple", [ "foo" ])
++@extension("x-tuple", #[ "foo" ])
+model Foo {}
+```

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -50,7 +50,7 @@ op listPets(): Pet[] | PetStoreResponse;
 Attach some custom data to the OpenAPI element generated from this type.
 
 ```typespec
-@TypeSpec.OpenAPI.extension(key: valueof string, value: unknown)
+@TypeSpec.OpenAPI.extension(key: valueof string, value: unknown | valueof unknown)
 ```
 
 ##### Target
@@ -59,10 +59,10 @@ Attach some custom data to the OpenAPI element generated from this type.
 
 ##### Parameters
 
-| Name  | Type             | Description                         |
-| ----- | ---------------- | ----------------------------------- |
-| key   | `valueof string` | Extension key. Must start with `x-` |
-| value | `unknown`        | Extension value.                    |
+| Name  | Type                           | Description                         |
+| ----- | ------------------------------ | ----------------------------------- |
+| key   | `valueof string`               | Extension key. Must start with `x-` |
+| value | `unknown` \| `valueof unknown` | Extension value.                    |
 
 ##### Examples
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -50,7 +50,7 @@ op listPets(): Pet[] | PetStoreResponse;
 Attach some custom data to the OpenAPI element generated from this type.
 
 ```typespec
-@TypeSpec.OpenAPI.extension(key: valueof string, value: unknown | valueof unknown)
+@TypeSpec.OpenAPI.extension(key: valueof string, value: valueof unknown)
 ```
 
 ##### Target
@@ -59,21 +59,16 @@ Attach some custom data to the OpenAPI element generated from this type.
 
 ##### Parameters
 
-| Name  | Type                           | Description                         |
-| ----- | ------------------------------ | ----------------------------------- |
-| key   | `valueof string`               | Extension key. Must start with `x-` |
-| value | `unknown` \| `valueof unknown` | Extension value.                    |
+| Name  | Type              | Description      |
+| ----- | ----------------- | ---------------- |
+| key   | `valueof string`  | Extension key.   |
+| value | `valueof unknown` | Extension value. |
 
 ##### Examples
 
 ```typespec
 @extension("x-custom", "My value")
-@extension(
-  "x-pageable",
-  {
-    nextLink: "x-next-link",
-  }
-)
+@extension("x-pageable", #{ nextLink: "x-next-link" })
 op read(): string;
 ```
 

--- a/packages/openapi/generated-defs/TypeSpec.OpenAPI.ts
+++ b/packages/openapi/generated-defs/TypeSpec.OpenAPI.ts
@@ -31,12 +31,12 @@ export type OperationIdDecorator = (
 /**
  * Attach some custom data to the OpenAPI element generated from this type.
  *
- * @param key Extension key. Must start with `x-`
+ * @param key Extension key.
  * @param value Extension value.
  * @example
  * ```typespec
  * @extension("x-custom", "My value")
- * @extension("x-pageable", {nextLink: "x-next-link"})
+ * @extension("x-pageable", #{nextLink: "x-next-link"})
  * op read(): string;
  * ```
  */
@@ -44,7 +44,7 @@ export type ExtensionDecorator = (
   context: DecoratorContext,
   target: Type,
   key: string,
-  value: Type | unknown,
+  value: unknown,
 ) => void;
 
 /**

--- a/packages/openapi/generated-defs/TypeSpec.OpenAPI.ts
+++ b/packages/openapi/generated-defs/TypeSpec.OpenAPI.ts
@@ -44,7 +44,7 @@ export type ExtensionDecorator = (
   context: DecoratorContext,
   target: Type,
   key: string,
-  value: Type,
+  value: Type | unknown,
 ) => void;
 
 /**

--- a/packages/openapi/lib/decorators.tsp
+++ b/packages/openapi/lib/decorators.tsp
@@ -30,7 +30,7 @@ extern dec operationId(target: Operation, operationId: valueof string);
  * op read(): string;
  * ```
  */
-extern dec extension(target: unknown, key: valueof string, value: unknown);
+extern dec extension(target: unknown, key: valueof string, value: unknown | (valueof unknown));
 
 /**
  * Specify that this model is to be treated as the OpenAPI `default` response.

--- a/packages/openapi/lib/decorators.tsp
+++ b/packages/openapi/lib/decorators.tsp
@@ -19,18 +19,18 @@ extern dec operationId(target: Operation, operationId: valueof string);
 /**
  * Attach some custom data to the OpenAPI element generated from this type.
  *
- * @param key Extension key. Must start with `x-`
+ * @param key Extension key.
  * @param value Extension value.
  *
  * @example
  *
  * ```typespec
  * @extension("x-custom", "My value")
- * @extension("x-pageable", {nextLink: "x-next-link"})
+ * @extension("x-pageable", #{nextLink: "x-next-link"})
  * op read(): string;
  * ```
  */
-extern dec extension(target: unknown, key: valueof string, value: unknown | (valueof unknown));
+extern dec extension(target: unknown, key: valueof string, value: valueof unknown);
 
 /**
  * Specify that this model is to be treated as the OpenAPI `default` response.

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -9,7 +9,6 @@ import {
   Namespace,
   Operation,
   Program,
-  reportDeprecated,
   Type,
   typespecTypeToJson,
   TypeSpecValue,
@@ -66,15 +65,6 @@ export const $extension: ExtensionDecorator = (
     if (diagnostics.length > 0) {
       context.program.reportDiagnostics(diagnostics);
     }
-    reportDeprecated(
-      context.program,
-      [
-        "Passing extension values as types will emit Open API schemas instead of raw values in a future version of TypeSpec.",
-        "To continue emitting raw values, use value kinds.",
-        "See https://typespec.io/docs/language-basics/values/ for more information.",
-      ].join("\n"),
-      entity,
-    );
     data = result;
   }
 

--- a/packages/openapi/test/decorators.test.ts
+++ b/packages/openapi/test/decorators.test.ts
@@ -76,11 +76,7 @@ describe("openapi: decorators", () => {
 
     it.for([
       { type: `{ name: "foo" }`, expected: { name: "foo" } },
-      { type: `{ items: [ {foo: "bar" }]}`, expected: { items: [{ foo: "bar" }] } },
       { type: `["foo"]`, expected: ["foo"] },
-      { type: `typeof true`, expected: true },
-      { type: `typeof 42`, expected: 42 },
-      { type: `typeof "hi"`, expected: "hi" },
     ])("treats type $type as raw value and emits diagnostic", async ({ type, expected }) => {
       const [{ Foo }, diagnostics] = await runner.compileAndDiagnose(`
           @extension("x-custom", ${type})
@@ -95,11 +91,6 @@ describe("openapi: decorators", () => {
       expectDiagnostics(diagnostics, {
         code: "deprecated",
         severity: "warning",
-        message: [
-          "Deprecated: Passing extension values as types will emit Open API schemas instead of raw values in a future version of TypeSpec.",
-          "To continue emitting raw values, use value kinds.",
-          "See https://typespec.io/docs/language-basics/values/ for more information.",
-        ].join("\n"),
       });
     });
 

--- a/packages/samples/specs/openapi-extensions/openapi-extensions.tsp
+++ b/packages/samples/specs/openapi-extensions/openapi-extensions.tsp
@@ -3,28 +3,15 @@ import "@typespec/openapi";
 
 using TypeSpec.OpenAPI;
 
-model MyConfig {
-  name: "Foo";
-  age: 12;
-  other: NestedConfig;
-}
-
-model NestedConfig {
-  id: "some";
-}
+const MyConfig = #{ name: "Foo", age: 12, other: NestedConfig };
+const NestedConfig = #{ id: "some" };
 
 model Foo {
   @extension("x-string", "string")
   @extension("x-number", 123)
   @extension("x-bool", true)
-  @extension("x-array", ["one", 2])
-  @extension(
-    "x-obj",
-    {
-      foo: 123,
-      bar: "string",
-    }
-  )
+  @extension("x-array", #["one", 2])
+  @extension("x-obj", #{ foo: 123, bar: "string" })
   @extension("x-model", MyConfig)
   id: string;
 }

--- a/packages/samples/test/output/openapi-extensions/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/openapi-extensions/@typespec/openapi3/openapi.yaml
@@ -38,29 +38,3 @@ components:
           x-bool: true
           x-number: 123
           x-string: string
-    MyConfig:
-      type: object
-      required:
-        - name
-        - age
-        - other
-      properties:
-        name:
-          type: string
-          enum:
-            - Foo
-        age:
-          type: number
-          enum:
-            - 12
-        other:
-          $ref: '#/components/schemas/NestedConfig'
-    NestedConfig:
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          enum:
-            - some

--- a/website/src/content/docs/docs/libraries/openapi/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/openapi/reference/decorators.md
@@ -37,7 +37,7 @@ op listPets(): Pet[] | PetStoreResponse;
 Attach some custom data to the OpenAPI element generated from this type.
 
 ```typespec
-@TypeSpec.OpenAPI.extension(key: valueof string, value: unknown)
+@TypeSpec.OpenAPI.extension(key: valueof string, value: unknown | valueof unknown)
 ```
 
 #### Target
@@ -46,10 +46,10 @@ Attach some custom data to the OpenAPI element generated from this type.
 
 #### Parameters
 
-| Name  | Type             | Description                         |
-| ----- | ---------------- | ----------------------------------- |
-| key   | `valueof string` | Extension key. Must start with `x-` |
-| value | `unknown`        | Extension value.                    |
+| Name  | Type                           | Description                         |
+| ----- | ------------------------------ | ----------------------------------- |
+| key   | `valueof string`               | Extension key. Must start with `x-` |
+| value | `unknown` \| `valueof unknown` | Extension value.                    |
 
 #### Examples
 

--- a/website/src/content/docs/docs/libraries/openapi/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/openapi/reference/decorators.md
@@ -37,7 +37,7 @@ op listPets(): Pet[] | PetStoreResponse;
 Attach some custom data to the OpenAPI element generated from this type.
 
 ```typespec
-@TypeSpec.OpenAPI.extension(key: valueof string, value: unknown | valueof unknown)
+@TypeSpec.OpenAPI.extension(key: valueof string, value: valueof unknown)
 ```
 
 #### Target
@@ -46,21 +46,16 @@ Attach some custom data to the OpenAPI element generated from this type.
 
 #### Parameters
 
-| Name  | Type                           | Description                         |
-| ----- | ------------------------------ | ----------------------------------- |
-| key   | `valueof string`               | Extension key. Must start with `x-` |
-| value | `unknown` \| `valueof unknown` | Extension value.                    |
+| Name  | Type              | Description      |
+| ----- | ----------------- | ---------------- |
+| key   | `valueof string`  | Extension key.   |
+| value | `valueof unknown` | Extension value. |
 
 #### Examples
 
 ```typespec
 @extension("x-custom", "My value")
-@extension(
-  "x-pageable",
-  {
-    nextLink: "x-next-link",
-  }
-)
+@extension("x-pageable", #{ nextLink: "x-next-link" })
 op read(): string;
 ```
 


### PR DESCRIPTION
Resolves #6076 
 
This PR makes a few changes to the `@typespec/openapi` `@extension` decorator to align it closer to the `@typespec/json-schema` `@extension` decorator.

`@extension` is updated in 3 ways:
1. The `x-` prefix is no longer required for the extension name.
2. Value kinds are now supported and will be inserted in the Open API doc as raw values.
3. Passing in types (e.g. `typeof "foo"`, model expressions, tuple types) retains current behavior but also triggers a deprecation warning.

## What's with the deprecation warning?
Prior to this PR, passed in types would be converted to JSON values (or emit an error if they couldn't be converted).
So the following TypeSpec
```tsp
@OpenAPI.extension("x-foo", { foo: true })
model Foo {}
```
would emit the following OpenAPI:
```yaml
Foo:
  type: object
  x-foo:
    foo: true
```
However, in a follow-up release, passing in the type `{ foo: true }` will cause an OpenAPI schema to be emitted instead:

```yaml
Foo:
  type: object
  x-foo:
    type: object
    required:
      - foo
    properties:
      foo:
        type: boolean
        enum:
          - true
```
To get back to the current behavior, `#{ foo: true }` should be passed instead.

The deprecation warning gives users at least 1 release to be aware of the change and update their code accordingly.

## Follow-ups

- typespec-azure PR: https://github.com/Azure/typespec-azure/pull/2236
- Update azure-specs repo to use values: https://github.com/Azure/azure-rest-api-specs/pull/32832
- Update azure-specs-pr repo: https://github.com/Azure/azure-rest-api-specs-pr/pull/21556