### PR TITLE
Fix syntax highlighting when using decorator before escaped identifier

### DIFF
--- a/.chronus/changes/fix-tmlanguage-decorator-escaped-id-2025-1-24-9-30-58.md
+++ b/.chronus/changes/fix-tmlanguage-decorator-escaped-id-2025-1-24-9-30-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix tmlanguage syntax highlighting when using decorator before escaped identifier

--- a/grammars/typespec.json
+++ b/grammars/typespec.json
@@ -58,7 +58,7 @@
           "name": "entity.name.tag.tsp"
         }
       },
-      "end": "(?=[_$[:alpha:]])|(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
+      "end": "(?=([_$[:alpha:]]|`))|(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
       "patterns": [
         {
           "include": "#token"
@@ -141,7 +141,7 @@
           "name": "entity.name.tag.tsp"
         }
       },
-      "end": "(?=[_$[:alpha:]])|(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
+      "end": "(?=([_$[:alpha:]]|`))|(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b)",
       "patterns": [
         {
           "include": "#token"
@@ -737,7 +737,7 @@
     },
     "namespace-name": {
       "name": "meta.namespace-name.typespec",
-      "begin": "(?=[_$[:alpha:]])",
+      "begin": "(?=([_$[:alpha:]]|`))",
       "end": "((?=\\{)|(?=,|;|@|\\)|\\}|\\b(?:extern)\\b|\\b(?:namespace|model|op|using|import|enum|alias|union|interface|dec|fn)\\b))",
       "patterns": [
         {

--- a/packages/compiler/src/server/tmlanguage.ts
+++ b/packages/compiler/src/server/tmlanguage.ts
@@ -59,7 +59,7 @@ const meta: typeof tm.meta = tm.meta;
 const identifierStart = "[_$[:alpha:]]";
 // cspell:disable-next-line
 const identifierContinue = "[_$[:alnum:]]";
-const beforeIdentifier = `(?=${identifierStart})`;
+const beforeIdentifier = `(?=(${identifierStart}|\`))`;
 const escapedIdentifier = "`(?:[^`\\\\]|\\\\.)*`";
 const simpleIdentifier = `\\b${identifierStart}${identifierContinue}*\\b`;
 const identifier = `${simpleIdentifier}|${escapedIdentifier}`;

--- a/packages/compiler/test/server/colorization.test.ts
+++ b/packages/compiler/test/server/colorization.test.ts
@@ -918,6 +918,26 @@ function testColorization(description: string, tokenize: Tokenize) {
         ]);
       });
 
+      it("decorators on escaped members", async () => {
+        const tokens = await tokenize("enum Direction { @foo `Val 123`, @foo(123) `456 after`}");
+        deepStrictEqual(tokens, [
+          Token.keywords.enum,
+          Token.identifiers.type("Direction"),
+          Token.punctuation.openBrace,
+          Token.identifiers.tag("@"),
+          Token.identifiers.tag("foo"),
+          Token.identifiers.variable("`Val 123`"),
+          Token.punctuation.comma,
+          Token.identifiers.tag("@"),
+          Token.identifiers.tag("foo"),
+          Token.punctuation.openParen,
+          Token.literals.numeric("123"),
+          Token.punctuation.closeParen,
+          Token.identifiers.variable("`456 after`"),
+          Token.punctuation.closeBrace,
+        ]);
+      });
+
       it("enum with string values", async () => {
         const tokens = await tokenize(`enum Direction { up: "Up", down: "Down"}`);
         deepStrictEqual(tokens, [


### PR DESCRIPTION
fix [#4720](https://github.com/microsoft/typespec/issues/4720)