### PR TITLE
Write comment statement

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -1313,7 +1313,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var accessibility = _isStruct ? MethodSignatureModifiers.Public : MethodSignatureModifiers.Internal;
             return new ConstructorProvider(
                 signature: new ConstructorSignature(Type, $"Initializes a new instance of {Type:C} for deserialization.", accessibility, Array.Empty<ParameterProvider>()),
-                bodyStatements: new MethodBodyStatement(),
+                bodyStatements: MethodBodyStatement.Empty,
                 this);
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/MethodProviderBenchmark.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/MethodProviderBenchmark.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TypeSpec.Generator.Perf
     public class MethodProviderBenchmark
     {
         private MethodSignature Signature { get; }
-        private MethodBodyStatement BodyStatement = new();
+        private MethodBodyStatement BodyStatement = MethodBodyStatement.Empty;
         private Dictionary<ParameterValidationType, List<ParameterProvider>>? ParamHash;
 
         public MethodProviderBenchmark()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/MethodBodyStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/MethodBodyStatement.cs
@@ -7,9 +7,9 @@ using System.Diagnostics;
 namespace Microsoft.TypeSpec.Generator.Statements
 {
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    public class MethodBodyStatement
+    public abstract class MethodBodyStatement
     {
-        internal virtual void Write(CodeWriter writer) { }
+        internal abstract void Write(CodeWriter writer);
         public static implicit operator MethodBodyStatement(MethodBodyStatement[] statements) => new MethodBodyStatements(statements);
         public static implicit operator MethodBodyStatement(List<MethodBodyStatement> statements) => new MethodBodyStatements(statements);
 
@@ -21,7 +21,15 @@ namespace Microsoft.TypeSpec.Generator.Statements
             }
         }
 
-        public static readonly MethodBodyStatement Empty = new();
+        private class PrivateEmptyStatement : MethodBodyStatement
+        {
+            internal override void Write(CodeWriter writer)
+            {
+                // Do nothing
+            }
+        }
+
+        public static readonly MethodBodyStatement Empty = new PrivateEmptyStatement();
         public static readonly MethodBodyStatement EmptyLine = new PrivateEmptyLineStatement();
 
         public string ToDisplayString() => GetDebuggerDisplay();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/SingleLineCommentStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/SingleLineCommentStatement.cs
@@ -16,5 +16,10 @@ namespace Microsoft.TypeSpec.Generator.Statements
 
         public SingleLineCommentStatement(string message) : this(FormattableStringHelpers.FromString(message))
         { }
+
+        internal override void Write(CodeWriter writer)
+        {
+            writer.WriteLine($"// {Message}");
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
             var condition = True;
             var increment = ValueExpression.Empty;
             var forStatement = new ForStatement(assignment, condition, increment);
-            var statementToAdd = new MethodBodyStatement();
+            var statementToAdd = MethodBodyStatement.Empty;
 
             forStatement.Add(statementToAdd);
 
@@ -73,7 +73,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
         public void ForeachStatementWithAddMethod()
         {
             var foreachStatement = new ForeachStatement(new CSharpType(typeof(int)), "item", ValueExpression.Empty, isAsync: false, out var itemReference);
-            var statementToAdd = new MethodBodyStatement();
+            var statementToAdd = MethodBodyStatement.Empty;
 
             foreachStatement.Add(statementToAdd);
 
@@ -98,7 +98,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
         public void IfStatementWithAddMethod()
         {
             var ifStatement = new IfStatement(True);
-            var statementToAdd = new MethodBodyStatement();
+            var statementToAdd = MethodBodyStatement.Empty;
 
             ifStatement.Add(statementToAdd);
 
@@ -139,7 +139,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
         public void IfElseStatementWithIfAndElse()
         {
             var condition = True;
-            var elseStatement = new MethodBodyStatement();
+            var elseStatement = MethodBodyStatement.Empty;
 
             var ifElseStatement = new IfElseStatement(new IfStatement(condition), elseStatement);
 
@@ -153,8 +153,8 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
         public void IfElseStatementWithConditionAndStatements()
         {
             var condition = True;
-            var ifStatement = new MethodBodyStatement();
-            var elseStatement = new MethodBodyStatement();
+            var ifStatement = MethodBodyStatement.Empty;
+            var elseStatement = MethodBodyStatement.Empty;
 
             var ifElseStatement = new IfElseStatement(condition, ifStatement, elseStatement);
 
@@ -170,7 +170,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
             var matchExpression = ValueExpression.Empty;
             var switchStatement = new SwitchStatement(matchExpression);
 
-            var caseStatement = new MethodBodyStatement();
+            var caseStatement = MethodBodyStatement.Empty;
             var switchCase = new SwitchCaseStatement(ValueExpression.Empty, caseStatement);
 
             switchStatement.Add(switchCase);
@@ -187,8 +187,8 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
 
             var caseStatements = new List<SwitchCaseStatement>
             {
-                new SwitchCaseStatement(ValueExpression.Empty, new MethodBodyStatement()),
-                new SwitchCaseStatement(ValueExpression.Empty, new MethodBodyStatement())
+                new SwitchCaseStatement(ValueExpression.Empty, MethodBodyStatement.Empty),
+                new SwitchCaseStatement(ValueExpression.Empty, MethodBodyStatement.Empty)
             };
 
             foreach (var switchCase in caseStatements)
@@ -207,8 +207,8 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
 
             var caseStatements = new List<SwitchCaseStatement>
             {
-                new SwitchCaseStatement(ValueExpression.Empty, new MethodBodyStatement()),
-                new SwitchCaseStatement(ValueExpression.Empty, new MethodBodyStatement())
+                new SwitchCaseStatement(ValueExpression.Empty, MethodBodyStatement.Empty),
+                new SwitchCaseStatement(ValueExpression.Empty, MethodBodyStatement.Empty)
             };
 
             foreach (var switchCase in caseStatements)
@@ -271,6 +271,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
             var switchStatement = new SwitchStatement(variableFoo);
             var usingStatement = new UsingScopeStatement(null, new CodeWriterDeclaration("x"), New.Instance(typeof(MemoryStream)))
             {
+                new SingleLineCommentStatement("some comment explaining the return"),
                 Return(variableFoo)
             };
 
@@ -545,6 +546,13 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
                 statement2
             };
             Assert.AreEqual(expectedOrder, result);
+        }
+
+        [Test]
+        public void SingleLineCommentStatement()
+        {
+            var comment = new SingleLineCommentStatement("This is a comment");
+            Assert.AreEqual("// This is a comment\n", comment.ToDisplayString());
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/TestData/StatementTests/TestSwitchStatementWithUsingStatementWrite.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/TestData/StatementTests/TestSwitchStatementWithUsingStatementWrite.cs
@@ -6,6 +6,7 @@ public bool Foo()
         case true:
             using (var x = new global::System.IO.MemoryStream())
             {
+                // some comment explaining the return
                 return foo;
             }
         default:


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/6136

Also make MethodBodyStatement.Write `abstract`.