### PR TITLE
Exclude tsp.exe from binskim

### DIFF
--- a/eng/common/pipelines/ci.yml
+++ b/eng/common/pipelines/ci.yml
@@ -12,6 +12,8 @@ pr:
 extends:
   template: /eng/common/pipelines/templates/1es-redirect.yml
   parameters:
+    BinSkimSettings:
+      targetPathExclusionPattern: "tsp.exe" # Flag issue with node binary which we can't fix https://github.com/nodejs/node/issues/42100
     stages:
       - stage: InitStage
         displayName: Initialize

--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -15,6 +15,8 @@ pr: none
 extends:
   template: /eng/common/pipelines/templates/1es-redirect.yml
   parameters:
+    BinSkimSettings:
+      targetPathExclusionPattern: "tsp.exe" # Flag issue with node binary which we can't fix https://github.com/nodejs/node/issues/42100
     variables:
       - template: /eng/tsp-core/pipelines/templates/variables/globals.yml@self
 


### PR DESCRIPTION
PR adding some baseline thing to give time to fix issues, https://github.com/microsoft/typespec/pull/6134

we can't actually fix those as we don't build this binary we just inject our code into node's so just ignoring the validation of the `tsp.exe`