### PR TITLE
Fix don't shrink icons when text is too long

### DIFF
--- a/packages/react-components/src/tree/tree.module.css
+++ b/packages/react-components/src/tree/tree.module.css
@@ -25,6 +25,7 @@
 
 .tree-row .caret {
   width: 16px;
+  flex: 0 0 16px;
   display: flex;
   align-items: center;
 }

--- a/packages/react-components/src/tree/tree.module.css
+++ b/packages/react-components/src/tree/tree.module.css
@@ -31,6 +31,7 @@
 
 .tree-row .icon {
   width: 16px;
+  flex: 0 0 16px;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
Before
<img width="118" alt="image" src="https://github.com/user-attachments/assets/d681f9ca-24cd-4351-bb0b-8c4265a88739" />
after
<img width="165" alt="image" src="https://github.com/user-attachments/assets/e0375a1a-6c34-47bc-8164-684cebdbc231" />
