### PR TITLE
[OpenAPI 3 Emitter] Reuse Operation IDs With Identical Values In @OperationId Decorators For Shared Routes

### DIFF
--- a/.chronus/changes/wanl-opid-2025-1-26-11-56-11.md
+++ b/.chronus/changes/wanl-opid-2025-1-26-11-56-11.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/openapi3"
 ---
 
-Reuse operation IDs when all `@operationId` decorators share the same value, which improve the usability for client code generation to leverage the shared operation ID.
+Shared operations operationId can now be set if they all share the same value provided by `@operationId` 

--- a/.chronus/changes/wanl-opid-2025-1-26-11-56-11.md
+++ b/.chronus/changes/wanl-opid-2025-1-26-11-56-11.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Reuse operation IDs when all `@operationId` decorators share the same value, which improve the usability for client code generation to leverage the shared operation ID.

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -710,7 +710,10 @@ function createOAPIEmitter(
   }
 
   function computeSharedOperationId(shared: SharedHttpOperation) {
-    return shared.operations.map((op) => resolveOperationId(program, op.operation)).join("_");
+    const operaionIds = shared.operations.map((op) => resolveOperationId(program, op.operation));
+    const uniqueOpIds = new Set<string>(operaionIds);
+    if (uniqueOpIds.size === 1) return uniqueOpIds.values().next().value;
+    return operaionIds.join("_");
   }
 
   function getOperationOrSharedOperation(operation: HttpOperation | SharedHttpOperation):

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -710,10 +710,10 @@ function createOAPIEmitter(
   }
 
   function computeSharedOperationId(shared: SharedHttpOperation) {
-    const operaionIds = shared.operations.map((op) => resolveOperationId(program, op.operation));
-    const uniqueOpIds = new Set<string>(operaionIds);
+    const operationIds = shared.operations.map((op) => resolveOperationId(program, op.operation));
+    const uniqueOpIds = new Set<string>(operationIds);
     if (uniqueOpIds.size === 1) return uniqueOpIds.values().next().value;
-    return operaionIds.join("_");
+    return operationIds.join("_");
   }
 
   function getOperationOrSharedOperation(operation: HttpOperation | SharedHttpOperation):

--- a/packages/openapi3/test/operation-id.test.ts
+++ b/packages/openapi3/test/operation-id.test.ts
@@ -1,0 +1,61 @@
+import { expect, it } from "vitest";
+import { OpenAPI3Document } from "../src/types.js";
+import { worksFor } from "./works-for.js";
+
+interface Case {
+  description: string;
+  code: string;
+  expectedOperationId: string;
+}
+
+const testCases: Case[] = [
+  {
+    description: "should reuse on the same operation IDs",
+    code: createCode("op1", "op1", "op1"),
+    expectedOperationId: "op1",
+  },
+  {
+    description: "should concat with different operation IDs",
+    code: createCode("op1", "op1", "op2"),
+    expectedOperationId: "op1_op1_op2",
+  },
+  {
+    description: "should concat with partial operation IDs",
+    code: createCode(undefined, "op1", "op1"),
+    expectedOperationId: "getWidget1_op1_op1",
+  },
+  {
+    description: "should concat with no operation IDs",
+    code: createCode(),
+    expectedOperationId: "getWidget1_getWidget2_getWidget3",
+  },
+];
+
+worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
+  it.each(testCases)("$description", async (c: Case) => {
+    const res: OpenAPI3Document = await openApiFor(c.code);
+    expect(res.paths["/{id}"].get?.operationId).toBe(c.expectedOperationId);
+  });
+});
+
+function createCode(id1?: string, id2?: string, id3?: string) {
+  return `
+        @service
+        namespace DemoService;
+        ${createOperationCodeBlock(1, id1)}
+        ${createOperationCodeBlock(2, id2)}
+        ${createOperationCodeBlock(3, id3)}
+        `;
+}
+
+function createOperationCodeBlock(operationIndex: number, id?: string) {
+  return `
+        @sharedRoute
+        ${createOperationIdDecorator(id)}
+        op getWidget${operationIndex}(@path id: string): void;
+        `;
+}
+
+function createOperationIdDecorator(id?: string) {
+  return id ? `@operationId("${id}")` : "";
+}


### PR DESCRIPTION
Fix: https://github.com/microsoft/typespec/issues/5513

This pull request introduces changes to reuse operation IDs when all `@operationId` decorators share the same value, which improve the usability for client code generation to leverage the shared operation ID.