### PR TITLE
Fixes repo build issues when running on Windows

### DIFF
--- a/.chronus/changes/fix-windows-build-2025-1-26-16-18-57.md
+++ b/.chronus/changes/fix-windows-build-2025-1-26-16-18-57.md
@@ -1,0 +1,8 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+  - "@typespec/internal-build-utils"
+---
+
+Adds test and internal dependencies to fix Windows build issues

--- a/e2e/e2e-tests.js
+++ b/e2e/e2e-tests.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 // @ts-check
 import { existsSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { readdir } from "fs/promises";
 import { join } from "path";
 import { repoRoot } from "../eng/common/scripts/helpers.js";
 import { runOrExit } from "../packages/internal-build-utils/dist/src/index.js";
@@ -14,7 +15,7 @@ async function main() {
   const packages = await packPackages();
 
   console.log("Check packages exists");
-  await runOrExit("ls", [`${repoRoot}/temp/artifacts`]);
+  await listDirectory(join(repoRoot, "temp", "artifacts"));
 
   console.log("Check cli is working");
   await runTypeSpec(packages["@typespec/compiler"], ["--help"], { cwd: e2eTestDir });
@@ -24,6 +25,18 @@ async function main() {
   await testBasicCurrentTgz(packages);
 }
 await main();
+
+/**
+ * @param {string} dir
+ */
+async function listDirectory(dir) {
+  try {
+    (await readdir(dir)).map((name) => console.log(name));
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
 
 function printInfo() {
   console.log("-".repeat(100));
@@ -72,7 +85,9 @@ async function testBasicLatest(packages) {
   console.log("Cleared basic-latest output");
 
   console.log("Installing basic-latest dependencies");
-  await runTypeSpec(packages["@typespec/compiler"], ["install"], { cwd: basicLatestDir });
+  await runTypeSpec(packages["@typespec/compiler"], ["install"], {
+    cwd: basicLatestDir,
+  });
   console.log("Installed basic-latest dependencies");
 
   console.log("Running tsp compile .");

--- a/packages/astro-utils/package.json
+++ b/packages/astro-utils/package.json
@@ -33,6 +33,7 @@
     "@expressive-code/core": "^0.40.1",
     "@typespec/playground": "workspace:~",
     "astro-expressive-code": "^0.40.1",
+    "pathe": "^2.0.2",
     "react": "~18.3.1",
     "typescript": "~5.7.3"
   }

--- a/packages/astro-utils/src/sidebar/index.ts
+++ b/packages/astro-utils/src/sidebar/index.ts
@@ -1,6 +1,6 @@
 import type { StarlightUserConfig } from "@astrojs/starlight/types";
 import { readdir, stat } from "fs/promises";
-import { join, parse, resolve } from "path/posix";
+import { join, parse, resolve } from "pathe";
 
 export type StarlightSidebarUserConfig = StarlightUserConfig["sidebar"];
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -120,6 +120,7 @@
     "@vitest/ui": "^3.0.3",
     "c8": "^10.1.3",
     "grammarkdown": "~3.3.2",
+    "pathe": "^2.0.2",
     "rimraf": "~6.0.1",
     "source-map-support": "~0.5.21",
     "tmlanguage-generator": "workspace:~",

--- a/packages/compiler/test/e2e/init-templates.e2e.ts
+++ b/packages/compiler/test/e2e/init-templates.e2e.ts
@@ -1,8 +1,7 @@
 import { ok } from "assert";
 import { SpawnOptions, spawn } from "child_process";
 import { rm } from "fs/promises";
-import { dirname } from "path";
-import { resolve } from "path/posix";
+import { dirname, resolve } from "pathe";
 import { fileURLToPath } from "url";
 import { beforeAll, describe, it } from "vitest";
 import { NodeHost } from "../../src/index.js";
@@ -89,7 +88,9 @@ describe("Init templates e2e tests", () => {
       directory: targetFolder,
       checkCommand: async (command: string, args: string[] = [], options: SpawnOptions = {}) => {
         const xplatCmd = process.platform === "win32" ? `${command}.cmd` : command;
+        const shell = process.platform === "win32" ? true : options.shell;
         const result = await execAsync(xplatCmd, args, {
+          shell,
           ...options,
           cwd: targetFolder,
         });

--- a/packages/compiler/test/e2e/scenarios/scenarios.e2e.ts
+++ b/packages/compiler/test/e2e/scenarios/scenarios.e2e.ts
@@ -1,5 +1,5 @@
 import { rejects } from "assert";
-import { resolve } from "path";
+import { normalize, resolve } from "path";
 import { describe, it } from "vitest";
 import { NodeHost, Program, compile, resolvePath } from "../../../src/core/index.js";
 import { CompilerOptions } from "../../../src/core/options.js";
@@ -67,7 +67,7 @@ describe("compiler: entrypoints", () => {
       });
       expectDiagnostics(program.diagnostics, {
         code: "js-error",
-        message: `Failed to load ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js due to the following JS error: Cannot find module '${scenarioRoot}/import-library-js-error/node_modules/my-lib/invalid-file-not-exists.js' imported from ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js`,
+        message: `Failed to load ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js due to the following JS error: Cannot find module '${normalize(`${scenarioRoot}/import-library-js-error/node_modules/my-lib/invalid-file-not-exists.js`)}' imported from ${normalize(`${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js`)}`,
       });
     });
 
@@ -77,7 +77,7 @@ describe("compiler: entrypoints", () => {
       });
       expectDiagnostics(program.diagnostics, {
         code: "js-error",
-        message: `Failed to load ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js due to the following JS error: Cannot find module '${scenarioRoot}/import-library-js-error/node_modules/my-lib/invalid-file-not-exists.js' imported from ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js`,
+        message: `Failed to load ${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js due to the following JS error: Cannot find module '${normalize(`${scenarioRoot}/import-library-js-error/node_modules/my-lib/invalid-file-not-exists.js`)}' imported from ${normalize(`${scenarioRoot}/import-library-js-error/node_modules/my-lib/index.js`)}`,
       });
     });
 

--- a/packages/compiler/vitest.config.e2e.ts
+++ b/packages/compiler/vitest.config.e2e.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    testTimeout: 60_000,
+    testTimeout: 90_000,
     isolate: false,
     coverage: {
       reporter: ["cobertura", "json", "text"],

--- a/packages/internal-build-utils/package.json
+++ b/packages/internal-build-utils/package.json
@@ -41,12 +41,14 @@
   ],
   "dependencies": {
     "@pnpm/find-workspace-packages": "^6.0.9",
+    "cross-spawn": "^7.0.6",
     "cspell": "^8.17.2",
     "semver": "^7.6.3",
     "strip-json-comments": "~5.0.1",
     "yargs": "~17.7.2"
   },
   "devDependencies": {
+    "@types/cross-spawn": "~6.0.6",
     "@types/node": "~22.10.10",
     "@types/semver": "^7.5.8",
     "@types/yargs": "~17.0.33",

--- a/packages/internal-build-utils/src/common.ts
+++ b/packages/internal-build-utils/src/common.ts
@@ -1,4 +1,5 @@
-import { ChildProcess, spawn, SpawnOptions } from "child_process";
+import { ChildProcess, SpawnOptions } from "child_process";
+import { spawn } from "cross-spawn";
 
 export class CommandFailedError extends Error {
   constructor(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       astro-expressive-code:
         specifier: ^0.40.1
         version: 0.40.1(astro@5.1.8(@azure/identity@4.6.0)(@azure/storage-blob@12.26.0)(@types/node@22.10.10)(jiti@1.21.6)(rollup@4.34.6)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))
+      pathe:
+        specifier: ^2.0.2
+        version: 2.0.2
       react:
         specifier: ~18.3.1
         version: 18.3.1
@@ -377,6 +380,9 @@ importers:
       grammarkdown:
         specifier: ~3.3.2
         version: 3.3.2
+      pathe:
+        specifier: ^2.0.2
+        version: 2.0.2
       rimraf:
         specifier: ~6.0.1
         version: 6.0.1
@@ -849,6 +855,9 @@ importers:
       '@pnpm/find-workspace-packages':
         specifier: ^6.0.9
         version: 6.0.9(@pnpm/logger@5.2.0)
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       cspell:
         specifier: ^8.17.2
         version: 8.17.2
@@ -862,6 +871,9 @@ importers:
         specifier: ~17.7.2
         version: 17.7.2
     devDependencies:
+      '@types/cross-spawn':
+        specifier: ~6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: ~22.10.10
         version: 22.10.10
@@ -2284,6 +2296,9 @@ importers:
       es-module-shims:
         specifier: ~2.0.5
         version: 2.0.5
+      pathe:
+        specifier: ^2.0.2
+        version: 2.0.2
       prism-react-renderer:
         specifier: ^2.4.0
         version: 2.4.0(react@18.3.1)

--- a/website/.scripts/regen-compiler-docs.ts
+++ b/website/.scripts/regen-compiler-docs.ts
@@ -8,7 +8,7 @@ import {
 
 import assert from "assert";
 import { writeFile } from "fs/promises";
-import { dirname, join, resolve } from "path";
+import { dirname, join, resolve } from "pathe";
 import { fileURLToPath } from "url";
 
 export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -7,7 +7,7 @@ import { processSidebar } from "@typespec/astro-utils/sidebar";
 import astroExpressiveCode from "astro-expressive-code";
 import rehypeAstroRelativeMarkdownLinks from "astro-rehype-relative-markdown-links";
 import { defineConfig } from "astro/config";
-import { resolve } from "path";
+import { resolve } from "pathe";
 import rehypeMermaid from "rehype-mermaid";
 import remarkHeadingID from "remark-heading-id";
 import { nodePolyfills } from "vite-plugin-node-polyfills";

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "es-module-shims": "~2.0.5",
+    "pathe": "^2.0.2",
     "prism-react-renderer": "^2.4.0",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",


### PR DESCRIPTION
Building the website and running e2e tests were failing when ran on windows for 2 reasons:
1. Changes to more recent versions of node.js when spawning processes
2. Issues with path resolution

1 was solved by using cross-spawn
2 was solved by using `pathe` instead of `path/posix`