### PR TITLE
[python] update regenerate to speed CI

### DIFF
--- a/packages/http-client-python/eng/scripts/ci/regenerate.ts
+++ b/packages/http-client-python/eng/scripts/ci/regenerate.ts
@@ -58,6 +58,7 @@ const EMITTER_OPTIONS: Record<string, Record<string, string> | Record<string, st
   },
   "type/array": {
     "package-name": "typetest-array",
+    "use-pyodide": "true",
   },
   "type/dictionary": {
     "package-name": "typetest-dictionary",
@@ -85,6 +86,7 @@ const EMITTER_OPTIONS: Record<string, Record<string, string> | Record<string, st
   },
   "type/model/inheritance/recursive": {
     "package-name": "typetest-model-recursive",
+    "use-pyodide": "true",
   },
   "type/model/usage": {
     "package-name": "typetest-model-usage",
@@ -317,7 +319,7 @@ function _getCmdList(spec: string, flags: RegenerateFlags): TspCommand[] {
 async function regenerate(flags: RegenerateFlagsInput): Promise<void> {
   if (flags.flavor === undefined) {
     await regenerate({ flavor: "azure", ...flags });
-    await regenerate({ flavor: "unbranded", pyodide: true, ...flags });
+    await regenerate({ flavor: "unbranded", ...flags });
   } else {
     const flagsResolved = { debug: false, flavor: flags.flavor, ...flags };
     const subdirectoriesForAzure = await getSubdirectories(AZURE_HTTP_SPECS, flagsResolved);

--- a/packages/http-client-python/eng/scripts/ci/run_apiview.py
+++ b/packages/http-client-python/eng/scripts/ci/run_apiview.py
@@ -8,6 +8,8 @@
 # This script is used to execute apiview generation within a tox environment. Depending on which package is being executed against,
 # a failure may be suppressed.
 
+import os
+import sys
 from subprocess import check_call, CalledProcessError
 import logging
 from util import run_check
@@ -37,4 +39,7 @@ def _single_dir_apiview(mod):
 
 
 if __name__ == "__main__":
+    if os.name == "nt":
+        logging.info("Skip running ApiView on Windows for now to reduce time cost in CI")
+        sys.exit(0)
     run_check("apiview", _single_dir_apiview, "APIView")


### PR DESCRIPTION
- We don't need to use all test cases with pyodide mode since it takes too long time. We can pick up several cases for pyodide mode.
- Apiview step costs about 16 minutes in Windows and we can skip it since there is already check in Linux.