### PR TITLE
Export missing DiscriminatedUnionLegacy

### DIFF
--- a/.chronus/changes/fix-compiler-discriminated-union-legacy-2025-1-27-22-7-24.md
+++ b/.chronus/changes/fix-compiler-discriminated-union-legacy-2025-1-27-22-7-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Export missing DiscriminatedUnionLegacy and getDiscriminatedUnionFromInheritance

--- a/.chronus/changes/fix-compiler-discriminated-union-legacy-2025-1-27-22-7-24.md
+++ b/.chronus/changes/fix-compiler-discriminated-union-legacy-2025-1-27-22-7-24.md
@@ -1,5 +1,5 @@
 ---
-changeKind: fix
+changeKind: internal
 packages:
   - "@typespec/compiler"
 ---

--- a/packages/compiler/src/core/helpers/index.ts
+++ b/packages/compiler/src/core/helpers/index.ts
@@ -1,4 +1,9 @@
-export { DiscriminatedUnion, getDiscriminatedUnion } from "./discriminator-utils.js";
+export {
+  DiscriminatedUnion,
+  DiscriminatedUnionLegacy,
+  getDiscriminatedUnion,
+  getDiscriminatedUnionFromInheritance,
+} from "./discriminator-utils.js";
 export { getLocationContext } from "./location-context.js";
 export * from "./operation-utils.js";
 export * from "./path-interpolation.js";


### PR DESCRIPTION
Exporting missing types for legacy discriminated unions.

* DiscriminatedUnionLegacy
* getDiscriminatedUnionFromInheritance