### PR TITLE
Fix `tsp info` crash

### DIFF
--- a/packages/compiler/src/core/cli/actions/info.ts
+++ b/packages/compiler/src/core/cli/actions/info.ts
@@ -11,9 +11,9 @@ export async function printInfoAction(host: CompilerHost): Promise<readonly Diag
   console.log(`Module: ${fileURLToPath(import.meta.url)}`);
 
   const config = await loadTypeSpecConfigForPath(host, cwd, true, true);
-  const { diagnostics, filename, ...restOfConfig } = config;
+  const { diagnostics, filename, file, ...restOfConfig } = config;
 
-  console.log(`User Config: ${config.filename ?? "No config file found"}`);
+  console.log(`User Config: ${filename ?? "No config file found"}`);
   console.log("-----------");
   console.log(stringify(restOfConfig));
   console.log("-----------");

--- a/packages/compiler/test/e2e/cli/cli.e2e.ts
+++ b/packages/compiler/test/e2e/cli/cli.e2e.ts
@@ -80,7 +80,8 @@ async function cleanOutputDir(scenarioName: string) {
   const dir = resolvePath(getScenarioDir(scenarioName), "tsp-output");
   await rm(dir, { recursive: true, force: true });
 }
-describe("cli", () => {
+
+describe("help", () => {
   it("shows help", async () => {
     const { stdout } = await execCliSuccess(["--help"], {
       cwd: getScenarioDir("simple"),
@@ -89,7 +90,19 @@ describe("cli", () => {
     expect(stdout).toContain("tsp compile <path>       Compile TypeSpec source.");
     expect(stdout).toContain("tsp format <include...>  Format given list of TypeSpec files.");
   });
+});
 
+describe("info", () => {
+  it("shows information about the current", async () => {
+    const { stdout } = await execCliSuccess(["info"], {
+      cwd: getScenarioDir("with-config"),
+    });
+    expect(stdout).toContain(`User Config:`);
+    expect(stdout).toContain(`outputDir: "{project-root}/tsp-output/{custom-dir}"`);
+  });
+});
+
+describe("compile", () => {
   describe("compiling spec with warning", () => {
     it("logs warning and succeed", async () => {
       const { stdout } = await execCliSuccess(["compile", ".", "--pretty", "false"], {


### PR DESCRIPTION
Command crashed becuse it tried to serialize some non serialzable object. Also added a test to catch new regressions