### PR TITLE
speed up binskim

### DIFF
--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -16,7 +16,7 @@ extends:
   template: /eng/common/pipelines/templates/1es-redirect.yml
   parameters:
     BinSkimSettings:
-      analyzeTargetGlob: +:file|**/dist/*.exe;-:f|**/tsp.exe # Flag issue with node binary which we can't fix https://github.com/nodejs/node/issues/42100
+      analyzeTargetGlob: +:file|*.exe;-:f|**/tsp.exe # Flag issue with node binary which we can't fix https://github.com/nodejs/node/issues/42100
     variables:
       - template: /eng/tsp-core/pipelines/templates/variables/globals.yml@self
 


### PR DESCRIPTION
With the current pattern, binskim takes 3-5min everytime it runs which is on every artifact we produce, which basically close to double the build time...

Maybe one day ms tooling will learn to use an efficient glob library