### PR TITLE
support using standalone tsp to start LSP server

### DIFF
--- a/.chronus/changes/vscode-standalone-cli-2025-2-3-9-39-31.md
+++ b/.chronus/changes/vscode-standalone-cli-2025-2-3-9-39-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - typespec-vscode
+---
+
+Support starting LSP using standalone tsp cli

--- a/packages/typespec-vscode/ThirdPartyNotices.txt
+++ b/packages/typespec-vscode/ThirdPartyNotices.txt
@@ -12,7 +12,8 @@ granted herein, whether by implication, estoppel or otherwise.
 2. brace-expansion version 2.0.1 (https://github.com/juliangruber/brace-expansion)
 3. minimatch version 5.1.6 (https://github.com/isaacs/minimatch)
 4. semver version 7.6.3 (https://github.com/npm/node-semver)
-5. yaml version 2.7.0 (github:eemeli/yaml)
+5. which version 5.0.0 (https://github.com/npm/node-which)
+6. yaml version 2.7.0 (github:eemeli/yaml)
 
 
 %% balanced-match NOTICES AND INFORMATION BEGIN HERE
@@ -113,6 +114,28 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 =====================================================");
 END OF semver NOTICES AND INFORMATION
+
+
+%% which NOTICES AND INFORMATION BEGIN HERE
+=====================================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+=====================================================");
+END OF which NOTICES AND INFORMATION
 
 
 %% yaml NOTICES AND INFORMATION BEGIN HERE

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -244,8 +244,9 @@
     "@rollup/plugin-typescript": "~12.1.0",
     "@types/mocha": "^10.0.9",
     "@types/node": "~22.10.10",
-    "@types/vscode": "~1.96.0",
     "@types/semver": "^7.5.8",
+    "@types/vscode": "~1.96.0",
+    "@types/which": "^3.0.4",
     "@typespec/compiler": "workspace:~",
     "@typespec/internal-build-utils": "workspace:~",
     "@vitest/coverage-v8": "^3.0.4",
@@ -260,6 +261,7 @@
     "typescript": "~5.7.3",
     "vitest": "^3.0.5",
     "vscode-languageclient": "~9.0.1",
+    "which": "^5.0.0",
     "yaml": "~2.7.0"
   }
 }

--- a/packages/typespec-vscode/src/tsp-executable-resolver.ts
+++ b/packages/typespec-vscode/src/tsp-executable-resolver.ts
@@ -116,7 +116,7 @@ export async function resolveTypeSpecServer(context: ExtensionContext): Promise<
   options.env["TYPESPEC_SKIP_COMPILER_RESOLVE"] = "1";
   const checkCliResult = await checkCliPromise;
   if (checkCliResult === "tsp-standalone") {
-    logger.debug("Start tsp server using standalong tsp cli");
+    logger.debug("Start tsp server using standalone tsp cli");
     return { command: "tsp", args: ["--server", serverPath, ...args], options };
   } else {
     logger.debug("Start tsp server using node");

--- a/packages/typespec-vscode/src/tsp-executable-resolver.ts
+++ b/packages/typespec-vscode/src/tsp-executable-resolver.ts
@@ -3,7 +3,7 @@ import { ExtensionContext, workspace } from "vscode";
 import { Executable, ExecutableOptions } from "vscode-languageclient/node.js";
 import logger from "./log/logger.js";
 import { SettingName } from "./types.js";
-import { checkTspCli } from "./typespec-utils.js";
+import { checkTspCliType } from "./typespec-utils.js";
 import { isFile, loadModule, useShellInExec } from "./utils.js";
 import { VSCodeVariableResolver } from "./vscode-variable-resolver.js";
 
@@ -44,7 +44,7 @@ export async function resolveTypeSpecCli(
 }
 
 export async function resolveTypeSpecServer(context: ExtensionContext): Promise<Executable> {
-  const checkCliPromise = checkTspCli();
+  const checkCliPromise = checkTspCliType();
   const nodeOptions = process.env.TYPESPEC_SERVER_NODE_OPTIONS;
   const args = ["--stdio"];
 

--- a/packages/typespec-vscode/src/tsp-executable-resolver.ts
+++ b/packages/typespec-vscode/src/tsp-executable-resolver.ts
@@ -3,8 +3,7 @@ import { ExtensionContext, workspace } from "vscode";
 import { Executable, ExecutableOptions } from "vscode-languageclient/node.js";
 import logger from "./log/logger.js";
 import { SettingName } from "./types.js";
-import { checkTspCliType } from "./typespec-utils.js";
-import { isFile, loadModule, useShellInExec } from "./utils.js";
+import { checkInstalledNode, isFile, loadModule, useShellInExec } from "./utils.js";
 import { VSCodeVariableResolver } from "./vscode-variable-resolver.js";
 
 /**
@@ -44,7 +43,7 @@ export async function resolveTypeSpecCli(
 }
 
 export async function resolveTypeSpecServer(context: ExtensionContext): Promise<Executable> {
-  const checkCliPromise = checkTspCliType();
+  const checkNodePromise = checkInstalledNode();
   const nodeOptions = process.env.TYPESPEC_SERVER_NODE_OPTIONS;
   const args = ["--stdio"];
 
@@ -114,13 +113,14 @@ export async function resolveTypeSpecServer(context: ExtensionContext): Promise<
   }
 
   options.env["TYPESPEC_SKIP_COMPILER_RESOLVE"] = "1";
-  const checkCliResult = await checkCliPromise;
-  if (checkCliResult === "tsp-standalone") {
+  const nodeInstallPath = await checkNodePromise;
+  if (nodeInstallPath.length > 0) {
+    logger.debug(`Start tsp server using node at ${nodeInstallPath}`);
+    return { command: "node", args: [serverPath, ...args], options };
+  } else {
+    // otherwise the local compiler should be installed by standalone tsp cli
     logger.debug("Start tsp server using standalone tsp cli");
     return { command: "tsp", args: ["--server", serverPath, ...args], options };
-  } else {
-    logger.debug("Start tsp server using node");
-    return { command: "node", args: [serverPath, ...args], options };
   }
 }
 

--- a/packages/typespec-vscode/src/typespec-utils.ts
+++ b/packages/typespec-vscode/src/typespec-utils.ts
@@ -1,7 +1,6 @@
 import { readFile } from "fs/promises";
 import path from "path";
 import vscode from "vscode";
-import which from "which";
 import { StartFileName } from "./const.js";
 import logger from "./log/logger.js";
 import { getDirectoryPath, normalizeSlashes } from "./path-utils.js";
@@ -53,17 +52,4 @@ export async function TraverseMainTspFileInWorkspace() {
         .filter((uri) => uri.scheme === "file" && !uri.fsPath.includes("node_modules"))
         .map((uri) => normalizeSlashes(uri.fsPath)),
     );
-}
-
-type TspCliType = "tsp-npm-global" | "tsp-standalone" | "not-available";
-export async function checkTspCliType(): Promise<TspCliType> {
-  try {
-    // using "which" instead of 'tsp --version' to do the check because 'tsp --version' is very slow
-    const found = await which("tsp");
-    // the standalone tsp is expected to be installed at .../.tsp/... folder
-    const isStandalone = found.length > 0 && found.includes(".tsp");
-    return isStandalone ? "tsp-standalone" : "tsp-npm-global";
-  } catch (e) {
-    return "not-available";
-  }
 }

--- a/packages/typespec-vscode/src/typespec-utils.ts
+++ b/packages/typespec-vscode/src/typespec-utils.ts
@@ -55,7 +55,7 @@ export async function TraverseMainTspFileInWorkspace() {
 }
 
 type TspCliType = "tsp-npm-global" | "tsp-standalone" | "not-available";
-export async function checkTspCli(): Promise<TspCliType> {
+export async function checkTspCliType(): Promise<TspCliType> {
   try {
     // use "where" or "which" command instead of "tsp --version" which is much slower
     const command = process.platform === "win32" ? "where" : "which";
@@ -64,7 +64,7 @@ export async function checkTspCli(): Promise<TspCliType> {
       return "not-available";
     } else {
       const founds = r.stdout.split("\n").filter((line) => !isWhitespaceStringOrUndefined(line));
-      // the standalone tsp is expected to be installed at .../.tsp/bin/... folder
+      // the standalone tsp is expected to be installed at .../.tsp/... folder
       const isStandalone = founds.length > 0 && founds[0].includes(".tsp");
       return isStandalone ? "tsp-standalone" : "tsp-npm-global";
     }

--- a/packages/typespec-vscode/src/utils.ts
+++ b/packages/typespec-vscode/src/utils.ts
@@ -4,9 +4,11 @@ import { readFile, realpath, stat } from "fs/promises";
 import { dirname } from "path";
 import { CancellationToken } from "vscode";
 import { Executable } from "vscode-languageclient/node.js";
+import which from "which";
 import logger from "./log/logger.js";
 import { getDirectoryPath, isUrl, joinPaths } from "./path-utils.js";
 import { ResultCode } from "./types.js";
+
 const ERROR_CODE_ENOENT = "ENOENT";
 
 export async function isFile(path: string) {
@@ -388,4 +390,15 @@ export async function loadPackageJsonFile(
   const packageJson = tryParseJson(content);
   if (!packageJson) return undefined;
   return packageJson as NodePackage;
+}
+
+/**
+ * @returns the path to the installed node executable, or empty string if not found.
+ */
+export async function checkInstalledNode(): Promise<string> {
+  try {
+    return await which("node");
+  } catch (e) {
+    return "";
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2131,6 +2131,9 @@ importers:
       '@types/vscode':
         specifier: ~1.96.0
         version: 1.96.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@typespec/compiler':
         specifier: workspace:~
         version: link:../compiler
@@ -2173,6 +2176,9 @@ importers:
       vscode-languageclient:
         specifier: ~9.0.1
         version: 9.0.1
+      which:
+        specifier: ^5.0.0
+        version: 5.0.0
       yaml:
         specifier: ~2.7.0
         version: 2.7.0
@@ -6314,6 +6320,9 @@ packages:
 
   '@types/vscode@1.96.0':
     resolution: {integrity: sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
   '@types/xml2js@0.4.14':
     resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
@@ -11552,7 +11561,7 @@ packages:
     engines: {node: '>= 14.16.0'}
 
   readline-sync@1.4.9:
-    resolution: {integrity: sha1-PtqOZfI80qF+YTAbHwADOWr17No=}
+    resolution: {integrity: sha512-mp5h1N39kuKbCRGebLPIKTBOhuDw55GaNg5S+K9TW9uDAS1wIHpGUc2YokdUMZJb8GqS49sWmWEDijaESYh0Hg==}
     engines: {node: '>= 0.8.0'}
 
   realpath-missing@1.1.0:
@@ -18715,6 +18724,8 @@ snapshots:
   '@types/uuid@9.0.8': {}
 
   '@types/vscode@1.96.0': {}
+
+  '@types/which@3.0.4': {}
 
   '@types/xml2js@0.4.14':
     dependencies:


### PR DESCRIPTION
using ```tsp --server``` to start local LSP if standalone tsp cli is found on the machine.

fixes #5902 