### PR TITLE
openapi3 - make `@typespec/versioning` an optional dependency

### DIFF
--- a/.chronus/changes/oa3-optional-versioning-2025-2-4-15-55-13.md
+++ b/.chronus/changes/oa3-optional-versioning-2025-2-4-15-55-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+`@typespec/versioning` is now an optional dependency.

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -75,6 +75,9 @@
     },
     "@typespec/xml": {
       "optional": true
+    },
+    "@typespec/versioning": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -84,7 +84,6 @@ import {
   resolveOperationId,
   shouldInline,
 } from "@typespec/openapi";
-import { getVersioningMutators } from "@typespec/versioning";
 import { stringify } from "yaml";
 import { getRef } from "./decorators.js";
 import { getExampleOrExamples, OperationExamples, resolveOperationExamples } from "./examples.js";
@@ -122,6 +121,7 @@ import {
   isSharedHttpOperation,
   SharedHttpOperation,
 } from "./util.js";
+import { resolveVersioningModule } from "./versioning-module.js";
 import { resolveVisibilityUsage, VisibilityUsageTracker } from "./visibility-usage.js";
 import { resolveXmlModule, XmlModule } from "./xml-module.js";
 
@@ -453,13 +453,14 @@ function createOAPIEmitter(
   }
 
   async function getOpenAPI(): Promise<OpenAPI3ServiceRecord[]> {
+    const versioningModule = await resolveVersioningModule();
     const serviceRecords: OpenAPI3ServiceRecord[] = [];
     const services = listServices(program);
     if (services.length === 0) {
       services.push({ type: program.getGlobalNamespaceType() });
     }
     for (const service of services) {
-      const versions = getVersioningMutators(program, service.type);
+      const versions = versioningModule?.getVersioningMutators(program, service.type);
       if (versions === undefined) {
         const document = await getOpenApiFromVersion(service);
         if (document === undefined) {

--- a/packages/openapi3/src/versioning-module.ts
+++ b/packages/openapi3/src/versioning-module.ts
@@ -1,0 +1,9 @@
+export type VersioningModule = typeof import("@typespec/versioning");
+
+export async function resolveVersioningModule(): Promise<VersioningModule | undefined> {
+  try {
+    return await import("@typespec/versioning");
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/6206

I tried writing tests but I couldn't get `vi.mock` to actually mock an import. I was able to manually verify that this works - as in it generates unversioned specs if the versioning package isn't installed.