### PR TITLE
Use github action for changes comment

### DIFF
--- a/.github/workflows/commenter.yml
+++ b/.github/workflows/commenter.yml
@@ -2,7 +2,7 @@ name: Make Change Comment
 
 on:
   workflow_run:
-    workflows: ["Consitency"]
+    workflows: ["Consistency"]
     types:
       - completed
 

--- a/.github/workflows/commenter.yml
+++ b/.github/workflows/commenter.yml
@@ -1,0 +1,34 @@
+name: Make Change Comment
+
+on:
+  workflow_run:
+    workflows: ["Consitency"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  # DO NOT BUILD ANYTHING FROM A PR HERE https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  commenter:
+    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'publish/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: comment
+          run-id: ${{github.event.workflow_run.id }}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+
+      - run: pnpm install --filter="@typespec/monorepo"
+        name: Install dependencies
+
+      - run: npx -p @chronus/github-pr-commenter --comment-file comment.json
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        name: Create/update comment

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Create PR Comment
         run: pnpm chronus-github get-pr-comment --out ./comment-out/comment.json
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -30,6 +30,15 @@ jobs:
       - run: pnpm install
         name: Install dependencies
 
+      - name: Create PR Comment
+        run: chronus-github get-pr-comment --out ./comment-out/comment.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: comment
+          path: comment-out/
+          retention-days: 1 # Only need for the next workflow so don't need to waste storageretention-days
+
       - run: npx chronus verify --since ${{ github.event.pull_request.base.ref }}
         name: Check changelog
         if: |

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -31,7 +31,7 @@ jobs:
         name: Install dependencies
 
       - name: Create PR Comment
-        run: chronus-github get-pr-comment --out ./comment-out/comment.json
+        run: pnpm chronus-github get-pr-comment --out ./comment-out/comment.json
 
       - uses: actions/upload-artifact@v4
         with:
@@ -39,7 +39,7 @@ jobs:
           path: comment-out/
           retention-days: 1 # Only need for the next workflow so don't need to waste storageretention-days
 
-      - run: npx chronus verify --since ${{ github.event.pull_request.base.ref }}
+      - run: pnpm chronus verify --since ${{ github.event.pull_request.base.ref }}
         name: Check changelog
         if: |
           !startsWith(github.head_ref, 'publish/') &&

--- a/eng/tsp-core/pipelines/pr-tools.yml
+++ b/eng/tsp-core/pipelines/pr-tools.yml
@@ -96,13 +96,13 @@ extends:
                   GH_TOKEN: $(azuresdk-github-pat)
                   VSCODE_DOWNLOAD_URL: $(vscodeUrl)
 
-          - job: change_comment
-            displayName: Describe changes on PR
-            condition: and(succeeded(), eq(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), false))
-            steps:
-              - checkout: self
+          # - job: change_comment
+          #   displayName: Describe changes on PR
+          #   condition: and(succeeded(), eq(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), false))
+          #   steps:
+          #     - checkout: self
 
-              - script: npx -p @chronus/github-pr-commenter@0.5.0 chronus-github-pr-commenter
-                displayName: Make comment about changes
-                env:
-                  GITHUB_TOKEN: $(azuresdk-github-pat)
+          #     - script: npx -p @chronus/github-pr-commenter@0.5.0 chronus-github-pr-commenter
+          #       displayName: Make comment about changes
+          #       env:
+          #         GITHUB_TOKEN: $(azuresdk-github-pat)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@alloy-js/prettier-plugin-alloy": "^0.1.0",
     "@chronus/chronus": "^0.17.0",
     "@chronus/github": "^0.4.9",
+    "@chronus/github-pr-commenter": "^0.5.9",
     "@eslint/js": "^9.21.0",
     "@microsoft/api-extractor": "^7.51.1",
     "@octokit/core": "^6.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@chronus/github':
         specifier: ^0.4.9
         version: 0.4.9
+      '@chronus/github-pr-commenter':
+        specifier: ^0.5.9
+        version: 0.5.9
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.21.0
@@ -3444,6 +3447,11 @@ packages:
 
   '@chronus/chronus@0.17.0':
     resolution: {integrity: sha512-i4ZnvCCNnB8/i+Xl+vVLizy15k5HDyAoTfvxmQEE9bAyOy78hlCxJDhGY1dOA1pVmLT3oq9kV2e4qbVAYsokBw==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+
+  '@chronus/github-pr-commenter@0.5.9':
+    resolution: {integrity: sha512-Iwrrjed8k13Zrgz8UTGMNHTEj/TbkTBNBvyKNGfUZXnWNmzD0W5V+GUKg0JF0ulfFMWSCh+bwKMW5qNEHziQeQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
 
@@ -14877,6 +14885,14 @@ snapshots:
       yaml: 2.7.0
       yargs: 17.7.2
       zod: 3.24.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  '@chronus/github-pr-commenter@0.5.9':
+    dependencies:
+      '@chronus/github': 0.4.9
+      '@octokit/rest': 21.1.0
     transitivePeerDependencies:
       - bluebird
       - supports-color


### PR DESCRIPTION
Use the same approach I used in the chronus repo and alloy. This is a bit faster than using ADO and right now will also use the version of github commenter saved in the workspace package.json which prevent the current issue of being out of date

workflows in pr do not have permission to write comments on pr so you have to save an artifact and then a job that is scoped at the repo and always running the main version pulls the comment from artifact and writes it

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ shows this exact example 