### PR TITLE
Fix tsp init not respecting default selected emitters

### DIFF
--- a/.chronus/changes/fix-tsp-init-selected-emitter-2025-2-6-0-55-9.md
+++ b/.chronus/changes/fix-tsp-init-selected-emitter-2025-2-6-0-55-9.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix `tsp init` not respecting default selected emitters

--- a/packages/compiler/src/init/init.ts
+++ b/packages/compiler/src/init/init.ts
@@ -317,7 +317,7 @@ async function selectEmitters(template: InitTemplate): Promise<Record<string, Em
           ? `${emitter.label.padEnd(maxLabelLength + 3)} ${pc.dim(`[${name}]`)}`
           : name,
         description: emitter.description,
-        selected: emitter.selected ?? false,
+        checked: emitter.selected ?? false,
       };
     }),
     theme: {


### PR DESCRIPTION

<img width="904" alt="image" src="https://github.com/user-attachments/assets/291fc961-84e7-465d-9c48-4f0f4f78af06" />
