### PR TITLE
Revert "[python] add bump for dev version for http-client-python"

### DIFF
--- a/packages/http-client-python/eng/pipeline/publish.yml
+++ b/packages/http-client-python/eng/pipeline/publish.yml
@@ -30,9 +30,3 @@ extends:
           LanguageShortName: "python"
           CadlRanchName: "@typespec/http-client-python"
           EnableCadlRanchReport: false
-      - script:
-          # https://github.com/timotheeguerin/chronus/issues/359, `--prerelease` does not respect `--only`
-          pnpm chronus version --prerelease --only @typespec/http-client-python
-          git add $(Build.SourcesDirectory)/packages/http-client-python
-          git checkout -- $(Build.SourcesDirectory)
-        displayName: Bump version for dev release of Python client


### PR DESCRIPTION
Reverts microsoft/typespec#6190

This PR seems block release for http-client-python:
![image](https://github.com/user-attachments/assets/314faec6-54ac-4f89-b5fc-6099e6ffbdf6)

To unblock release, we have to revert this PR. After we find the root cause, we could add this PR back.