### PR TITLE
http-client-java, fix duplicate mock test

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/javamodel/JavaPackage.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/javamodel/JavaPackage.java
@@ -349,11 +349,13 @@ public class JavaPackage {
         }
     }
 
-    protected void checkDuplicateFile(String filePath) {
+    protected boolean checkDuplicateFile(String filePath) {
         if (filePaths.contains(filePath)) {
 //            throw new IllegalStateException(String.format("Name conflict for output file '%1$s'.", filePath));
             logger.warn(String.format("Name conflict for output file '%1$s'.", filePath));
+            return true;
         }
+        return false;
     }
 
     public void addJsonMergePatchHelper(List<ClientModel> models) {

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/javamodel/FluentJavaPackage.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/javamodel/FluentJavaPackage.java
@@ -120,7 +120,9 @@ public class FluentJavaPackage extends JavaPackage {
         FluentMethodMockTestTemplate.ClientMethodInfo info
             = new FluentMethodMockTestTemplate.ClientMethodInfo(className, unitTest);
         FluentMethodMockTestTemplate.getInstance().write(info, javaFile);
-        addJavaFile(javaFile);
+        if (!checkDuplicateFile(javaFile.getFilePath())) {
+            addJavaFile(javaFile);
+        }
     }
 
     public void addLiveTests(FluentLiveTests liveTests) {


### PR DESCRIPTION
We'll truncate mock test class name when the file path is too long. This will result in a duplicate file path in edge cases:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4623919&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=c10d5f44-55ce-55d7-7975-407ed75d9a96&l=40534