### PR TITLE
Add  the doc to describe the advanced configuration for client emitters

### DIFF
--- a/website/src/content/current-sidebar.ts
+++ b/website/src/content/current-sidebar.ts
@@ -141,7 +141,7 @@ const sidebar: SidebarItem[] = [
       ]),
       {
         label: "Clients",
-        items: ["emitters/clients/introduction"],
+        items: ["emitters/clients/introduction", "emitters/clients/advanced-configurations"],
       },
     ],
   },

--- a/website/src/content/docs/docs/emitters/clients/advanced-configurations.mdx
+++ b/website/src/content/docs/docs/emitters/clients/advanced-configurations.mdx
@@ -1,0 +1,82 @@
+---
+title: Advanced Client Emitter Configurations
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+## Advanced Configurations for Client Emitters
+
+This guide provides detailed information on advanced configurations available for client emitters in TypeSpec. These configurations allow you to customize the behavior and output of the generated clients for different programming languages.
+
+### Configuration Flags
+
+| **Configuration Name**       | **Type** | **Possible Values** | **C#**            | **Java**          | **Python**        | **JS**            |
+| ---------------------------- | -------- | ------------------- | ----------------- | ----------------- | ----------------- | ----------------- |
+| generate-protocol-methods    | boolean  | true, false         | User configurable | User configurable | Not used          | Not used          |
+| generate-convenience-methods | boolean  | true, false         | User configurable | User configurable | Not used          | Not used          |
+| flatten-union-as-enum        | boolean  | true, false         | Not used          | Not used          | Not used          | Fixed value       |
+| examples-dir                 | string   | directory path      | User configurable | User configurable | User configurable | User configurable |
+| namespace                    | string   | namespace path      | User configurable | User configurable | User configurable | User configurable |
+| api-version                  | string   | version string      | User configurable | User configurable | User configurable | User configurable |
+
+### Configuration Descriptions
+
+#### generate-protocol-methods
+
+- **Description**: Determines whether to generate protocol methods. Protocol methods are essential for low-level HTTP operations.
+
+#### generate-convenience-methods
+
+- **Description**: Specifies whether to generate convenience methods. These methods enhance the SDK's usability by simplifying API calls.
+
+#### flatten-union-as-enum
+
+- **Description**: Flattens union types as enums in the generated client.
+
+#### examples-dir
+
+- **Description**: Specifies the directory where example files are stored. **This configuration is only valid when generating SDKs targeting Azure Services.**
+
+#### namespace
+
+- **Description**: Specifies the namespace for the generated client. **This configuration is only valid when generating SDKs targeting Azure Services.**
+
+#### api-version
+
+- **Description**: Specifies the API version for the generated client.
+
+### Sample tspconfig.yaml
+
+Below is a sample `tspconfig.yaml` file demonstrating the advanced configurations for client emitters:
+
+```yaml
+emit:
+  - "@typespec/http-client-csharp"
+  - "@typespec/http-client-java"
+  - "@typespec/http-client-python"
+  - "@typespec/http-client-js"
+options:
+  "@typespec/http-client-csharp":
+    emitter-output-dir: "{project-root}/clients/dotnet"
+    generate-protocol-methods: true
+    generate-convenience-methods: true
+    api-version: "v1"
+  "@typespec/http-client-java":
+    emitter-output-dir: "{project-root}/clients/java"
+    generate-protocol-methods: true
+    generate-convenience-methods: true
+    api-version: "v1"
+  "@typespec/http-client-python":
+    emitter-output-dir: "{project-root}/clients/python"
+    api-version: "v1"
+  "@typespec/http-client-js":
+    emitter-output-dir: "{project-root}/clients/javascript"
+    flatten-union-as-enum: true
+    api-version: "v1"
+```
+
+<Aside>
+
+**Note**: These configurations are subject to change as the client emitters are actively being developed.
+
+</Aside>


### PR DESCRIPTION
This pull request adds a new guide for advanced client emitter configurations and updates the sidebar to include this new documentation. 

Documentation updates:

* Added a new file `advanced-configurations.mdx` to provide detailed information on advanced configurations available for client emitters in TypeSpec. This includes configuration flags, descriptions, and a sample `tspconfig.yaml` file.