### PR TITLE
Fix path for emitted files 

### DIFF
--- a/.chronus/changes/fix-path-emitted-files-2025-2-6-13-20-48.md
+++ b/.chronus/changes/fix-path-emitted-files-2025-2-6-13-20-48.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix path for emitted files

--- a/.chronus/changes/fix-path-emitted-files-2025-2-6-13-20-48.md
+++ b/.chronus/changes/fix-path-emitted-files-2025-2-6-13-20-48.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/compiler"
 ---
 
-Fix path for emitted files
+Fixed an issue where the `--emit-files` flag on emitters with nested folders was not generating the correct paths to the files.

--- a/packages/compiler/src/core/emitter-utils.ts
+++ b/packages/compiler/src/core/emitter-utils.ts
@@ -1,4 +1,4 @@
-import { getDirectoryPath, getRelativePathFromDirectory } from "./path-utils.js";
+import { getDirectoryPath } from "./path-utils.js";
 import type { Program } from "./program.js";
 
 export type NewLine = "lf" | "crlf";
@@ -26,7 +26,7 @@ export async function emitFile(program: Program, options: EmitFileOptions): Prom
       ? options.content.replace(/(\r\n|\n|\r)/gm, "\r\n")
       : options.content;
 
-  emittedFilesPaths.push(getRelativePathFromDirectory(outputFolder, options.path, true));
+  emittedFilesPaths.push(options.path);
 
   return await program.host.writeFile(options.path, content);
 }

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -171,7 +171,7 @@ export async function compile(
     await emit(emitter, program, options);
 
     if (options.listFiles) {
-      logEmittedFilesPath(program.projectRoot, emitter.emitterOutputDir);
+      logEmittedFilesPath(program.projectRoot);
     }
   }
   return program;
@@ -937,10 +937,9 @@ async function runEmitter(emitter: EmitterRef, program: Program) {
   }
 }
 
-function logEmittedFilesPath(projectRoot: string, emitterOutputDir: string) {
-  const relativePathForEmittedFiles = `./${getRelativePathFromDirectory(projectRoot, emitterOutputDir, false)}/`;
-  flushEmittedFilesPaths().forEach((message) =>
+function logEmittedFilesPath(projectRoot: string) {
+  flushEmittedFilesPaths().forEach((filePath) => {
     // eslint-disable-next-line no-console
-    console.log(`\t${relativePathForEmittedFiles}${message}`),
-  );
+    console.log(`\t./${getRelativePathFromDirectory(projectRoot, filePath, false)}`);
+  });
 }


### PR DESCRIPTION
The relative wasn't correct when nested folder in the path. I was overprocessing the path. Fixing this 