### PR TITLE
[VSCode]update Text and resolve process bar does not appear issue

### DIFF
--- a/.chronus/changes/TextRefine-2025-2-7-15-11-45.md
+++ b/.chronus/changes/TextRefine-2025-2-7-15-11-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - typespec-vscode
+---
+
+update wording for code generation

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -119,14 +119,14 @@
           "group": "typespec@2"
         },
         {
-          "command": "typespec.generateCode",
+          "command": "typespec.emitCode",
           "when": "explorerResourceIsFolder || resourceLangId == typespec",
           "group": "typespec@1"
         }
       ],
       "editor/context": [
         {
-          "command": "typespec.generateCode",
+          "command": "typespec.emitCode",
           "when": "resourceLangId == typespec",
           "group": "typespec@1"
         }
@@ -162,8 +162,8 @@
         "category": "TypeSpec"
       },
       {
-        "command": "typespec.generateCode",
-        "title": "Generate from TypeSpec",
+        "command": "typespec.emitCode",
+        "title": "Emit from TypeSpec",
         "category": "TypeSpec"
       },
       {

--- a/packages/typespec-vscode/src/extension.ts
+++ b/packages/typespec-vscode/src/extension.ts
@@ -52,11 +52,11 @@ export async function activate(context: ExtensionContext) {
 
   /* emit command. */
   context.subscriptions.push(
-    commands.registerCommand(CommandName.GenerateCode, async (uri: vscode.Uri) => {
+    commands.registerCommand(CommandName.EmitCode, async (uri: vscode.Uri) => {
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Window,
-          title: "Generate from TypeSpec...",
+          title: "Emit from TypeSpec...",
           cancellable: false,
         },
         async () => await emitCode(context, uri),

--- a/packages/typespec-vscode/src/types.ts
+++ b/packages/typespec-vscode/src/types.ts
@@ -9,7 +9,7 @@ export const enum CommandName {
   InstallGlobalCompilerCli = "typespec.installGlobalCompilerCli",
   CreateProject = "typespec.createProject",
   OpenUrl = "typespec.openUrl",
-  GenerateCode = "typespec.generateCode",
+  EmitCode = "typespec.emitCode",
   ImportFromOpenApi3 = "typespec.importFromOpenApi3",
 }
 

--- a/packages/typespec-vscode/src/vscode-cmd/emit-code/emit-code.ts
+++ b/packages/typespec-vscode/src/vscode-cmd/emit-code/emit-code.ts
@@ -645,7 +645,7 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
           const selectedItems = await vscode.window.showQuickPick(existingEmitterQuickPickItems, {
             title: "Generate from TypeSpec",
             canPickMany: true,
-            placeHolder: "Select emitters for code emitting",
+            placeHolder: "Select emitters",
             ignoreFocusOut: true,
           });
           if (selectedItems) {

--- a/packages/typespec-vscode/src/vscode-cmd/emit-code/emit-code.ts
+++ b/packages/typespec-vscode/src/vscode-cmd/emit-code/emit-code.ts
@@ -40,7 +40,7 @@ async function configureEmitter(context: vscode.ExtensionContext): Promise<Emitt
       label: PreDefinedEmitterPickItems[kind]?.label ?? kind,
       detail:
         PreDefinedEmitterPickItems[kind]?.detail ??
-        `Generate ${kind} code from TypeSpec files. Supported languages are ${supportedLanguages}.`,
+        `Emit ${kind} code from TypeSpec files. Supported languages are ${supportedLanguages}.`,
       emitterKind: kind,
       iconPath: {
         light: Uri.file(context.asAbsolutePath(`./icons/${kind.toLowerCase()}.light.svg`)),
@@ -50,13 +50,13 @@ async function configureEmitter(context: vscode.ExtensionContext): Promise<Emitt
   };
   const codeTypesToEmit = emitterKinds.map((kind) => toEmitterTypeQuickPickItem(kind));
   const codeType = await vscode.window.showQuickPick(codeTypesToEmit, {
-    title: "Generate from TypeSpec",
+    title: "Emit from TypeSpec",
     canPickMany: false,
     placeHolder: "Select an emitter type",
     ignoreFocusOut: true,
   });
   if (!codeType) {
-    logger.info("No emitter Type selected. Generating Cancelled.");
+    logger.info("No emitter Type selected. Emitting Cancelled.");
     return undefined;
   }
 
@@ -78,7 +78,7 @@ async function configureEmitter(context: vscode.ExtensionContext): Promise<Emitt
       sourceRepo: e.sourceRepo,
       emitterKind: e.kind,
       label: e.language,
-      detail: `Generate ${e.kind} code for ${e.language} by TypeSpec library ${e.package}.`,
+      detail: `Emit ${e.kind} code for ${e.language} by TypeSpec library ${e.package}.`,
       picked: false,
       fromConfig: false,
       buttons: buttons,
@@ -98,9 +98,9 @@ async function configureEmitter(context: vscode.ExtensionContext): Promise<Emitt
 
   const emitterSelector = vscode.window.createQuickPick<EmitQuickPickItem>();
   emitterSelector.items = all;
-  emitterSelector.title = `Generate from TypeSpec`;
+  emitterSelector.title = `Emit from TypeSpec`;
   emitterSelector.canSelectMany = false;
-  emitterSelector.placeholder = `Select a Language for${codeType.emitterKind !== EmitterKind.Unknown ? " " + codeType.emitterKind : ""} code generation`;
+  emitterSelector.placeholder = `Select a Language for${codeType.emitterKind !== EmitterKind.Unknown ? " " + codeType.emitterKind : ""} code Emitting`;
   emitterSelector.ignoreFocusOut = true;
   emitterSelector.onDidTriggerItemButton(async (e) => {
     if (e.button.tooltip === "More details") {
@@ -109,15 +109,22 @@ async function configureEmitter(context: vscode.ExtensionContext): Promise<Emitt
     }
   });
   emitterSelector.show();
-  const selectedEmitter = await new Promise<EmitQuickPickItem>((resolve) => {
+  const selectedEmitter = await new Promise<EmitQuickPickItem | undefined>((resolve) => {
     emitterSelector.onDidAccept(() => {
       resolve(emitterSelector.selectedItems[0]);
+      emitterSelector.hide();
+    });
+
+    emitterSelector.onDidHide(() => {
+      if (emitterSelector.selectedItems.length === 0) {
+        resolve(undefined);
+      }
       emitterSelector.dispose();
     });
   });
 
   if (!selectedEmitter) {
-    logger.info("No language selected. Generating Cancelled.");
+    logger.info("No language selected. Emitting Cancelled.");
     return undefined;
   }
   return {
@@ -133,7 +140,7 @@ async function configureEmitter(context: vscode.ExtensionContext): Promise<Emitt
 async function doEmit(mainTspFile: string, emitters: Emitter[]) {
   if (!mainTspFile || !(await isFile(mainTspFile))) {
     logger.error(
-      "Invalid typespec project. There is no main tsp file in the project. Generating Cancelled.",
+      "Invalid typespec project. There is no main tsp file in the project. Emitting Cancelled.",
       [],
       { showOutput: false, showPopup: true },
     );
@@ -141,7 +148,7 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
   }
 
   if (emitters.length === 0) {
-    logger.info("No emitter. Generating skipped.");
+    logger.info("No emitter. Emitting skipped.");
     return;
   }
   const baseDir = getDirectoryPath(mainTspFile);
@@ -238,7 +245,7 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
   if (installPackageQuickPickItems.length > 0) {
     const installPackagesSelector = vscode.window.createQuickPick();
     installPackagesSelector.items = installPackageQuickPickItems;
-    installPackagesSelector.title = `Generate from TypeSpec`;
+    installPackagesSelector.title = `Emit from TypeSpec`;
     installPackagesSelector.canSelectMany = true;
     installPackagesSelector.placeholder = "Here are libraries to install or update.";
     installPackagesSelector.ignoreFocusOut = true;
@@ -253,11 +260,16 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
     const selectedPackages = await new Promise<readonly any[]>((resolve) => {
       installPackagesSelector.onDidAccept(() => {
         resolve(installPackagesSelector.selectedItems);
+        installPackagesSelector.hide();
+      });
+
+      installPackagesSelector.onDidHide(() => {
+        resolve([]);
         installPackagesSelector.dispose();
       });
     });
     if (!selectedPackages || selectedPackages.length === 0) {
-      logger.info("No package selected. Generating Cancelled.", [], {
+      logger.info("No package selected. Emitting Cancelled.", [], {
         showOutput: true,
         showPopup: true,
       });
@@ -287,7 +299,7 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
         },
       );
       if (!installResult) {
-        logger.error(`Error occurred when installing packages. Generating Cancelled.`, [], {
+        logger.error(`Error occurred when installing packages. Emitting Cancelled.`, [], {
           showOutput: false,
           showPopup: true,
         });
@@ -300,7 +312,7 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
   const cli = await resolveTypeSpecCli(baseDir);
   if (!cli) {
     logger.error(
-      "Cannot find TypeSpec CLI. Please install @typespec/compiler. Generating Cancelled.",
+      "Cannot find TypeSpec CLI. Please install @typespec/compiler. Emitting Cancelled.",
       [],
       {
         showOutput: true,
@@ -379,12 +391,12 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
   const allCodesToGenerate = generations
     .map((g) => `${g.codeInfo} under directory ${g.outputDir}`)
     .join(", ");
-  logger.info(`Start to generate ${allCodesToGenerate}...`);
+  logger.info(`Start to emit ${allCodesToGenerate}...`);
   const codeInfoStr = generations.map((g) => g.codeInfo).join(", ");
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
-      title: `Generating ${codeInfoStr}...`,
+      title: `Emitting ${codeInfoStr}...`,
       cancellable: false,
     },
     async () => {
@@ -398,12 +410,12 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
           false,
         );
         if (compileResult.exitCode !== 0) {
-          logger.error(`Generating ${codeInfoStr}...Failed`, [], {
+          logger.error(`Emitting ${codeInfoStr}...Failed`, [], {
             showOutput: true,
             showPopup: true,
           });
         } else {
-          logger.info(`Generating ${codeInfoStr}...Succeeded`, [], {
+          logger.info(`Emitting ${codeInfoStr}...Succeeded`, [], {
             showOutput: true,
             showPopup: true,
           });
@@ -415,12 +427,12 @@ async function doEmit(mainTspFile: string, emitters: Emitter[]) {
           if (execOutput.stdout !== "") details.push(execOutput.stdout);
           if (execOutput.stderr !== "") details.push(execOutput.stderr);
           if (execOutput.error) details.push(execOutput.error);
-          logger.error(`Generating ${codeInfoStr}...Failed.`, details, {
+          logger.error(`Emitting ${codeInfoStr}...Failed.`, details, {
             showOutput: true,
             showPopup: true,
           });
         } else {
-          logger.error(`Generating ${codeInfoStr}...Failed.`, [err], {
+          logger.error(`Emitting ${codeInfoStr}...Failed.`, [err], {
             showOutput: true,
             showPopup: true,
           });
@@ -436,7 +448,7 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
     const targetPathes = await TraverseMainTspFileInWorkspace();
     logger.info(`Found ${targetPathes.length} ${StartFileName} files`);
     if (targetPathes.length === 0) {
-      logger.info(`No entrypoint file (${StartFileName}) found. Generating Cancelled.`, [], {
+      logger.info(`No entrypoint file (${StartFileName}) found. Emitting Cancelled.`, [], {
         showOutput: true,
         showPopup: true,
       });
@@ -458,13 +470,13 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
         toProjectPickItem(filePath),
       );
       const selectedProjectFile = await vscode.window.showQuickPick(typespecProjectQuickPickItems, {
-        title: "Generate from TypeSpec",
+        title: "Emit from TypeSpec",
         canPickMany: false,
         placeHolder: "Select a project",
         ignoreFocusOut: true,
       });
       if (!selectedProjectFile) {
-        logger.info("No project selected. Generating Cancelled.", [], {
+        logger.info("No project selected. Emitting Cancelled.", [], {
           showOutput: true,
           showPopup: true,
         });
@@ -484,7 +496,7 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
     tspProjectFile = tspStartFile;
   }
 
-  logger.info(`Generate from entrypoint file: ${tspProjectFile}`);
+  logger.info(`Emit from entrypoint file: ${tspProjectFile}`);
   const baseDir = getDirectoryPath(tspProjectFile);
   const tspConfigFile = path.join(baseDir, TspConfigFileName);
   let configYaml = tryParseYaml(""); //generate a empty yaml
@@ -567,7 +579,7 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
       kind: vscode.QuickPickItemKind.Separator,
       info: undefined,
       label: "multiple selection",
-      description: "Select multiple configured emitters for code generation",
+      description: "Select multiple configured emitters for code emitting",
       package: "",
       fromConfig: false,
       picked: false,
@@ -586,14 +598,14 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
     const separatorItem = {
       kind: vscode.QuickPickItemKind.Separator,
       info: undefined,
-      description: "Choose another emitter for code generation",
+      description: "Choose another emitter for code emitting",
       package: "",
       fromConfig: false,
       picked: false,
     };
     const newEmitterQuickPickItem = {
       label: "Choose another emitter",
-      description: "Choose another emitter for code generation",
+      description: "Choose another emitter for code emitting",
       picked: false,
       fromConfig: false,
       package: "",
@@ -612,9 +624,9 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
     );
     const existingEmittersSelector = vscode.window.createQuickPick<any>();
     existingEmittersSelector.items = allPickItems;
-    existingEmittersSelector.title = `Generate from TypeSpec`;
+    existingEmittersSelector.title = `Emit from TypeSpec`;
     existingEmittersSelector.canSelectMany = false;
-    existingEmittersSelector.placeholder = "Select emitters for code generation";
+    existingEmittersSelector.placeholder = "Select emitters for code emitting";
     existingEmittersSelector.ignoreFocusOut = true;
 
     existingEmittersSelector.show();
@@ -625,14 +637,15 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
         if (selectedItem === newEmitterQuickPickItem) {
           const newEmitter = await configureEmitter(context);
           if (!newEmitter) {
-            return;
+            resolve([]);
+          } else {
+            resolve([toEmitterQuickPickItem(newEmitter)]);
           }
-          resolve([toEmitterQuickPickItem(newEmitter)]);
         } else if (selectedItem === selectMultipleQuickPick) {
           const selectedItems = await vscode.window.showQuickPick(existingEmitterQuickPickItems, {
             title: "Generate from TypeSpec",
             canPickMany: true,
-            placeHolder: "Select emitters for code generation",
+            placeHolder: "Select emitters for code emitting",
             ignoreFocusOut: true,
           });
           if (selectedItems) {
@@ -642,12 +655,19 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
           }
         } else {
           resolve([...existingEmittersSelector.selectedItems]);
-          existingEmittersSelector.dispose();
+          existingEmittersSelector.hide();
         }
+      });
+
+      existingEmittersSelector.onDidHide(() => {
+        if (existingEmittersSelector.selectedItems.length === 0) {
+          resolve([]);
+        }
+        existingEmittersSelector.dispose();
       });
     });
     if (!selectedExistingEmitters || selectedExistingEmitters.length === 0) {
-      logger.info("No emitter selected. Generating Cancelled.");
+      logger.info("No emitter selected. Emitting Cancelled.");
       return;
     }
     logger.info(`Selected emitters: ${selectedExistingEmitters.map((e) => e.package).join(", ")}`);
@@ -669,7 +689,7 @@ export async function emitCode(context: vscode.ExtensionContext, uri: vscode.Uri
     if (selectedEmitter) {
       await doEmit(tspProjectFile, [selectedEmitter]);
     } else {
-      logger.info("No emitter selected. Generating Cancelled.");
+      logger.info("No emitter selected. Emitting Cancelled.");
       return;
     }
   }

--- a/packages/typespec-vscode/src/vscode-cmd/emit-code/emitter.ts
+++ b/packages/typespec-vscode/src/vscode-cmd/emit-code/emitter.ts
@@ -20,16 +20,16 @@ export interface Emitter {
 export const PreDefinedEmitterPickItems: Record<string, vscode.QuickPickItem> = {
   openapi: {
     label: "OpenAPI Document",
-    detail: "Generating OpenAPI3 Document from TypeSpec files.",
+    detail: "Emitting OpenAPI3 Document from TypeSpec files.",
   },
   client: {
     label: "Client Code",
     detail:
-      "Generating Client Code from TypeSpec files. Supported languages are .NET, Python, Java, JavaScript.",
+      "Emitting Client Code from TypeSpec files. Supported languages are .NET, Python, Java, JavaScript.",
   },
   server: {
     label: "<PREVIEW> Server Stub",
-    detail: "Generating Server Stub from TypeSpec files. Supported languages are .NET, JavaScript.",
+    detail: "Emitting Server Stub from TypeSpec files. Supported languages are .NET, JavaScript.",
   },
 };
 


### PR DESCRIPTION
Fix https://github.com/microsoft/typespec/issues/6316

- update to use `Emit` for Text consistence between vscode extension and CLI
- When click `Esc`, call resolve to complete promise, and close and dispose the quickpick, the progress status will disappear in the status bar.