### PR TITLE
Use cached tsp scripts when duplicated to avoid breaking virtualFs in playground

### DIFF
--- a/packages/compiler/src/core/source-loader.ts
+++ b/packages/compiler/src/core/source-loader.ts
@@ -146,8 +146,10 @@ export async function createSourceLoader(
   async function loadTypeSpecScript(file: SourceFile): Promise<TypeSpecScriptNode> {
     // This is not a diagnostic because the compiler should never reuse the same path.
     // It's the caller's responsibility to use unique paths.
+    
+    // Dedup sourceFiles loading in virtualFs
     if (sourceFiles.has(file.path)) {
-      throw new RangeError("Duplicate script path: " + file.path);
+      return sourceFiles.get(file.path)!!;
     }
 
     const script = parseOrReuse(file);


### PR DESCRIPTION
Some resource providers, like [devcenter](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/devcenter/DevCenter/shared/models.tsp#L4), have circular dependences in their model tsp file, 

in `shared/modelss.tsp`, imported the entry `../main.tsp` again:
```
import "@azure-tools/typespec-azure-core";
import "../main.tsp";
```

which caused dup main.tsp error in virtualFs system of `typespec-aaz` emitter.

Seems the following line's `RangeError`  is not necessary and can just return the cached dup tsp file before? Test working well in our virtualFs. Please check if the following line can be adjusted as we put. 

Thanks.

