### PR TITLE
rest - filter string constant path http properties when using `@autoRoute`

### DIFF
--- a/.chronus/changes/rest-prop-filtering-2025-2-7-9-50-32.md
+++ b/.chronus/changes/rest-prop-filtering-2025-2-7-9-50-32.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/rest"
+---
+
+Updates `@autoRoute` behavior to apply same HttpOperationParameter filtering to HttpProperty

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -143,7 +143,7 @@ describe("rest: routes", () => {
   });
 
   it("autoRoute operations filter out path parameters with a string literal type", async () => {
-    const routes = await getRoutesFor(
+    const operations = await getOperations(
       `
       model ThingId {
         @path
@@ -167,14 +167,58 @@ describe("rest: routes", () => {
       }
       `,
     );
-
-    deepStrictEqual(routes, [
-      {
-        verb: "get",
-        path: "/subscriptions/{subscriptionId}/providers/Microsoft.Things/things/{thingId}",
-        params: ["subscriptionId", "thingId"],
-      },
+    expect(operations.length).toBe(1);
+    const operation = operations[0];
+    expect(operation.verb).toBe("get");
+    expect(operation.path).toBe(
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Things/things/{thingId}",
+    );
+    const operationParams = operation.parameters.parameters;
+    const operationProps = operation.parameters.properties;
+    expect(operationParams.map((p) => p.name)).toEqual(["subscriptionId", "thingId"]);
+    expect(operationProps.map((p) => (p as any).options.name)).toEqual([
+      "subscriptionId",
+      "thingId",
     ]);
+  });
+
+  it("autoRoute operations does not filter out non-param http properties", async () => {
+    const operations = await getOperations(
+      `
+      model ThingId {
+        @path
+        @segment("things")
+        thingId: string;
+      }
+
+      @autoRoute
+      interface Things {
+        @put
+        op WithFilteredParam(
+          @path
+          @segment("subscriptions")
+          subscriptionId: string,
+
+          @path
+          @segment("providers")
+          provider: "Microsoft.Things",
+          ...ThingId,
+
+          @header contentType: "text/plain",
+
+          @body body: "Test Content"
+        ): string;
+      }
+      `,
+    );
+    expect(operations.length).toBe(1);
+    const operation = operations[0];
+    expect(operation.verb).toBe("put");
+    expect(operation.path).toBe(
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Things/things/{thingId}",
+    );
+    const operationProps = operation.parameters.properties;
+    expect(operationProps.map((p) => p.kind)).toEqual(["path", "path", "contentType", "body"]);
   });
 
   it("emit diagnostic if passing arguments to autoroute decorators", async () => {


### PR DESCRIPTION
#6311 switched openapi3 to use `HttpProperty` instead of `HttpOperationParameter`. The `@typespec/rest` package did some filtering of parameters under a couple conditions (including path constants) that wasn't applied to properties. This caused an extra path parameter to be emitted in OpenAPI3 (and typespec-autorest when eventually applying the same changes there).

This PR applies the same `@autoRoute` parameter filtering to properties.