### PR TITLE
Tweaks cli output

### DIFF
--- a/.chronus/changes/cli-output-tweaks-2025-2-8-22-29-7.md
+++ b/.chronus/changes/cli-output-tweaks-2025-2-8-22-29-7.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Improvements to the CLI output

--- a/packages/compiler/src/core/cli/utils.ts
+++ b/packages/compiler/src/core/cli/utils.ts
@@ -54,7 +54,11 @@ export function withCliHostAndDiagnostics<T extends CliHostArgs>(
 }
 
 export function createCLICompilerHost(options: CliHostArgs): CliCompilerHost {
-  const logSink = createConsoleSink({ pretty: options.pretty, pathRelativeTo: process.cwd() });
+  const logSink = createConsoleSink({
+    pretty: options.pretty,
+    pathRelativeTo: process.cwd(),
+    trackAction: true,
+  });
   const logger = createLogger({ sink: logSink, level: options.debug ? "trace" : "warning" });
   return { ...NodeHost, logSink, logger, debug: options.debug ?? false };
 }

--- a/packages/compiler/src/core/logger/console-sink.browser.ts
+++ b/packages/compiler/src/core/logger/console-sink.browser.ts
@@ -10,30 +10,9 @@ export function createConsoleSink(options: any): LogSink {
 
   return {
     log,
-    trackAction: (message, finalMessage, action) => trackAction(message, finalMessage, action),
   };
 }
 
 export function formatLog(log: ProcessedLog): string {
   return JSON.stringify(log);
-}
-
-async function trackAction<T>(
-  message: string,
-  finalMessage: string,
-  asyncAction: () => Promise<T>,
-): Promise<T> {
-  // eslint-disable-next-line no-console
-  console.log(message);
-
-  try {
-    const result = await asyncAction();
-    // eslint-disable-next-line no-console
-    console.log(`✓ ${finalMessage}`);
-    return result;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log(`x ${message}`);
-    throw error;
-  }
 }

--- a/packages/compiler/src/core/logger/console-sink.ts
+++ b/packages/compiler/src/core/logger/console-sink.ts
@@ -36,7 +36,7 @@ export function createConsoleSink(options: ConsoleSinkOptions = {}): LogSink {
         ? getRelativePathFromDirectory(options.pathRelativeTo, path, false)
         : path,
     trackAction: options.trackAction
-      ? (message, finalMessage, action) => trackAction(message, finalMessage, action, options)
+      ? (message, finalMessage, action) => trackAction(message, finalMessage, action)
       : undefined,
   };
 }
@@ -151,7 +151,6 @@ export async function trackAction<T>(
   message: string,
   finalMessage: string,
   asyncAction: (task: TrackActionTask) => Promise<T>,
-  options: FormatLogOptions,
 ): Promise<T> {
   const task = new DynamicTask(message, finalMessage, process.stdout);
   task.start();

--- a/packages/compiler/src/core/logger/console-sink.ts
+++ b/packages/compiler/src/core/logger/console-sink.ts
@@ -152,7 +152,7 @@ export async function trackAction<T>(
   finalMessage: string,
   asyncAction: (task: TrackActionTask) => Promise<T>,
 ): Promise<T> {
-  const task = new DynamicTask(message, finalMessage, process.stdout);
+  const task = new DynamicTask(message, finalMessage, process.stderr);
   task.start();
 
   try {

--- a/packages/compiler/src/core/logger/dynamic-task.ts
+++ b/packages/compiler/src/core/logger/dynamic-task.ts
@@ -1,0 +1,107 @@
+import isUnicodeSupported from "is-unicode-supported";
+import pc from "picocolors";
+import { TaskStatus, TrackActionTask } from "../types.js";
+
+const StatusIcons = {
+  success: pc.green("✔"),
+  failure: pc.red("×"),
+  warn: pc.yellow("⚠"),
+  skipped: pc.gray("•"),
+};
+
+export class DynamicTask implements TrackActionTask {
+  #stream: NodeJS.WriteStream;
+  #message: string;
+  #spinner: () => string;
+  #interval: NodeJS.Timeout | undefined;
+  #isTTY: boolean;
+  #running: boolean;
+  #finalMessage: string;
+
+  constructor(message: string, finalMessage: string, stream: NodeJS.WriteStream) {
+    this.#message = message;
+    this.#finalMessage = finalMessage;
+    this.#stream = stream;
+    this.#spinner = createSpinner();
+    this.#isTTY = stream.isTTY && !process.env.CI;
+    this.#running = true;
+  }
+
+  get message() {
+    return this.#message;
+  }
+
+  get isStopped() {
+    return !this.#running;
+  }
+
+  set message(newMessage: string) {
+    this.#message = newMessage;
+    this.#printProgress();
+  }
+
+  start() {
+    if (this.#isTTY) {
+      this.#interval = setInterval(() => {
+        this.#printProgress();
+      }, 100);
+    } else {
+      this.#stream.write(`- ${this.#message}\n`);
+    }
+  }
+
+  succeed(message?: string) {
+    this.stop("success", message);
+  }
+  fail(message?: string) {
+    this.stop("failure", message);
+  }
+  warn(message?: string) {
+    this.stop("warn", message);
+  }
+  skip(message?: string) {
+    this.stop("skipped", message);
+  }
+
+  stop(status: TaskStatus, message?: string) {
+    this.#running = false;
+    this.#message = message ?? this.#finalMessage;
+    if (this.#interval) {
+      clearInterval(this.#interval);
+      this.#interval = undefined;
+    }
+    this.#clear();
+    this.#stream.write(`${StatusIcons[status]} ${this.#message}\n`);
+  }
+
+  #printProgress() {
+    if (!this.#isTTY) {
+      return;
+    }
+    this.#clear();
+    this.#clear();
+    this.#stream.write(`${pc.yellow(this.#spinner())} ${this.#message}`);
+  }
+
+  #clear() {
+    if (!this.#isTTY) {
+      return;
+    }
+
+    this.#stream.cursorTo(0);
+    this.#stream.clearLine(0);
+  }
+}
+
+function createSpinner(): () => string {
+  let index = 0;
+
+  return () => {
+    index = ++index % spinnerFrames.length;
+    return spinnerFrames[index];
+  };
+}
+
+export const spinnerFrames = isUnicodeSupported()
+  ? ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+  : ["-", "\\", "|", "/"];

--- a/packages/compiler/src/core/logger/logger.ts
+++ b/packages/compiler/src/core/logger/logger.ts
@@ -33,7 +33,15 @@ export function createLogger(options: LoggerOptions): Logger {
     trackAction: async (message, finalMessage, action) =>
       config.sink.trackAction
         ? config.sink.trackAction(message, finalMessage, action)
-        : action({ message: "", fail() {}, warn() {} }),
+        : action({
+            message: "",
+            fail() {},
+            warn() {},
+            succeed() {},
+            skip() {},
+            stop() {},
+            isStopped: false,
+          }),
   };
 }
 

--- a/packages/compiler/src/core/logger/logger.ts
+++ b/packages/compiler/src/core/logger/logger.ts
@@ -31,7 +31,9 @@ export function createLogger(options: LoggerOptions): Logger {
     warn: (message) => log({ level: "warning", message }),
     error: (message) => log({ level: "error", message }),
     trackAction: async (message, finalMessage, action) =>
-      config.sink.trackAction ? config.sink.trackAction(message, finalMessage, action) : action(),
+      config.sink.trackAction
+        ? config.sink.trackAction(message, finalMessage, action)
+        : action({ message: "", fail() {}, warn() {} }),
   };
 }
 

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2498,10 +2498,17 @@ export interface RelatedSourceLocation {
 }
 
 /** @internal */
+export type TaskStatus = "success" | "failure" | "skipped" | "warn";
+
+/** @internal */
 export interface TrackActionTask {
   message: string;
+  readonly isStopped: boolean;
+  succeed(message?: string): void;
   fail(message?: string): void;
   warn(message?: string): void;
+  skip(message?: string): void;
+  stop(status: TaskStatus, message?: string): void;
 }
 
 export interface LogSink {

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2497,6 +2497,13 @@ export interface RelatedSourceLocation {
   readonly location: SourceLocation;
 }
 
+/** @internal */
+export interface TrackActionTask {
+  message: string;
+  fail(message?: string): void;
+  warn(message?: string): void;
+}
+
 export interface LogSink {
   log(log: ProcessedLog): void;
 
@@ -2506,7 +2513,11 @@ export interface LogSink {
   /**
    * @internal
    */
-  trackAction?<T>(message: string, finalMessage: string, asyncAction: () => Promise<T>): Promise<T>;
+  trackAction?<T>(
+    message: string,
+    finalMessage: string,
+    asyncAction: (task: TrackActionTask) => Promise<T>,
+  ): Promise<T>;
 }
 
 export interface Logger {
@@ -2516,7 +2527,11 @@ export interface Logger {
   log(log: LogInfo): void;
 
   /** @internal */
-  trackAction<T>(message: string, finalMessage: string, asyncAction: () => Promise<T>): Promise<T>;
+  trackAction<T>(
+    message: string,
+    finalMessage: string,
+    asyncAction: (task: TrackActionTask) => Promise<T>,
+  ): Promise<T>;
 }
 
 export interface TracerOptions {

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2499,6 +2499,10 @@ export interface RelatedSourceLocation {
 
 export interface LogSink {
   log(log: ProcessedLog): void;
+
+  /** @internal */
+  getPath?(path: string): string;
+
   /**
    * @internal
    */
@@ -2510,6 +2514,8 @@ export interface Logger {
   warn(message: string): void;
   error(message: string): void;
   log(log: LogInfo): void;
+
+  /** @internal */
   trackAction<T>(message: string, finalMessage: string, asyncAction: () => Promise<T>): Promise<T>;
 }
 

--- a/packages/compiler/test/logger/tracer.test.ts
+++ b/packages/compiler/test/logger/tracer.test.ts
@@ -13,7 +13,7 @@ describe("compiler: tracer", () => {
       error: () => {},
       warn: () => {},
       trace: () => {},
-      trackAction: async (_x, _y, action) => action(),
+      trackAction: async (_x, _y, action: any) => action(),
     };
   });
 


### PR DESCRIPTION
A few fix to the new cli output
1. Always output the emitter output dir
2. Path logged are dimmed
3. Path logged use same logic as the diagnostic path resolution(It was broken here if running nested in a project
<img width="618" alt="image" src="https://github.com/user-attachments/assets/316e0f02-6d53-47cd-8618-495152ba2ea8" />

4. The progress tracker is initialized in teh cli host instead of `NodeHost` so it doesn't show up in all programmatic use of the compiler by default.
5. Diagnostic reported during stage mark the stage as a failure 
<img width="626" alt="image" src="https://github.com/user-attachments/assets/e791e54b-8c2b-4ae3-a4e2-be7a12d02008" />

and if warning happens during the stage 
<img width="492" alt="image" src="https://github.com/user-attachments/assets/06aa6e26-ab02-47aa-9d21-f88aa086d882" />


