### PR TITLE
fix(http-client-js): handle model property references in union types

### DIFF
--- a/.chronus/changes/fix-property-refernece-property-2025-2-10-20-45-0.md
+++ b/.chronus/changes/fix-property-refernece-property-2025-2-10-20-45-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-js"
+---
+
+handle model property references in union types correctly

--- a/packages/http-client-js/test/scenarios/serializers/property_references_property.md
+++ b/packages/http-client-js/test/scenarios/serializers/property_references_property.md
@@ -1,0 +1,72 @@
+# Property References in Model Serialization
+
+This test verifies that property references in TypeSpec models are correctly serialized, particularly in scenarios involving nullable property references. This was created to address a specific issue where property references combined with nullable types were causing incorrect serialization.
+
+## Background
+
+When a model property references another model's property (e.g., `TodoItemPatch.title` referencing `TodoItem.title`), the emitter needs to:
+
+1. Correctly unpack the referenced property
+2. Handle cases where the reference is combined with a nullable type
+3. Generate appropriate serialization code
+
+### Key Concepts
+
+- Property References: Using dot notation to reference properties from other models (e.g., `TodoItem.title`)
+- Nullable References: Combining property references with null union type (e.g., `TodoItem.assignedTo | null`)
+
+## Spec
+
+```tsp
+namespace Test;
+model TodoItem {
+  id: safeint;
+  title: string;
+  assignedTo: string;
+}
+
+model TodoItemPatch {
+  title?: TodoItem.title;
+  assignedTo?: TodoItem.assignedTo | null;
+}
+@patch op update(
+  @header contentType: "application/merge-patch+json",
+  @path id: TodoItem.id,
+  @body patch: TodoItemPatch,
+): TodoItem;
+```
+
+## Serializer
+
+Validates that the serializer generates the correct serialization logic for:
+
+- Direct property references (`title?: TodoItem.title`)
+- Nullable property references (`assignedTo?: TodoItem.assignedTo | null`)
+
+```ts src/models/serializers.ts function jsonTodoItemPatchToTransportTransform
+export function jsonTodoItemPatchToTransportTransform(input_?: TodoItemPatch | null): any {
+  if (!input_) {
+    return input_ as any;
+  }
+  return {
+    title: input_.title,
+    assignedTo: input_.assignedTo,
+  }!;
+}
+```
+
+## Deserializer
+
+Validates the deserialization logic maintains type consistency when converting from transport to application models.
+
+```ts src/models/serializers.ts function jsonTodoItemPatchToApplicationTransform
+export function jsonTodoItemPatchToApplicationTransform(input_?: any): TodoItemPatch {
+  if (!input_) {
+    return input_ as any;
+  }
+  return {
+    title: input_.title,
+    assignedTo: input_.assignedTo,
+  }!;
+}
+```


### PR DESCRIPTION
### Why this change is needed
This change addresses a bug in `@typespec/http-client-js` where properties that reference another model's property (e.g., `TodoItem.assignedTo`) were being incorrectly serialized with duplicated property names in the output. This issue was particularly evident when the property was part of a union type with `null` (e.g., `TodoItem.assignedTo | null`).

### What has changed
- **Bug Fix**: Updated the `unpackProperty` function in `unpack-model-property.ts` to correctly handle union types that include model property references. The function now recursively unpacks the non-null variant if it is a `ModelProperty`.
- **Documentation**: Enhanced the Copilot instructions with a new "Debugging and Troubleshooting" section to provide better guidance on handling TypeSpec type system issues, common transformation patterns, and debugging strategies.

### Testing
- **Test Case**: Added a test case in `property_references_property.md` to verify that the JSON transforms correctly handle properties that reference another model's property. This test ensures that the generated code does not include duplicated property names.

### Implications
- **Emitter Output**: The generated TypeScript code for models with properties that reference other model properties will now be correct, without duplicated property names.
- **User-Facing APIs**: No changes to user-facing APIs, but the generated client code will be more accurate and reliable.