### PR TITLE
Add ref docs for http client js

### DIFF
--- a/.chronus/changes/docs-ref-doc-http-client-js-2025-2-10-21-17-35.md
+++ b/.chronus/changes/docs-ref-doc-http-client-js-2025-2-10-21-17-35.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/http-client-js"
+---
+
+Add ref docs for http client js

--- a/packages/http-client-js/README.md
+++ b/packages/http-client-js/README.md
@@ -1,26 +1,9 @@
-# Http Client JavaScript
+# @typespec/http-client-js
 
-## Environment Variables
+TypeSpec library for emitting Http Client libraries for JavaScript/TypeScript
 
-### `TYPESPEC_JS_EMITTER_TESTING`
+## Install
 
-This environment variable is used to enable testing-specific options in the TypeSpec JavaScript emitter.
-
-- **Name:** `TYPESPEC_JS_EMITTER_TESTING`
-- **Type:** `boolean`
-- **Default:** `false`
-- **Description:** When set to `true`, enables testing-specific options in the TypeSpec JavaScript emitter. This is used to configure the client for testing purposes, such as allowing insecure connections and setting retry options.
-
-#### Usage
-
-To enable testing-specific options, set the environment variable before running your tests:
-
-```sh
-export TYPESPEC_JS_EMITTER_TESTING=true
-```
-
-Or, if you are using a script, you can set it inline:
-
-```sh
-TYPESPEC_JS_EMITTER_TESTING=true node your-script.js
+```bash
+npm install @typespec/http-client-js
 ```

--- a/packages/http-client-js/README.md
+++ b/packages/http-client-js/README.md
@@ -38,3 +38,5 @@ options:
 ### `package-name`
 
 **Type:** `string`
+
+Name of the package as it will be in package.json

--- a/packages/http-client-js/package.json
+++ b/packages/http-client-js/package.json
@@ -19,7 +19,7 @@
     "stop:server": "npx tsp-spector server stop",
     "test:e2e": "npm run emit:e2e && node eng/scripts/run-e2e-tests.js",
     "run:e2e": "node eng/scripts/run-e2e-tests.js",
-    "regen-docs": "tspd doc .  --enable-experimental  --output-dir ../../website/src/content/docs/docs/emitters/clients/http-client-js/reference",
+    "regen-docs": "tspd doc .  --enable-experimental  --output-dir ../../website/src/content/docs/docs/emitters/clients/http-client-js/reference --skip-js",
     "emit:e2e": "node eng/scripts/emit-e2e.js"
   },
   "exports": {

--- a/packages/http-client-js/package.json
+++ b/packages/http-client-js/package.json
@@ -19,6 +19,7 @@
     "stop:server": "npx tsp-spector server stop",
     "test:e2e": "npm run emit:e2e && node eng/scripts/run-e2e-tests.js",
     "run:e2e": "node eng/scripts/run-e2e-tests.js",
+    "regen-docs": "tspd doc .  --enable-experimental  --output-dir ../../website/src/content/docs/docs/emitters/clients/http-client-js/reference",
     "emit:e2e": "node eng/scripts/emit-e2e.js"
   },
   "exports": {
@@ -63,6 +64,7 @@
     "@typespec/http-specs": "0.1.0-alpha.11",
     "@typespec/spector": "workspace:^",
     "@typespec/ts-http-runtime": "0.1.0",
+    "@typespec/tspd": "workspace:^",
     "@typespec/versioning": "workspace:^",
     "@vitest/ui": "^3.0.7",
     "picocolors": "~1.1.1",

--- a/packages/http-client-js/src/lib.ts
+++ b/packages/http-client-js/src/lib.ts
@@ -8,7 +8,12 @@ const EmitterOptionsSchema: JSONSchemaType<JsClientEmitterOptions> = {
   type: "object",
   additionalProperties: true,
   properties: {
-    "package-name": { type: "string", nullable: true, default: "test-package" },
+    "package-name": {
+      type: "string",
+      nullable: true,
+      default: "test-package",
+      description: "Name of the package as it will be in package.json",
+    },
   },
   required: [],
 };

--- a/packages/tspd/src/cli.ts
+++ b/packages/tspd/src/cli.ts
@@ -78,6 +78,10 @@ async function main() {
           })
           .option("output-dir", {
             type: "string",
+          })
+          .positional("skip-js", {
+            description: "Skip generating JS API docs.",
+            type: "boolean",
           });
       },
       async (args) => {
@@ -86,6 +90,9 @@ async function main() {
         const diagnostics = await generateLibraryDocs(
           resolvedRoot,
           args["output-dir"] ?? resolvePath(resolvedRoot, "docs"),
+          {
+            skipJSApi: args["skip-js"],
+          },
         );
         // const diagnostics = await generateExternSignatures(host, resolvedRoot);
         if (diagnostics.length > 0) {

--- a/packages/tspd/src/ref-doc/experimental.ts
+++ b/packages/tspd/src/ref-doc/experimental.ts
@@ -14,13 +14,16 @@ import { renderToAstroStarlightMarkdown } from "./emitters/starlight.js";
 import { extractLibraryRefDocs, ExtractRefDocOptions, extractRefDocs } from "./extractor.js";
 import { TypeSpecRefDocBase } from "./types.js";
 
+export interface GenerateLibraryDocsOptions {
+  skipJSApi?: boolean;
+}
 /**
  * @experimental this is for experimental and is for internal use only. Breaking change to this API can happen at anytime.
  */
 export async function generateLibraryDocs(
   libraryPath: string,
   outputDir: string,
-  skipJSApi: boolean = false,
+  options: GenerateLibraryDocsOptions = {},
 ): Promise<readonly Diagnostic[]> {
   const diagnostics = createDiagnosticCollector();
   const pkgJson = await readPackageJson(libraryPath);
@@ -38,7 +41,7 @@ export async function generateLibraryDocs(
     config ?? {},
   );
   await writeFile(joinPaths(libraryPath, "README.md"), readme);
-  if (pkgJson.main && !skipJSApi) {
+  if (pkgJson.main && !options.skipJSApi) {
     await generateJsApiDocs(libraryPath, joinPaths(outputDir, "js-api"));
   }
   return diagnostics.diagnostics;

--- a/packages/tspd/src/ref-doc/extractor.ts
+++ b/packages/tspd/src/ref-doc/extractor.ts
@@ -96,7 +96,7 @@ export async function extractLibraryRefDocs(
     namespaces: [],
     getNamedTypeRefDoc: (type) => undefined,
   };
-  const tspMain = getExport(pkgJson, ".", "tsp");
+  const tspMain = getExport(pkgJson, ".", "typespec");
   if (tspMain) {
     const main = resolvePath(libraryPath, tspMain);
     const program = await compile(NodeHost, main, {

--- a/packages/tspd/src/ref-doc/extractor.ts
+++ b/packages/tspd/src/ref-doc/extractor.ts
@@ -80,6 +80,10 @@ type Mutable<T> =
   // brand to force explicit conversion.
   { -readonly [P in keyof T]: T[P]};
 
+function getExport(pkgJson: PackageJson, path: string, condition: string) {
+  return (pkgJson as any).exports?.[path]?.[condition];
+}
+
 export async function extractLibraryRefDocs(
   libraryPath: string,
 ): Promise<[TypeSpecLibraryRefDoc, readonly Diagnostic[]]> {
@@ -92,8 +96,9 @@ export async function extractLibraryRefDocs(
     namespaces: [],
     getNamedTypeRefDoc: (type) => undefined,
   };
-  if (pkgJson.tspMain) {
-    const main = resolvePath(libraryPath, pkgJson.tspMain);
+  const tspMain = getExport(pkgJson, ".", "tsp");
+  if (tspMain) {
+    const main = resolvePath(libraryPath, tspMain);
     const program = await compile(NodeHost, main, {
       parseOptions: { comments: true, docs: true },
     });
@@ -104,8 +109,9 @@ export async function extractLibraryRefDocs(
     }
   }
 
-  if (pkgJson.main) {
-    const entrypoint = await import(pathToFileURL(resolvePath(libraryPath, pkgJson.main)).href);
+  const main = getExport(pkgJson, ".", "import") ?? getExport(pkgJson, ".", "default");
+  if (main) {
+    const entrypoint = await import(pathToFileURL(resolvePath(libraryPath, main)).href);
     const lib: TypeSpecLibrary<any> | undefined = entrypoint.$lib;
     if (lib?.emitter?.options) {
       refDoc.emitter = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,6 +751,9 @@ importers:
       '@typespec/ts-http-runtime':
         specifier: 0.1.0
         version: 0.1.0
+      '@typespec/tspd':
+        specifier: workspace:^
+        version: link:../tspd
       '@typespec/versioning':
         specifier: workspace:^
         version: link:../versioning

--- a/website/src/content/current-sidebar.ts
+++ b/website/src/content/current-sidebar.ts
@@ -141,7 +141,15 @@ const sidebar: SidebarItem[] = [
       ]),
       {
         label: "Clients",
-        items: ["emitters/clients/introduction"],
+        items: [
+          "emitters/clients/introduction",
+          createLibraryReferenceStructure(
+            "emitters/clients/http-client-js",
+            "Javascript",
+            false,
+            [],
+          ),
+        ],
       },
     ],
   },

--- a/website/src/content/docs/docs/emitters/clients/http-client-js/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/http-client-js/reference/emitter.md
@@ -1,12 +1,6 @@
-# @typespec/http-client-js
-
-TypeSpec library for emitting Http Client libraries for JavaScript/TypeScript
-
-## Install
-
-```bash
-npm install @typespec/http-client-js
-```
+---
+title: "Emitter usage"
+---
 
 ## Usage
 

--- a/website/src/content/docs/docs/emitters/clients/http-client-js/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/http-client-js/reference/emitter.md
@@ -32,3 +32,5 @@ options:
 ### `package-name`
 
 **Type:** `string`
+
+Name of the package as it will be in package.json

--- a/website/src/content/docs/docs/emitters/clients/http-client-js/reference/index.mdx
+++ b/website/src/content/docs/docs/emitters/clients/http-client-js/reference/index.mdx
@@ -1,0 +1,29 @@
+---
+title: Overview
+sidebar_position: 0
+toc_min_heading_level: 2
+toc_max_heading_level: 3
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+TypeSpec library for emitting Http Client libraries for JavaScript/TypeScript
+
+## Install
+
+<Tabs>
+<TabItem  label="In a spec" default>
+
+```bash
+npm install @typespec/http-client-js
+```
+
+</TabItem>
+<TabItem  label="In a library" default>
+
+```bash
+npm install --save-peer @typespec/http-client-js
+```
+
+</TabItem>
+</Tabs>

--- a/website/src/content/docs/docs/emitters/clients/http-client-js/reference/index.mdx
+++ b/website/src/content/docs/docs/emitters/clients/http-client-js/reference/index.mdx
@@ -27,3 +27,7 @@ npm install --save-peer @typespec/http-client-js
 
 </TabItem>
 </Tabs>
+
+## Emitter usage
+
+[See documentation](./emitter.md)


### PR DESCRIPTION
updated tspd to only support `exports` instead of `main` and `tspMain`