### PR TITLE
[http-specs] remove tsv test and migrate ssv/pipes test of collection format.

### DIFF
--- a/.chronus/changes/migrate_to_encode-2025-2-11-15-24-31.md
+++ b/.chronus/changes/migrate_to_encode-2025-2-11-15-24-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@typespec/http-specs"
+---
+
+Remove tsv test and migrate ssv/pipes test of collection format.

--- a/packages/http-specs/specs/encode/bytes/main.tsp
+++ b/packages/http-specs/specs/encode/bytes/main.tsp
@@ -59,10 +59,7 @@ namespace Query {
     value=dGVzdA, dGVzdA
     """)
   op base64urlArray(
-    #suppress "deprecated" "Deprecated in next release"
-    @query({
-      format: "csv",
-    })
+    @query
     value: base64urlBytes[],
   ): NoContentResponse;
 }

--- a/packages/http-specs/specs/encode/datetime/main.tsp
+++ b/packages/http-specs/specs/encode/datetime/main.tsp
@@ -72,10 +72,7 @@ namespace Query {
     value=1686566864, 1686734256
     """)
   op unixTimestampArray(
-    #suppress "deprecated" "Deprecated in next release"
-    @query({
-      format: "csv",
-    })
+    @query
     value: unixTimestampDatetime[],
   ): NoContentResponse;
 }

--- a/packages/http-specs/specs/encode/duration/main.tsp
+++ b/packages/http-specs/specs/encode/duration/main.tsp
@@ -79,10 +79,7 @@ namespace Query {
     Expected query parameter `input=36,47`
     """)
   op int32SecondsArray(
-    #suppress "deprecated" "Deprecated in next release"
-    @query({
-      format: "csv",
-    })
+    @query
     input: Int32Duration[],
   ): NoContentResponse;
 }

--- a/packages/http-specs/specs/parameters/collection-format/main.tsp
+++ b/packages/http-specs/specs/parameters/collection-format/main.tsp
@@ -27,25 +27,9 @@ namespace Query {
     """)
   @route("/ssv")
   op ssv(
-    #suppress "deprecated" "Deprecated in next release"
     @doc("Possible values for colors are [blue,red,green]")
-    @query({
-      format: "ssv",
-    })
-    colors: string[],
-  ): NoContentResponse;
-
-  @scenario
-  @scenarioDoc("""
-    This test is testing sending a tsv collection format array query parameters
-    """)
-  @route("/tsv")
-  op tsv(
-    #suppress "deprecated" "Deprecated in next release"
-    @doc("Possible values for colors are [blue,red,green]")
-    @query({
-      format: "tsv",
-    })
+    @query
+    @encode(ArrayEncoding.spaceDelimited)
     colors: string[],
   ): NoContentResponse;
 
@@ -55,11 +39,9 @@ namespace Query {
     """)
   @route("/pipes")
   op pipes(
-    #suppress "deprecated" "Deprecated in next release"
     @doc("Possible values for colors are [blue,red,green]")
-    @query({
-      format: "pipes",
-    })
+    @query
+    @encode(ArrayEncoding.pipeDelimited)
     colors: string[],
   ): NoContentResponse;
 

--- a/packages/http-specs/specs/parameters/collection-format/mockapi.ts
+++ b/packages/http-specs/specs/parameters/collection-format/mockapi.ts
@@ -46,18 +46,6 @@ Scenarios.Parameters_CollectionFormat_Query_ssv = passOnSuccess({
   kind: "MockApiDefinition",
 });
 
-Scenarios.Parameters_CollectionFormat_Query_tsv = passOnSuccess({
-  uri: `/parameters/collection-format/query/tsv`,
-  method: "get",
-  request: {
-    params: { colors: colors.join("\t") },
-  },
-  response: {
-    status: 204,
-  },
-  kind: "MockApiDefinition",
-});
-
 Scenarios.Parameters_CollectionFormat_Query_pipes = passOnSuccess({
   uri: `/parameters/collection-format/query/pipes`,
   method: "get",


### PR DESCRIPTION
related task for https://github.com/microsoft/typespec/pull/6305.