### PR TITLE
fix(http-js-emitter): Handle HttpPart with a property decorated with @body

### DIFF
--- a/.chronus/changes/fix-js-emitter-multipart-2025-2-12-1-5-7.md
+++ b/.chronus/changes/fix-js-emitter-multipart-2025-2-12-1-5-7.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-js"
+---
+
+Fix Multipart handling for model with @body

--- a/packages/http-client-js/src/components/serializers.tsx
+++ b/packages/http-client-js/src/components/serializers.tsx
@@ -1,4 +1,5 @@
 import * as ts from "@alloy-js/typescript";
+import { $ } from "@typespec/compiler/experimental/typekit";
 import {
   DateDeserializer,
   DateRfc3339Serializer,
@@ -40,12 +41,19 @@ export function ModelSerializers(props: ModelSerializersProps) {
       ))}
       {dataTypes
         .filter((m) => m.kind === "Model" || m.kind === "Union")
-        .map((type) => (
-          <EncodingProvider defaults={{ bytes: "base64" }}>
-            <JsonTransformDeclaration type={type} target="transport" />
-            <JsonTransformDeclaration type={type} target="application" />
-          </EncodingProvider>
-        ))}
+        .map((type) => {
+          let bytesDefaultEncoding: "base64" | "none" = "base64";
+          if ($.model.is(type) && type.baseModel && $.model.isHttpFile(type.baseModel)) {
+            bytesDefaultEncoding = "none";
+          }
+
+          return (
+            <EncodingProvider defaults={{ bytes: bytesDefaultEncoding }}>
+              <JsonTransformDeclaration type={type} target="transport" />
+              <JsonTransformDeclaration type={type} target="application" />
+            </EncodingProvider>
+          );
+        })}
     </ts.SourceFile>
   );
 }

--- a/packages/http-client-js/src/components/transforms/multipart/simple-part-transform.tsx
+++ b/packages/http-client-js/src/components/transforms/multipart/simple-part-transform.tsx
@@ -16,6 +16,11 @@ export function SimplePartTransform(props: SimplePartTransformProps) {
   const partName = ts.ValueExpression({ jsValue: props.part.name });
   const partContentType = props.part.body.contentTypes[0] ?? "application/json";
   const partRef = getPartRef(props.itemRef, applicationName);
+  let bodyRef = ay.code`${partRef}`;
+
+  if (props.part.body.property) {
+    bodyRef = ay.code`${partRef}.${props.part.body.property.name}`;
+  }
 
   if (!partContentType.startsWith("application/json")) {
     reportDiagnostic($.program, {
@@ -27,12 +32,13 @@ export function SimplePartTransform(props: SimplePartTransformProps) {
 
   return (
     <ts.ObjectExpression>
-      <ts.ObjectProperty name="name" jsValue={partName} />,
-      <ts.ObjectProperty
-        name="body"
-        value={<JsonTransform itemRef={partRef} target="transport" type={props.part.body.type} />}
-      />
-      ,
+      <ay.List comma line>
+        <ts.ObjectProperty name="name" jsValue={partName} />
+        <ts.ObjectProperty
+          name="body"
+          value={<JsonTransform itemRef={bodyRef} target="transport" type={props.part.body.type} />}
+        />
+      </ay.List>
     </ts.ObjectExpression>
   );
 }

--- a/packages/http-client-js/test/e2e/http/payload/multipart/main.test.ts
+++ b/packages/http-client-js/test/e2e/http/payload/multipart/main.test.ts
@@ -4,30 +4,26 @@ import { fileURLToPath } from "url";
 import { beforeEach, describe, it } from "vitest";
 import { FormDataClient, HttpPartsClient } from "../../../generated/payload/multipart/src/index.js";
 
-describe("Payload.MultiPart", () => {
-  let __filename;
-  let __dirname;
-  let jpegContents: Uint8Array;
-  let pngContents: Uint8Array;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
+const jpegImagePath = resolve(__dirname, "../../../assets/image.jpg");
+const jpegBuffer = await readFile(jpegImagePath);
+const jpegContents = new Uint8Array(jpegBuffer);
+
+const pngImagePath = resolve(__dirname, "../../../assets/image.png");
+const pngBuffer = await readFile(pngImagePath);
+const pngContents = new Uint8Array(pngBuffer);
+
+describe("Payload.MultiPart", () => {
+  // Skipping as implicit multipart is going to be deprecated in TypeSpec
   describe.skip("FormDataClient", () => {
     const client = new FormDataClient({
       allowInsecureConnection: true,
       retryOptions: { maxRetries: 1 },
     });
 
-    beforeEach(async () => {
-      __filename = fileURLToPath(import.meta.url);
-      __dirname = dirname(__filename);
-
-      const jpegImagePath = resolve(__dirname, "../../../assets/image.jpg");
-      const jpegBuffer = await readFile(jpegImagePath);
-      jpegContents = new Uint8Array(jpegBuffer);
-
-      const pngImagePath = resolve(__dirname, "../../../assets/image.png");
-      const pngBuffer = await readFile(pngImagePath);
-      pngContents = new Uint8Array(pngBuffer);
-    });
+    beforeEach(async () => {});
 
     it("should send mixed parts with multipart/form-data", async () => {
       await client.basic({
@@ -82,7 +78,7 @@ describe("Payload.MultiPart", () => {
     });
   });
 
-  describe.skip("FormDataClient.HttpParts.ContentType", () => {
+  describe("FormDataClient.HttpParts.ContentType", () => {
     const client = new HttpPartsClient({
       allowInsecureConnection: true,
       retryOptions: { maxRetries: 1 },
@@ -93,7 +89,7 @@ describe("Payload.MultiPart", () => {
         profileImage: {
           contents: jpegContents,
           contentType: "image/jpg",
-          filename: "image.jpg",
+          filename: "hello.jpg",
         },
       });
     });
@@ -102,8 +98,8 @@ describe("Payload.MultiPart", () => {
       await client.contentTypeClient.requiredContentType({
         profileImage: {
           contents: jpegContents,
-          contentType: "image/jpg",
-          filename: "image.jpg",
+          contentType: "application/octet-stream",
+          filename: "hello.jpg",
         },
       });
     });
@@ -112,14 +108,14 @@ describe("Payload.MultiPart", () => {
       await client.contentTypeClient.optionalContentType({
         profileImage: {
           contents: jpegContents,
-          filename: "image.jpg",
+          filename: "hello.jpg",
         },
       });
     });
   });
 
   describe("FormDataClient.HttpParts", () => {
-    it.skip("should send json array and file array", async () => {
+    it("should send json array and file array", async () => {
       const client = new HttpPartsClient({
         allowInsecureConnection: true,
         retryOptions: {
@@ -146,7 +142,7 @@ describe("Payload.MultiPart", () => {
   });
 
   describe("FormDataClient.HttpParts.NonString", () => {
-    it.skip("should handle non-string float", async () => {
+    it("should handle non-string float", async () => {
       const client = new HttpPartsClient({
         allowInsecureConnection: true,
         retryOptions: {

--- a/packages/http-client-js/test/scenarios/multipart/file_content_type.md
+++ b/packages/http-client-js/test/scenarios/multipart/file_content_type.md
@@ -60,3 +60,18 @@ export function jsonFileWithHttpPartSpecificContentTypeRequestToApplicationTrans
   }!;
 }
 ```
+
+```ts src/models/serializers.ts function jsonFileSpecificContentTypeToApplicationTransform
+export function jsonFileSpecificContentTypeToApplicationTransform(
+  input_?: any,
+): FileSpecificContentType {
+  if (!input_) {
+    return input_ as any;
+  }
+  return {
+    filename: input_.filename,
+    contentType: input_.contentType,
+    contents: input_.contents,
+  }!;
+}
+```

--- a/packages/http-client-js/test/scenarios/multipart/non-string-float.md
+++ b/packages/http-client-js/test/scenarios/multipart/non-string-float.md
@@ -1,10 +1,12 @@
-# Should handle an http part with anonymous model
+# Tests content-type: multipart/form-data for non string
+
+## Spec
 
 ```tsp
-@service
 namespace Test;
-
-op foo(
+@post
+@route("/non-string-float")
+op float(
   @header contentType: "multipart/form-data",
   @multipartBody body: {
     temperature: HttpPart<{
@@ -17,13 +19,13 @@ op foo(
 
 ## Operation
 
-```ts src/api/testClientOperations.ts function foo
-export async function foo(
+```ts src/api/testClientOperations.ts function float
+export async function float(
   client: TestClientContext,
   body: { temperature: { body: number; contentType: "text/plain" } },
-  options?: FooOptions,
+  options?: FloatOptions,
 ): Promise<void> {
-  const path = parse("/").expand({});
+  const path = parse("/non-string-float").expand({});
   const httpRequestOptions = {
     headers: {
       "content-type": options?.contentType ?? "multipart/form-data",


### PR DESCRIPTION
**Why**
The emitter had 2 issues related to MultiPart Form Data
1. Incorrectly encoding files as base64 string
2. When the part model had @body we need to honor the model property names

**What Changed**
- Enhanced multipart/form-data serialization:
  - Fixed body property access for HttpPart transformations
  - Skip setting bytes encoding when in a multipart file

**Testing**
- Added/updated literate tests:
  - `test/scenarios/multipart/non-string-float.md` updated expectation for correct property access
  - `test/scenarios/multipart/file_content_type.md` updated expectation for correct property access
  - `test/scenarios/multipart/anonymous_part.md` for anonymous models in part
- Enabled E2E tests verify proper runtime functionality
