### PR TITLE
Add E2E tests job to build stage in Publish pipeline

### DIFF
--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -33,6 +33,7 @@ extends:
         jobs:
           - template: /eng/tsp-core/pipelines/jobs/build-for-publish.yml@self
           - template: /eng/tsp-core/pipelines/jobs/cli/build-tsp-cli-all.yml@self
+          - template: /eng/tsp-core/pipelines/jobs/e2e.yml@self
 
       - stage: publish_npm
         displayName: Publish Npm Packages


### PR DESCRIPTION
Adds end-to-end (E2E) tests as a separate job within the existing build stage of the publish pipeline.