### PR TITLE
Fix handling of record types

### DIFF
--- a/.chronus/changes/fix-record-rc-2025-2-13-23-23-20.md
+++ b/.chronus/changes/fix-record-rc-2025-2-13-23-23-20.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Fix handling of record types

--- a/packages/http-server-csharp/src/lib/utils.ts
+++ b/packages/http-server-csharp/src/lib/utils.ts
@@ -171,6 +171,16 @@ export function getCSharpType(
           }),
         };
       }
+      if (isRecord(type))
+        return {
+          type: new CSharpType({
+            name: "JsonObject",
+            namespace: "System.Text.Json.Nodes",
+            isBuiltIn: false,
+            isValueType: false,
+            isClass: false,
+          }),
+        };
       let name: string = type.name;
       if (isTemplateInstance(type)) {
         name = getModelInstantiationName(program, type, name);
@@ -711,6 +721,7 @@ export class HttpMetadata {
     switch (responseType.kind) {
       case "Model":
         if (responseType.indexer && responseType.indexer.key.name !== "string") return responseType;
+        if (isRecord(responseType)) return responseType;
         const bodyProp = new ModelInfo().filterAllProperties(
           program,
           responseType,
@@ -1284,7 +1295,10 @@ export class CSharpOperationHelpers {
           return cachedResult;
         }
         if (isRecord(tsType)) {
-          modelResult = { typeReference: code`JsonObject`, nullableType: false };
+          modelResult = {
+            typeReference: code`System.Text.Json.Nodes.JsonObject`,
+            nullableType: false,
+          };
         } else {
           modelResult = {
             typeReference: code`${this.emitter.emitTypeReference(tsType)}`,

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -941,6 +941,56 @@ it("generates appropriate types for literals in operation parameters", async () 
   );
 });
 
+it("generates appropriate types for records", async () => {
+  await compileAndValidateMultiple(
+    runner,
+    `
+      /** A simple test model*/
+      model BarResponse {
+        /** Typed record */
+        recordProp: Record<string>;
+        /** Floating point literal */
+        stringMap: Record<string>;
+      }
+
+      @route("/foo") @post op foo(recordProp: Record<string>): Record<unknown>;
+      @route("/foo") @get op bar(): BarResponse;
+      `,
+    [
+      [
+        "BarResponse.cs",
+        [
+          "public partial class BarResponse",
+          "public System.Text.Json.Nodes.JsonObject RecordProp { get; set; }",
+          "public System.Text.Json.Nodes.JsonObject StringMap { get; set; }",
+        ],
+      ],
+      [
+        "ContosoOperationsFooRequest.cs",
+        [
+          "public partial class ContosoOperationsFooRequest",
+          "public System.Text.Json.Nodes.JsonObject RecordProp { get; set; }",
+        ],
+      ],
+      [
+        "ContosoOperationsController.cs",
+        [
+          "[ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(System.Text.Json.Nodes.JsonObject))]",
+          `public virtual async Task<IActionResult> Foo(ContosoOperationsFooRequest body)`,
+          `public virtual async Task<IActionResult> Bar()`,
+        ],
+      ],
+      [
+        "IContosoOperations.cs",
+        [
+          `Task<System.Text.Json.Nodes.JsonObject> FooAsync( System.Text.Json.Nodes.JsonObject recordProp);`,
+          `Task<BarResponse> BarAsync( );`,
+        ],
+      ],
+    ],
+  );
+});
+
 it("generates appropriate types for literal tuples in operation parameters", async () => {
   await compileAndValidateMultiple(
     runner,


### PR DESCRIPTION
Fix for #6437  Cleans up handling of record types in operation signatures and models.