### PR TITLE
[http-server-js]  Return Data Stubs from Controllers

### DIFF
--- a/.chronus/changes/feature-js-server-stubs-2025-2-14-3-23-42.md
+++ b/.chronus/changes/feature-js-server-stubs-2025-2-14-3-23-42.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-server-js"
+---
+
+Return data stubs from scaffolded controllers

--- a/packages/http-server-js/src/scripts/scaffold/bin.mts
+++ b/packages/http-server-js/src/scripts/scaffold/bin.mts
@@ -26,6 +26,7 @@ import { bifilter, indent } from "../../util/iter.js";
 import { createOnceQueue } from "../../util/once-queue.js";
 import { tryGetOpenApi3 } from "../../util/openapi3.js";
 import { writeModuleFile } from "../../write.js";
+import { mockType } from "./data-mocks.js";
 
 function spawn(command: string, args: string[], options: SpawnOptions): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -664,7 +665,15 @@ function* emitControllerOperationHandlers(
       yield `async ${opName}(ctx: HttpContext, ${paramsDeclarationLine}): ${returnType} {`;
     }
 
-    yield "  throw new NotImplementedError();";
+    const mockReturn = mockType(op.returnType);
+
+    if (mockReturn === undefined) {
+      yield "  throw new NotImplementedError();";
+    } else if (mockReturn === "void") {
+      yield "  return;";
+    } else {
+      yield `  return ${mockReturn};`;
+    }
     yield "}";
     yield "";
   }

--- a/packages/http-server-js/src/scripts/scaffold/bin.mts
+++ b/packages/http-server-js/src/scripts/scaffold/bin.mts
@@ -610,10 +610,7 @@ function* emitControllerOperationHandlers(
   httpOperations: Set<HttpOperation>,
   module: Module,
 ): Iterable<string> {
-  module.imports.push({
-    binder: ["NotImplementedError"],
-    from: httpHelperModule,
-  });
+  let importNotImplementedError = false;
   for (const httpOperation of httpOperations) {
     // TODO: unify construction of signature with emitOperation in common/interface.ts
     const op = httpOperation.operation;
@@ -668,6 +665,7 @@ function* emitControllerOperationHandlers(
     const mockReturn = mockType(op.returnType);
 
     if (mockReturn === undefined) {
+      importNotImplementedError = true;
       yield "  throw new NotImplementedError();";
     } else if (mockReturn === "void") {
       yield "  return;";
@@ -676,6 +674,13 @@ function* emitControllerOperationHandlers(
     }
     yield "}";
     yield "";
+  }
+
+  if (importNotImplementedError) {
+    module.imports.push({
+      binder: ["NotImplementedError"],
+      from: httpHelperModule,
+    });
   }
 }
 

--- a/packages/http-server-js/src/scripts/scaffold/data-mocks.ts
+++ b/packages/http-server-js/src/scripts/scaffold/data-mocks.ts
@@ -147,7 +147,7 @@ export function mockType(type: Type): string | undefined {
   }
 
   if (isVoidType(type)) {
-    return "undefined"; // Return 'undefined' string for void type
+    return "void";
   }
 
   return undefined;

--- a/packages/http-server-js/src/scripts/scaffold/data-mocks.ts
+++ b/packages/http-server-js/src/scripts/scaffold/data-mocks.ts
@@ -1,0 +1,152 @@
+import {
+  isErrorType,
+  isVoidType,
+  LiteralType,
+  Model,
+  ModelProperty,
+  Scalar,
+  Type,
+  Union,
+} from "@typespec/compiler";
+import { $ } from "@typespec/compiler/experimental/typekit";
+import { parseCase } from "../../util/case.js";
+
+function mockModel(type: Model): string {
+  if ($.array.is(type)) {
+    return mockArray(type);
+  }
+
+  if ($.record.is(type)) {
+    return mockRecord(type);
+  }
+
+  const mock: string[][] = [];
+  const properties = $.model.getProperties(type, { includeExtended: true });
+  for (const [name, prop] of properties) {
+    if (prop.optional) {
+      continue;
+    }
+
+    const propMock = mockType(prop.type);
+
+    if (!propMock) {
+      throw new Error(`Could not mock property ${name} of type ${prop.type.kind}`);
+    }
+
+    const propName = parseCase(name).camelCase;
+    mock.push([propName, propMock]);
+  }
+
+  return `{
+    ${mock.map(([name, value]) => `${name}: ${value}`).join(",\n")}
+  }`;
+}
+
+function mockArray(type: Model): string {
+  const elementType = $.array.getElementType(type);
+  const mockedType = mockType(elementType) ?? "";
+  return `[${mockedType}]`;
+}
+
+function mockRecord(type: Model): string {
+  const elementType = $.record.getElementType(type);
+  const mockedType = mockType(elementType);
+
+  if (mockedType === undefined) {
+    return "{}";
+  }
+
+  return `{
+    mockKey: ${mockedType},
+  }`;
+}
+
+function mockModelProperty(prop: ModelProperty): any {
+  return mockType(prop.type);
+}
+
+function mockLiteral(type: LiteralType): any {
+  return JSON.stringify(type.value);
+}
+
+export function mockType(type: Type): string | undefined {
+  if ($.model.is(type)) {
+    return mockModel(type);
+  }
+
+  if ($.literal.is(type)) {
+    return mockLiteral(type);
+  }
+
+  if ($.modelProperty.is(type)) {
+    return mockModelProperty(type);
+  }
+
+  if ($.scalar.is(type)) {
+    return mockScalar(type);
+  }
+
+  if ($.union.is(type)) {
+    return mockUnion(type);
+  }
+
+  if (isVoidType(type)) {
+    return "void";
+  }
+
+  return undefined;
+}
+
+function mockUnion(union: Union): string | undefined {
+  for (const variant of union.variants.values()) {
+    if (isErrorType(variant.type)) {
+      continue;
+    }
+    return mockType(variant.type);
+  }
+
+  return undefined;
+}
+
+function mockScalar(scalar: Scalar) {
+  if ($.scalar.isBoolean(scalar) || $.scalar.extendsBoolean(scalar)) {
+    return JSON.stringify(true);
+  }
+  if ($.scalar.isNumeric(scalar) || $.scalar.extendsNumeric(scalar)) {
+    return JSON.stringify(42);
+  }
+
+  if ($.scalar.isUtcDateTime(scalar) || $.scalar.extendsUtcDateTime(scalar)) {
+    return "new Date()";
+  }
+
+  if ($.scalar.isBytes(scalar) || $.scalar.extendsBytes(scalar)) {
+    return "new Uint8Array()";
+  }
+
+  if ($.scalar.isDuration(scalar) || $.scalar.extendsDuration(scalar)) {
+    return JSON.stringify("P1Y2M3DT4H5M6S");
+  }
+
+  if ($.scalar.isOffsetDateTime(scalar) || $.scalar.extendsOffsetDateTime(scalar)) {
+    return JSON.stringify("2022-01-01T00:00:00Z");
+  }
+
+  if ($.scalar.isPlainDate(scalar) || $.scalar.extendsPlainDate(scalar)) {
+    return JSON.stringify("2022-01-01");
+  }
+
+  if ($.scalar.isPlainTime(scalar) || $.scalar.extendsPlainTime(scalar)) {
+    return JSON.stringify("00:00:00");
+  }
+
+  if ($.scalar.isUrl(scalar) || $.scalar.extendsUrl(scalar)) {
+    return JSON.stringify("https://example.com");
+  }
+
+  if ($.scalar.isString(scalar) || $.scalar.extendsString(scalar)) {
+    return JSON.stringify("mock-string");
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
This PR improves the HTTP server JS implementation by replacing `NonImplemented` exception throws with mock data stubs generated based on TypeSpec models.

## Changes
- data-mocks.ts utility to generates mock values conforming with the returnType TypeSpec models

## Testing
Manually tested with various specs including E2E Todo