### PR TITLE
http-client-java, remove deprecated syntax in local tsp

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-test/tsp/enum.tsp
+++ b/packages/http-client-java/generator/http-client-generator-test/tsp/enum.tsp
@@ -193,14 +193,10 @@ interface EnumOp {
   @post
   @route("operation/stringenumarrayheader")
   setStringEnumArrayHeader(
-    @header({
-      format: "csv",
-    })
+    @header
     colorArray: ColorModel[],
 
-    @header({
-      format: "csv",
-    })
+    @header
     colorArrayOpt?: ColorModel[],
   ): string;
 }


### PR DESCRIPTION

The deprecated `format` options is now [removed](https://github.com/microsoft/typespec/pull/6305) from the `@typespec/http` package, updating the `http-client-java` to reflect that removal.