### PR TITLE
Fix: Missed allowing reserved keyword when printing enum members

### DIFF
--- a/.chronus/changes/fix-enum-members-also-allow-reserved-2025-2-13-21-52-47.md
+++ b/.chronus/changes/fix-enum-members-also-allow-reserved-2025-2-13-21-52-47.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+

--- a/packages/compiler/src/formatter/print/printer.ts
+++ b/packages/compiler/src/formatter/print/printer.ts
@@ -679,7 +679,7 @@ export function printEnumMember(
   print: PrettierChildPrint,
 ) {
   const node = path.node;
-  const id = path.call(print, "id");
+  const id = printIdentifier(node.id, "allow-reserved");
   const value = node.value ? [": ", path.call(print, "value")] : "";
   const { decorators } = printDecorators(path, options, print, {
     tryInline: DecoratorsTryInline.enumMember,


### PR DESCRIPTION
Blocking typespec-azure pr https://github.com/Azure/typespec-azure/pull/2384