### PR TITLE
[http-spec] change `nextToken` to `token` of the response for continuation token tests to prevent http header auto renaming

### DIFF
--- a/.chronus/changes/nextToken_to_token-2025-2-14-14-22-38.md
+++ b/.chronus/changes/nextToken_to_token-2025-2-14-14-22-38.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@typespec/http-specs"
+---
+
+Change `nextToken` to token for continuation token test to prevent http header auto renaming.

--- a/packages/http-specs/spec-summary.md
+++ b/packages/http-specs/spec-summary.md
@@ -1677,7 +1677,7 @@ Expected response body:
     { "id": "1", "name": "dog" },
     { "id": "2", "name": "cat" }
   ],
-  "nextToken": "page2"
+  "token": "page2"
 }
 ```
 
@@ -1725,7 +1725,7 @@ Expected response body:
 ```
 
 Expected response header:
-next-token=page2
+token=page2
 
 2. Next page request:
    Expected route: /payload/pageable/server-driven-pagination/continuationtoken/request-header-response-header?bar=bar
@@ -1767,7 +1767,7 @@ Expected response body:
     { "id": "1", "name": "dog" },
     { "id": "2", "name": "cat" }
   ],
-  "nextToken": "page2"
+  "token": "page2"
 }
 ```
 
@@ -1814,7 +1814,7 @@ Expected response body:
 ```
 
 Expected response header:
-next-token=page2
+token=page2
 
 2. Next page request:
    Expected route: /payload/pageable/server-driven-pagination/continuationtoken/request-query-response-header?bar=bar&token=page2

--- a/packages/http-specs/specs/payload/pageable/main.tsp
+++ b/packages/http-specs/specs/payload/pageable/main.tsp
@@ -78,7 +78,7 @@ namespace ServerDrivenPagination {
           { "id": "1", "name": "dog" },
           { "id": "2", "name": "cat" }
         ],
-        "nextToken": "page2"
+        "token": "page2"
       }
       ```
       
@@ -103,7 +103,7 @@ namespace ServerDrivenPagination {
       @pageItems
       pets: Pet[];
 
-      @continuationToken nextToken?: string;
+      @continuationToken token?: string;
     };
 
     @scenario
@@ -124,7 +124,7 @@ namespace ServerDrivenPagination {
           { "id": "1", "name": "dog" },
           { "id": "2", "name": "cat" }
         ],
-        "nextToken": "page2"
+        "token": "page2"
       }
       ```
       
@@ -150,7 +150,7 @@ namespace ServerDrivenPagination {
       @pageItems
       pets: Pet[];
 
-      @continuationToken nextToken?: string;
+      @continuationToken token?: string;
     };
 
     @scenario
@@ -175,7 +175,7 @@ namespace ServerDrivenPagination {
       ```
       
       Expected response header:
-      next-token=page2
+      token=page2
       
       2. Next page request:
       Expected route: /payload/pageable/server-driven-pagination/continuationtoken/request-query-response-header?bar=bar&token=page2
@@ -198,7 +198,7 @@ namespace ServerDrivenPagination {
       @pageItems
       pets: Pet[];
 
-      @continuationToken @header nextToken?: string;
+      @continuationToken @header token?: string;
     };
 
     @scenario
@@ -222,7 +222,7 @@ namespace ServerDrivenPagination {
       ```
       
       Expected response header:
-      next-token=page2
+      token=page2
       
       2. Next page request:
       Expected route: /payload/pageable/server-driven-pagination/continuationtoken/request-header-response-header?bar=bar
@@ -246,7 +246,7 @@ namespace ServerDrivenPagination {
       @pageItems
       pets: Pet[];
 
-      @continuationToken @header nextToken?: string;
+      @continuationToken @header token?: string;
     };
   }
 }

--- a/packages/http-specs/specs/payload/pageable/mockapi.ts
+++ b/packages/http-specs/specs/payload/pageable/mockapi.ts
@@ -22,7 +22,7 @@ const FirstResponseTokenInBody = {
   status: 200,
   body: json({
     pets: FirstPage,
-    nextToken: "page2",
+    token: "page2",
   }),
 };
 
@@ -39,7 +39,7 @@ const FirstResponseTokenInHeader = {
     pets: FirstPage,
   }),
   headers: {
-    "next-token": "page2",
+    token: "page2",
     foo: "foo",
   },
 };


### PR DESCRIPTION
try to prevent mis-leading of testing header wire name because http lib does kebab renaming for header params. 