### PR TITLE
Clean up dependencies on emitter-framework, http-client and http-client-js

### DIFF
--- a/.chronus/changes/fix-emitter-framework-dependencies-2025-2-16-16-41-50.md
+++ b/.chronus/changes/fix-emitter-framework-dependencies-2025-2-16-16-41-50.md
@@ -1,0 +1,9 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/emitter-framework"
+  - "@typespec/http-client-js"
+  - "@typespec/http-client"
+---
+
+Update dependency structure for EmitterFramework, HttpClient and JS Emitter

--- a/packages/emitter-framework/package.json
+++ b/packages/emitter-framework/package.json
@@ -31,15 +31,18 @@
   "license": "MIT",
   "description": "",
   "peerDependencies": {
+    "@alloy-js/core": "^0.6.0",
+    "@alloy-js/typescript": "^0.6.0",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/rest": "workspace:^"
   },
-  "dependencies": {
-    "@alloy-js/core": "^0.6.0",
-    "@alloy-js/typescript": "^0.6.0"
-  },
   "devDependencies": {
+    "@alloy-js/core": "^0.6.0",
+    "@alloy-js/typescript": "^0.6.0",
+    "@typespec/compiler": "workspace:^",
+    "@typespec/http": "workspace:^",
+    "@typespec/rest": "workspace:^",
     "@alloy-js/babel-preset": "^0.2.0",
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.26.9",

--- a/packages/http-client-js/package.json
+++ b/packages/http-client-js/package.json
@@ -45,17 +45,18 @@
   "description": "TypeSpec library for emitting Http Client libraries for JavaScript/TypeScript",
   "peerDependencies": {
     "@typespec/compiler": "workspace:^",
-    "@typespec/emitter-framework": "workspace:^",
     "@typespec/http": "workspace:^",
-    "@typespec/http-client": "workspace:^",
     "@typespec/rest": "workspace:^"
   },
   "dependencies": {
+    "@typespec/emitter-framework": "workspace:^",
+    "@typespec/http-client": "workspace:^",
     "@alloy-js/core": "^0.6.0",
     "@alloy-js/typescript": "^0.6.0",
     "prettier": "~3.5.3"
   },
   "devDependencies": {
+    "@typespec/http": "workspace:^",
     "@alloy-js/babel-preset": "^0.2.0",
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.26.9",

--- a/packages/http-client-js/src/components/output.tsx
+++ b/packages/http-client-js/src/components/output.tsx
@@ -2,7 +2,6 @@ import * as ay from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { TransformNamePolicyContext } from "@typespec/emitter-framework";
 import { ClientLibrary } from "@typespec/http-client/components";
-import { httpParamsMutator } from "../utils/operations.js";
 import { EncodingProvider } from "./encoding-provider.jsx";
 import { httpRuntimeTemplateLib } from "./external-packages/ts-http-runtime.js";
 import { uriTemplateLib } from "./external-packages/uri-template.js";
@@ -17,7 +16,7 @@ export function Output(props: OutputProps) {
   const defaultTransformNamePolicy = createTransformNamePolicy();
   return (
     <ay.Output namePolicy={tsNamePolicy} externals={[uriTemplateLib, httpRuntimeTemplateLib]}>
-      <ClientLibrary operationMutators={[httpParamsMutator]}>
+      <ClientLibrary>
         <TransformNamePolicyContext.Provider value={defaultTransformNamePolicy}>
           <EncodingProvider>{props.children}</EncodingProvider>
         </TransformNamePolicyContext.Provider>

--- a/packages/http-client-js/test/scenarios/auth/basic_auth.md
+++ b/packages/http-client-js/test/scenarios/auth/basic_auth.md
@@ -7,9 +7,7 @@ This test validates that the emitter can handle a basic authentication scheme co
 The spec contains a simple service with a Bearer authentication scheme
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 @useAuth(BasicAuth)
 namespace Test;
 

--- a/packages/http-client-js/test/scenarios/auth/bearer.md
+++ b/packages/http-client-js/test/scenarios/auth/bearer.md
@@ -7,9 +7,7 @@ This test validates that the emitter can handle a simple bearer authentication s
 The spec contains a simple service with a Bearer authentication scheme
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 @useAuth(BearerAuth)
 namespace Test;
 

--- a/packages/http-client-js/test/scenarios/auth/client_parameters.md
+++ b/packages/http-client-js/test/scenarios/auth/client_parameters.md
@@ -7,9 +7,7 @@ This test validates that the emitter can generate the correct client signature w
 The spec contains 2 Schemas Bearer and ApiKey
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 @useAuth(BearerAuth | ApiKeyAuth<ApiKeyLocation.header, "X-API-KEY">)
 namespace Test;
 

--- a/packages/http-client-js/test/scenarios/auth/client_structure.md
+++ b/packages/http-client-js/test/scenarios/auth/client_structure.md
@@ -3,9 +3,7 @@
 ## TypeSpec
 
 ```tsp
-@service({
-  title: "My API",
-})
+@service(#{ title: "My API" })
 @useAuth(BearerAuth)
 namespace MyApi;
 

--- a/packages/http-client-js/test/scenarios/auth/key_credential.md
+++ b/packages/http-client-js/test/scenarios/auth/key_credential.md
@@ -7,9 +7,7 @@ This test validates that the emitter can handle a key auth scheme correctly with
 The spec contains a simple service with a ApiKey authentication scheme
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 @useAuth(ApiKeyAuth<ApiKeyLocation.header, "X-API-KEY">)
 namespace Test;
 

--- a/packages/http-client-js/test/scenarios/auth/sub_client_override.md
+++ b/packages/http-client-js/test/scenarios/auth/sub_client_override.md
@@ -7,9 +7,7 @@ The sub client sets NoAuth to override the auth scheme of the parent
 The spec contains a client with BasicAuth and a sub client with no auth
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 @useAuth(BasicAuth)
 namespace Test;
 

--- a/packages/http-client-js/test/scenarios/client/client_context.md
+++ b/packages/http-client-js/test/scenarios/client/client_context.md
@@ -3,9 +3,7 @@
 ## TypeSpec
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 op foo(): void;
 ```

--- a/packages/http-client-js/test/scenarios/client/dotted_namespace.md
+++ b/packages/http-client-js/test/scenarios/client/dotted_namespace.md
@@ -5,9 +5,7 @@
 A dotted namespace where only the last part has content. The leading namespaces have no operations and a single sub namespace
 
 ```tsp
-@service({
-  title: "TestService",
-})
+@service(#{ title: "TestService" })
 namespace Foo.Bar.Baz;
 @get op get(): string[];
 ```

--- a/packages/http-client-js/test/scenarios/client/nested_client.md
+++ b/packages/http-client-js/test/scenarios/client/nested_client.md
@@ -5,9 +5,7 @@ This specs nests namespace > namespace > interface
 ## TypeSpec
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 model Widget {

--- a/packages/http-client-js/test/scenarios/client/wrapping_namespace.md
+++ b/packages/http-client-js/test/scenarios/client/wrapping_namespace.md
@@ -9,9 +9,7 @@ In this scenario the emitter is expected to resolve the root namespace as a clie
 A dotted namespace where only the last part has stuff
 
 ```tsp
-@service({
-  title: "TestService",
-})
+@service(#{ title: "TestService" })
 namespace Foo;
 
 @route("/bar")

--- a/packages/http-client-js/test/scenarios/http-operations/basic-request.md
+++ b/packages/http-client-js/test/scenarios/http-operations/basic-request.md
@@ -5,9 +5,7 @@ This test verifies that a basic `GET` request with no headers, body, or paramete
 ## TypeSpec
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @route("/widgets")
@@ -46,9 +44,7 @@ This test verifies that a `POST` request with headers, a body, and query paramet
 ## TypeSpec
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @test
@@ -110,9 +106,7 @@ This test verifies that a `GET` request with a scalar body is correctly handled.
 ## TypeSpec
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @route("/widgets")

--- a/packages/http-client-js/test/scenarios/http-operations/basic-response.md
+++ b/packages/http-client-js/test/scenarios/http-operations/basic-response.md
@@ -5,9 +5,7 @@ This test verifies that a response with status `204` and no body is correctly ha
 ## **TypeSpec**
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @route("/widgets")
@@ -48,9 +46,7 @@ This test verifies that a response with a body containing a `Widget` model is co
 ## **TypeSpec**
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @test
@@ -115,9 +111,7 @@ This test verifies that a response with multiple status codes (`200` and `204`) 
 ## **TypeSpec**
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @test
@@ -172,9 +166,7 @@ This test verifies that a response with multiple content types is correctly hand
 ## **TypeSpec**
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 model Widget {

--- a/packages/http-client-js/test/scenarios/http-operations/path-parameter-in-model.md
+++ b/packages/http-client-js/test/scenarios/http-operations/path-parameter-in-model.md
@@ -7,9 +7,7 @@ A request that sends a request with a path parameter as a property of the input 
 The path parameter is a property of a spread model input in the operation signature
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 model ReadParams {

--- a/packages/http-client-js/test/scenarios/http-operations/path-parameter.md
+++ b/packages/http-client-js/test/scenarios/http-operations/path-parameter.md
@@ -7,9 +7,7 @@ A request that sends a request with a path parameter directly on the operation s
 The path parameter is a positional parameter in the operation signature
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @route("/widgets")

--- a/packages/http-client-js/test/scenarios/http-operations/scalar-payload.md
+++ b/packages/http-client-js/test/scenarios/http-operations/scalar-payload.md
@@ -7,9 +7,7 @@ A request that sends a body payload of scalar type
 The body is modeled as an explicit body property of type int32
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @route("/widgets")

--- a/packages/http-client-js/test/scenarios/http-operations/with-parameters.md
+++ b/packages/http-client-js/test/scenarios/http-operations/with-parameters.md
@@ -5,9 +5,7 @@ A typical request with path, query header and body parameters. The body is model
 ## TypeSpec
 
 ```tsp
-@service({
-  title: "Widget Service",
-})
+@service(#{ title: "Widget Service" })
 namespace DemoService;
 
 @test

--- a/packages/http-client-js/test/scenarios/serializers/polymorphic_single_level_inheritance.md
+++ b/packages/http-client-js/test/scenarios/serializers/polymorphic_single_level_inheritance.md
@@ -5,9 +5,7 @@
 The following TypeSpec block defines a service and several data models that serve as the foundation for our serializer tests. It starts with a base model, Bird, which uses a discriminator (kind) to support polymorphic behavior. Several derived models—SeaGull, Sparrow, Goose, and Eagle—are declared, each with a specific kind value to enable precise runtime type dispatching. Notably, the Eagle model includes additional complex properties (an array, a record, and a singular instance of Bird) to thoroughly test serialization of nested and compound types. This specification also exposes an HTTP GET endpoint returning a polymorphic Bird instance, ensuring that the generated TypeScript serializers handle these scenarios correctly.
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 namespace Test;
 
 @doc("This is base model for polymorphic single level inheritance with a discriminator.")

--- a/packages/http-client-js/test/scenarios/serializers/spread.md
+++ b/packages/http-client-js/test/scenarios/serializers/spread.md
@@ -3,9 +3,7 @@
 ## Typespec
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 namespace Test;
 alias MultipleRequestParameters = {
   @path

--- a/packages/http-client-js/test/scenarios/serializers/string_union.md
+++ b/packages/http-client-js/test/scenarios/serializers/string_union.md
@@ -3,9 +3,7 @@
 ## Typespec
 
 ```tsp
-@service({
-  title: "Test Service",
-})
+@service(#{ title: "Test Service" })
 namespace Test;
 union ServerExtensibleEnum {
   string,

--- a/packages/http-client-js/test/scenarios/server/multiple-parameters.md
+++ b/packages/http-client-js/test/scenarios/server/multiple-parameters.md
@@ -5,9 +5,7 @@
 This spec defines a server that has a host template and and endpoint to fill it out.
 
 ```tsp
-@service({
-  title: "Parametrized Endpoint",
-})
+@service(#{ title: "Parametrized Endpoint" })
 @server(
   "{endpoint}/server/path/multiple/{apiVersion}",
   "Test server with path parameters.",

--- a/packages/http-client-js/test/scenarios/server/parametrized-endpoint.md
+++ b/packages/http-client-js/test/scenarios/server/parametrized-endpoint.md
@@ -5,9 +5,7 @@
 This spec defines a server that has a host template and and endpoint to fill it out.
 
 ```tsp
-@service({
-  title: "Parametrized Endpoint",
-})
+@service(#{ title: "Parametrized Endpoint" })
 @server(
   "{foo}/server/path/multiple",
   "Test server with path parameters.",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -18,12 +18,17 @@
       "import": "./dist/src/components/index.js"
     }
   },
-  "dependencies": {
+  "peerDependencies": {
     "@alloy-js/core": "^0.6.0",
-    "@typespec/compiler": "workspace:^",
-    "@typespec/http": "workspace:^"
+    "@alloy-js/typescript": "^0.6.0",
+    "@typespec/http": "workspace:^",
+    "@typespec/compiler": "workspace:^"
   },
   "devDependencies": {
+    "@alloy-js/core": "^0.6.0",
+    "@alloy-js/typescript": "^0.6.0",
+    "@typespec/http": "workspace:^",
+    "@typespec/compiler": "workspace:^",
     "@alloy-js/babel-preset": "^0.2.0",
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.26.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,26 +406,16 @@ importers:
         version: 9.2.0
 
   packages/emitter-framework:
-    dependencies:
+    devDependencies:
+      '@alloy-js/babel-preset':
+        specifier: ^0.2.0
+        version: 0.2.0(@babel/core@7.26.9)
       '@alloy-js/core':
         specifier: ^0.6.0
         version: 0.6.0
       '@alloy-js/typescript':
         specifier: ^0.6.0
         version: 0.6.0
-      '@typespec/compiler':
-        specifier: workspace:^
-        version: link:../compiler
-      '@typespec/http':
-        specifier: workspace:^
-        version: link:../http
-      '@typespec/rest':
-        specifier: workspace:^
-        version: link:../rest
-    devDependencies:
-      '@alloy-js/babel-preset':
-        specifier: ^0.2.0
-        version: 0.2.0(@babel/core@7.26.9)
       '@babel/cli':
         specifier: ^7.24.8
         version: 7.26.4(@babel/core@7.26.9)
@@ -438,6 +428,15 @@ importers:
       '@types/minimist':
         specifier: ^1.2.5
         version: 1.2.5
+      '@typespec/compiler':
+        specifier: workspace:^
+        version: link:../compiler
+      '@typespec/http':
+        specifier: workspace:^
+        version: link:../http
+      '@typespec/rest':
+        specifier: workspace:^
+        version: link:../rest
       concurrently:
         specifier: ^9.1.2
         version: 9.1.2
@@ -664,20 +663,16 @@ importers:
         version: 3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.7)(happy-dom@17.2.2)(jiti@2.4.2)(jsdom@26.0.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/http-client:
-    dependencies:
-      '@alloy-js/core':
-        specifier: ^0.6.0
-        version: 0.6.0
-      '@typespec/compiler':
-        specifier: workspace:^
-        version: link:../compiler
-      '@typespec/http':
-        specifier: workspace:^
-        version: link:../http
     devDependencies:
       '@alloy-js/babel-preset':
         specifier: ^0.2.0
         version: 0.2.0(@babel/core@7.26.9)
+      '@alloy-js/core':
+        specifier: ^0.6.0
+        version: 0.6.0
+      '@alloy-js/typescript':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@babel/cli':
         specifier: ^7.24.8
         version: 7.26.4(@babel/core@7.26.9)
@@ -690,6 +685,12 @@ importers:
       '@types/node':
         specifier: ~22.13.9
         version: 22.13.9
+      '@typespec/compiler':
+        specifier: workspace:^
+        version: link:../compiler
+      '@typespec/http':
+        specifier: workspace:^
+        version: link:../http
       eslint:
         specifier: ^9.21.0
         version: 9.21.0(jiti@2.4.2)
@@ -717,9 +718,6 @@ importers:
       '@typespec/emitter-framework':
         specifier: workspace:^
         version: link:../emitter-framework
-      '@typespec/http':
-        specifier: workspace:^
-        version: link:../http
       '@typespec/http-client':
         specifier: workspace:^
         version: link:../http-client
@@ -745,6 +743,9 @@ importers:
       '@types/yargs':
         specifier: ~17.0.33
         version: 17.0.33
+      '@typespec/http':
+        specifier: workspace:^
+        version: link:../http
       '@typespec/http-specs':
         specifier: workspace:^
         version: link:../http-specs


### PR DESCRIPTION
This PR updates the dependency structure of the following packages to ensure a cleaner and more accurate dependency resolution:

### **Dependency Updates by Package**

#### **@typespec/emitter-framework**
**Peer Dependencies:**
- **Rationale:** `emitter-framework` requires the following dependencies to function but does not install them directly. Consumers (Emitter and TypeSpec projects) must provide these:
  - `@alloy-js/core` - Provided by consuming emitter
  - `@alloy-js/typescript` - Provided by consuming emitter
  - `@typespec/compiler` - Provided by TypeSpec project
  - `@typespec/http` - Provided by TypeSpec project
  - `@typespec/rest` - Provided by TypeSpec project

---

#### **@typespec/http-client**
**Peer Dependencies:**
- **Rationale:** Anything using `http-client` must already provide these dependencies, so they should be marked as peer dependencies:
  - `@alloy-js/core` - Provided by consuming emitter
  -  @alloy-js/typescript` - Provided by consuming emitter
  - `@typespec/compiler` - Provided by TypeSpec project
  - `@typespec/http` - Provided by TypeSpec project
  - 
---

#### **@typespec/http-client-js**
**Peer Dependencies:**
- **Rationale:** The `http-client-js` emitter is typically installed within a TypeSpec project that also includes the necessary dependencies for compilation. These should be peer dependencies:
  - `@typespec/compiler` - Provided by TypeSpec project
  - `@typespec/http` - Provided by TypeSpec project
  - `@typespec/rest` - Provided by TypeSpec project

**Dependencies:**
- **Rationale:** The emitter itself requires the following packages to function properly, and these should be installed automatically when using the emitter (instead of relying on the end-user to install them manually):
  - `@typespec/emitter-framework`
  - `@typespec/http-client`
  - `@alloy-js/core`
  - `@alloy-js/typescript`
