### PR TITLE
openapi3 - support @encode for @query parameters

### DIFF
--- a/.chronus/changes/oa3-support-encode-query-2025-2-14-15-30-23.md
+++ b/.chronus/changes/oa3-support-encode-query-2025-2-14-15-30-23.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Adds support for `@encode` to specify array encodings for `@query` parameters

--- a/packages/openapi3/src/encoding.ts
+++ b/packages/openapi3/src/encoding.ts
@@ -1,11 +1,11 @@
 import { type ModelProperty, Program, type Scalar, getEncode } from "@typespec/compiler";
 import { ObjectBuilder } from "@typespec/compiler/emitter-framework";
-import { isHeader } from "@typespec/http";
+import { isHeader, isQueryParam } from "@typespec/http";
 import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { getSchemaForStdScalars } from "./std-scalar-schemas.js";
 import type { OpenAPI3Schema, OpenAPISchema3_1 } from "./types.js";
 
-function isQueryParameterStyleEncoding(encoding: string | undefined): boolean {
+function isParameterStyleEncoding(encoding: string | undefined): boolean {
   if (!encoding) return false;
   return ["ArrayEncoding.pipeDelimited", "ArrayEncoding.spaceDelimited"].includes(encoding);
 }
@@ -23,7 +23,7 @@ export function applyEncoding(
   const encodeData = getEncode(program, typespecType);
   if (encodeData) {
     // Query parameters have a couple of special cases where encoding ends up as style.
-    if (isQueryParameterStyleEncoding(encodeData.encoding)) {
+    if (isQueryParam(program, typespecType) && isParameterStyleEncoding(encodeData.encoding)) {
       return targetObject;
     }
     const newType = getSchemaForStdScalars(encodeData.type as any, options);

--- a/packages/openapi3/src/encoding.ts
+++ b/packages/openapi3/src/encoding.ts
@@ -5,6 +5,11 @@ import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { getSchemaForStdScalars } from "./std-scalar-schemas.js";
 import type { OpenAPI3Schema, OpenAPISchema3_1 } from "./types.js";
 
+function isQueryParameterStyleEncoding(encoding: string | undefined): boolean {
+  if (!encoding) return false;
+  return ["ArrayEncoding.pipeDelimited", "ArrayEncoding.spaceDelimited"].includes(encoding);
+}
+
 export function applyEncoding(
   program: Program,
   typespecType: Scalar | ModelProperty,
@@ -17,6 +22,10 @@ export function applyEncoding(
 
   const encodeData = getEncode(program, typespecType);
   if (encodeData) {
+    // Query parameters have a couple of special cases where encoding ends up as style.
+    if (isQueryParameterStyleEncoding(encodeData.encoding)) {
+      return targetObject;
+    }
     const newType = getSchemaForStdScalars(encodeData.type as any, options);
     targetObject.type = newType.type;
     // If the target already has a format it takes priority. (e.g. int32)

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1417,14 +1417,6 @@ function createOAPIEmitter(
       options,
     );
 
-    // Remove invalid encodings that are meant to be on the `style` field
-    if (
-      schema.format &&
-      ["ArrayEncoding.pipeDelimited", "ArrayEncoding.spaceDelimited"].includes(schema.format)
-    ) {
-      delete schema.format;
-    }
-
     if (param.defaultValue) {
       schema.default = getDefaultValue(program, param.defaultValue, param);
     }

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -43,7 +43,10 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
         explode: false,
         style: style,
       });
-      expect(param.schema.format).toBeUndefined();
+      expect(param.schema).toStrictEqual({
+        type: "array",
+        items: { type: "string" },
+      });
     });
 
     describe("doesn't set explode if explode: true (Openapi3.0 inverse default)", () => {

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -32,6 +32,20 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
       strictEqual(param.name, "$select");
     });
 
+    it.each([
+      { encoding: "ArrayEncoding.pipeDelimited", style: "pipeDelimited" },
+      { encoding: "ArrayEncoding.spaceDelimited", style: "spaceDelimited" },
+    ])("can set style to $style with @encode($encoding)", async ({ encoding, style }) => {
+      const param = await getQueryParam(
+        `op test(@query @encode(${encoding}) myParam: string[]): void;`,
+      );
+      expect(param).toMatchObject({
+        explode: false,
+        style: style,
+      });
+      expect(param.schema.format).toBeUndefined();
+    });
+
     describe("doesn't set explode if explode: true (Openapi3.0 inverse default)", () => {
       it("with option", async () => {
         const param = await getQueryParam(


### PR DESCRIPTION
Fixes #6463 

Note - this only actually impacted `@query` for openapi3 since the special array encodings aren't actually valid for headers to begin with. However the array encoding formats will be removed now for header parameters if they were for some reason used.