### PR TITLE
Link to TypeSpec homepage in emitters

### DIFF
--- a/.chronus/changes/homepage-link-2025-2-17-9-36-2.md
+++ b/.chronus/changes/homepage-link-2025-2-17-9-36-2.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-js"
+---
+
+Add homepage and readme links

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.9",
   "author": "Microsoft Corporation",
   "description": "The typespec library that can be used to generate C# models from a TypeSpec REST protocol binding",
-  "homepage": "https://github.com/Microsoft/typespec",
+  "homepage": "https://typespec.io",
   "readme": "https://github.com/Microsoft/typespec/blob/main/packages/http-client-csharp/readme.md",
   "license": "MIT",
   "repository": {

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -6,7 +6,7 @@
     "TypeSpec"
   ],
   "author": "Microsoft Corporation",
-  "homepage": "https://github.com/Microsoft/typespec",
+  "homepage": "https://typespec.io",
   "readme": "https://github.com/Microsoft/typespec/blob/main/packages/http-client-java/README.md",
   "repository": {
     "type": "git",

--- a/packages/http-client-js/package.json
+++ b/packages/http-client-js/package.json
@@ -2,6 +2,8 @@
   "name": "@typespec/http-client-js",
   "version": "0.1.0",
   "type": "module",
+  "homepage": "https://typespec.io",
+  "readme": "https://github.com/microsoft/typespec/blob/main/packages/http-client-js/README.md",
   "scripts": {
     "build-src": "babel src -d dist/src --extensions .ts,.tsx",
     "build": "tsc -p . && npm run build-src",


### PR DESCRIPTION
Makes all of the emitters consistently link to the typespec homepage.