### PR TITLE
http-client-java, update nodejs engines to >=20

### DIFF
--- a/eng/emitters/pipelines/templates/jobs/test-job.yml
+++ b/eng/emitters/pipelines/templates/jobs/test-job.yml
@@ -69,7 +69,7 @@ jobs:
           AdditionalInitializeSteps: ${{ parameters.AdditionalInitializeSteps }}
           PackagePath: ${{ parameters.PackagePath }}
           LanguageShortName: ${{ parameters.LanguageShortName }}
-          NodeVersion: $(nodeVersion)
+          NodeVersion: ${{ parameters.NodeVersion }}
           BuildArtifactName: ${{ parameters.BuildArtifactName }}
           ${{ if ne(length(parameters.TestMatrix), 0) }}:
             TestArgs: $(TestArguments)

--- a/eng/emitters/pipelines/templates/steps/test-step.yml
+++ b/eng/emitters/pipelines/templates/steps/test-step.yml
@@ -11,7 +11,6 @@ parameters:
     type: string
 
   # Node version
-  #  Currently not installing node in this template, but keeping this parameter for future use
   - name: NodeVersion
     type: string
     default: "20.x"
@@ -47,6 +46,12 @@ steps:
   - download: current
     artifact: ${{ parameters.BuildArtifactName }}
     displayName: Download build artifacts
+
+  - task: NodeTool@0
+    displayName: Install Node.js
+    retryCountOnTaskFailure: 3
+    inputs:
+      versionSpec: ${{ parameters.NodeVersion }}
 
   - ${{ parameters.AdditionalInitializeSteps }}
 

--- a/packages/http-client-java/.npmrc
+++ b/packages/http-client-java/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -42,7 +42,7 @@
         "vitest": "^3.0.8"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@azure-tools/typespec-autorest": ">=0.52.0 <1.0.0",

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -25,7 +25,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp ./emitter/temp ./generator/target/emitter.jar",


### PR DESCRIPTION
typespec would require nodejs >=20, therefore same for emitter

I had to make some change to shared emitter job/step file, to enable "Install Node.js" step in test CI.

I've also run a "publish" pipeline for java emitter, so far so good https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4662414&view=results