### PR TITLE
http-specs, prepare release 0.1.0-alpha.13

### DIFF
--- a/.chronus/changes/deprecate-implicit-multipart-2025-2-14-20-1-30.md
+++ b/.chronus/changes/deprecate-implicit-multipart-2025-2-14-20-1-30.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@typespec/http-specs"
----
-
-Suppress implicit multipart deprecation for this release

--- a/.chronus/changes/http-specs_remove-discriminated-union-2025-2-13-10-42-35.md
+++ b/.chronus/changes/http-specs_remove-discriminated-union-2025-2-13-10-42-35.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@typespec/http-specs"
----
-
-Remove SpreadRecordForDiscriminatedUnion case

--- a/.chronus/changes/migrate_to_encode-2025-2-11-15-24-31.md
+++ b/.chronus/changes/migrate_to_encode-2025-2-11-15-24-31.md
@@ -1,7 +1,0 @@
----
-changeKind: breaking
-packages:
-  - "@typespec/http-specs"
----
-
-Remove tsv test and migrate ssv/pipes test of collection format.

--- a/.chronus/changes/reserve-keywords-2025-2-13-1-29-22.md
+++ b/.chronus/changes/reserve-keywords-2025-2-13-1-29-22.md
@@ -1,8 +1,6 @@
 ---
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
 changeKind: internal
 packages:
-  - "@typespec/http-specs"
   - "@typespec/openapi3"
   - "@typespec/protobuf"
 ---

--- a/packages/http-specs/CHANGELOG.md
+++ b/packages/http-specs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @typespec/http-specs
 
+## 0.1.0-alpha.13
+
+### Breaking Changes
+
+- [#6361](https://github.com/microsoft/typespec/pull/6361) Remove tsv test and migrate ssv/pipes test of collection format.
+
+### Bug Fixes
+
+- [#6464](https://github.com/microsoft/typespec/pull/6464) Suppress implicit multipart deprecation for this release
+- [#6425](https://github.com/microsoft/typespec/pull/6425) Remove SpreadRecordForDiscriminatedUnion case
+
+
 ## 0.1.0-alpha.12
 
 ### Features

--- a/packages/http-specs/package.json
+++ b/packages/http-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-specs",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "description": "Spec scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
mostly for nightly build

Feel free to close, if we already release a new version of http-specs lib with 0.67