### PR TITLE
[http] Fix handling of media types for literal types.

### DIFF
--- a/.chronus/changes/witemple-msft-http-media-type-literals-2025-2-18-11-24-40.md
+++ b/.chronus/changes/witemple-msft-http-media-type-literals-2025-2-18-11-24-40.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http"
+---
+
+HTTP Media type resolution logic now treats literal types (String, Boolean, Numeric, and StringTemplate types) as equivalent to their given scalar types for the purposes of resolving their Media Type.

--- a/packages/samples/test/output/testserver/body-boolean/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-boolean/@typespec/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ paths:
         '200':
           description: The request has succeeded.
           content:
-            application/json:
+            text/plain:
               schema:
                 type: boolean
                 enum:
@@ -44,7 +44,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          text/plain:
             schema:
               type: boolean
               enum:
@@ -94,7 +94,7 @@ paths:
         '200':
           description: The request has succeeded.
           content:
-            application/json:
+            text/plain:
               schema:
                 type: boolean
                 enum:
@@ -121,7 +121,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          text/plain:
             schema:
               type: boolean
               enum:

--- a/packages/samples/test/output/testserver/body-string/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-string/@typespec/openapi3/openapi.yaml
@@ -57,7 +57,7 @@ paths:
         '200':
           description: The request has succeeded.
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
                 enum:
@@ -88,7 +88,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          text/plain:
             schema:
               type: string
               enum:
@@ -184,7 +184,7 @@ paths:
         '200':
           description: The request has succeeded.
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
                 enum:
@@ -215,7 +215,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          text/plain:
             schema:
               type: string
               enum:
@@ -272,7 +272,7 @@ paths:
         '200':
           description: The request has succeeded.
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
                 enum:
@@ -303,7 +303,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          text/plain:
             schema:
               type: string
               enum:


### PR DESCRIPTION
fix #6511
This PR fixes the way that literal types are handled in media type resolution. It treats them as equivalent to their closest scalars:

- String: TypeSpec.string
- StringLiteral: TypeSpec.string
- Boolean: TypeSpec.boolean
- Numeric: TypeSpec.numeric

Adds a regression test to ensure that in the case of an "extensible enum" union, having both `string` and string literal variants results in a single content-type: `"text/plain"`.