### PR TITLE
Migrate legacy multipart http-specs scenarios to new HttpPart variant

### DIFF
--- a/.chronus/changes/remove-old-multipart-2025-2-21-11-20-5.md
+++ b/.chronus/changes/remove-old-multipart-2025-2-21-11-20-5.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-specs"
+---
+
+Update outdated multipart cases

--- a/packages/http-specs/specs/payload/multipart/main.tsp
+++ b/packages/http-specs/specs/payload/multipart/main.tsp
@@ -9,8 +9,8 @@ using Spector;
 namespace Payload.MultiPart;
 
 model MultiPartRequest {
-  id: string;
-  profileImage: bytes;
+  id: HttpPart<string>;
+  profileImage: HttpPart<bytes>;
 }
 
 model Address {
@@ -52,25 +52,25 @@ model ComplexHttpPartsModelRequest {
 }
 
 model ComplexPartsRequest {
-  id: string;
-  address: Address;
-  profileImage: bytes;
-  pictures: bytes[];
+  id: HttpPart<string>;
+  address: HttpPart<Address>;
+  profileImage: HttpPart<bytes>;
+  pictures: HttpPart<bytes>[];
 }
 
 model JsonPartRequest {
-  address: Address;
-  profileImage: bytes;
+  address: HttpPart<Address>;
+  profileImage: HttpPart<bytes>;
 }
 
 model BinaryArrayPartsRequest {
-  id: string;
-  pictures: bytes[];
+  id: HttpPart<string>;
+  pictures: HttpPart<bytes>[];
 }
 
 model MultiBinaryPartsRequest {
-  profileImage: bytes;
-  picture?: bytes;
+  profileImage: HttpPart<bytes>;
+  picture?: HttpPart<bytes>;
 }
 
 @route("/form-data")
@@ -106,8 +106,7 @@ namespace FormData {
   @route("/mixed-parts")
   op basic(
     @header contentType: "multipart/form-data",
-    #suppress "deprecated" "For testing to migrate for 1.0-rc"
-    @body body: MultiPartRequest,
+    @multipartBody body: MultiPartRequest,
   ): NoContentResponse;
 
   @scenario
@@ -167,8 +166,7 @@ namespace FormData {
   @route("/complex-parts")
   op fileArrayAndBasic(
     @header contentType: "multipart/form-data",
-    #suppress "deprecated" "For testing to migrate for 1.0-rc"
-    @body body: ComplexPartsRequest,
+    @multipartBody body: ComplexPartsRequest,
   ): NoContentResponse;
 
   @scenario
@@ -204,8 +202,7 @@ namespace FormData {
   @route("/json-part")
   op jsonPart(
     @header contentType: "multipart/form-data",
-    #suppress "deprecated" "For testing to migrate for 1.0-rc"
-    @body body: JsonPartRequest,
+    @multipartBody body: JsonPartRequest,
   ): NoContentResponse;
 
   @scenario
@@ -244,8 +241,7 @@ namespace FormData {
   @route("/binary-array-parts")
   op binaryArrayParts(
     @header contentType: "multipart/form-data",
-    #suppress "deprecated" "For testing to migrate for 1.0-rc"
-    @body body: BinaryArrayPartsRequest,
+    @multipartBody body: BinaryArrayPartsRequest,
   ): NoContentResponse;
 
   @scenario
@@ -279,8 +275,7 @@ namespace FormData {
   @route("/multi-binary-parts")
   op multiBinaryParts(
     @header contentType: "multipart/form-data",
-    #suppress "deprecated" "For testing to migrate for 1.0-rc"
-    @body body: MultiBinaryPartsRequest,
+    @multipartBody body: MultiBinaryPartsRequest,
   ): NoContentResponse;
 
   @scenario
@@ -309,8 +304,7 @@ namespace FormData {
   @route("/check-filename-and-content-type")
   op checkFileNameAndContentType(
     @header contentType: "multipart/form-data",
-    #suppress "deprecated" "For testing to migrate for 1.0-rc"
-    @body body: MultiPartRequest,
+    @multipartBody body: MultiPartRequest,
   ): NoContentResponse;
 
   #suppress "deprecated" "For testing to migrate for 1.0-rc"
@@ -340,7 +334,9 @@ namespace FormData {
   @route("/anonymous-model")
   op anonymousModel(
     @header contentType: "multipart/form-data",
-    profileImage: MultiPartRequest.profileImage,
+    @multipartBody body: {
+      profileImage: HttpPart<bytes>;
+    },
   ): NoContentResponse;
 
   namespace HttpParts {

--- a/packages/http-specs/specs/payload/multipart/main.tsp
+++ b/packages/http-specs/specs/payload/multipart/main.tsp
@@ -307,7 +307,6 @@ namespace FormData {
     @multipartBody body: MultiPartRequest,
   ): NoContentResponse;
 
-  #suppress "deprecated" "For testing to migrate for 1.0-rc"
   @scenario
   @scenarioDoc("""
     Expect request (


### PR DESCRIPTION
fix https://github.com/Azure/typespec-azure/issues/2398

To reduce effort of language emitter owner, I transfer the cases of old multipart to cases with new multipart format, without changing case name, model name and response type. So theoritically, language emitter owner don't need update existing test cases.