### PR TITLE
Add sdk-context-options to options

### DIFF
--- a/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/packages/http-client-csharp/emitter/src/emitter.ts
@@ -68,7 +68,7 @@ export async function $onEmit(context: EmitContext<CSharpEmitterOptions>) {
       ...(await createSdkContext(
         context,
         "@typespec/http-client-csharp",
-        defaultSDKContextOptions,
+        options["sdk-context-options"] ?? defaultSDKContextOptions,
       )),
       logger: logger,
       __typeCache: {

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -1,4 +1,4 @@
-import { SdkEmitterOptions } from "@azure-tools/typespec-client-generator-core";
+import { CreateSdkContextOptions, SdkEmitterOptions } from "@azure-tools/typespec-client-generator-core";
 import { EmitContext, JSONSchemaType, resolvePath } from "@typespec/compiler";
 import { _defaultGeneratorName, tspOutputFileName } from "./constants.js";
 import { LoggerLevel } from "./lib/logger-level.js";
@@ -22,6 +22,7 @@ export interface CSharpEmitterOptions extends SdkEmitterOptions {
   "generator-name"?: string;
   "emitter-extension-path"?: string;
   "update-code-model"?: (model: CodeModel) => CodeModel;
+  "sdk-context-options"?: CreateSdkContextOptions;
 }
 
 /**
@@ -60,6 +61,7 @@ export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = 
     "generator-name": { type: "string", nullable: true },
     "emitter-extension-path": { type: "string", nullable: true },
     "update-code-model": { type: "object", nullable: true },
+    "sdk-context-options": { type: "object", nullable: true },
   },
   required: [],
 };
@@ -83,6 +85,7 @@ export const defaultOptions = {
   "generator-name": _defaultGeneratorName,
   "emitter-extension-path": undefined,
   "update-code-model": (model: CodeModel) => model,
+  "sdk-context-options": undefined,
 };
 
 /**

--- a/packages/http-client-csharp/emitter/test/Unit/emitter.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/emitter.test.ts
@@ -20,6 +20,7 @@ import {
   createEmitterTestHost,
   typeSpecCompile,
 } from "./utils/test-util.js";
+import { createSdkContext } from "@azure-tools/typespec-client-generator-core";
 
 describe("$onEmit tests", () => {
   afterAll(() => {
@@ -92,6 +93,22 @@ describe("$onEmit tests", () => {
     context.options["update-code-model"] = updateCallback;
     await $onEmit(context);
     expect(updateCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should set additional-decorators to the sdk context", async () => {
+    const context: EmitContext<CSharpEmitterOptions> = createEmitterContext(program);
+    const additionalDecorators = ["Decorator1", "Decorator2"];
+    context.options["sdk-context-options"] = {
+      versioning: {
+        previewStringRegex: /$/,
+      },
+      additionalDecorators: additionalDecorators,
+    };
+    await $onEmit(context);
+
+    expect(createSdkContext).toHaveBeenCalledWith(expect.anything(), expect.any(String), expect.objectContaining({
+      additionalDecorators: additionalDecorators,
+    }));
   });
 
   it("should set newProject to true if .csproj file DOES NOT exist", async () => {


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-net/pull/48893#discussion_r2005264091

Keep `setSDKContextOptions` for now to unblock the tsp version bump in autorest.csharp.