### PR TITLE
Fix js emitter formatting

### DIFF
--- a/.chronus/changes/fix-js-emitter-formatting-2025-2-20-18-53-48.md
+++ b/.chronus/changes/fix-js-emitter-formatting-2025-2-20-18-53-48.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-js"
+---
+
+Fix formatting issues and don't export serializers

--- a/packages/http-client-js/src/components/client.tsx
+++ b/packages/http-client-js/src/components/client.tsx
@@ -1,6 +1,5 @@
 import * as ay from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
-import { ClassDeclaration } from "@alloy-js/typescript";
 import { $ } from "@typespec/compiler/experimental/typekit";
 import { ClassMethod } from "@typespec/emitter-framework/typescript";
 import * as cl from "@typespec/http-client";
@@ -54,19 +53,19 @@ export function ClientClass(props: ClientClassProps) {
   const subClients = props.client.subClients;
   const operations = props.client.operations;
   return (
-    <ClassDeclaration export name={clientName} refkey={clientClassRef}>
-      <ay.StatementList>
+    <ts.ClassDeclaration export name={clientName} refkey={clientClassRef}>
+      <ay.List hardline>
         <ts.ClassField
           name="context"
           jsPrivate
           refkey={contextMemberRef}
           type={contextDeclarationRef}
         />
-        <ay.For each={subClients} hardline joiner=";">
+        <ay.For each={subClients} hardline semicolon>
           {(subClient) => <SubClientClassField client={subClient} />}
         </ay.For>
-        <ClientConstructor client={props.client} />;<br />
-        <ay.For each={operations} hardline joiner=";">
+        <ClientConstructor client={props.client} />
+        <ay.For each={operations} hardline semicolon>
           {(op) => {
             const parameters = getOperationParameters(op.httpOperation);
             const args = Object.keys(parameters).map((p) => p);
@@ -83,14 +82,13 @@ export function ClientClass(props: ClientClassProps) {
                 <ts.FunctionCallExpression
                   target={ay.refkey(op.httpOperation.operation)}
                   args={[contextMemberRef, ...args]}
-                />
-                ;
+                />;
               </ClassMethod>
             );
           }}
         </ay.For>
-      </ay.StatementList>
-    </ClassDeclaration>
+      </ay.List>
+    </ts.ClassDeclaration>
   );
 }
 

--- a/packages/http-client-js/src/components/client.tsx
+++ b/packages/http-client-js/src/components/client.tsx
@@ -82,7 +82,8 @@ export function ClientClass(props: ClientClassProps) {
                 <ts.FunctionCallExpression
                   target={ay.refkey(op.httpOperation.operation)}
                   args={[contextMemberRef, ...args]}
-                />;
+                />
+                ;
               </ClassMethod>
             );
           }}

--- a/packages/http-client-js/src/emitter.tsx
+++ b/packages/http-client-js/src/emitter.tsx
@@ -33,7 +33,9 @@ export async function $onEmit(context: EmitContext<JsClientEmitterOptions>) {
           <ay.SourceDirectory path="models">
             <ts.BarrelFile export="models" />
             <Models />
-            <ModelSerializers />
+            <ay.SourceDirectory path="internal">
+              <ModelSerializers />
+            </ay.SourceDirectory>
           </ay.SourceDirectory>
           <ay.SourceDirectory path="api">
             <OperationsDirectory />


### PR DESCRIPTION
Removes un-necessary semicolons on client class generation and moves serializers into a sub folder to avoid them being exported externally 