### PR TITLE
Re-enable spector scenarios

### DIFF
--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/_Type/Property/AdditionalProperties/AdditionalPropertiesTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/_Type/Property/AdditionalProperties/AdditionalPropertiesTests.cs
@@ -792,7 +792,6 @@ namespace TestProjects.Spector.Tests.Http._Type.Property.AdditionalProperties
         });
 
         [SpectorTest]
-        [Ignore("https://github.com/microsoft/typespec/issues/6426")]
         public Task SpreadRecordNonDiscriminatedUnionPut() => Test(async host =>
         {
             var value = new SpreadRecordForNonDiscriminatedUnion("abc")
@@ -825,7 +824,6 @@ namespace TestProjects.Spector.Tests.Http._Type.Property.AdditionalProperties
         });
 
         [SpectorTest]
-        [Ignore("https://github.com/microsoft/typespec/issues/6426")]
         public Task SpreadRecordNonDiscriminatedUnion2Put() => Test(async host =>
         {
             var value = new SpreadRecordForNonDiscriminatedUnion2("abc")


### PR DESCRIPTION
With the latest tsp compiler version 0.67.1, these spector scenarios can be re-enabled.