### PR TITLE
Fix: Standalone CLI tsp install broken

### DIFF
--- a/.chronus/changes/fix-tsp-install-standalone-2025-2-24-11-51-3.md
+++ b/.chronus/changes/fix-tsp-install-standalone-2025-2-24-11-51-3.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix `tsp install` broken in standalone CLI

--- a/packages/compiler/src/install/install.ts
+++ b/packages/compiler/src/install/install.ts
@@ -224,7 +224,10 @@ async function runPackageManager(
   const child = fork(binPath, packageManager.commands.install, {
     stdio,
     cwd: directory,
-    env: process.env,
+    env: {
+      ...process.env,
+      TYPESPEC_CLI_PASSTHROUGH: "1",
+    },
   });
 
   const stdout: string[] = [];

--- a/packages/standalone/scripts/check.ts
+++ b/packages/standalone/scripts/check.ts
@@ -1,13 +1,26 @@
 import { execa } from "execa";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { resolve } from "path";
 
+const projectDir = resolve(import.meta.dirname, "..");
+const distDir = resolve(projectDir, "dist");
+const exe = process.platform === "win32" ? "tsp.exe" : "tsp";
+const exePath = resolve(distDir, exe);
 await main();
 
 async function main() {
-  const exe = process.platform === "win32" ? "tsp.exe" : "tsp";
-  console.log(`Checking ${exe} is running`);
-  const result = await execa`dist/${exe} --help`;
+  await commandRuns();
+  await installWorks();
+}
+
+async function run(args: string[], options: { cwd?: string; env?: Record<string, string> } = {}) {
+  return await execa(exePath, args, options);
+}
+
+async function commandRuns() {
+  const result = await run(["--help"]);
   if (result.stdout.includes("tsp <command>")) {
-    console.log("✅ working!");
+    console.log("✅ command working!");
   } else {
     console.error("Executable is not working");
     console.error(result.stdout);
@@ -15,4 +28,22 @@ async function main() {
     console.error(result.stderr);
     process.exit(1);
   }
+}
+
+async function installWorks() {
+  const testDir = resolve(projectDir, "temp", "install-test");
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(testDir, { recursive: true });
+  await writeFile(
+    resolve(testDir, "package.json"),
+    JSON.stringify({ name: "test", dependencies: { "@typespec/compiler": "latest" } }),
+  );
+  await run(["install"], {
+    cwd: testDir,
+    env: {
+      TYPESPEC_COMPILER_PATH: resolve(projectDir, "..", "compiler", "cmd", "tsp.js"),
+    },
+  });
+
+  console.log("✅ install working!");
 }

--- a/packages/standalone/src/cli.ts
+++ b/packages/standalone/src/cli.ts
@@ -15,109 +15,121 @@ import { homedir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 
-const tspDir = homedir() + "/.tsp";
-
-const args = parseArgs({
-  options: {
-    server: { type: "string" },
-    "no-cache": { type: "boolean", default: false },
-  },
-  strict: false,
-});
-async function main() {
-  if (args.values.server) {
-    await import(pathToFileURL(args.values.server as string).href);
-  } else {
-    await installAndRun({ noCache: args.values["no-cache"] as boolean });
-  }
-}
-async function installAndRun({ noCache }: { noCache: boolean }) {
-  await install({
-    noCache,
-    installDir: tspDir + "/compiler-installs",
+if (process.env.TYPESPEC_CLI_PASSTHROUGH === "1") {
+  process.argv.shift(); // We receive ["tsp", "tsp", "entrypoint"] and we want to match ["node", "entrypoint"]
+  process.execArgv = [];
+  import(process.argv[1]).catch((e) => {
+    // eslint-disable-next-line no-console
+    console.log(e);
+    process.exit(1);
   });
+} else {
+  const tspDir = homedir() + "/.tsp";
 
-  const url = pathToFileURL(
-    tspDir + "/compiler-installs/node_modules/@typespec/compiler/cmd/tsp.js",
-  ).href;
-  (globalThis as any).TYPESPEC_ENGINE = "tsp";
-  await import(url);
-}
-
-main().catch((error) => {
-  // eslint-disable-next-line no-console
-  console.error(error);
-  process.exit(1);
-});
-
-interface InstallOptions {
-  installDir: string;
-  noCache?: boolean;
-}
-
-const plugins = {
-  "@yarnpkg/plugin-npm": npmPlugin,
-  "@yarnpkg/plugin-nm": nmPlugin,
-  "@yarnpkg/plugin-pnp": pnpPlugin,
-};
-async function install(options: InstallOptions) {
-  const installDir = options.installDir;
-  if (options.noCache) {
-    await rm(installDir, { recursive: true, force: true });
-  }
-  await mkdir(installDir, { recursive: true });
-  await writeFile(
-    installDir + "/package.json",
-    JSON.stringify({
-      dependencies: { "@typespec/compiler": process.env.TYPESPEC_CLI_GLOBAL_VERSION ?? "latest" },
-    }),
-    "utf8",
-  );
-
-  const path = npath.toPortablePath(installDir);
-  const configuration = await Configuration.find(path, {
-    modules: new Map(Object.entries(plugins)),
-    plugins: new Set(Object.keys(plugins)),
-  });
-  configuration.use(`<compat>`, { nodeLinker: `node-modules` }, path, {
-    overwrite: true,
-  });
-  const cache = await Cache.find(configuration);
-  const { project } = await Project.find(configuration, path);
-  await project.restoreInstallState({ restoreResolutions: false });
-
-  const report = await ErrorReport.start(
-    {
-      configuration,
-      stdout: process.stdout,
+  const args = parseArgs({
+    options: {
+      server: { type: "string" },
+      "no-cache": { type: "boolean", default: false },
     },
-    async (report: ErrorReport) => {
-      await project.install({
-        cache,
-        report,
-      });
-    },
-  );
-
-  if (report.hasErrors()) {
-    throw new Error(report.errorReport);
+    strict: false,
+  });
+  async function main() {
+    if (args.values.server) {
+      await import(pathToFileURL(args.values.server as string).href);
+    } else if (process.env.TYPESPEC_COMPILER_PATH) {
+      await import(pathToFileURL(process.env.TYPESPEC_COMPILER_PATH).href);
+    } else {
+      await installAndRun({ noCache: args.values["no-cache"] as boolean });
+    }
   }
-}
+  async function installAndRun({ noCache }: { noCache: boolean }) {
+    await install({
+      noCache,
+      installDir: tspDir + "/compiler-installs",
+    });
 
-class ErrorReport extends LightReport {
-  errors: { name: string; text: string }[] = [];
+    const url = pathToFileURL(
+      tspDir + "/compiler-installs/node_modules/@typespec/compiler/cmd/tsp.js",
+    ).href;
+    (globalThis as any).TYPESPEC_ENGINE = "tsp";
+    await import(url);
+  }
 
-  static start = (
-    opts: Parameters<typeof LightReport.start>[0],
-    cb: (report: ErrorReport) => Promise<void>,
-  ) => super.start(opts, cb as any) as Promise<ErrorReport>;
+  main().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exit(1);
+  });
 
-  reportError = (name: MessageName, text: string) =>
-    this.errors.push({ name: stringifyMessageName(name), text });
+  interface InstallOptions {
+    installDir: string;
+    noCache?: boolean;
+  }
 
-  hasErrors = () => this.errors.length > 0;
+  const plugins = {
+    "@yarnpkg/plugin-npm": npmPlugin,
+    "@yarnpkg/plugin-nm": nmPlugin,
+    "@yarnpkg/plugin-pnp": pnpPlugin,
+  };
+  async function install(options: InstallOptions) {
+    const installDir = options.installDir;
+    if (options.noCache) {
+      await rm(installDir, { recursive: true, force: true });
+    }
+    await mkdir(installDir, { recursive: true });
+    await writeFile(
+      installDir + "/package.json",
+      JSON.stringify({
+        dependencies: { "@typespec/compiler": process.env.TYPESPEC_CLI_GLOBAL_VERSION ?? "latest" },
+      }),
+      "utf8",
+    );
 
-  get errorReport() {
-    return this.errors.map((error) => `${error.name} - ${error.text}`).join("\n");
+    const path = npath.toPortablePath(installDir);
+    const configuration = await Configuration.find(path, {
+      modules: new Map(Object.entries(plugins)),
+      plugins: new Set(Object.keys(plugins)),
+    });
+    configuration.use(`<compat>`, { nodeLinker: `node-modules` }, path, {
+      overwrite: true,
+    });
+    const cache = await Cache.find(configuration);
+    const { project } = await Project.find(configuration, path);
+    await project.restoreInstallState({ restoreResolutions: false });
+
+    const report = await ErrorReport.start(
+      {
+        configuration,
+        stdout: process.stdout,
+      },
+      async (report: ErrorReport) => {
+        await project.install({
+          cache,
+          report,
+        });
+      },
+    );
+
+    if (report.hasErrors()) {
+      throw new Error(report.errorReport);
+    }
+  }
+
+  class ErrorReport extends LightReport {
+    errors: { name: string; text: string }[] = [];
+
+    static start = (
+      opts: Parameters<typeof LightReport.start>[0],
+      cb: (report: ErrorReport) => Promise<void>,
+    ) => super.start(opts, cb as any) as Promise<ErrorReport>;
+
+    reportError = (name: MessageName, text: string) =>
+      this.errors.push({ name: stringifyMessageName(name), text });
+
+    hasErrors = () => this.errors.length > 0;
+
+    get errorReport() {
+      return this.errors.map((error) => `${error.name} - ${error.text}`).join("\n");
+    }
   }
 }

--- a/packages/standalone/vitest.config.e2e.ts
+++ b/packages/standalone/vitest.config.e2e.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    testTimeout: 90_000,
+    isolate: false,
+    coverage: {
+      reporter: ["cobertura", "json", "text"],
+    },
+    outputFile: {
+      junit: "./test-results.xml",
+    },
+
+    include: ["test/**/*.e2e.ts"],
+  },
+});


### PR DESCRIPTION
fix #6645

Issue is that when we use `child_process.fork` it doesn't start node only but again our executable(which make sense) so adding an environment varialbe to allow pass through 