### PR TITLE
Update CODEOWNERS for python

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 # Python
 ######################
 /packages/http-client-python/                @iscai-msft @tadelesh @msyyc @timotheeguerin @lmazuel
+/website/src/content/docs/docs/emitters/clients/http-client-python/               @iscai-msft @tadelesh @msyyc @timotheeguerin @lmazuel
 
 ######################
 # JavaScript


### PR DESCRIPTION
https://github.com/microsoft/typespec/tree/main/website/src/content/docs/docs/emitters/clients/http-client-python Python owners may update the docs time to time like https://github.com/microsoft/typespec/pull/6665.