### PR TITLE
Update to the prettier plugin build

### DIFF
--- a/.chronus/changes/prettier-rollup-to-esbuild-2025-2-25-17-42-11-2.md
+++ b/.chronus/changes/prettier-rollup-to-esbuild-2025-2-25-17-42-11-2.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/prettier-plugin-typespec"
+---
+
+Migrate to ESM. This shouldn't be breaking as we didn't support prettier < 3.

--- a/.chronus/changes/prettier-rollup-to-esbuild-2025-2-25-17-42-11.md
+++ b/.chronus/changes/prettier-rollup-to-esbuild-2025-2-25-17-42-11.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: breaking
+packages:
+  - "@typespec/compiler"
+---
+
+Moved `TypeSpecPrettierPlugin` type to internal. If wanting to use the prettier pluging programmatically, use it from the `@typespec/prettier-plugin-typespec` package

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -41,6 +41,7 @@
     "./ast": {
       "import": "./dist/src/ast/index.js"
     },
+   
     "./experimental": {
       "types": "./dist/src/experimental/index.d.ts",
       "default": "./dist/src/experimental/index.js"
@@ -52,6 +53,9 @@
     "./internals": {
       "types": "./dist/src/internals/index.d.ts",
       "import": "./dist/src/internals/index.js"
+    },
+    "./internals/prettier-formatter": {
+      "import": "./dist/src/internals/prettier-formatter.js"
     }
   },
   "browser": {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -41,7 +41,6 @@
     "./ast": {
       "import": "./dist/src/ast/index.js"
     },
-   
     "./experimental": {
       "types": "./dist/src/experimental/index.d.ts",
       "default": "./dist/src/experimental/index.js"

--- a/packages/compiler/src/core/diagnostics.ts
+++ b/packages/compiler/src/core/diagnostics.ts
@@ -1,4 +1,3 @@
-import { formatLog } from "./logger/console-sink.js";
 import type { Program } from "./program.js";
 import { createSourceFile } from "./source-file.js";
 import {
@@ -33,26 +32,8 @@ export function logDiagnostics(diagnostics: readonly Diagnostic[], logger: LogSi
   }
 }
 
-export interface FormatDiagnosticOptions {
-  readonly pretty?: boolean;
-  readonly pathRelativeTo?: string;
-}
-
-export function formatDiagnostic(diagnostic: Diagnostic, options: FormatDiagnosticOptions = {}) {
-  return formatLog(
-    {
-      code: diagnostic.code,
-      level: diagnostic.severity,
-      message: diagnostic.message,
-      url: diagnostic.url,
-      sourceLocation: getSourceLocation(diagnostic.target, { locateId: true }),
-      related: getRelatedLocations(diagnostic),
-    },
-    { pretty: options?.pretty ?? false, pathRelativeTo: options?.pathRelativeTo },
-  );
-}
-
-function getRelatedLocations(diagnostic: Diagnostic): RelatedSourceLocation[] {
+/** @internal */
+export function getRelatedLocations(diagnostic: Diagnostic): RelatedSourceLocation[] {
   return getDiagnosticTemplateInstantitationTrace(diagnostic.target).map((x) => {
     return {
       message: "occurred while instantiating template",

--- a/packages/compiler/src/core/logger/console-sink.browser.ts
+++ b/packages/compiler/src/core/logger/console-sink.browser.ts
@@ -1,6 +1,6 @@
 // noop logger shouldn't be used in browser
 
-import { LogSink, ProcessedLog } from "../types.js";
+import type { Diagnostic, LogSink, ProcessedLog } from "../types.js";
 
 export function createConsoleSink(options: any): LogSink {
   function log(data: ProcessedLog) {
@@ -14,5 +14,9 @@ export function createConsoleSink(options: any): LogSink {
 }
 
 export function formatLog(log: ProcessedLog): string {
+  return JSON.stringify(log);
+}
+
+export function formatDiagnostic(log: Diagnostic): string {
   return JSON.stringify(log);
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -35,7 +35,6 @@ export {
   compilerAssert,
   createDiagnosticCollector,
   defineCodeFix,
-  formatDiagnostic,
   getSourceLocation,
   ignoreDiagnostics,
   logDiagnostics,
@@ -101,6 +100,7 @@ export {
   setTypeSpecNamespace,
 } from "./core/library.js";
 export { resolveLinterDefinition } from "./core/linter.js";
+export { formatDiagnostic } from "./core/logger/console-sink.js";
 export { NodeHost } from "./core/node-host.js";
 export { isNumeric, Numeric } from "./core/numeric.js";
 export type { CompilerOptions } from "./core/options.js";

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -105,7 +105,6 @@ export { NodeHost } from "./core/node-host.js";
 export { isNumeric, Numeric } from "./core/numeric.js";
 export type { CompilerOptions } from "./core/options.js";
 export { getPositionBeforeTrivia } from "./core/parser-utils.js";
-export * as TypeSpecPrettierPlugin from "./formatter/index.js";
 export {
   $defaultVisibility,
   $discriminator,

--- a/packages/compiler/src/internals/prettier-formatter.ts
+++ b/packages/compiler/src/internals/prettier-formatter.ts
@@ -1,5 +1,5 @@
 /**
  * Reexport the bare minimum for rollup to do the tree shaking.
  */
-import TypeSpecPrettierPlugin from "@typespec/compiler/internals/prettier-formatter";
+import * as TypeSpecPrettierPlugin from "../formatter/index.js";
 export default TypeSpecPrettierPlugin;

--- a/packages/compiler/src/server/compile-service.ts
+++ b/packages/compiler/src/server/compile-service.ts
@@ -7,10 +7,11 @@ import {
 } from "../config/config-loader.js";
 import { resolveOptionsFromConfig } from "../config/config-to-options.js";
 import { TypeSpecConfig } from "../config/types.js";
-import { compilerAssert, formatDiagnostic } from "../core/diagnostics.js";
+import { compilerAssert } from "../core/diagnostics.js";
 import { builtInLinterRule_UnusedTemplateParameter } from "../core/linter-rules/unused-template-parameter.rule.js";
 import { builtInLinterRule_UnusedUsing } from "../core/linter-rules/unused-using.rule.js";
 import { builtInLinterLibraryName } from "../core/linter.js";
+import { formatDiagnostic } from "../core/logger/console-sink.js";
 import { CompilerOptions } from "../core/options.js";
 import { parse } from "../core/parser.js";
 import { getDirectoryPath, joinPaths } from "../core/path-utils.js";

--- a/packages/compiler/src/testing/expect.ts
+++ b/packages/compiler/src/testing/expect.ts
@@ -1,5 +1,6 @@
 import { fail, match, strictEqual } from "assert";
-import { formatDiagnostic, getSourceLocation } from "../core/diagnostics.js";
+import { getSourceLocation } from "../core/diagnostics.js";
+import { formatDiagnostic } from "../core/logger/console-sink.js";
 import { NoTarget, type Diagnostic } from "../core/types.js";
 import { isArray } from "../utils/misc.js";
 import { resolveVirtualPath } from "./test-utils.js";

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -1,7 +1,8 @@
 import assert, { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { CharCode } from "../src/core/charcode.js";
-import { formatDiagnostic, logVerboseTestOutput } from "../src/core/diagnostics.js";
+import { logVerboseTestOutput } from "../src/core/diagnostics.js";
+import { formatDiagnostic } from "../src/core/logger/console-sink.js";
 import { hasParseError, parse, visitChildren } from "../src/core/parser.js";
 import {
   IdentifierNode,

--- a/packages/compiler/test/scanner.test.ts
+++ b/packages/compiler/test/scanner.test.ts
@@ -3,7 +3,8 @@ import { readFile } from "fs/promises";
 import { URL } from "url";
 import { describe, it } from "vitest";
 import { isIdentifierContinue, isIdentifierStart } from "../src/core/charcode.js";
-import { DiagnosticHandler, formatDiagnostic } from "../src/core/diagnostics.js";
+import { DiagnosticHandler } from "../src/core/diagnostics.js";
+import { formatDiagnostic } from "../src/core/logger/console-sink.js";
 import {
   KeywordLimit,
   Keywords,

--- a/packages/prettier-plugin-typespec/ThirdPartyNotices.txt
+++ b/packages/prettier-plugin-typespec/ThirdPartyNotices.txt
@@ -7,19 +7,3 @@ This project incorporates components from the projects listed below. The
 original copyright notices and the licenses under which Microsoft received such
 components are set forth below. Microsoft reserves all rights not expressly
 granted herein, whether by implication, estoppel or otherwise.
-
-1. prettier version 3.5.3 (prettier/prettier)
-
-
-%% prettier NOTICES AND INFORMATION BEGIN HERE
-=====================================================
-Copyright © James Long and contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-=====================================================");
-END OF prettier NOTICES AND INFORMATION

--- a/packages/prettier-plugin-typespec/package.json
+++ b/packages/prettier-plugin-typespec/package.json
@@ -3,8 +3,10 @@
   "version": "0.67.1",
   "description": "",
   "main": "dist/index.js",
+  "type": "module",
   "scripts": {
-    "build": "rollup --config 2>&1 && npm run generate-third-party-notices",
+    "build": "pnpm compile && pnpm generate-third-party-notices",
+    "compile": "tsx ./scripts/build.ts",
     "test": "vitest run",
     "test:ci": "vitest run",
     "generate-third-party-notices": "typespec-build-tool generate-third-party-notices"
@@ -15,13 +17,9 @@
     "prettier": "~3.5.3"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "~28.0.3",
-    "@rollup/plugin-json": "~6.1.0",
-    "@rollup/plugin-node-resolve": "~16.0.1",
-    "@rollup/plugin-replace": "~6.0.2",
     "@typespec/compiler": "workspace:^",
     "@typespec/internal-build-utils": "workspace:^",
-    "rollup": "~4.36.0",
+    "esbuild": "^0.25.1",
     "vitest": "^3.0.9"
   },
   "files": [

--- a/packages/prettier-plugin-typespec/scripts/build.ts
+++ b/packages/prettier-plugin-typespec/scripts/build.ts
@@ -7,5 +7,6 @@ await build({
   platform: "node",
   target: "node22",
   format: "esm",
+  sourcemap: true,
   external: ["prettier", "fs/promises", "ajv", "yaml"],
 });

--- a/packages/prettier-plugin-typespec/scripts/build.ts
+++ b/packages/prettier-plugin-typespec/scripts/build.ts
@@ -1,0 +1,11 @@
+import { build } from "esbuild";
+// Build the extension
+await build({
+  entryPoints: ["src/index.mjs"],
+  bundle: true,
+  outfile: "dist/index.js",
+  platform: "node",
+  target: "node22",
+  format: "esm",
+  external: ["prettier", "fs/promises", "ajv", "yaml"],
+});

--- a/packages/prettier-plugin-typespec/vitest.config.ts
+++ b/packages/prettier-plugin-typespec/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import { defaultTypeSpecVitestConfig } from "../../vitest.workspace.js";
+
+export default mergeConfig(defaultTypeSpecVitestConfig, defineConfig({}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1551,27 +1551,15 @@ importers:
         specifier: ~3.5.3
         version: 3.5.3
     devDependencies:
-      '@rollup/plugin-commonjs':
-        specifier: ~28.0.3
-        version: 28.0.3(rollup@4.36.0)
-      '@rollup/plugin-json':
-        specifier: ~6.1.0
-        version: 6.1.0(rollup@4.36.0)
-      '@rollup/plugin-node-resolve':
-        specifier: ~16.0.1
-        version: 16.0.1(rollup@4.36.0)
-      '@rollup/plugin-replace':
-        specifier: ~6.0.2
-        version: 6.0.2(rollup@4.36.0)
       '@typespec/compiler':
         specifier: workspace:^
         version: link:../compiler
       '@typespec/internal-build-utils':
         specifier: workspace:^
         version: link:../internal-build-utils
-      rollup:
-        specifier: ~4.36.0
-        version: 4.36.0
+      esbuild:
+        specifier: ^0.25.1
+        version: 0.25.1
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.11)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@26.0.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -5407,15 +5395,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/plugin-replace@6.0.2':
-    resolution: {integrity: sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -17190,13 +17169,6 @@ snapshots:
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
-    optionalDependencies:
-      rollup: 4.36.0
-
-  '@rollup/plugin-replace@6.0.2(rollup@4.36.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
-      magic-string: 0.30.17
     optionalDependencies:
       rollup: 4.36.0
 


### PR DESCRIPTION
Changes: 
- Somehow we were not testing it
- Build migrated from rollup to esbuild
- Moved the plugin export to internal in compiler(missed in last internal migration)
- Produce esm. Prettier 3 which is the only version we support does support esm