### PR TITLE
fix: Handle enum values in @extension decorators to avoid circular JSON references

### DIFF
--- a/packages/json-schema/src/decorators.ts
+++ b/packages/json-schema/src/decorators.ts
@@ -288,16 +288,17 @@ export function setExtension(program: Program, target: Type, key: string, value:
       key,
       value: typespecTypeToJson(value.properties.get("value")!.type, target)[0],
     });
-  } else if (typeof value === "object" && value !== null && isType(value)) {
+  } else if (typeof value === "object" && value !== null && "entityKind" in value && value.entityKind === "Type") {
     // Handle enum members and other TypeSpec types to avoid circular references
-    if (value.kind === "EnumMember") {
-      extensions.push({ key, value: value.value ?? value.name });
-    } else if (value.kind === "String") {
-      extensions.push({ key, value: value.value });
-    } else if (value.kind === "Number") {
-      extensions.push({ key, value: value.value });
-    } else if (value.kind === "Boolean") {
-      extensions.push({ key, value: value.value });
+    const typeValue = value as Type; // Type assertion since we've verified entityKind === "Type"
+    if (typeValue.kind === "EnumMember") {
+      extensions.push({ key, value: (typeValue as any).value ?? (typeValue as any).name });
+    } else if (typeValue.kind === "String") {
+      extensions.push({ key, value: (typeValue as any).value });
+    } else if (typeValue.kind === "Number") {
+      extensions.push({ key, value: (typeValue as any).value });
+    } else if (typeValue.kind === "Boolean") {
+      extensions.push({ key, value: (typeValue as any).value });
     } else {
       // For other TypeSpec types, preserve the original value
       extensions.push({ key, value });

--- a/packages/json-schema/src/decorators.ts
+++ b/packages/json-schema/src/decorators.ts
@@ -6,7 +6,6 @@ import {
   type Namespace,
   type Program,
   type Scalar,
-  serializeValueAsJson,
   setTypeSpecNamespace,
   type Tuple,
   type Type,
@@ -293,11 +292,11 @@ export function setExtension(program: Program, target: Type, key: string, value:
     // Handle enum members and other TypeSpec types to avoid circular references
     if (value.kind === "EnumMember") {
       extensions.push({ key, value: value.value ?? value.name });
-    } else if (value.kind === "StringLiteral") {
+    } else if (value.kind === "String") {
       extensions.push({ key, value: value.value });
-    } else if (value.kind === "NumericLiteral") {
+    } else if (value.kind === "Number") {
       extensions.push({ key, value: value.value });
-    } else if (value.kind === "BooleanLiteral") {
+    } else if (value.kind === "Boolean") {
       extensions.push({ key, value: value.value });
     } else {
       // For other TypeSpec types, preserve the original value

--- a/packages/json-schema/src/decorators.ts
+++ b/packages/json-schema/src/decorators.ts
@@ -6,6 +6,7 @@ import {
   type Namespace,
   type Program,
   type Scalar,
+  serializeValueAsJson,
   setTypeSpecNamespace,
   type Tuple,
   type Type,
@@ -288,6 +289,20 @@ export function setExtension(program: Program, target: Type, key: string, value:
       key,
       value: typespecTypeToJson(value.properties.get("value")!.type, target)[0],
     });
+  } else if (typeof value === "object" && value !== null && isType(value)) {
+    // Handle enum members and other TypeSpec types to avoid circular references
+    if (value.kind === "EnumMember") {
+      extensions.push({ key, value: value.value ?? value.name });
+    } else if (value.kind === "StringLiteral") {
+      extensions.push({ key, value: value.value });
+    } else if (value.kind === "NumericLiteral") {
+      extensions.push({ key, value: value.value });
+    } else if (value.kind === "BooleanLiteral") {
+      extensions.push({ key, value: value.value });
+    } else {
+      // For other TypeSpec types, preserve the original value
+      extensions.push({ key, value });
+    }
   } else {
     extensions.push({ key, value });
   }

--- a/packages/json-schema/test/circular-references.test.ts
+++ b/packages/json-schema/test/circular-references.test.ts
@@ -1,0 +1,49 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { compileWithEnumExtension, expectDiagnosticEmpty } from "./utils.js";
+
+describe("json-schema: circular references", () => {
+  it("can use enum values in @extension decorator without circular reference errors", async () => {
+    const { diagnostics } = await compileWithEnumExtension(`
+      @jsonSchema
+      namespace Test;
+      
+      const MetadataTag = "x-metadata";
+      
+      enum MetadataValue {
+        Foo: "foo",
+        Bar: "bar"
+      }
+      
+      @extension(MetadataTag, MetadataValue.Foo)
+      model Car {
+        kind: string;
+        brand: string;
+        "model": string;
+      }
+    `);
+    
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("can use enum values of different types in @extension decorator", async () => {
+    const { diagnostics } = await compileWithEnumExtension(`
+      @jsonSchema
+      namespace Test;
+      
+      const MetadataTag = "x-metadata";
+      
+      enum NumericMetadata {
+        One: 1,
+        Two: 2
+      }
+      
+      @extension(MetadataTag, NumericMetadata.One)
+      model Truck {
+        brand: string;
+      }
+    `);
+    
+    expectDiagnosticEmpty(diagnostics);
+  });
+});

--- a/packages/json-schema/test/utils.ts
+++ b/packages/json-schema/test/utils.ts
@@ -1,13 +1,10 @@
 import { createAssetEmitter } from "@typespec/asset-emitter";
-import type { Diagnostic, Program } from "@typespec/compiler";
-import { createTestHost, expectDiagnosticEmpty as expectEmpty } from "@typespec/compiler/testing";
+import type { Diagnostic } from "@typespec/compiler";
+import { createTestHost, expectDiagnosticEmpty } from "@typespec/compiler/testing";
 import { parse } from "yaml";
 import { JsonSchemaEmitter } from "../src/json-schema-emitter.js";
 import type { JSONSchemaEmitterOptions } from "../src/lib.js";
 import { JsonSchemaTestLibrary } from "../src/testing/index.js";
-
-// Re-export for use in tests
-export { expectEmpty as expectDiagnosticEmpty };
 
 export async function getHostForTspFile(contents: string, decorators?: Record<string, any>) {
   const host = await createTestHost({
@@ -88,27 +85,4 @@ export async function emitSchema(
   const [schemas, diagnostics] = await emitSchemaWithDiagnostics(code, options, testOptions);
   expectEmpty(diagnostics);
   return schemas;
-}
-
-export async function compileWithEnumExtension(code: string): Promise<{program: Program, diagnostics: readonly Diagnostic[]}> {
-  const host = await createTestHost({
-    libraries: [JsonSchemaTestLibrary],
-  });
-  
-  const fullCode = `
-    import "@typespec/json-schema"; 
-    using JsonSchema; 
-    ${code}
-  `;
-  
-  host.addTypeSpecFile("main.tsp", fullCode);
-  await host.compileAndDiagnose("main.tsp", {
-    noEmit: true,
-  });
-  
-  // At this point diagnostics should be properly populated
-  return { 
-    program: host.program, 
-    diagnostics: host.program.diagnostics
-  };
 }


### PR DESCRIPTION
Fixes issue #6695 where enum values used with @extension decorators caused a circular reference error during JSON serialization. This change handles enum members and other TypeSpec types properly to avoid circular references.