### PR TITLE
Revert "Migrate bundler to esbuild"

### DIFF
--- a/.chronus/changes/migrate-esbuild-bundler-2025-2-26-13-49-41.md
+++ b/.chronus/changes/migrate-esbuild-bundler-2025-2-26-13-49-41.md
@@ -1,6 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/prettier-plugin-typespec"
----
-

--- a/.chronus/changes/migrate-esbuild-bundler-2025-2-26-20-17-50.md
+++ b/.chronus/changes/migrate-esbuild-bundler-2025-2-26-20-17-50.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: feature
-packages:
-  - "@typespec/bundler"
----
-
-Migrate bundler build system to esbuild

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -42,11 +42,17 @@
     "!dist/test/**"
   ],
   "dependencies": {
+    "@rollup/plugin-alias": "~5.1.1",
+    "@rollup/plugin-commonjs": "~28.0.3",
+    "@rollup/plugin-inject": "~5.0.5",
+    "@rollup/plugin-json": "~6.1.0",
+    "@rollup/plugin-multi-entry": "~6.0.1",
+    "@rollup/plugin-node-resolve": "~16.0.1",
+    "@rollup/plugin-virtual": "~3.0.2",
     "@typespec/compiler": "workspace:^",
-    "esbuild": "^0.25.1",
-    "esbuild-plugins-node-modules-polyfill": "^1.7.0",
     "node-stdlib-browser": "~1.3.1",
     "picocolors": "~1.1.1",
+    "rollup": "~4.36.0",
     "yargs": "~17.7.2"
   },
   "devDependencies": {

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -1,8 +1,14 @@
+import alias from "@rollup/plugin-alias";
+import commonjs from "@rollup/plugin-commonjs";
+import inject from "@rollup/plugin-inject";
+import json from "@rollup/plugin-json";
+import nodeResolve from "@rollup/plugin-node-resolve";
+import virtual from "@rollup/plugin-virtual";
 import { compile, joinPaths, NodeHost, normalizePath, resolvePath } from "@typespec/compiler";
-import { BuildOptions, BuildResult, context, Plugin } from "esbuild";
-import { nodeModulesPolyfillPlugin } from "esbuild-plugins-node-modules-polyfill";
 import { mkdir, readFile, realpath, writeFile } from "fs/promises";
+import stdLibBrowser from "node-stdlib-browser";
 import { basename, join, resolve } from "path";
+import { OutputChunk, rollup, RollupBuild, RollupOptions, watch } from "rollup";
 import { relativeTo } from "./utils.js";
 
 export interface BundleManifest {
@@ -59,12 +65,13 @@ interface PackageJson {
 
 export async function createTypeSpecBundle(libraryPath: string): Promise<TypeSpecBundle> {
   const definition = await resolveTypeSpecBundleDefinition(libraryPath);
-  const context = await createEsBuildContext(definition);
+  const rollupOptions = await createRollupConfig(definition);
+  const bundle = await rollup(rollupOptions);
+
   try {
-    const result = await context.rebuild();
-    return resolveTypeSpecBundle(definition, result);
+    return generateTypeSpecBundle(definition, bundle);
   } finally {
-    await context.dispose();
+    await bundle.close();
   }
 }
 
@@ -73,18 +80,32 @@ export async function watchTypeSpecBundle(
   onBundle: (bundle: TypeSpecBundle) => void,
 ) {
   const definition = await resolveTypeSpecBundleDefinition(libraryPath);
-  const context = await createEsBuildContext(definition, [
-    {
-      name: "example",
-      setup(build) {
-        build.onEnd((result) => {
-          const bundle = resolveTypeSpecBundle(definition, result);
-          onBundle(bundle);
-        });
-      },
+  const rollupOptions = await createRollupConfig(definition);
+  const watcher = watch({
+    ...rollupOptions,
+    watch: {
+      skipWrite: true,
     },
-  ]);
-  await context.watch();
+  });
+
+  watcher.on("event", async (event) => {
+    switch (event.code) {
+      case "BUNDLE_START":
+        break;
+      case "BUNDLE_END":
+        try {
+          const typespecBundle = await generateTypeSpecBundle(definition, event.result);
+          onBundle(typespecBundle);
+        } finally {
+          await event.result.close();
+        }
+        break;
+      case "ERROR":
+        // eslint-disable-next-line no-console
+        console.error("Error bundling", event.error);
+        await event.result?.close();
+    }
+  });
 }
 
 export async function bundleTypeSpecLibrary(libraryPath: string, outputDir: string) {
@@ -119,7 +140,7 @@ async function resolveTypeSpecBundleDefinition(
   };
 }
 
-async function createEsBuildContext(definition: TypeSpecBundleDefinition, plugins: Plugin[] = []) {
+async function createRollupConfig(definition: TypeSpecBundleDefinition): Promise<RollupOptions> {
   const libraryPath = definition.path;
   const program = await compile(NodeHost, libraryPath, {
     noEmit: true,
@@ -137,7 +158,6 @@ async function createEsBuildContext(definition: TypeSpecBundleDefinition, plugin
   for (const [filename, sourceFile] of program.sourceFiles) {
     typespecFiles[filename] = sourceFile.file.text;
   }
-
   const content = createBundleEntrypoint({
     libraryPath,
     mainFile: definition.main,
@@ -153,64 +173,64 @@ async function createEsBuildContext(definition: TypeSpecBundleDefinition, plugin
       ];
     }),
   );
-
-  const virtualPlugin: Plugin = {
-    name: "virtual",
-    setup(build) {
-      build.onResolve({ filter: /^virtual:/ }, (args) => {
-        return {
-          path: args.path,
-          namespace: "virtual",
-        };
-      });
-      build.onResolve({ filter: /.*/ }, (args) => {
-        if (
-          definition.packageJson.peerDependencies &&
-          Object.keys(definition.packageJson.peerDependencies).some((x) => args.path.startsWith(x))
-        ) {
-          return { path: args.path, external: true };
-        }
-        return null;
-      });
-
-      build.onLoad({ filter: /^virtual:/, namespace: "virtual" }, async (args) => {
-        return {
-          contents: content,
-          resolveDir: libraryPath,
-        };
-      });
-    },
-  };
-  return await context({
-    write: false,
-    entryPoints: {
-      index: "virtual:entry.js",
+  return {
+    input: {
+      index: "entry.js",
       ...extraEntry,
     },
-    bundle: true,
-    outdir: "out",
-    platform: "browser",
-    format: "esm",
-    target: "es2024",
-    plugins: [virtualPlugin, nodeModulesPolyfillPlugin({}), ...plugins],
-  });
+    output: {
+      esModule: true,
+    },
+    plugins: [
+      (virtual as any)({
+        "entry.js": content,
+      }),
+      (commonjs as any)(),
+      (json as any)(),
+      (alias as any)({
+        entries: stdLibBrowser,
+      }),
+      (nodeResolve as any)({ preferBuiltins: true, browser: true }),
+      (inject as any)({
+        process: stdLibBrowser.process,
+      }),
+    ],
+    external: (id) => {
+      return (
+        definition.packageJson.peerDependencies &&
+        !!Object.keys(definition.packageJson.peerDependencies).find((x) => id.startsWith(x))
+      );
+    },
+    onwarn: (warning, warn) => {
+      if (warning.code === "THIS_IS_UNDEFINED" || warning.code === "CIRCULAR_DEPENDENCY") {
+        return;
+      }
+      warn(warning);
+    },
+  };
 }
 
-function resolveTypeSpecBundle(
+async function generateTypeSpecBundle(
   definition: TypeSpecBundleDefinition,
-  result: BuildResult<BuildOptions>,
-): TypeSpecBundle {
+  bundle: RollupBuild,
+): Promise<TypeSpecBundle> {
+  const { output } = await bundle.generate({
+    dir: "virtual",
+  });
+
   return {
     definition,
     manifest: createManifest(definition),
-    files: result.outputFiles!.map((file) => {
-      const entry = definition.exports[basename(file.path)];
-      return {
-        filename: file.path.split("/out/")[1],
-        content: file.text,
-        export: entry ? getExportEntryPoint(entry) : undefined,
-      };
-    }),
+    files: output
+      .filter((x): x is OutputChunk => "code" in x)
+      .map((chunk) => {
+        const entry = definition.exports[basename(chunk.fileName)];
+        return {
+          filename: chunk.fileName,
+          content: chunk.code,
+          export: entry ? getExportEntryPoint(entry) : undefined,
+        };
+      }),
   };
 }
 

--- a/packages/bundler/src/vite/vite-plugin.ts
+++ b/packages/bundler/src/vite/vite-plugin.ts
@@ -36,6 +36,14 @@ export function typespecBundlePlugin(options: TypeSpecBundlePluginOptions): Plug
       }
     },
     async configureServer(server) {
+      for (const library of options.libraries) {
+        await watchBundleLibrary(config.root, library, (bundle) => {
+          bundles[library] = bundle;
+          definitions[library] = bundle.definition;
+          server.ws.send({ type: "full-reload" });
+        });
+      }
+
       server.middlewares.use((req, res, next) => {
         const id = req.url;
         if (id === undefined) {
@@ -77,14 +85,6 @@ export function typespecBundlePlugin(options: TypeSpecBundlePluginOptions): Plug
         }
         next();
       });
-
-      for (const library of options.libraries) {
-        void watchBundleLibrary(config.root, library, (bundle) => {
-          bundles[library] = bundle;
-          definitions[library] = bundle.definition;
-          server.ws.send({ type: "full-reload" });
-        });
-      }
     },
 
     async generateBundle() {

--- a/packages/prettier-plugin-typespec/rollup.config.mjs
+++ b/packages/prettier-plugin-typespec/rollup.config.mjs
@@ -1,0 +1,36 @@
+// @ts-check
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import resolve from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
+import { defineConfig } from "rollup";
+
+export default defineConfig({
+  input: "src/index.mjs",
+  output: {
+    file: "dist/index.js",
+    format: "commonjs",
+    sourcemap: true,
+    exports: "default",
+  },
+  inlineDynamicImports: true,
+  context: "this",
+  external: ["fs/promises", "prettier"],
+  treeshake: {
+    // Ignore those 2 modules are they aren't used in the code needed for the formatter.
+    // Otherwise rollup think they have side effect and to include a lot of unnecessary code in the bundle.
+    moduleSideEffects: ["ajv"],
+  },
+  plugins: [
+    resolve({ preferBuiltins: true }),
+    commonjs(),
+    json(),
+    replace({
+      values: {
+        "export const typespecVersion = getVersion();": `export const typespecVersion = "";`,
+      },
+      delimiters: ["", ""],
+      preventAssignment: true,
+    }),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,21 +252,39 @@ importers:
 
   packages/bundler:
     dependencies:
+      '@rollup/plugin-alias':
+        specifier: ~5.1.1
+        version: 5.1.1(rollup@4.36.0)
+      '@rollup/plugin-commonjs':
+        specifier: ~28.0.3
+        version: 28.0.3(rollup@4.36.0)
+      '@rollup/plugin-inject':
+        specifier: ~5.0.5
+        version: 5.0.5(rollup@4.36.0)
+      '@rollup/plugin-json':
+        specifier: ~6.1.0
+        version: 6.1.0(rollup@4.36.0)
+      '@rollup/plugin-multi-entry':
+        specifier: ~6.0.1
+        version: 6.0.1(rollup@4.36.0)
+      '@rollup/plugin-node-resolve':
+        specifier: ~16.0.1
+        version: 16.0.1(rollup@4.36.0)
+      '@rollup/plugin-virtual':
+        specifier: ~3.0.2
+        version: 3.0.2(rollup@4.36.0)
       '@typespec/compiler':
         specifier: workspace:^
         version: link:../compiler
-      esbuild:
-        specifier: ^0.25.1
-        version: 0.25.1
-      esbuild-plugins-node-modules-polyfill:
-        specifier: ^1.7.0
-        version: 1.7.0(esbuild@0.25.1)
       node-stdlib-browser:
         specifier: ~1.3.1
         version: 1.3.1
       picocolors:
         specifier: ~1.1.1
         version: 1.1.1
+      rollup:
+        specifier: ~4.36.0
+        version: 4.36.0
       yargs:
         specifier: ~17.7.2
         version: 17.7.2
@@ -4805,9 +4823,6 @@ packages:
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
-  '@jspm/core@2.1.0':
-    resolution: {integrity: sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==}
-
   '@koa/cors@5.0.0':
     resolution: {integrity: sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==}
     engines: {node: '>= 14.0.0'}
@@ -5289,6 +5304,15 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
+  '@rollup/plugin-alias@5.1.1':
+    resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/plugin-babel@6.0.4':
     resolution: {integrity: sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==}
     engines: {node: '>=14.0.0'}
@@ -5329,6 +5353,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-multi-entry@6.0.1':
+    resolution: {integrity: sha512-AXm6toPyTSfbYZWghQGbom1Uh7dHXlrGa+HoiYNhQtDUE3Q7LqoUYdVQx9E1579QWS1uOiu+cZRSE4okO7ySgw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/plugin-node-resolve@16.0.1':
     resolution: {integrity: sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==}
     engines: {node: '>=14.0.0'}
@@ -5349,6 +5382,15 @@ packages:
       rollup:
         optional: true
       tslib:
+        optional: true
+
+  '@rollup/plugin-virtual@3.0.2':
+    resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
         optional: true
 
   '@rollup/pluginutils@5.1.4':
@@ -8092,12 +8134,6 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
-  esbuild-plugins-node-modules-polyfill@1.7.0:
-    resolution: {integrity: sha512-Z81w5ReugIBAgufGeGWee+Uxzgs5Na4LprUAK3XlJEh2ktY3LkNuEGMaZyBXxQxGK8SQDS5yKLW5QKGF5qLjYA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      esbuild: '>=0.14.0 <=0.25.x'
-
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -9636,6 +9672,10 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  matched@5.0.1:
+    resolution: {integrity: sha512-E1fhSTPRyhAlNaNvGXAgZQlq1hL0bgYMTk/6bktVlIhzUnX/SZs7296ACdVeNJE8xFNGSuvd9IpI7vSnmcqLvw==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -11052,10 +11092,6 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  resolve.exports@2.0.3:
-    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
-    engines: {node: '>=10'}
 
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
@@ -16087,8 +16123,6 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@jspm/core@2.1.0': {}
-
   '@koa/cors@5.0.0':
     dependencies:
       vary: 1.1.2
@@ -16801,6 +16835,10 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
+  '@rollup/plugin-alias@5.1.1(rollup@4.36.0)':
+    optionalDependencies:
+      rollup: 4.36.0
+
   '@rollup/plugin-babel@6.0.4(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@4.36.0)':
     dependencies:
       '@babel/core': 7.26.10
@@ -16838,6 +16876,13 @@ snapshots:
     optionalDependencies:
       rollup: 4.36.0
 
+  '@rollup/plugin-multi-entry@6.0.1(rollup@4.36.0)':
+    dependencies:
+      '@rollup/plugin-virtual': 3.0.2(rollup@4.36.0)
+      matched: 5.0.1
+    optionalDependencies:
+      rollup: 4.36.0
+
   '@rollup/plugin-node-resolve@16.0.1(rollup@4.36.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
@@ -16856,6 +16901,10 @@ snapshots:
     optionalDependencies:
       rollup: 4.36.0
       tslib: 2.8.1
+
+  '@rollup/plugin-virtual@3.0.2(rollup@4.36.0)':
+    optionalDependencies:
+      rollup: 4.36.0
 
   '@rollup/pluginutils@5.1.4(rollup@4.36.0)':
     dependencies:
@@ -20416,13 +20465,6 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
 
-  esbuild-plugins-node-modules-polyfill@1.7.0(esbuild@0.25.1):
-    dependencies:
-      '@jspm/core': 2.1.0
-      esbuild: 0.25.1
-      local-pkg: 1.1.1
-      resolve.exports: 2.0.3
-
   esbuild-register@3.6.0(esbuild@0.25.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
@@ -22313,6 +22355,11 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@15.0.7: {}
+
+  matched@5.0.1:
+    dependencies:
+      glob: 7.2.3
+      picomatch: 2.3.1
 
   math-intrinsics@1.1.0: {}
 
@@ -24254,8 +24301,6 @@ snapshots:
       path-is-absolute: 1.0.1
 
   resolve-pkg-maps@1.0.0: {}
-
-  resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
     dependencies:


### PR DESCRIPTION
Reverts microsoft/typespec#6706

Seems to cause issue in the typespec azure playground. 

Reverting to give time to figuring out