### PR TITLE
[http-server-csharp]: Fix overridden exception properties and default status code

### DIFF
--- a/.chronus/changes/fix-error-overrides-2025-2-28-21-53-13.md
+++ b/.chronus/changes/fix-error-overrides-2025-2-28-21-53-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Fix default status code and overridden properties

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -83,6 +83,7 @@ words:
   - Hdvcmxk
   - headasbooleanfalse
   - headasbooleantrue
+  - hresult
   - hscs
   - hsjs
   - HSTS

--- a/packages/http-server-csharp/src/lib/service.ts
+++ b/packages/http-server-csharp/src/lib/service.ts
@@ -312,8 +312,24 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
       if (!isErrorModel(program, model)) return undefined;
       const constructor = this.getExceptionConstructorData(program, model, modelName);
       const isParent = !!model.derivedModels?.length;
-      return `public ${className}(${constructor.properties}) : base(${constructor.statusCode?.value ?? `default`}${constructor.header ? `, \n\t\t headers: new(){${constructor.header}}` : ""}${constructor.value ? `, \n\t\t value: new{${constructor.value}}` : ""}) 
+      return `public ${className}(${constructor.properties}) : base(${constructor.statusCode?.value ?? `400`}${constructor.header ? `, \n\t\t headers: new(){${constructor.header}}` : ""}${constructor.value ? `, \n\t\t value: new{${constructor.value}}` : ""}) 
         { ${constructor.body ? `\n${constructor.body}` : ""}\n\t}${isParent ? `\npublic ${className}(int statusCode, object? value = null, Dictionary<string, string>? headers = default): base(statusCode, value, headers) {}\n` : ""}`;
+    }
+
+    isDuplicateExceptionName(name: string): boolean {
+      const exceptionPropertyNames: string[] = [
+        "value",
+        "headers",
+        "stacktrace",
+        "source",
+        "message",
+        "innerexception",
+        "hresult",
+        "data",
+        "targetsite",
+        "helplink",
+      ];
+      return exceptionPropertyNames.includes(name.toLowerCase());
     }
 
     getExceptionConstructorData(program: Program, model: Model, modelName: string) {
@@ -346,7 +362,7 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
 
       for (const { prop, defaultValue } of sortedProperties) {
         let propertyName = ensureCSharpIdentifier(program, prop, prop.name);
-        if (modelName === propertyName) {
+        if (modelName === propertyName || this.isDuplicateExceptionName(propertyName)) {
           propertyName = `${propertyName}Prop`;
         }
 
@@ -487,7 +503,12 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
       const doc = getDoc(this.emitter.getProgram(), property);
       const attributes = getModelAttributes(this.emitter.getProgram(), property, propertyName);
       const modelName: string | undefined = this.emitter.getContext()["name"];
-      if (modelName === propertyName) {
+      if (
+        modelName === propertyName ||
+        (this.isDuplicateExceptionName(propertyName) &&
+          property.model &&
+          isErrorModel(this.emitter.getProgram(), property.model))
+      ) {
         propertyName = `${propertyName}Prop`;
         attributes.push(
           getEncodedNameAttribute(this.emitter.getProgram(), property, propertyName)!,

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -2078,9 +2078,9 @@ describe("emit correct code for `@error` models", () => {
           "ApiError.cs",
           [
             "public partial class ApiError : HttpServiceException {",
-            "public ApiError(string code, string message) : base(default,",
+            "public ApiError(string code, string message) : base(400,",
             "public string Code { get; set; }",
-            "public string Message { get; set; }",
+            "public string MessageProp { get; set; }",
           ],
         ],
         ["Error.cs", ["public partial class Error : ApiError {", "public Error() : base(500)"]],
@@ -2137,7 +2137,7 @@ describe("emit correct code for `@error` models", () => {
       `,
       "Error.cs",
       [
-        `public Error(string code, string message) : base(default,`,
+        `public Error(string code, string message) : base(400,`,
         `value: new{code = code,message = message}) `,
       ],
     );
@@ -2158,7 +2158,56 @@ describe("emit correct code for `@error` models", () => {
       [
         `public Error(string code, string message) : base(200,`,
         `Code = code;`,
-        `Message = message;`,
+        `MessageProp = message;`,
+      ],
+    );
+  });
+  it("renames body properties that conflict with properties from exception", async () => {
+    await compileAndValidateSingleModel(
+      runner,
+      `
+        @error
+        model Error {
+          @statusCode
+          statusCode: 200;
+          code: string;
+          message: string;
+          value: string;
+          headers: string;
+          stackTrace: string;
+          source: string;
+          innerException: string;
+          hResult: string;
+          data: string;
+          targetSite: string;
+          helpLink: string;
+        }
+      `,
+      "Error.cs",
+      [
+        `public Error(string code, string message, string value, string headers, string stackTrace, string source, string innerException, string hResult, string data, string targetSite, string helpLink) : base(200,`,
+        `Code = code;`,
+        `MessageProp = message;`,
+        `ValueProp = value;`,
+        `HeadersProp = headers;`,
+        `StackTraceProp = stackTrace;`,
+        `SourceProp = source;`,
+        `InnerExceptionProp = innerException;`,
+        `HResultProp = hResult;`,
+        `DataProp = data;`,
+        `TargetSiteProp = targetSite;`,
+        `HelpLinkProp = helpLink;`,
+        `public string Code { get; set; }`,
+        `public string MessageProp { get; set; }`,
+        `public string ValueProp { get; set; }`,
+        `public string HeadersProp { get; set; }`,
+        `public string StackTraceProp { get; set; }`,
+        `public string SourceProp { get; set; }`,
+        `public string InnerExceptionProp { get; set; }`,
+        `public string HResultProp { get; set; }`,
+        `public string DataProp { get; set; }`,
+        `public string TargetSiteProp { get; set; }`,
+        `public string HelpLinkProp { get; set; }`,
       ],
     );
   });


### PR DESCRIPTION
Fixes #6768 

These both impact the spec in the init template:

- Error type uses statusCode '0'
- `Message` field overrides `Message` field from exception, resultingin compiler warning.