### PR TITLE
spec: allow named template args in grammar

### DIFF
--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -527,7 +527,15 @@ IdentifierOrMemberExpression :
     IdentifierOrMemberExpression `.` Identifier
 
 TemplateArguments :
-    `<` ExpressionList `>`
+    `<` TemplateArgumentList `>`
+
+TemplateArgumentList :
+    TemplateArgument
+    TemplateArgumentList `,` TemplateArgument
+
+TemplateArgument :
+    Expression
+    Identifier `=` Expression
 
 ParenthesizedExpression[InParameter] :
     [~InParameter] `(` Expression `)`


### PR DESCRIPTION
I missed this when I added this feature to the compiler. This change will allow other tools that work with this grammar file to recognize these nodes (e.g. tree-sitter impls).