### PR TITLE
[hsjs] Fix spector test compile failure type/array

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-spector-compile-fix-2-2025-3-1-14-36-45.md
+++ b/.chronus/changes/witemple-msft-hsjs-spector-compile-fix-2-2025-3-1-14-36-45.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/http-server-js"
 ---
 
-Correct implementation of JSON body deserialization when the body type is an array requiring interior serialization/deserialization.
+Correct implementation of JSON body deserialization when the body type is an array or record requiring interior serialization/deserialization.

--- a/.chronus/changes/witemple-msft-hsjs-spector-compile-fix-2-2025-3-1-14-36-45.md
+++ b/.chronus/changes/witemple-msft-hsjs-spector-compile-fix-2-2025-3-1-14-36-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Correct implementation of JSON body deserialization when the body type is an array requiring interior serialization/deserialization.

--- a/packages/http-server-js/.testignore
+++ b/packages/http-server-js/.testignore
@@ -10,7 +10,6 @@ payload/multipart
 payload/xml
 response/status-code-range
 streaming/jsonl
-type/array
 type/enum/fixed
 type/property/additional-properties
 type/property/value-types

--- a/packages/http-server-js/src/common/serialization/index.ts
+++ b/packages/http-server-js/src/common/serialization/index.ts
@@ -28,6 +28,14 @@ export function requireSerialization(
     throw new UnimplementedError(`no implementation of JSON serialization for type '${type.kind}'`);
   }
 
+  // Ignore array and record types
+  if (
+    ctx.program.checker.isStdType(type, "Record") ||
+    ctx.program.checker.isStdType(type, "Array")
+  ) {
+    return requireSerialization(ctx, (type as Model).indexer!.value, contentType);
+  }
+
   let serializationsForType = _SERIALIZATIONS_MAP.get(type);
 
   if (!serializationsForType) {


### PR DESCRIPTION
- When serialization is required for an array or record type, pass through the serialization requirement to the underlying type in the indexer.
- When the body type is an array or record, correctly deserialize the body as a literal array or record.