### PR TITLE
[hsjs] Fix spector compile failure special-words

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-spector-compile-fix-3-2025-3-1-15-18-33.md
+++ b/.chronus/changes/witemple-msft-hsjs-spector-compile-fix-3-2025-3-1-15-18-33.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Handle parameter and variable names that could be keywords correctly in more cases, preventing syntax errors.

--- a/packages/http-server-js/.testignore
+++ b/packages/http-server-js/.testignore
@@ -1,4 +1,3 @@
-special-words
 authentication/oauth2
 authentication/union
 encode/bytes

--- a/packages/http-server-js/src/common/interface.ts
+++ b/packages/http-server-js/src/common/interface.ts
@@ -6,6 +6,7 @@ import { JsContext, Module, PathCursor } from "../ctx.js";
 import { parseCase } from "../util/case.js";
 import { getAllProperties } from "../util/extends.js";
 import { bifilter, indent } from "../util/iter.js";
+import { keywordSafe } from "../util/keywords.js";
 import { emitDocumentation } from "./documentation.js";
 import { emitTypeReference, isValueLiteralType } from "./reference.js";
 import { emitUnionType } from "./union.js";
@@ -75,7 +76,7 @@ export function* emitOperation(ctx: JsContext, op: Operation, module: Module): I
     if (param.optional || isValueLiteralType(param.type)) continue;
 
     const paramNameCase = parseCase(param.name);
-    const paramName = paramNameCase.camelCase;
+    const paramName = keywordSafe(paramNameCase.camelCase);
 
     const outputTypeReference = emitTypeReference(ctx, param.type, param, module, {
       altName: opNameCase.pascalCase + paramNameCase.pascalCase,
@@ -129,7 +130,7 @@ export function emitOptionsType(
   ctx.syntheticModule.declarations.push([
     `export interface ${optionsTypeName} {`,
     ...options.flatMap((p) => [
-      `  ${parseCase(p.name).camelCase}?: ${emitTypeReference(ctx, p.type, p, module, {
+      `  ${keywordSafe(parseCase(p.name).camelCase)}?: ${emitTypeReference(ctx, p.type, p, module, {
         altName: optionsTypeName + parseCase(p.name).pascalCase,
       })};`,
     ]),

--- a/packages/http-server-js/src/http/server/index.ts
+++ b/packages/http-server-js/src/http/server/index.ts
@@ -274,6 +274,7 @@ function* emitRawServerOperation(
   for (const param of parameters) {
     let paramBaseExpression;
     const paramNameCase = parseCase(param.name);
+    const paramNameSafe = keywordSafe(paramNameCase.camelCase);
     const isBodyField = bodyFields.has(param.name) && bodyFields.get(param.name) === param.type;
     const isBodyExact = operation.parameters.body?.property === param;
     if (isBodyField) {
@@ -290,9 +291,9 @@ function* emitRawServerOperation(
 
         const encoder = jsScalar.http[httpOperationParam.type];
 
-        paramBaseExpression = encoder.decode(paramNameCase.camelCase);
+        paramBaseExpression = encoder.decode(paramNameSafe);
       } else {
-        paramBaseExpression = paramNameCase.camelCase;
+        paramBaseExpression = paramNameSafe;
       }
     }
 
@@ -304,7 +305,7 @@ function* emitRawServerOperation(
     }
   }
 
-  const paramLines = requiredParams.map((p) => `${p},`);
+  const paramLines = requiredParams.map((p) => `${keywordSafe(p)},`);
 
   if (hasOptions) {
     paramLines.push(
@@ -515,6 +516,7 @@ function* emitHeaderParamBinding(
   parameter: Extract<HttpOperationParameter, { type: "header" }>,
 ): Iterable<string> {
   const nameCase = parseCase(parameter.param.name);
+  const name = keywordSafe(nameCase.camelCase);
   const headerName = parameter.name.toLowerCase();
 
   // See https://nodejs.org/api/http.html#messageheaders
@@ -523,10 +525,10 @@ function* emitHeaderParamBinding(
 
   const assertion = canBeArrayType ? "" : " as string | undefined";
 
-  yield `const ${nameCase.camelCase} = ${names.ctx}.request.headers[${JSON.stringify(headerName)}]${assertion};`;
+  yield `const ${name} = ${names.ctx}.request.headers[${JSON.stringify(headerName)}]${assertion};`;
 
   if (!parameter.param.optional) {
-    yield `if (${nameCase.camelCase} === undefined) {`;
+    yield `if (${name} === undefined) {`;
     // prettier-ignore
     yield `  return ${names.ctx}.errorHandlers.onInvalidRequest(${names.ctx}, ${JSON.stringify(operation.path)}, "missing required header '${headerName}'");`;
     yield "}";
@@ -550,11 +552,13 @@ function* emitQueryParamBinding(
 ): Iterable<string> {
   const nameCase = parseCase(parameter.param.name);
 
+  const name = keywordSafe(nameCase.camelCase);
+
   // UrlSearchParams annoyingly returns null for missing parameters instead of undefined.
-  yield `const ${nameCase.camelCase} = ${names.queryParams}.get(${JSON.stringify(parameter.name)}) ?? undefined;`;
+  yield `const ${name} = ${names.queryParams}.get(${JSON.stringify(parameter.name)}) ?? undefined;`;
 
   if (!parameter.param.optional) {
-    yield `if (!${nameCase.camelCase}) {`;
+    yield `if (!${name}) {`;
     yield `  return ${names.ctx}.errorHandlers.onInvalidRequest(${names.ctx}, ${JSON.stringify(operation.path)}, "missing required query parameter '${parameter.name}'");`;
     yield "}";
     yield "";


### PR DESCRIPTION
This change handles names that could be keywords correctly in more cases and enables compiling the spector test `special-words`.