### PR TITLE
Pull back vscode to 0.68 as vs marketplace doesn't allow prerelease tags

### DIFF
--- a/packages/typespec-vscode/CHANGELOG.md
+++ b/packages/typespec-vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - typespec-vscode
 
-## 1.0.0-rc.0
+## 0.68.0
 
 ### Bump dependencies
 

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typespec-vscode",
-  "version": "1.0.0-rc.0",
+  "version": "0.68.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec language support for VS Code",
   "homepage": "https://typespec.io",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc7bb1ea-bb77-4b64-98f3-abcb70d38f19)
