### PR TITLE
[python] fix license for legacy SDK

### DIFF
--- a/packages/http-client-python/CHANGELOG.md
+++ b/packages/http-client-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @typespec/http-client-python
 
+## 0.9.1
+
+### Bug Fixes
+
+- [6846](https://github.com/microsoft/typespec/pull/6846) fix license header for legacy SDK
+
 ## 0.9.0
 
 ### Features

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -163,6 +163,7 @@ async function onEmitMain(context: EmitContext<PythonEmitterOptions>) {
   }
 
   for (const [key, value] of Object.entries(resolvedOptions)) {
+    if (key === "license") continue; // skip license since it is passed in codeModel
     commandArgs[key] = value;
   }
   if (resolvedOptions["generate-packaging-files"]) {

--- a/packages/http-client-python/emitter/src/external-process.ts
+++ b/packages/http-client-python/emitter/src/external-process.ts
@@ -22,6 +22,7 @@ export async function saveCodeModelAsYaml(name: string, codemodel: unknown): Pro
   const filename = createTempPath(".yaml", name);
   const yamlStr = jsyaml.dump(codemodel);
   await writeFile(filename, yamlStr);
+  await writeFile(joinPaths("C:/dev/typespec/packages/http-client-python", "alpha", "output.yaml"), yamlStr);
   return filename;
 }
 

--- a/packages/http-client-python/generator/pygen/codegen/models/code_model.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/code_model.py
@@ -415,7 +415,7 @@ class CodeModel:  # pylint: disable=too-many-public-methods, disable=too-many-in
             license_header = self.yaml_data.get("licenseInfo", {}).get("header", "")
         else:
             # typespec azure case without custom license and swagger case
-            license_header = self.options.get("header_text", DEFAULT_HEADER_TEXT)
+            license_header = self.options.get("header_text") or DEFAULT_HEADER_TEXT
         if license_header:
             license_header = license_header.replace("\n", "\n# ")
             license_header = (

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://typespec.io",


### PR DESCRIPTION
- For legacy code, we hope to keep license header even if it is not configured in tspconfig.yaml
- Fix crash when configure `license` in tspconfig.yaml