### PR TITLE
[Java] Fixes regression in method parameter transformation

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ParametersTransformationProcessor.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ParametersTransformationProcessor.java
@@ -14,7 +14,6 @@ import com.microsoft.typespec.http.client.generator.core.model.clientmodel.Param
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ParameterTransformation;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ParameterTransformations;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -66,9 +65,8 @@ public final class ParametersTransformationProcessor {
             Transformation.create(transformations, outParameter);
         }
 
-        final List<ParameterTransformation> list = transformations.stream()
-            .map(Transformation::toImmutable)
-            .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+        final List<ParameterTransformation> list
+            = transformations.stream().map(Transformation::toImmutable).collect(Collectors.toList());
         return new ParameterTransformations(list);
     }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ParameterTransformations.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ParameterTransformations.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.typespec.http.client.generator.core.model.clientmodel;
 
+import com.microsoft.typespec.http.client.generator.core.mapper.CollectionUtil;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.examplemodel.MethodParameter;
 import java.util.List;
 import java.util.Objects;
@@ -17,7 +18,7 @@ public final class ParameterTransformations {
     private final List<ParameterTransformation> transformations;
 
     public ParameterTransformations(List<ParameterTransformation> parameterTransformations) {
-        this.transformations = parameterTransformations;
+        this.transformations = CollectionUtil.toImmutableList(parameterTransformations);
     }
 
     /**
@@ -143,5 +144,35 @@ public final class ParameterTransformations {
 
     private static boolean matches(ClientMethodParameter param0, MethodParameter param1) {
         return Objects.equals(param0.getName(), param1.getClientMethodParameter().getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || this.getClass() != o.getClass()) {
+            return false;
+        }
+
+        final int s = this.transformations.size();
+        final ParameterTransformations t = (ParameterTransformations) o;
+        if (s != t.transformations.size()) {
+            return false;
+        }
+        for (int i = 0; i < s; i++) {
+            if (!this.transformations.get(i).equals(t.transformations.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return transformations.stream()
+            .filter(Objects::nonNull)
+            .mapToInt(Objects::hashCode)
+            .reduce(1, (a, b) -> a * 31 + b);
     }
 }


### PR DESCRIPTION
This PR addresses a regression introduced in the [PR](https://github.com/microsoft/typespec/pull/6737).

In 6737, a `List<MethodTransformationDetails>` representing mappings were replaced with a new type `ParameterTransformations` that composes an `immutable` list of mapping. 

The original list was the JDK `ArrayList<>` that internally implements `equals()` and `hashcode()` (e.g., those equality impl ensures different list with zero elements as equal).

The new type `ParameterTransformations` introduced inherits the `equals()` and `hashcode()` from `Object`, so two distinct references are always different. Additionally, the composed `immutable` list is JDK `ImmutableList`, unlike `ArrayList`, it doesn’t not implement `equals()` and `hashcode()` but inherits Object's.

The `ClientMethod` composes `ParameterTransformations ` (earlier `List< MethodTransformationDetails >`) property. 

The generator needs to find distinct list of `ClientMethods`, and the proper comparison requires all composed properties type to support equality checks. So, with changes 6737, there were duplicate `ClientMethod`, resulting in emitted Java class to have same function appears twice.

Fixes: https://github.com/Azure/autorest.java/issues/3061

Autorest [PR](https://github.com/Azure/autorest.java/pull/3063)