### PR TITLE
Use vscode stable for web tests

### DIFF
--- a/.chronus/changes/fix-vscode-web-test-stable-2025-3-7-9-16-10.md
+++ b/.chronus/changes/fix-vscode-web-test-stable-2025-3-7-9-16-10.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - typespec-vscode
+---
+

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -254,7 +254,7 @@
     "deploy": "vsce publish",
     "open-in-browser": "vscode-test-web --extensionDevelopmentPath=. .",
     "test:e2e": "pnpm test:web",
-    "test:web": "vscode-test-web --extensionDevelopmentPath=. --headless --extensionTestsPath=dist/test/web/suite.js ./test/web/data"
+    "test:web": "vscode-test-web --quality stable --extensionDevelopmentPath=. --headless --extensionTestsPath=dist/test/web/suite.js ./test/web/data"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~28.0.3",


### PR DESCRIPTION
Insiders seems to be failing with a confusing error 
```
Error: ESM modules are not supported in the web worker extension host
        at CU.zb (http://localhost:3000/static/build/out/vs/workbench/api/worker/extensionHostWorkerMain.js:168:769)
        at CU.sb (http://localhost:3000/static/build/out/vs/workbench/api/worker/extensionHostWorkerMain.js:121:17438)
        at async CU.$extensionTestsExecute (http://localhost:3000/static/build/out/vs/workbench/api/worker/extensionHostWorkerMain.js:121:17158)
Error running tests: Error: Test failed
    at /Users/timotheeguerin/dev/azsdk/typespec/node_modules/.pnpm/@vscode+test-web@0.0.67/node_modules/@vscode/test-web/out/server/index.js:60:23
    at async BindingCall.call (/Users/timotheeguerin/dev/azsdk/typespec/node_modules/.pnpm/playwright-core@1.51.1/node_modules/playwright-core/lib/client/page.js:740:130)
    at async Page._onBinding (/Users/timotheeguerin/dev/azsdk/typespec/node_modules/.pnpm/playwright-core@1.51.1/node_modules/playwright-core/lib/client/page.js:182:7)
```

depsite the build here already being commonjs