### PR TITLE
Realm handle multiple instances

### DIFF
--- a/.chronus/changes/realm-handle-multiple-instances-2025-3-7-16-44-1.md
+++ b/.chronus/changes/realm-handle-multiple-instances-2025-3-7-16-44-1.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Realm handle multiple instance of compiler loaded at once

--- a/packages/compiler/src/experimental/realm.ts
+++ b/packages/compiler/src/experimental/realm.ts
@@ -3,6 +3,8 @@ import { Program } from "../core/program.js";
 import { Type } from "../core/types.js";
 import { createTypekit, Typekit } from "./typekit/index.js";
 
+(globalThis as any).realmForType ??= new WeakMap<Type, Realm>();
+
 /**
  * A Realm's view of a Program's state map for a given state key.
  *
@@ -234,5 +236,5 @@ export class Realm {
     return this.#types;
   }
 
-  static realmForType = new WeakMap<Type, Realm>();
+  static realmForType = (globalThis as any).realmForType;
 }

--- a/packages/compiler/src/experimental/realm.ts
+++ b/packages/compiler/src/experimental/realm.ts
@@ -3,8 +3,6 @@ import { Program } from "../core/program.js";
 import { Type } from "../core/types.js";
 import { createTypekit, Typekit } from "./typekit/index.js";
 
-(globalThis as any).realmForType ??= new WeakMap<Type, Realm>();
-
 /**
  * A Realm's view of a Program's state map for a given state key.
  *
@@ -236,5 +234,20 @@ export class Realm {
     return this.#types;
   }
 
-  static realmForType = (globalThis as any).realmForType;
+  static realmForType = singleton("Realm.realmForType", () => new WeakMap<Type, Realm>());
+}
+
+/**
+ * Create a singleton instance that is shared across the process.
+ * This is to have a true singleton even if multiple instance of the compiler/library are loaded.
+ * @param key - The key to use for the singleton.
+ * @param init - The function to call to create the singleton.
+ */
+function singleton<T>(key: string, init: () => T): T {
+  const sym = Symbol.for(key);
+  if (!(globalThis as any)[sym]) {
+    (globalThis as any)[sym] = init();
+  }
+
+  return (globalThis as any)[sym];
 }


### PR DESCRIPTION
fix [#6625](https://github.com/microsoft/typespec/issues/6625)

Problem is that Realm assume its a singleton but if you load different instance of a library it loads multiple singleton and fails


We could maybe expose a `singleton` helper that would help deal with that automatically.