### PR TITLE
[hsjs] Fix some more spector test compile errors

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-spector-fix-4-2025-3-7-14-3-32.md
+++ b/.chronus/changes/witemple-msft-hsjs-spector-fix-4-2025-3-7-14-3-32.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-server-js"
+---
+
+Added typereferences for Tuples and EnumMember types.

--- a/.chronus/changes/witemple-msft-hsjs-spector-fix-4-2025-3-7-14-4-14.md
+++ b/.chronus/changes/witemple-msft-hsjs-spector-fix-4-2025-3-7-14-4-14.md
@@ -1,0 +1,9 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Corrected router parameter generation so that it avoids using JavaScript reserved keywords for route controller parameters.
+
+Corrected models that extend `Record` so that they refer to TypeScript's `Record` type by name instead of using a literal interface with an indexer.

--- a/packages/http-server-js/.testignore
+++ b/packages/http-server-js/.testignore
@@ -1,5 +1,3 @@
-authentication/oauth2
-authentication/union
 encode/bytes
 encode/datetime
 encode/duration
@@ -10,4 +8,3 @@ payload/xml
 response/status-code-range
 streaming/jsonl
 type/enum/fixed
-type/model/inheritance/enum-discriminator

--- a/packages/http-server-js/.testignore
+++ b/packages/http-server-js/.testignore
@@ -10,5 +10,4 @@ payload/xml
 response/status-code-range
 streaming/jsonl
 type/enum/fixed
-type/property/value-types
 type/model/inheritance/enum-discriminator

--- a/packages/http-server-js/.testignore
+++ b/packages/http-server-js/.testignore
@@ -10,6 +10,5 @@ payload/xml
 response/status-code-range
 streaming/jsonl
 type/enum/fixed
-type/property/additional-properties
 type/property/value-types
 type/model/inheritance/enum-discriminator

--- a/packages/http-server-js/src/common/model.ts
+++ b/packages/http-server-js/src/common/model.ts
@@ -131,9 +131,9 @@ export function emitWellKnownModel(
   switch (type.name) {
     case "Record": {
       const arg = type.indexer!.value;
-      return `{ [k: string]: ${emitTypeReference(ctx, arg, type, module, {
+      return `Record<string, ${emitTypeReference(ctx, arg, type, module, {
         altName: preferredAlternativeName && getRecordValueName(preferredAlternativeName),
-      })} }`;
+      })}>`;
     }
     case "Array": {
       const arg = type.indexer!.value;

--- a/packages/http-server-js/src/common/reference.ts
+++ b/packages/http-server-js/src/common/reference.ts
@@ -231,6 +231,18 @@ export function emitTypeReference(
     case "Number":
     case "Boolean":
       return String(type.value);
+    case "EnumMember": {
+      if (typeof type.value === "string") {
+        return escapeUnsafeChars(JSON.stringify(type.value));
+      } else if (typeof type.value === "number") {
+        return String(type.value);
+      } else if (type.value === undefined) {
+        return escapeUnsafeChars(JSON.stringify(type.name));
+      } else {
+        void (type.value satisfies never);
+        return "unknown";
+      }
+    }
     case "Intrinsic":
       switch (type.name) {
         case "never":
@@ -275,6 +287,11 @@ export function emitTypeReference(
       });
 
       return typeName;
+    }
+    case "Tuple": {
+      const elementTypes = type.values.map((e) => emitTypeReference(ctx, e, position, module));
+
+      return `[${elementTypes.join(", ")}]`;
     }
     case "ModelProperty":
     case "UnionVariant": {

--- a/packages/http-server-js/src/common/reference.ts
+++ b/packages/http-server-js/src/common/reference.ts
@@ -276,7 +276,8 @@ export function emitTypeReference(
 
       return typeName;
     }
-    case "ModelProperty": {
+    case "ModelProperty":
+    case "UnionVariant": {
       // Forward to underlying type.
       return emitTypeReference(ctx, type.type, position, module, options);
     }

--- a/packages/http-server-js/src/http/server/router.ts
+++ b/packages/http-server-js/src/http/server/router.ts
@@ -134,12 +134,12 @@ function* emitRouterDefinition(
   yield `export function create${routerName}(`;
 
   for (const [param] of backends.values()) {
-    yield `  ${param.camelCase}: ${param.pascalCase},`;
+    yield `  ${keywordSafe(param.camelCase)}: ${param.pascalCase},`;
   }
 
   yield `  options: RouterOptions<{`;
   for (const [param] of backends.values()) {
-    yield `    ${param.camelCase}: ${param.pascalCase}<HttpContext>,`;
+    yield `    ${keywordSafe(param.camelCase)}: ${param.pascalCase}<HttpContext>,`;
   }
   yield `  }> = {}`;
   yield `): ${routerName} {`;
@@ -328,7 +328,7 @@ function* emitRouteOperationDispatch(
         backend.snakeCase + "_" + parseCase(operation.operation.name).snakeCase,
       );
 
-      const backendMemberName = backend.camelCase;
+      const backendMemberName = keywordSafe(backend.camelCase);
 
       const parameters =
         operation.parameters.length > 0
@@ -408,7 +408,7 @@ function* emitRouteOperationDispatchMultiple(
       backend.snakeCase + "_" + parseCase(operation.operation.name).snakeCase,
     );
 
-    const backendMemberName = backend.camelCase;
+    const backendMemberName = keywordSafe(backend.camelCase);
 
     const parameters =
       operation.parameters.length > 0


### PR DESCRIPTION
This PR addresses compile failures in the following spector tests:

- authentication/oauth2
- authentication/union
- type/property/additional-properties
- type/property/value-types
- type/model/inheritance/enum-discriminator

The following fixes unblock these tests:

- Support emitting type references for tuples (as TypeScript array-tuples), union variants (as passthrough), and enum members (as string/number literals).
- Use Record instead of interface literals with indexers for Record instance references
- Ensure that router construction is keyword-safe when it creates parameter names.