### PR TITLE
Fix union instance in json schema and openapi3 emitters

### DIFF
--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -268,6 +268,14 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
     return values;
   }
 
+  unionInstantiation(union: Union, name: string): EmitterOutput<Record<string, any>> {
+    if (!name) {
+      return this.unionLiteral(union);
+    }
+
+    return this.unionDeclaration(union, name);
+  }
+
   unionDeclaration(union: Union, name: string): EmitterOutput<object> {
     const key = isOneOf(this.emitter.getProgram(), union) ? "oneOf" : "anyOf";
 

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -286,6 +286,14 @@ export class OpenAPI3SchemaEmitterBase<
     return this.modelDeclaration(model, name);
   }
 
+  unionInstantiation(union: Union, name: string): EmitterOutput<Record<string, any>> {
+    if (!name) {
+      return this.unionLiteral(union);
+    }
+
+    return this.unionDeclaration(union, name);
+  }
+
   arrayDeclaration(array: Model, name: string, elementType: Type): EmitterOutput<object> {
     const schema = new ObjectBuilder({
       type: "array",


### PR DESCRIPTION
fix #6868 (Compiler crash when using union instance in union)
fix #6869  (Union instance generated incorrectly when in response)