### PR TITLE
[hsjs] Unblock spector test type/enum/fixed

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-spector-fix-5-2025-3-8-11-25-35.md
+++ b/.chronus/changes/witemple-msft-hsjs-spector-fix-5-2025-3-8-11-25-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-server-js"
+---
+
+Added support for Enums in request/response serialization.

--- a/packages/http-server-js/.testignore
+++ b/packages/http-server-js/.testignore
@@ -7,4 +7,3 @@ payload/multipart
 payload/xml
 response/status-code-range
 streaming/jsonl
-type/enum/fixed

--- a/packages/http-server-js/src/common/enum.ts
+++ b/packages/http-server-js/src/common/enum.ts
@@ -21,7 +21,8 @@ export function* emitEnum(ctx: JsContext, enum_: Enum): Iterable<string> {
 
   for (const member of enum_.members.values()) {
     const nameCase = parseCase(member.name);
-    yield `  ${nameCase.pascalCase} = ${JSON.stringify(member.value)},`;
+    const value = member.value ?? member.name;
+    yield `  ${nameCase.pascalCase} = ${JSON.stringify(value)},`;
   }
 
   yield `}`;

--- a/packages/http-server-js/src/common/serialization/index.ts
+++ b/packages/http-server-js/src/common/serialization/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // Licensed under the MIT license.
 
-import { Model, NoTarget, Scalar, Type, Union } from "@typespec/compiler";
+import { Enum, Model, NoTarget, Scalar, Type, Union } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/experimental/typekit";
 import { JsContext, Module, completePendingDeclarations } from "../../ctx.js";
 import { UnimplementedError } from "../../util/error.js";
@@ -10,10 +10,16 @@ import { createOrGetModuleForNamespace } from "../namespace.js";
 import { emitTypeReference } from "../reference.js";
 import { emitJsonSerialization, requiresJsonSerialization } from "./json.js";
 
-export type SerializableType = Model | Scalar | Union;
+export type SerializableType = Model | Scalar | Union | Enum;
 
 export function isSerializableType(t: Type): t is SerializableType {
-  return t.kind === "Model" || t.kind === "Scalar" || t.kind === "Union" || t.kind === "Intrinsic";
+  return (
+    t.kind === "Model" ||
+    t.kind === "Scalar" ||
+    t.kind === "Union" ||
+    t.kind === "Intrinsic" ||
+    t.kind === "Enum"
+  );
 }
 
 export type SerializationContentType = "application/json";


### PR DESCRIPTION
This PR adds Enums to the serialization table in HSJS. We treat them as _never_ requiring custom serialization, but adding them to the table fixes a logical error that caused the emitter to crash whenever it would attempt to (de)serialize an enum value.