### PR TITLE
Improve errors when loading invalid libraries

### DIFF
--- a/.chronus/changes/invalid-library-error-improvments-2025-3-8-16-8-16.md
+++ b/.chronus/changes/invalid-library-error-improvments-2025-3-8-16-8-16.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Improve errors when loading libraries with invalid exports/main fields

--- a/packages/compiler/src/core/source-loader.ts
+++ b/packages/compiler/src/core/source-loader.ts
@@ -383,8 +383,11 @@ export async function loadJsFile(
 export function moduleResolutionErrorToDiagnostic(
   e: ResolveModuleError,
   specifier: string,
-  target: DiagnosticTarget | typeof NoTarget,
+  sourceTarget: DiagnosticTarget | typeof NoTarget,
 ): Diagnostic {
+  const target: DiagnosticTarget | typeof NoTarget = e.pkgJson
+    ? { file: createSourceFile(e.pkgJson.file.text, e.pkgJson.file.path), pos: 0, end: 0 }
+    : sourceTarget;
   switch (e.code) {
     case "MODULE_NOT_FOUND":
       return createDiagnostic({ code: "import-not-found", format: { path: specifier }, target });

--- a/packages/compiler/src/module-resolver/module-resolver.ts
+++ b/packages/compiler/src/module-resolver/module-resolver.ts
@@ -302,7 +302,6 @@ export async function resolveModule(
         subPath === "" ? "." : `./${subPath}`,
         pkg.exports,
       );
-      console.log("Resolved", match);
     } catch (error) {
       if (error instanceof NoMatchingConditionsError) {
         // For back compat we allow to fallback to main field for the `.` entry.

--- a/packages/compiler/src/module-resolver/module-resolver.ts
+++ b/packages/compiler/src/module-resolver/module-resolver.ts
@@ -66,6 +66,7 @@ export class ResolveModuleError extends Error {
   public constructor(
     public code: ResolveModuleErrorCode,
     message: string,
+    public pkgJson?: PackageJsonFile,
   ) {
     super(message);
   }
@@ -224,7 +225,7 @@ export async function resolveModule(
   }
 
   async function resolveNodePackageImports(
-    pkg: PackageJson,
+    pkg: PackageJsonFile,
     pkgDir: string,
   ): Promise<ResolvedModule | undefined> {
     if (!pkg.imports) return undefined;
@@ -247,15 +248,15 @@ export async function resolveModule(
       );
     } catch (error) {
       if (error instanceof InvalidPackageTargetError) {
-        throw new ResolveModuleError("INVALID_MODULE_IMPORT_TARGET", error.message);
+        throw new ResolveModuleError("INVALID_MODULE_IMPORT_TARGET", error.message, pkg);
       } else if (error instanceof EsmResolveError) {
-        throw new ResolveModuleError("INVALID_MODULE", error.message);
+        throw new ResolveModuleError("INVALID_MODULE", error.message, pkg);
       } else {
         throw error;
       }
     }
     if (!match) return undefined;
-    const resolved = await resolveEsmMatch(match, true);
+    const resolved = await resolveEsmMatch(match, true, pkg);
     return {
       type: "module",
       mainFile: resolved,
@@ -271,7 +272,7 @@ export async function resolveModule(
    */
   async function resolveNodePackageExports(
     subPath: string,
-    pkg: PackageJson,
+    pkg: PackageJsonFile,
     pkgDir: string,
   ): Promise<ResolvedModule | undefined> {
     if (!pkg.exports) return undefined;
@@ -286,7 +287,7 @@ export async function resolveModule(
           conditions: options.conditions ?? [],
           ignoreDefaultCondition: options.fallbackOnMissingCondition,
           resolveId: (id: string, baseDir: string) => {
-            throw new ResolveModuleError("INVALID_MODULE", "Not supported");
+            throw new ResolveModuleError("INVALID_MODULE", "Not supported", pkg);
           },
         },
         subPath === "" ? "." : `./${subPath}`,
@@ -298,18 +299,18 @@ export async function resolveModule(
         if (subPath === "") {
           return;
         } else {
-          throw new ResolveModuleError("INVALID_MODULE", error.message);
+          throw new ResolveModuleError("INVALID_MODULE", error.message, pkg);
         }
       } else if (error instanceof InvalidPackageTargetError) {
-        throw new ResolveModuleError("INVALID_MODULE_EXPORT_TARGET", error.message);
+        throw new ResolveModuleError("INVALID_MODULE_EXPORT_TARGET", error.message, pkg);
       } else if (error instanceof EsmResolveError) {
-        throw new ResolveModuleError("INVALID_MODULE", error.message);
+        throw new ResolveModuleError("INVALID_MODULE", error.message, pkg);
       } else {
         throw error;
       }
     }
     if (!match) return undefined;
-    const resolved = await resolveEsmMatch(match, false);
+    const resolved = await resolveEsmMatch(match, false, pkg);
     return {
       type: "module",
       mainFile: resolved,
@@ -318,7 +319,7 @@ export async function resolveModule(
     };
   }
 
-  async function resolveEsmMatch(match: string, isImports: boolean) {
+  async function resolveEsmMatch(match: string, isImports: boolean, pkg: PackageJsonFile) {
     const resolved = await realpath(fileURLToPath(match));
     if (await isFile(host, resolved)) {
       return resolved;
@@ -326,6 +327,7 @@ export async function resolveModule(
     throw new ResolveModuleError(
       isImports ? "INVALID_MODULE_IMPORT_TARGET" : "INVALID_MODULE_EXPORT_TARGET",
       `Import "${specifier}" resolving to "${resolved}" is not a file.`,
+      pkg,
     );
   }
 
@@ -344,7 +346,7 @@ export async function resolveModule(
     return undefined;
   }
 
-  async function loadPackage(directory: string, pkg: PackageJson, subPath?: string) {
+  async function loadPackage(directory: string, pkg: PackageJsonFile, subPath?: string) {
     const e = await resolveNodePackageExports(subPath ?? "", pkg, directory);
     if (e) return e;
 
@@ -356,11 +358,22 @@ export async function resolveModule(
 
   async function loadPackageLegacy(
     directory: string,
-    pkg: PackageJson,
+    pkg: PackageJsonFile,
   ): Promise<ResolvedModule | undefined> {
     const mainFile = options.resolveMain ? options.resolveMain(pkg) : pkg.main;
+    if (mainFile === undefined || mainFile === null) {
+      throw new ResolveModuleError(
+        "INVALID_MODULE",
+        `Package ${pkg.name} is missing a main file or exports field.`,
+        pkg,
+      );
+    }
     if (typeof mainFile !== "string") {
-      throw new TypeError(`package "${pkg.name}" main must be a string but was '${mainFile}'`);
+      throw new ResolveModuleError(
+        "INVALID_MAIN",
+        `Package ${pkg.name} main file "${mainFile}" must be a string.`,
+        pkg,
+      );
     }
 
     const mainFullPath = resolvePath(directory, mainFile);
@@ -368,8 +381,10 @@ export async function resolveModule(
     try {
       loaded = (await loadAsFile(mainFullPath)) ?? (await loadAsDirectory(mainFullPath));
     } catch (e) {
-      throw new Error(
-        `Cannot find module '${mainFullPath}'. Please verify that the package.json has a valid "main" entry`,
+      throw new ResolveModuleError(
+        "INVALID_MAIN",
+        `Package ${pkg.name} main file "${mainFile}" is not pointing to a valid file or directory.`,
+        pkg,
       );
     }
 
@@ -387,6 +402,7 @@ export async function resolveModule(
       throw new ResolveModuleError(
         "INVALID_MAIN",
         `Package ${pkg.name} main file "${mainFile}" is not pointing to a valid file or directory.`,
+        pkg,
       );
     }
   }
@@ -411,9 +427,22 @@ export async function resolveModule(
   }
 }
 
-async function readPackage(host: ResolveModuleHost, pkgfile: string): Promise<PackageJson> {
+interface PackageJsonFile extends PackageJson {
+  readonly file: {
+    readonly path: string;
+    readonly text: string;
+  };
+}
+
+async function readPackage(host: ResolveModuleHost, pkgfile: string): Promise<PackageJsonFile> {
   const content = await host.readFile(pkgfile);
-  return JSON.parse(content);
+  return {
+    ...JSON.parse(content),
+    file: {
+      path: pkgfile,
+      text: content,
+    },
+  };
 }
 
 async function isDirectory(host: ResolveModuleHost, path: string) {

--- a/packages/compiler/test/module-resolver/module-resolver.test.ts
+++ b/packages/compiler/test/module-resolver/module-resolver.test.ts
@@ -230,6 +230,7 @@ describe("packages", () => {
           new ResolveModuleError(
             "INVALID_MODULE_EXPORT_TARGET",
             `Import "test-lib" resolving to "/ws/proj/node_modules/test-lib/missing.js" is not a file.`,
+            expect.anything(),
           ),
         );
       });
@@ -244,6 +245,7 @@ describe("packages", () => {
           new ResolveModuleError(
             "INVALID_MODULE_EXPORT_TARGET",
             `Could not resolve import "test-lib"  using exports defined in file:///ws/proj/node_modules/test-lib. Invalid mapping: "index.js".`,
+            expect.anything(),
           ),
         );
       });
@@ -261,6 +263,7 @@ describe("packages", () => {
           new ResolveModuleError(
             "INVALID_MODULE",
             `Could not resolve import "test-lib/named"  using exports defined in file:///ws/proj/node_modules/test-lib.`,
+            expect.anything(),
           ),
         );
       });
@@ -366,6 +369,7 @@ describe("packages", () => {
               new ResolveModuleError(
                 "INVALID_MODULE",
                 `Could not resolve import "test-lib/named"  using exports defined in file:///ws/proj/node_modules/test-lib.`,
+                expect.anything(),
               ),
             );
           });
@@ -537,6 +541,7 @@ describe("resolve self", () => {
           new ResolveModuleError(
             "INVALID_MODULE_IMPORT_TARGET",
             `Import "#utils" resolving to "/ws/proj/missing.js" is not a file.`,
+            expect.anything(),
           ),
         );
       });
@@ -552,6 +557,7 @@ describe("resolve self", () => {
           new ResolveModuleError(
             "INVALID_MODULE",
             `Could not resolve import "#utils"  using imports defined in file:///ws/proj.`,
+            expect.anything(),
           ),
         );
       });
@@ -564,6 +570,7 @@ describe("resolve self", () => {
           new ResolveModuleError(
             "INVALID_MODULE",
             `Could not resolve import "#utils"  using imports defined in file:///ws/proj.`,
+            expect.anything(),
           ),
         );
       });
@@ -592,6 +599,7 @@ describe("resolve self", () => {
               new ResolveModuleError(
                 "INVALID_MODULE",
                 `Could not resolve import "#utils"  using imports defined in file:///ws/proj.`,
+                expect.anything(),
               ),
             );
           });


### PR DESCRIPTION


## Target the package.json of the invalid library
Making it easier to find where the issue is
<img width="992" alt="image" src="https://github.com/user-attachments/assets/e04c2ed4-cb6e-4a2c-b624-6d2a3c5afda8" />

Previously we  either were tagging nobody if importing an emitter or the `import` statement.

## Library with missing `main` and `exports` now report this error 
<img width="990" alt="image" src="https://github.com/user-attachments/assets/d863c8b0-68a0-419b-9b16-40bf77a05434" />

## Library export point to missing file 
fix #2191: Export/main points to invalid file 
<img width="978" alt="image" src="https://github.com/user-attachments/assets/2bb9da3e-8dca-4378-a0c6-267f7006cbfe" />

