### PR TITLE
[hsjs] Support scalar content-types and extended shared route differentiation.

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-scalar-media-types-2025-3-8-12-39-23.md
+++ b/.chronus/changes/witemple-msft-hsjs-scalar-media-types-2025-3-8-12-39-23.md
@@ -1,0 +1,11 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-server-js"
+---
+
+Enabled 'text/plain' serialization for scalars that extend `TypeSpec.string`.
+
+Enabled fallback logic for all unrecognized content-types with a body type that is or extends `TypeSpec.bytes`.
+
+Enhanced route differentiation logic for shared routes, allowing them to differentiate routes in more cases using headers other than `content-type`.

--- a/packages/http-server-js/.testignore
+++ b/packages/http-server-js/.testignore
@@ -1,8 +1,5 @@
-encode/bytes
 encode/datetime
 encode/duration
-payload/content-negotiation
-payload/media-type
 payload/multipart
 payload/xml
 response/status-code-range

--- a/packages/http-server-js/src/http/server/index.ts
+++ b/packages/http-server-js/src/http/server/index.ts
@@ -41,6 +41,7 @@ import { module as headerHelpers } from "../../../generated-defs/helpers/header.
 import { module as httpHelpers } from "../../../generated-defs/helpers/http.js";
 import { getJsScalar } from "../../common/scalar.js";
 import { requiresJsonSerialization } from "../../common/serialization/json.js";
+import { getFullyQualifiedTypeName } from "../../util/name.js";
 
 const DEFAULT_CONTENT_TYPE = "application/json";
 
@@ -296,7 +297,7 @@ function* emitRawServerOperation(
 
         break;
       }
-      case "multipart/form-data":
+      case "multipart/form-data": {
         if (body.bodyKind === "multipart") {
           yield* indent(
             emitMultipart(ctx, module, operation, body, names.ctx, bodyName, bodyTypeName),
@@ -305,7 +306,88 @@ function* emitRawServerOperation(
           yield* indent(emitMultipartLegacy(names.ctx, bodyName, bodyTypeName));
         }
         break;
+      }
+      case "text/plain": {
+        const string = ctx.program.checker.getStdType("string");
+        const [assignable] = ctx.program.checker.isTypeAssignableTo(
+          body.type,
+          string,
+          body.property ?? body.type,
+        );
+        if (!assignable) {
+          const name =
+            ("namespace" in body.type &&
+              body.type.namespace &&
+              getFullyQualifiedTypeName(body.type)) ||
+            ("name" in body.type && typeof body.type.name === "string" && body.type.name) ||
+            "<unknown>";
+          reportDiagnostic(ctx.program, {
+            code: "unrecognized-media-type",
+            target: body.property ?? body.type,
+            format: {
+              mediaType: contentType,
+              type: name,
+            },
+          });
+        }
+
+        yield `  const ${bodyName} = await new Promise(function parse${bodyNameCase.pascalCase}(resolve, reject) {`;
+        yield `    const chunks: Array<Buffer> = [];`;
+        yield `    ${names.ctx}.request.on("data", function appendChunk(chunk) { chunks.push(chunk); });`;
+        yield `    ${names.ctx}.request.on("end", function finalize() {`;
+        yield `      try {`;
+        yield `        const body = Buffer.concat(chunks).toString();`;
+        yield `        resolve(body);`;
+        yield `      } catch (e) {`;
+        yield `        ${names.ctx}.errorHandlers.onInvalidRequest(`;
+        yield `          ${names.ctx},`;
+        yield `          ${JSON.stringify(operation.path)},`;
+        yield `          "invalid text in request body",`;
+        yield `        );`;
+        yield `        reject(e);`;
+        yield `      }`;
+        yield `    });`;
+        yield `    ${names.ctx}.request.on("error", reject);`;
+        yield `  }) as string;`;
+        yield "";
+        break;
+      }
+      case "application/octet-stream":
       default:
+        {
+          if (!ctx.program.checker.isStdType(body.type, "bytes")) {
+            const name =
+              ("namespace" in body.type &&
+                body.type.namespace &&
+                getFullyQualifiedTypeName(body.type)) ||
+              ("name" in body.type && typeof body.type.name === "string" && body.type.name) ||
+              "<unknown>";
+
+            reportDiagnostic(ctx.program, {
+              code: "unrecognized-media-type",
+              target: body.property ?? body.type,
+              format: {
+                mediaType: contentType,
+                type: name,
+              },
+            });
+          }
+          yield `  const ${bodyName} = await new Promise(function parse${bodyNameCase.pascalCase}(resolve, reject) {`;
+          yield `    const chunks: Array<Buffer> = [];`;
+          yield `    ${names.ctx}.request.on("data", function appendChunk(chunk) { chunks.push(chunk); });`;
+          yield `    ${names.ctx}.request.on("end", function finalize() {`;
+          yield `      try {`;
+          yield `        const body = Buffer.concat(chunks);`;
+          yield `        resolve(body);`;
+          yield `      } catch (e) {`;
+          yield `        reject(e);`;
+          yield `      }`;
+          yield `    });`;
+          yield `    ${names.ctx}.request.on("error", reject);`;
+          yield `  }) as Buffer;`;
+          yield "";
+          break;
+        }
         throw new UnimplementedError(`request deserialization for content-type: '${contentType}'`);
     }
 

--- a/packages/http-server-js/src/http/server/router.ts
+++ b/packages/http-server-js/src/http/server/router.ts
@@ -7,7 +7,8 @@ import {
   HttpService,
   HttpVerb,
   OperationContainer,
-  getHttpOperation,
+  getHeaderFieldName,
+  isHeader,
 } from "@typespec/http";
 import {
   createOrGetModuleForNamespace,
@@ -22,9 +23,7 @@ import { HttpContext } from "../index.js";
 
 import { module as headerHelpers } from "../../../generated-defs/helpers/header.js";
 import { module as routerHelper } from "../../../generated-defs/helpers/router.js";
-import { parseHeaderValueParameters } from "../../helpers/header.js";
-import { reportDiagnostic } from "../../lib.js";
-import { UnimplementedError } from "../../util/error.js";
+import { differentiateModelTypes, writeCodeTree } from "../../util/differentiate.js";
 
 /**
  * Emit a router for the HTTP operations defined in a given service.
@@ -261,7 +260,9 @@ function* emitRouteHandler(
 
   yield `if (path.length === 0) {`;
   if (routeTree.operations.size > 0) {
-    yield* indent(emitRouteOperationDispatch(ctx, routeHandlers, routeTree.operations, backends));
+    yield* indent(
+      emitRouteOperationDispatch(ctx, routeHandlers, routeTree.operations, backends, module),
+    );
   } else {
     // Not found
     yield `  return ${onRouteNotFound}(ctx);`;
@@ -318,6 +319,7 @@ function* emitRouteOperationDispatch(
   routeHandlers: string,
   operations: Map<HttpVerb, RouteOperation[]>,
   backends: Map<OperationContainer, [ReCase, string]>,
+  module: Module,
 ): Iterable<string> {
   yield `switch (request.method) {`;
   for (const [verb, operationList] of operations.entries()) {
@@ -339,11 +341,10 @@ function* emitRouteOperationDispatch(
       yield `    return ${routeHandlers}.${operationName}(ctx, ${backendMemberName}${parameters});`;
     } else {
       // Shared route
-      const route = getHttpOperation(ctx.program, operationList[0].operation)[0].path;
       yield `  case ${JSON.stringify(verb.toUpperCase())}:`;
       yield* indent(
         indent(
-          emitRouteOperationDispatchMultiple(ctx, routeHandlers, operationList, route, backends),
+          emitRouteOperationDispatchMultiple(ctx, routeHandlers, operationList, backends, module),
         ),
       );
     }
@@ -366,64 +367,50 @@ function* emitRouteOperationDispatchMultiple(
   ctx: HttpContext,
   routeHandlers: string,
   operations: RouteOperation[],
-  route: string,
   backends: Map<OperationContainer, [ReCase, string]>,
+  module: Module,
 ): Iterable<string> {
-  const usedContentTypes = new Set<string>();
-  const contentTypeMap = new Map<RouteOperation, string>();
+  const differentiated = differentiateModelTypes(
+    ctx,
+    module,
+    new Set(operations.map((op) => op.operation.parameters)),
+    {
+      renderPropertyName(prop): string {
+        return getHeaderFieldName(ctx.program, prop);
+      },
+      filter(prop): boolean {
+        return isHeader(ctx.program, prop);
+      },
+      else: {
+        kind: "verbatim",
+        body: [`return ctx.errorHandlers.onRequestNotFound(ctx);`],
+      },
+    },
+  );
 
-  for (const operation of operations) {
-    const [httpOperation] = getHttpOperation(ctx.program, operation.operation);
-    const operationContentType = httpOperation.parameters.parameters.find(
-      (param) => param.type === "header" && param.name.toLowerCase() === "content-type",
-    )?.param.type;
-
-    if (!operationContentType || operationContentType.kind !== "String") {
-      throw new UnimplementedError(
-        "Only string content-types are supported for route differentiation.",
+  yield* writeCodeTree(ctx, differentiated, {
+    referenceModelProperty(p) {
+      const headerName = getHeaderFieldName(ctx.program, p);
+      return `request.headers["${headerName}"]`;
+    },
+    *renderResult(type) {
+      const operation = operations.find((op) => op.operation.parameters === type)!;
+      const [backend] = backends.get(operation.container)!;
+      const operationName = keywordSafe(
+        backend.snakeCase + "_" + parseCase(operation.operation.name).snakeCase,
       );
-    }
 
-    if (usedContentTypes.has(operationContentType.value)) {
-      reportDiagnostic(ctx.program, {
-        code: "undifferentiable-route",
-        target: httpOperation.operation,
-      });
-    }
+      const backendMemberName = keywordSafe(backend.camelCase);
 
-    usedContentTypes.add(operationContentType.value);
+      const parameters =
+        operation.parameters.length > 0
+          ? ", " + operation.parameters.map((param) => parseCase(param.name).camelCase).join(", ")
+          : "";
 
-    contentTypeMap.set(operation, operationContentType.value);
-  }
-
-  const contentTypeName = ctx.gensym("contentType");
-
-  yield `const ${contentTypeName} = parseHeaderValueParameters(request.headers["content-type"])?.value;`;
-
-  yield `switch (${contentTypeName}) {`;
-
-  for (const [operation, contentType] of contentTypeMap.entries()) {
-    const [backend] = backends.get(operation.container)!;
-    const operationName = keywordSafe(
-      backend.snakeCase + "_" + parseCase(operation.operation.name).snakeCase,
-    );
-
-    const backendMemberName = keywordSafe(backend.camelCase);
-
-    const parameters =
-      operation.parameters.length > 0
-        ? ", " + operation.parameters.map((param) => parseCase(param.name).camelCase).join(", ")
-        : "";
-
-    const contentTypeValue = parseHeaderValueParameters(contentType).value;
-
-    yield `  case ${JSON.stringify(contentTypeValue)}:`;
-    yield `    return ${routeHandlers}.${operationName}(ctx, ${backendMemberName}${parameters});`;
-  }
-
-  yield `  default:`;
-  yield `    return ctx.errorHandlers.onInvalidRequest(ctx, ${JSON.stringify(route)}, \`No operation in route '${route}' matched content-type "\${${contentTypeName}}"\`);`;
-  yield "}";
+      yield `return ${routeHandlers}.${operationName}(ctx, ${backendMemberName}${parameters});`;
+    },
+    subject: "(request.headers)",
+  });
 }
 
 /**

--- a/packages/http-server-js/src/lib.ts
+++ b/packages/http-server-js/src/lib.ts
@@ -148,6 +148,12 @@ export const $lib = createTypeSpecLibrary({
         default: paramMessage`Unknown encoding '${"encoding"}' to type '${"target"}' for type '${"type"}'.`,
       },
     },
+    "unrecognized-media-type": {
+      severity: "error",
+      messages: {
+        default: paramMessage`unrecognized media (MIME) type '${"mediaType"}' for type '${"type"}'.`,
+      },
+    },
   },
 });
 


### PR DESCRIPTION
This PR does three things:

- Enables fallback content-type handling for types that are or extend `TypeSpec.bytes`. Any unrecognized content-type is now allowed if the body is-or-extends `bytes` and is deserialized as a Buffer.
- Enables text/plain serialization for types that are or extend `TypeSpec.string`. This isn't enough to cover all scalars, but will unblock `string` and types that extend it when the content type is `text/plain`. In the future we should apply string decoding logic for all scalars and treat this as equivalent to JSON for models.
- Enhances shared route differentiation. It now uses `differentiateModelTypes` which is the same function used to split model types apart in unions for response differentiation. The differentiation logic was enhanced with a property filter, and for the purposes of shared route differentiation I only allow headers. In the future this could be extended to allow query parameters (by definition, there are no different path parameters in a shared route).

This unblocks the following spector tests from compiling:

- encode/bytes
- payload/content-negotiation
- payload/media-type
- 
Closes https://github.com/microsoft/typespec/issues/3782
Closes https://github.com/microsoft/typespec/issues/6378
Closes https://github.com/microsoft/typespec/issues/6377