### PR TITLE
Improve performance of publish pipeline

### DIFF
--- a/eng/tsp-core/pipelines/jobs/build-packages.yml
+++ b/eng/tsp-core/pipelines/jobs/build-packages.yml
@@ -49,7 +49,7 @@ jobs:
         displayName: Regen manifest for compiler
         workingDirectory: ./packages/compiler
 
-      - script: pnpm chronus pack --exclude standalone --pack-destination $(Build.ArtifactStagingDirectory)/npm-packages-next
+      - script: pnpm chronus pack --exclude standalone --exclude typespec-vs --pack-destination $(Build.ArtifactStagingDirectory)/npm-packages-next
         displayName: Pack next packages
 
       # Publish Next playground
@@ -59,12 +59,12 @@ jobs:
           azureSubscription: "Azure SDK Engineering System"
           scriptLocation: inlineScript
           inlineScript: |
-            az storage blob upload-batch ^
-              --auth-mode login ^
-              --destination $web ^
-              --account-name "cadlplayground" ^
-              --destination-path / ^
-              --source "./packages/playground-website/dist/web/" ^
+            az storage blob upload-batch \
+              --auth-mode login \
+              --destination $web \
+              --account-name "cadlplayground" \
+              --destination-path / \
+              --source "./packages/playground-website/dist/web/" \
               --overwrite
 
     templateContext:

--- a/eng/tsp-core/pipelines/jobs/build-packages.yml
+++ b/eng/tsp-core/pipelines/jobs/build-packages.yml
@@ -34,13 +34,6 @@ jobs:
           Contents: "*.vsix"
           TargetFolder: "$(Build.ArtifactStagingDirectory)/vscode-extension"
 
-      - task: CopyFiles@2
-        displayName: "Copy VS extension .vsix to artifact directory"
-        inputs:
-          SourceFolder: "$(Build.SourcesDirectory)/packages/typespec-vs"
-          Contents: "*.vsix"
-          TargetFolder: "$(Build.ArtifactStagingDirectory)/vs-extension"
-
       - task: AzureCLI@1
         displayName: "Publish bundled packages to package storage"
         inputs:
@@ -90,8 +83,3 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)/vscode-extension
           artifact: vscode-extension-unsigned
           displayName: Publish VSCode extension(.vsix) as pipeline artifacts
-
-        - output: pipelineArtifact
-          path: $(Build.ArtifactStagingDirectory)/vs-extension
-          artifact: vs-extension-unsigned
-          displayName: Publish VS extension(.vsix) as pipeline artifacts

--- a/eng/tsp-core/pipelines/jobs/build-packages.yml
+++ b/eng/tsp-core/pipelines/jobs/build-packages.yml
@@ -61,7 +61,7 @@ jobs:
           inlineScript: |
             az storage blob upload-batch \
               --auth-mode login \
-              --destination $web \
+              --destination "$web" \
               --account-name "cadlplayground" \
               --destination-path / \
               --source "./packages/playground-website/dist/web/" \

--- a/eng/tsp-core/pipelines/jobs/build-packages.yml
+++ b/eng/tsp-core/pipelines/jobs/build-packages.yml
@@ -1,7 +1,10 @@
 jobs:
   - job: build
     displayName: Build Packages
-
+    pool:
+      name: $(LINUXPOOL)
+      image: $(LINUXVMIMAGE)
+      os: linux
     variables:
       TYPESPEC_SKIP_DOCUSAURUS_BUILD: true # Disable docusaurus build
 

--- a/eng/tsp-core/pipelines/jobs/build-packages.yml
+++ b/eng/tsp-core/pipelines/jobs/build-packages.yml
@@ -61,7 +61,7 @@ jobs:
           inlineScript: |
             az storage blob upload-batch \
               --auth-mode login \
-              --destination "$web" \
+              --destination '$web' \
               --account-name "cadlplayground" \
               --destination-path / \
               --source "./packages/playground-website/dist/web/" \

--- a/eng/tsp-core/pipelines/jobs/build-vs.yml
+++ b/eng/tsp-core/pipelines/jobs/build-vs.yml
@@ -1,0 +1,36 @@
+jobs:
+  - job: build_vs
+    displayName: Build VS extension
+    pool:
+      name: $(WINDOWSPOOL)
+      image: $(WINDOWSVMIMAGE)
+      os: windows
+
+    variables:
+      TYPESPEC_SKIP_DOCUSAURUS_BUILD: true # Disable docusaurus build
+
+    steps:
+      - template: /eng/tsp-core/pipelines/templates/install.yml
+        parameters:
+          useDotNet: true
+
+      - script: pnpm run update-telemetry-key $(vscode.telemetryKey)
+        workingDirectory: $(Build.SourcesDirectory)/packages/typespec-vscode
+        displayName: Update vscode telemetry key
+
+      - script: pnpm build --filter "typespec-vs"
+        displayName: Build
+
+      - task: CopyFiles@2
+        displayName: "Copy VS extension .vsix to artifact directory"
+        inputs:
+          SourceFolder: "$(Build.SourcesDirectory)/packages/typespec-vs"
+          Contents: "*.vsix"
+          TargetFolder: "$(Build.ArtifactStagingDirectory)/vs-extension"
+
+    templateContext:
+      outputs:
+        - output: pipelineArtifact
+          path: $(Build.ArtifactStagingDirectory)/vs-extension
+          artifact: vs-extension-unsigned
+          displayName: Publish VS extension(.vsix) as pipeline artifacts

--- a/eng/tsp-core/pipelines/jobs/build-vs.yml
+++ b/eng/tsp-core/pipelines/jobs/build-vs.yml
@@ -14,11 +14,7 @@ jobs:
         parameters:
           useDotNet: true
 
-      - script: pnpm run update-telemetry-key $(vscode.telemetryKey)
-        workingDirectory: $(Build.SourcesDirectory)/packages/typespec-vscode
-        displayName: Update vscode telemetry key
-
-      - script: pnpm build --filter "typespec-vs"
+      - script: pnpm build --filter "typespec-vs..."
         displayName: Build
 
       - task: CopyFiles@2

--- a/eng/tsp-core/pipelines/jobs/build-vs.yml
+++ b/eng/tsp-core/pipelines/jobs/build-vs.yml
@@ -14,7 +14,7 @@ jobs:
         parameters:
           useDotNet: true
 
-      - script: pnpm build --filter "typespec-vs..."
+      - script: pnpm -r --filter "typespec-vs..." build
         displayName: Build
 
       - task: CopyFiles@2

--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -96,25 +96,3 @@ extends:
                 displayName: "Build"
               - script: docker push $(imageName) --all-tags
                 displayName: "Push"
-
-      - stage: validate_manifest
-        displayName: Validate Manifest
-        dependsOn: build
-        jobs:
-          - job: validate_manifest
-            displayName: Validate Manifest
-            pool:
-              name: $(WINDOWSPOOL)
-              image: $(WINDOWSVMIMAGE)
-              os: windows
-            variables:
-              TYPESPEC_SKIP_DOCUSAURUS_BUILD: true # Disable docusaurus build
-            steps:
-              - template: /eng/tsp-core/pipelines/templates/install.yml
-              - template: /eng/tsp-core/pipelines/templates/build.yml
-
-              - script: pnpm run validate-scenarios --debug
-                displayName: Validate Scenarios
-
-              - script: pnpm run validate-mock-apis --debug
-                displayName: Validate mock apis

--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -4,6 +4,7 @@ trigger:
   branches:
     include:
       - main
+      - publish-perf
       # For patch releases
       - release/*
   paths:
@@ -25,13 +26,9 @@ extends:
         dependsOn: []
         displayName: Build
 
-        pool:
-          name: $(WINDOWSPOOL)
-          image: $(WINDOWSVMIMAGE)
-          os: windows
-
         jobs:
-          - template: /eng/tsp-core/pipelines/jobs/build-for-publish.yml@self
+          - template: /eng/tsp-core/pipelines/jobs/build-packages.yml@self
+          - template: /eng/tsp-core/pipelines/jobs/build-vs.yml@self
           - template: /eng/tsp-core/pipelines/jobs/cli/build-tsp-cli-all.yml@self
           - template: /eng/tsp-core/pipelines/jobs/e2e.yml@self
             parameters:

--- a/packages/typespec-vs/package.json
+++ b/packages/typespec-vs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "typespec-vs",
+  "private": true,
   "author": "Microsoft Corporation",
   "version": "0.68.0",
   "description": "TypeSpec Language Support for Visual Studio",

--- a/packages/typespec-vs/package.json
+++ b/packages/typespec-vs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "typespec-vs",
-  "private": true,
   "author": "Microsoft Corporation",
   "version": "0.68.0",
   "description": "TypeSpec Language Support for Visual Studio",


### PR DESCRIPTION

- Split VS build from the rest to move the rest of  build to linux which is much faster (20min vs 30-35min for the build job)
- Delete the validate manifest job that is pointless