### PR TITLE
Make Typekit cahces use Program and Weakmap

### DIFF
--- a/.chronus/changes/joheredi-internal-typekit-cache-cleanup-2025-3-8-20-24-49.md
+++ b/.chronus/changes/joheredi-internal-typekit-cache-cleanup-2025-3-8-20-24-49.md
@@ -1,0 +1,9 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+  - "@typespec/http-client-js"
+  - "@typespec/http-client"
+---
+
+Update Typekit caches to use Program and WeekMap

--- a/packages/compiler/src/experimental/typekit/kits/model.ts
+++ b/packages/compiler/src/experimental/typekit/kits/model.ts
@@ -5,6 +5,7 @@ import {
   getDiscriminatedUnionFromInheritance,
 } from "../../../core/helpers/discriminator-utils.js";
 import { getDiscriminator } from "../../../core/intrinsic-type-state.js";
+import { Program } from "../../../core/program.js";
 import type {
   Model,
   ModelIndexer,
@@ -141,7 +142,7 @@ declare module "../define-kit.js" {
   interface Typekit extends TypekitExtension {}
 }
 
-const spreadCache = new Map<Model, Model>();
+const _spreadCache = new WeakMap<Program, WeakMap<Model, Model>>();
 defineKit<TypekitExtension>({
   model: {
     create(desc) {
@@ -172,6 +173,7 @@ defineKit<TypekitExtension>({
       return getEffectiveModelType(this.program, model, filter);
     },
     getSpreadType(model) {
+      const spreadCache = getSpreadCache(this.program);
       if (spreadCache.has(model)) {
         return spreadCache.get(model);
       }
@@ -255,3 +257,10 @@ defineKit<TypekitExtension>({
     },
   },
 });
+
+function getSpreadCache(program: Program): WeakMap<Model, Model> {
+  if (!_spreadCache.has(program)) {
+    _spreadCache.set(program, new WeakMap());
+  }
+  return _spreadCache.get(program)!;
+}

--- a/packages/http-client-js/test/scenarios/auth/bearer.md
+++ b/packages/http-client-js/test/scenarios/auth/bearer.md
@@ -26,7 +26,7 @@ The client signature should include a positional parameter for credential of typ
 export class TestClient {
   #context: TestClientContext;
 
-  constructor(endpoint: string, credential: BasicCredential, options?: TestClientOptions) {
+  constructor(endpoint: string, credential: BearerTokenCredential, options?: TestClientOptions) {
     this.#context = createTestClientContext(endpoint, credential, options);
   }
   async valid(options?: ValidOptions) {
@@ -42,7 +42,7 @@ The client context should setup the pipeline to use the credential in the Author
 ```ts src/api/testClientContext.ts function createTestClientContext
 export function createTestClientContext(
   endpoint: string,
-  credential: BasicCredential,
+  credential: BearerTokenCredential,
   options?: TestClientOptions,
 ): TestClientContext {
   const params: Record<string, any> = {

--- a/packages/http-client-js/test/scenarios/auth/client_structure.md
+++ b/packages/http-client-js/test/scenarios/auth/client_structure.md
@@ -27,7 +27,7 @@ export class MyApiClient {
   #context: MyApiClientContext;
   fooClient: FooClient;
   barClient: BarClient;
-  constructor(endpoint: string, credential: BasicCredential, options?: MyApiClientOptions) {
+  constructor(endpoint: string, credential: BearerTokenCredential, options?: MyApiClientOptions) {
     this.#context = createMyApiClientContext(endpoint, credential, options);
     this.fooClient = new FooClient(endpoint, credential, options);
     this.barClient = new BarClient(endpoint, credential, options);

--- a/packages/http-client/src/typekit/kits/operation.ts
+++ b/packages/http-client/src/typekit/kits/operation.ts
@@ -3,7 +3,7 @@ import { defineKit } from "@typespec/compiler/experimental/typekit";
 import { HttpOperation } from "@typespec/http";
 import { InternalClient as Client } from "../../interfaces.js";
 import { getConstructors } from "../../utils/client-helpers.js";
-import { clientOperationCache } from "./client.js";
+import { getOperationClientMapping } from "./client.js";
 import { AccessKit, getAccess, getName, NameKit } from "./utils.js";
 
 export interface SdkOperationKit extends NameKit<Operation>, AccessKit<Operation> {
@@ -46,13 +46,8 @@ declare module "@typespec/compiler/experimental/typekit" {
 defineKit<SdkKit>({
   operation: {
     getClient(operation) {
-      for (const [client, operations] of clientOperationCache.entries()) {
-        if (operations.includes(operation)) {
-          return client;
-        }
-      }
-
-      return undefined;
+      const operationClientMapping = getOperationClientMapping(this.program);
+      return operationClientMapping.get(operation);
     },
     getOverloads(client, operation) {
       if (operation.name === "constructor") {


### PR DESCRIPTION
Some tests were having issues in which caches were keeping information from previous programs. Switching to WeakMap and adding a map layer on program.