### PR TITLE
[python] update check for azure generation

### DIFF
--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -37,10 +37,7 @@ function addDefaultOptions(sdkContext: PythonSdkContext) {
     // if they pass in a flavor other than azure, we want to ignore the value
     (options as any).flavor = undefined;
   }
-  if (
-    (options as any).flavor === undefined &&
-    sdkContext.emitContext.emitterOutputDir.includes("azure")
-  ) {
+  if (sdkContext.sdkPackage.crossLanguagePackageId.toLowerCase().includes("azure")) {
     (options as any).flavor = "azure";
   }
 


### PR DESCRIPTION
Our current check for azure generation is kind of brittle, it depends on the location that a user is generating from to include "azure" in the path. Better to check the package id has "azure" in it