### PR TITLE
[hsjs] Ignore uninstantiated operations in `visitAllTypes`

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-ignore-uninstantiated-floating-ops-2025-3-9-11-28-51.md
+++ b/.chronus/changes/witemple-msft-hsjs-ignore-uninstantiated-floating-ops-2025-3-9-11-28-51.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Correctly ignore uninstantiated operations that are direct children of namespaces. This prevents a fatal error where TemplateParameter types can be encountered in such templates.

--- a/packages/http-server-js/src/common/namespace.ts
+++ b/packages/http-server-js/src/common/namespace.ts
@@ -23,7 +23,15 @@ import { emitOperationGroup } from "./interface.js";
  * @param namespace - The root namespace to begin traversing.
  */
 export function visitAllTypes(ctx: JsContext, namespace: Namespace) {
-  const { enums, interfaces, models, unions, namespaces, scalars, operations } = namespace;
+  const {
+    enums,
+    interfaces,
+    models,
+    unions,
+    namespaces,
+    scalars,
+    operations: _operations,
+  } = namespace;
 
   for (const type of cat<DeclarationType>(
     enums.values(),
@@ -41,7 +49,9 @@ export function visitAllTypes(ctx: JsContext, namespace: Namespace) {
     visitAllTypes(ctx, ns);
   }
 
-  if (operations.size > 0) {
+  const operations = [..._operations.values()].filter((op) => op.isFinished);
+
+  if (operations.length > 0) {
     // If the namespace has any floating operations in it, we will synthesize an interface for them in the parent module.
     // This requires some special handling by other parts of the emitter to ensure that the interface for a namespace's
     // own operations is properly imported.


### PR DESCRIPTION
We recently merged a change that ignores uninstantiated types in `visitAllTypes`, but it didn't correctly ignore uninstantiated operations within namespaces when emitting namespace interfaces. This change corrects that problem.

Closes #5580 