### PR TITLE
resolve default template parameters from parent containers

### DIFF
--- a/.chronus/changes/fix-templ-param-alias-is-2025-3-9-13-34-54.md
+++ b/.chronus/changes/fix-templ-param-alias-is-2025-3-9-13-34-54.md
@@ -1,0 +1,22 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fixes template argument resolution when a default template parameter value is resolved by a parent container (e.g. interface)
+For example:
+```tsp
+interface Resource<T> {
+  read<U = T>(): U;
+}
+
+model Foo {
+  type: "foo";
+}
+
+alias FooResource = Resource<Foo>;
+
+op readFoo is FooResource.read;
+```
+The `returnType` for `readFoo` would be model `Foo`. Previously the `returnType` resolved to a `TemplateParameter`.

--- a/packages/compiler/test/checker/templates.test.ts
+++ b/packages/compiler/test/checker/templates.test.ts
@@ -405,13 +405,17 @@ describe("compiler: templates", () => {
       "main.tsp",
       `
         @test interface A<T> {
-          op foo<U = T>(): U;
+          op foo<R = T, P = R>(params: P): R;
         }
         alias B = A<string>;
         @test op MyOp is B.foo;
       `,
     );
     const { MyOp } = (await testHost.compile("main.tsp")) as { MyOp: Operation };
+    const params = MyOp.parameters.properties.get("params");
+    ok(params, "Expected params to be defined");
+    strictEqual(params.type.kind, "Scalar");
+    strictEqual(params.type.name, "string");
     strictEqual(MyOp.returnType.kind, "Scalar");
     strictEqual(MyOp.returnType.name, "string");
   });

--- a/packages/compiler/test/checker/templates.test.ts
+++ b/packages/compiler/test/checker/templates.test.ts
@@ -420,6 +420,26 @@ describe("compiler: templates", () => {
     strictEqual(MyOp.returnType.name, "string");
   });
 
+  it("can use parent parameters default in default", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+        @test interface MyInterface<A, B = string> {
+          op foo<R = B, P = R>(params: P): R;
+        }
+        alias AliasedInterface = MyInterface<string>;
+        @test op MyOp is AliasedInterface.foo;
+      `,
+    );
+    const { MyOp } = (await testHost.compile("main.tsp")) as { MyOp: Operation };
+    const params = MyOp.parameters.properties.get("params");
+    ok(params, "Expected params to be defined");
+    strictEqual(params.type.kind, "Scalar");
+    strictEqual(params.type.name, "string");
+    strictEqual(MyOp.returnType.kind, "Scalar");
+    strictEqual(MyOp.returnType.name, "string");
+  });
+
   it("can override default provided by parent parameters", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",


### PR DESCRIPTION
Meant to partially address #6745 

The `extends` case still acts oddly (and may be fixed when #6699 is fixed). 

This case still won't produce any output:
```tsp
interface Resource<T> {
  read<U = T>(): U;
}

model Foo {
  type: "foo";
}

interface FooResource extends Resource<Foo> {}
```
Because even though all the `Resource` template parameters are provided in the `extends`, the operation in `FooResource` does not get instantiated. I'm not 100% convinced this case is a bug though.