### PR TITLE
[http] Slightly stronger types for multipart resolution.

### DIFF
--- a/.chronus/changes/witemple-msft-http-multipart-stronger-2025-3-10-14-3-13.md
+++ b/.chronus/changes/witemple-msft-http-multipart-stronger-2025-3-10-14-3-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http"
+---
+
+Improved types for HTTP multipart payloads for more precise guarantees and additional information about the resolution of individual parts.

--- a/.chronus/changes/witemple-msft-http-multipart-stronger-2025-3-10-14-4-49.md
+++ b/.chronus/changes/witemple-msft-http-multipart-stronger-2025-3-10-14-4-49.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-js"
+---
+
+Changed `MultipartTransform` slightly to avoid a bizarre TypeScript type checking error.

--- a/packages/http-client-js/src/components/transforms/multipart/multipart-transform.tsx
+++ b/packages/http-client-js/src/components/transforms/multipart/multipart-transform.tsx
@@ -22,7 +22,7 @@ export function MultipartTransform(props: MultipartTransformProps) {
 
   const partTransform = (
     <ay.For each={httpParts} comma line>
-      {(part) => <HttpPartTransform part={part} itemRef={itemRef} />}
+      {(part, _) => <HttpPartTransform part={part} itemRef={itemRef} />}
     </ay.For>
   );
 

--- a/packages/http/src/payload.ts
+++ b/packages/http/src/payload.ts
@@ -32,8 +32,10 @@ import { Visibility } from "./metadata.js";
 import { HttpFileModel, getHttpFileModel, getHttpPart } from "./private.decorators.js";
 import {
   HttpOperationFileBody,
+  HttpOperationModelPart,
   HttpOperationMultipartBody,
-  HttpOperationPart,
+  HttpOperationPartCommon,
+  HttpOperationTuplePart,
   HttpPayloadBody,
 } from "./types.js";
 
@@ -421,11 +423,17 @@ function resolveMultiPartBodyFromModel(
   visibility: Visibility,
 ): DiagnosticResult<HttpOperationMultipartBody | undefined> {
   const diagnostics = createDiagnosticCollector();
-  const parts: HttpOperationPart[] = [];
+  const parts: HttpOperationModelPart[] = [];
   for (const item of type.properties.values()) {
     const part = diagnostics.pipe(resolvePartOrParts(program, item.type, visibility, item));
     if (part) {
-      parts.push({ ...part, name: part.name ?? item.name, optional: item.optional });
+      parts.push({
+        partKind: "model",
+        ...part,
+        name: part.name ?? item.name,
+        optional: item.optional,
+        property: item,
+      });
     }
   }
 
@@ -440,6 +448,7 @@ function resolveMultiPartBodyFromModel(
 
   return diagnostics.wrap({
     bodyKind: "multipart",
+    multipartKind: "model",
     ...resolvedContentTypes,
     parts,
     property,
@@ -461,7 +470,7 @@ function resolveMultiPartBodyFromTuple(
   visibility: Visibility,
 ): DiagnosticResult<HttpOperationMultipartBody | undefined> {
   const diagnostics = createDiagnosticCollector();
-  const parts: HttpOperationPart[] = [];
+  const parts: HttpOperationTuplePart[] = [];
 
   const contentTypes =
     contentTypeProperty && diagnostics.pipe(getContentTypes(contentTypeProperty?.property));
@@ -477,7 +486,7 @@ function resolveMultiPartBodyFromTuple(
       );
     }
     if (part) {
-      parts.push(part);
+      parts.push({ partKind: "tuple", ...part, optional: false });
     }
   }
 
@@ -492,6 +501,7 @@ function resolveMultiPartBodyFromTuple(
 
   return diagnostics.wrap({
     bodyKind: "multipart",
+    multipartKind: "tuple",
     ...resolvedContentTypes,
     parts,
     property,
@@ -504,7 +514,7 @@ function resolvePartOrParts(
   type: Type,
   visibility: Visibility,
   property?: ModelProperty,
-): DiagnosticResult<HttpOperationPart | undefined> {
+): DiagnosticResult<HttpOperationPartCommon | undefined> {
   if (type.kind === "Model" && isArrayModelType(program, type)) {
     const [part, diagnostics] = resolvePart(program, type.indexer.value, visibility, property);
     if (part) {
@@ -521,7 +531,7 @@ function resolvePart(
   type: Type,
   visibility: Visibility,
   property?: ModelProperty,
-): DiagnosticResult<HttpOperationPart | undefined> {
+): DiagnosticResult<HttpOperationPartCommon | undefined> {
   const diagnostics = createDiagnosticCollector();
   const part = getHttpPart(program, type);
   if (part) {

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -483,25 +483,33 @@ export interface HttpOperationBody extends HttpOperationBodyBase, HttpBody {
 }
 
 /** Body marked with `@multipartBody` */
-export interface HttpOperationMultipartBody extends HttpOperationBodyBase {
+export type HttpOperationMultipartBody =
+  | HttpOperationMultipartBodyModel
+  | HttpOperationMultipartBodyTuple;
+
+export interface HttpOperationMultipartBodyCommon extends HttpOperationBodyBase {
   readonly bodyKind: "multipart";
-  readonly type: Model | Tuple;
   /** Property annotated with `@multipartBody` */
   readonly property: ModelProperty;
   readonly parts: HttpOperationPart[];
 }
 
+export interface HttpOperationMultipartBodyModel extends HttpOperationMultipartBodyCommon {
+  readonly multipartKind: "model";
+  readonly type: Model;
+  readonly parts: HttpOperationModelPart[];
+}
+
+export interface HttpOperationMultipartBodyTuple extends HttpOperationMultipartBodyCommon {
+  readonly multipartKind: "tuple";
+  readonly type: Tuple;
+  readonly parts: HttpOperationTuplePart[];
+}
+
 /** The possible bodies of a multipart part. */
 export type HttpOperationMultipartPartBody = HttpOperationBody | HttpOperationFileBody;
 
-/** Represent an part in a multipart body. */
-export interface HttpOperationPart {
-  /** Property that defined the part if the model form is used. */
-  readonly property?: ModelProperty;
-  /** Part name */
-  readonly name?: string;
-  /** If the part is optional */
-  readonly optional: boolean;
+export interface HttpOperationPartCommon {
   /** Part body */
   readonly body: HttpOperationMultipartPartBody;
   /** If the Part is an HttpFile this is the property defining the filename */
@@ -510,6 +518,28 @@ export interface HttpOperationPart {
   readonly headers: HeaderProperty[];
   /** If there can be multiple of that part */
   readonly multi: boolean;
+  /** The part name, if any. */
+  readonly name?: string;
+  /** If the part is optional */
+  readonly optional: boolean;
+}
+
+export type HttpOperationPart = HttpOperationModelPart | HttpOperationTuplePart;
+
+/** Represents a part in a multipart body that comes from a model property. */
+export interface HttpOperationModelPart extends HttpOperationPartCommon {
+  readonly partKind: "model";
+  /** Property that defined the part if the model form is used. */
+  readonly property: ModelProperty;
+  /** Part name */
+  readonly name: string;
+}
+
+/** Represents a part in a multipart body that comes from a tuple entry. */
+export interface HttpOperationTuplePart extends HttpOperationPartCommon {
+  readonly partKind: "tuple";
+  /** Property that defined the part -- always undefined for tuple entry parts. */
+  readonly property?: undefined;
 }
 
 /**


### PR DESCRIPTION
This PR makes the types returned from `@typespec/http` for multipart payloads slightly more accurate by splitting the tuple and model forms of multipart bodies into separate types with their own `multipartKind` and stricter subtypes about what kinds of parts they can have inside them, whether or not they can be named, whether or not they are optional, etc.

The types of the parts are also split into two `partKind` types: `tuple` and `model`. The guarantees given are as follows:

**For model-based multipart payloads**:
- `type` is guaranteed to be a `Model`.
- `parts` are guaranteed to be only model-based parts.

**For tuple-based multipart payloads**:
- `type` is guaranteed to be a `Tuple`.
- `parts` are guaranteed to be only tuple-based parts.

**For model-based parts**:
- `name` is required.
- `property` is required and refers to the ModelProperty that defined the _part_ (and we remember to set it -- we weren't doing this correctly).

**For tuple-based parts**:
- `name` is optional.
- `property` is _guaranteed_ to be `undefined`.