### PR TITLE
[emitter-framework] Use Alloy for InterfaceMember

### DIFF
--- a/.chronus/changes/interface-member-alloy-2025-3-10-22-28-59.md
+++ b/.chronus/changes/interface-member-alloy-2025-3-10-22-28-59.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/emitter-framework"
+---
+
+InterfaceMember should use Alloy

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -35,26 +35,17 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
 
   const extendsType = props.extends ?? getExtendsType(props.type);
 
-  const members = props.type ? [membersFromType(props.type)] : [];
-
-  const children = [...members];
-
-  if (Array.isArray(props.children)) {
-    children.push(...props.children);
-  } else if (props.children) {
-    children.push(props.children);
-  }
-
   return (
     <ts.InterfaceDeclaration
       default={props.default}
       export={props.export}
-      children={children}
       kind={props.kind}
       name={name}
       refkey={refkey}
       extends={extendsType}
-    ></ts.InterfaceDeclaration>
+    >
+      {interfaceMembers(props)}
+    </ts.InterfaceDeclaration>
   );
 }
 
@@ -69,13 +60,10 @@ export interface InterfaceExpressionProps extends ts.InterfaceExpressionProps {
 }
 
 export function InterfaceExpression({ type, children }: InterfaceExpressionProps) {
-  const members = type ? membersFromType(type) : [];
-
   return (
     <>
       {"{"}
-      {members}
-      {children}
+      {interfaceMembers({ type, children })}
       {"}"}
     </>
   );
@@ -123,7 +111,7 @@ function getExtendsType(type: Model | Interface): Children | undefined {
   );
 }
 
-function membersFromType(type: Model | Interface): Children {
+function interfaceMembers({ type, children }: TypedInterfaceDeclarationProps) {
   let typeMembers: RekeyableMap<string, ModelProperty | Operation> | undefined;
   if ($.model.is(type)) {
     typeMembers = $.model.getProperties(type);
@@ -143,10 +131,13 @@ function membersFromType(type: Model | Interface): Children {
   }
 
   return (
-    <ay.For each={Array.from(typeMembers.entries())} line>
-      {([_, prop]) => {
-        return <InterfaceMember type={prop} />;
-      }}
-    </ay.For>
+    <>
+      <ay.For each={Array.from(typeMembers.entries())} line ender=";">
+        {([_, prop]) => {
+          return <InterfaceMember type={prop} />;
+        }}
+      </ay.For>
+      {children}
+    </>
   );
 }

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -49,13 +49,12 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
     <ts.InterfaceDeclaration
       default={props.default}
       export={props.export}
+      children={children}
       kind={props.kind}
       name={name}
       refkey={refkey}
       extends={extendsType}
-    >
-      {children}
-    </ts.InterfaceDeclaration>
+    ></ts.InterfaceDeclaration>
   );
 }
 

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -1,7 +1,14 @@
 import * as ay from "@alloy-js/core";
 import { Children, refkey as getRefkey, mapJoin } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
-import { Interface, Model, ModelProperty, Operation, RekeyableMap } from "@typespec/compiler";
+import {
+  Interface,
+  isNeverType,
+  Model,
+  ModelProperty,
+  Operation,
+  RekeyableMap,
+} from "@typespec/compiler";
 import { $ } from "@typespec/compiler/experimental/typekit";
 import { createRekeyableMap } from "@typespec/compiler/utils";
 import { reportDiagnostic } from "../../lib.js";
@@ -133,9 +140,18 @@ function InterfaceBody(props: TypedInterfaceDeclarationProps): Children {
     typeMembers = createRekeyableMap(props.type.operations);
   }
 
+  // Ensure that we have members to render, otherwise skip rendering the ender property.
+  const validTypeMembers = Array.from(typeMembers.values()).filter((member) => {
+    if ($.modelProperty.is(member) && isNeverType(member.type)) {
+      return false;
+    }
+    return true;
+  });
+  const enderProp = validTypeMembers.length > 0 ? { ender: ";" } : {};
+
   return (
     <>
-      <ay.For each={Array.from(typeMembers.values())} line ender=";">
+      <ay.For each={validTypeMembers} line {...enderProp}>
         {(typeMember) => {
           return <InterfaceMember type={typeMember} />;
         }}

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -44,7 +44,7 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
       refkey={refkey}
       extends={extendsType}
     >
-      {interfaceMembers(props)}
+      <InterfaceBody {...props} />
     </ts.InterfaceDeclaration>
   );
 }
@@ -59,11 +59,11 @@ export interface InterfaceExpressionProps extends ts.InterfaceExpressionProps {
   type: Model | Interface;
 }
 
-export function InterfaceExpression({ type, children }: InterfaceExpressionProps) {
+export function InterfaceExpression(props: InterfaceExpressionProps) {
   return (
     <>
       {"{"}
-      {interfaceMembers({ type, children })}
+      <InterfaceBody {...props} />
       {"}"}
     </>
   );
@@ -111,11 +111,14 @@ function getExtendsType(type: Model | Interface): Children | undefined {
   );
 }
 
-function interfaceMembers({ type, children }: TypedInterfaceDeclarationProps) {
+/**
+ * Renders the members of an interface from its properties, including any additional children.
+ */
+function InterfaceBody(props: TypedInterfaceDeclarationProps): Children {
   let typeMembers: RekeyableMap<string, ModelProperty | Operation> | undefined;
-  if ($.model.is(type)) {
-    typeMembers = $.model.getProperties(type);
-    const additionalProperties = $.model.getAdditionalPropertiesRecord(type);
+  if ($.model.is(props.type)) {
+    typeMembers = $.model.getProperties(props.type);
+    const additionalProperties = $.model.getAdditionalPropertiesRecord(props.type);
     if (additionalProperties) {
       typeMembers.set(
         "additionalProperties",
@@ -127,17 +130,17 @@ function interfaceMembers({ type, children }: TypedInterfaceDeclarationProps) {
       );
     }
   } else {
-    typeMembers = createRekeyableMap(type.operations);
+    typeMembers = createRekeyableMap(props.type.operations);
   }
 
   return (
     <>
-      <ay.For each={Array.from(typeMembers.entries())} line ender=";">
-        {([_, prop]) => {
-          return <InterfaceMember type={prop} />;
+      <ay.For each={Array.from(typeMembers.values())} line ender=";">
+        {(typeMember) => {
+          return <InterfaceMember type={typeMember} />;
         }}
       </ay.For>
-      {children}
+      {props.children}
     </>
   );
 }

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -68,11 +68,9 @@ export interface InterfaceExpressionProps extends ts.InterfaceExpressionProps {
 
 export function InterfaceExpression(props: InterfaceExpressionProps) {
   return (
-    <>
-      {"{"}
+    <ay.Block>
       <InterfaceBody {...props} />
-      {"}"}
-    </>
+    </ay.Block>
   );
 }
 

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -51,6 +51,7 @@ export function InterfaceMember(props: InterfaceMemberProps) {
           </>
         }
         refkey={props.refkey ?? ay.refkey(props.type)}
+        readonly={Boolean(props.type.decorators?.find((d) => d.decorator.name === "@readonly"))}
       />
     );
   }

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -1,4 +1,5 @@
-import { useTSNamePolicy } from "@alloy-js/typescript";
+import * as ay from "@alloy-js/core";
+import * as ts from "@alloy-js/typescript";
 import { isNeverType, ModelProperty, Operation } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/experimental/typekit";
 import { getHttpPart } from "@typespec/http";
@@ -8,39 +9,49 @@ import { TypeExpression } from "./type-expression.js";
 export interface InterfaceMemberProps {
   type: ModelProperty | Operation;
   optional?: boolean;
+  refkey?: ay.Refkey;
 }
 
-export function InterfaceMember({ type, optional }: InterfaceMemberProps) {
-  const namer = useTSNamePolicy();
-  const name = namer.getName(type.name, "object-member-getter");
+export function InterfaceMember(props: InterfaceMemberProps) {
+  const namer = ts.useTSNamePolicy();
+  const name = namer.getName(props.type.name, "object-member-getter");
 
-  if ($.modelProperty.is(type)) {
-    const optionality = optional === true || type.optional === true ? "?" : "";
-
-    if (isNeverType(type.type)) {
+  if ($.modelProperty.is(props.type)) {
+    if (isNeverType(props.type.type)) {
       return null;
     }
 
-    let unpackedType = type.type;
-    const part = getHttpPart($.program, type.type);
+    let unpackedType = props.type.type;
+    const part = getHttpPart($.program, props.type.type);
     if (part) {
       unpackedType = part.type;
     }
 
     return (
-      <>
-        "{name}"{optionality}: <TypeExpression type={unpackedType} />;
-      </>
+      <ts.InterfaceMember
+        name={name}
+        optional={props.optional === true || props.type.optional === true}
+        type={<TypeExpression type={unpackedType} />}
+        refkey={ay.refkey(props.type)}
+        readonly={Boolean(props.type.decorators?.find((d) => d.decorator.name === "@readonly"))}
+      />
     );
   }
 
-  if ($.operation.is(type)) {
-    const returnType = <TypeExpression type={type.returnType} />;
-    const params = <FunctionDeclaration.Parameters type={type.parameters} />;
+  if ($.operation.is(props.type)) {
+    const returnType = <TypeExpression type={props.type.returnType} />;
+    const params = <FunctionDeclaration.Parameters type={props.type.parameters} />;
+
     return (
-      <>
-        {name}({params}): {returnType};
-      </>
+      <ts.InterfaceMember
+        name={name}
+        type={
+          <>
+            ({params}): {returnType}
+          </>
+        }
+        refkey={props.refkey ?? ay.refkey(props.type)}
+      />
     );
   }
 }

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -30,10 +30,9 @@ export function InterfaceMember(props: InterfaceMemberProps) {
     return (
       <ts.InterfaceMember
         name={name}
-        optional={props.optional === true || props.type.optional === true}
+        optional={props.optional ?? props.type.optional}
         type={<TypeExpression type={unpackedType} />}
         refkey={ay.refkey(props.type)}
-        readonly={Boolean(props.type.decorators?.find((d) => d.decorator.name === "@readonly"))}
       />
     );
   }
@@ -47,11 +46,10 @@ export function InterfaceMember(props: InterfaceMemberProps) {
         name={name}
         type={
           <>
-            ({params}): {returnType}
+            ({params}) =&gt {returnType}
           </>
         }
         refkey={props.refkey ?? ay.refkey(props.type)}
-        readonly={Boolean(props.type.decorators?.find((d) => d.decorator.name === "@readonly"))}
       />
     );
   }

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -39,15 +39,19 @@ export function InterfaceMember(props: InterfaceMemberProps) {
 
   if ($.operation.is(props.type)) {
     const returnType = <TypeExpression type={props.type.returnType} />;
-    const params = <FunctionDeclaration.Parameters type={props.type.parameters} />;
+    const params = (
+      <ay.Scope>
+        <FunctionDeclaration.Parameters type={props.type.parameters} />
+      </ay.Scope>
+    );
 
     return (
       <ts.InterfaceMember
         name={name}
         type={
-          <ay.Scope>
+          <>
             ({params}) =&gt {returnType}
-          </ay.Scope>
+          </>
         }
         refkey={props.refkey ?? ay.refkey(props.type)}
       />

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -9,7 +9,6 @@ import { TypeExpression } from "./type-expression.js";
 export interface InterfaceMemberProps {
   type: ModelProperty | Operation;
   optional?: boolean;
-  refkey?: ay.Refkey;
 }
 
 export function InterfaceMember(props: InterfaceMemberProps) {
@@ -32,7 +31,6 @@ export function InterfaceMember(props: InterfaceMemberProps) {
         name={name}
         optional={props.optional ?? props.type.optional}
         type={<TypeExpression type={unpackedType} />}
-        refkey={ay.refkey(props.type)}
       />
     );
   }
@@ -53,7 +51,6 @@ export function InterfaceMember(props: InterfaceMemberProps) {
             ({params}) =&gt {returnType}
           </>
         }
-        refkey={props.refkey ?? ay.refkey(props.type)}
       />
     );
   }

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -45,9 +45,9 @@ export function InterfaceMember(props: InterfaceMemberProps) {
       <ts.InterfaceMember
         name={name}
         type={
-          <>
+          <ay.Scope>
             ({params}) =&gt {returnType}
-          </>
+          </ay.Scope>
         }
         refkey={props.refkey ?? ay.refkey(props.type)}
       />

--- a/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
@@ -337,6 +337,39 @@ describe("Typescript Interface", () => {
         expect(actualContent).toBe(expectedContent);
       });
 
+      it("renders an empty interface", async () => {
+        const program = await getProgram(`
+        namespace DemoService;
+    
+        model Widget{
+          property: never;
+        }
+        `);
+
+        const [namespace] = program.resolveTypeReference("DemoService");
+        const models = Array.from((namespace as Namespace).models.values());
+
+        const res = render(
+          <Output>
+            <SourceFile path="test.ts">
+              <InterfaceDeclaration export type={models[0]} />
+            </SourceFile>
+          </Output>,
+        );
+
+        const testFile = res.contents.find((file) => file.path === "test.ts");
+        assert(testFile, "test.ts file not rendered");
+        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
+        const expectedContent = await format(
+          `export interface Widget {
+          }`,
+          {
+            parser: "typescript",
+          },
+        );
+        expect(actualContent).toBe(expectedContent);
+      });
+
       it("can override interface name", async () => {
         const program = await getProgram(`
         namespace DemoService;

--- a/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
@@ -675,7 +675,7 @@ describe("Typescript Interface", () => {
         const expectedContent = await format(
           `export interface WidgetOperationsExtended {
           getName: (id: string) => Widget;
-          delete: (id_2: string) => void;
+          delete: (id: string) => void;
         }
         export interface Widget {
           id: string;

--- a/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
@@ -337,7 +337,7 @@ describe("Typescript Interface", () => {
         expect(actualContent).toBe(expectedContent);
       });
 
-      it("renders an empty interface", async () => {
+      it("renders an empty interface with a never-typed member", async () => {
         const program = await getProgram(`
         namespace DemoService;
     

--- a/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
@@ -505,7 +505,7 @@ describe("Typescript Interface", () => {
       });
     });
 
-    describe.skip("Bound to Interface", () => {
+    describe("Bound to Interface", () => {
       it("creates an interface", async () => {
         const program = await getProgram(`
         namespace DemoService;
@@ -531,7 +531,7 @@ describe("Typescript Interface", () => {
         const actualContent = await format(testFile.contents as string, { parser: "typescript" });
         const expectedContent = await format(
           `export interface WidgetOperations {
-          getName(id: string): string;
+          getName: (id: string) => string;
         }`,
           {
             parser: "typescript",
@@ -572,8 +572,8 @@ describe("Typescript Interface", () => {
         const actualContent = await format(testFile.contents as string, { parser: "typescript" });
         const expectedContent = await format(
           `export interface WidgetOperations {
-          getName(foo: Foo): string;
-          getOtherName(name: string): string
+          getName: (foo: Foo) => string;
+          getOtherName: (name: string) => string
         }
         export interface Foo {
           name: string;
@@ -621,7 +621,7 @@ describe("Typescript Interface", () => {
         const actualContent = await format(testFile.contents as string, { parser: "typescript" });
         const expectedContent = await format(
           `export interface WidgetOperations {
-          getName(id: string): Widget;
+          getName: (id: string) => Widget;
         }
         export interface Widget {
           id: string;
@@ -674,8 +674,8 @@ describe("Typescript Interface", () => {
         const actualContent = await format(testFile.contents as string, { parser: "typescript" });
         const expectedContent = await format(
           `export interface WidgetOperationsExtended {
-          getName(id: string): Widget;
-          delete(id: string): void;
+          getName: (id: string) => Widget;
+          delete: (id_2: string) => void;
         }
         export interface Widget {
           id: string;

--- a/packages/emitter-framework/test/typescript/components/member-expression.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/member-expression.test.tsx
@@ -36,7 +36,7 @@ describe("Typescript Enum Member Expression", () => {
         three = 3
       }
       interface Bar {
-        "one": Foo.one;
+        one: Foo.one;
       }
     `);
   });
@@ -70,7 +70,7 @@ describe("Typescript Enum Member Expression", () => {
         three = "three"
       }
       interface Bar {
-        "one": Foo.one;
+        one: Foo.one;
       }
     `);
   });
@@ -102,7 +102,7 @@ describe("Typescript Union Member Expression", () => {
     expect(output).toBe(d`
       type Foo = 1 | 2 | 3;
       interface Bar {
-        "one": 1;
+        one: 1;
       }
     `);
   });
@@ -132,7 +132,7 @@ describe("Typescript Union Member Expression", () => {
     expect(output).toBe(d`
       type Foo = "one" | "two" | "three";
       interface Bar {
-        "one": "one";
+        one: "one";
       }
     `);
   });

--- a/packages/http-client-js/test/scenarios/models/inline-models.md
+++ b/packages/http-client-js/test/scenarios/models/inline-models.md
@@ -21,6 +21,9 @@ op foo(): Widget;
 ```ts src/models/models.ts interface Widget
 export interface Widget {
   name: string;
-  subWidget: { location: string; age?: number };
+  subWidget: {
+    location: string;
+    age?: number
+  };
 }
 ```

--- a/packages/http-client-js/test/scenarios/models/inline-models.md
+++ b/packages/http-client-js/test/scenarios/models/inline-models.md
@@ -23,7 +23,7 @@ export interface Widget {
   name: string;
   subWidget: {
     location: string;
-    age?: number
+    age?: number;
   };
 }
 ```

--- a/packages/http-client-js/test/scenarios/multipart/anonymous_part.md
+++ b/packages/http-client-js/test/scenarios/multipart/anonymous_part.md
@@ -24,7 +24,7 @@ export async function foo(
     temperature: {
       body: number;
       contentType: "text/plain";
-    }
+    };
   },
   options?: FooOptions,
 ): Promise<void> {

--- a/packages/http-client-js/test/scenarios/multipart/anonymous_part.md
+++ b/packages/http-client-js/test/scenarios/multipart/anonymous_part.md
@@ -20,7 +20,12 @@ op foo(
 ```ts src/api/testClientOperations.ts function foo
 export async function foo(
   client: TestClientContext,
-  body: { temperature: { body: number; contentType: "text/plain" } },
+  body: {
+    temperature: {
+      body: number;
+      contentType: "text/plain";
+    }
+  },
   options?: FooOptions,
 ): Promise<void> {
   const path = parse("/").expand({});

--- a/packages/http-client-js/test/scenarios/multipart/non-string-float.md
+++ b/packages/http-client-js/test/scenarios/multipart/non-string-float.md
@@ -26,7 +26,7 @@ export async function float(
     temperature: {
       body: number;
       contentType: "text/plain";
-    }
+    };
   },
   options?: FloatOptions,
 ): Promise<void> {

--- a/packages/http-client-js/test/scenarios/multipart/non-string-float.md
+++ b/packages/http-client-js/test/scenarios/multipart/non-string-float.md
@@ -22,7 +22,12 @@ op float(
 ```ts src/api/testClientOperations.ts function float
 export async function float(
   client: TestClientContext,
-  body: { temperature: { body: number; contentType: "text/plain" } },
+  body: {
+    temperature: {
+      body: number;
+      contentType: "text/plain";
+    }
+  },
   options?: FloatOptions,
 ): Promise<void> {
   const path = parse("/non-string-float").expand({});

--- a/packages/http-client-js/test/scenarios/operation-parameters/body_root_anonymous.md
+++ b/packages/http-client-js/test/scenarios/operation-parameters/body_root_anonymous.md
@@ -21,7 +21,12 @@ The operation has has no required parameters so options and client should be the
 ```ts src/api/testClientOperations.ts function create
 export async function create(
   client: TestClientContext,
-  widget: { id: string; name: string; age?: string; foo?: string },
+  widget: {
+    id: string;
+    name: string;
+    age?: string;
+    foo?: string;
+  },
   options?: CreateOptions,
 ): Promise<void> {
   const path = parse("/").expand({});
@@ -69,7 +74,12 @@ export class TestClient {
     this.#context = createTestClientContext(endpoint, options);
   }
   async create(
-    widget: { id: string; name: string; age?: string; foo?: string },
+    widget: {
+      id: string;
+      name: string;
+      age?: string;
+      foo?: string;
+    },
     options?: CreateOptions,
   ) {
     return create(this.#context, widget, options);


### PR DESCRIPTION
## What

Removes bespoke implementation of InterfaceMember in favor of Alloy
Updates test expectation

## Why

Using Alloy here provides a few benefits: proper quoting of member names,
formatting, etc.

Resolves #6916 

## Callouts

Please review carefully as this is my first PR in this space