### PR TITLE
[http-client-java]mgmt mock test, fix HEAD operation tests

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/example/ModelExampleWriter.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/example/ModelExampleWriter.java
@@ -108,8 +108,16 @@ public class ModelExampleWriter {
 
         private final List<String> assertions = new ArrayList<>();
 
-        private void addEqualsAssertion(String expected, String code) {
-            assertions.add(String.format("Assertions.assertEquals(%1$s, %2$s);", expected, code));
+        private void addEqualsAssertion(String expected, String code, boolean booleanAssertion) {
+            if (booleanAssertion) {
+                if (Boolean.parseBoolean(expected)) {
+                    assertions.add(String.format("Assertions.assertTrue(%s);", code));
+                } else {
+                    assertions.add(String.format("Assertions.assertFalse(%s);", code));
+                }
+            } else {
+                assertions.add(String.format("Assertions.assertEquals(%1$s, %2$s);", expected, code));
+            }
         }
 
         public void accept(ExampleNode node, String getterCode) {
@@ -117,7 +125,7 @@ public class ModelExampleWriter {
                 node.getClientType().addImportsTo(imports, false);
 
                 addEqualsAssertion(node.getClientType().defaultValueExpression(((LiteralNode) node).getLiteralsValue()),
-                    getterCode);
+                    getterCode, node.getClientType().asNullable() == ClassType.BOOLEAN);
             } else if (node instanceof ObjectNode) {
                 // additionalProperties
             } else if (node instanceof ListNode) {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ModelTestCaseUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ModelTestCaseUtil.java
@@ -105,8 +105,7 @@ public class ModelTestCaseUtil {
         } else if (type.asNullable() == ClassType.DOUBLE) {
             return RANDOM.nextDouble() * 100;
         } else if (type.asNullable() == ClassType.BOOLEAN) {
-            // always returns false for boolean, for HEAD operation
-            return false;
+            return RANDOM.nextBoolean();
         } else if (type == ClassType.STRING) {
             return randomString();
         } else if (type.asNullable() == ClassType.UNIX_TIME_LONG) {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ModelTestCaseUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ModelTestCaseUtil.java
@@ -105,7 +105,8 @@ public class ModelTestCaseUtil {
         } else if (type.asNullable() == ClassType.DOUBLE) {
             return RANDOM.nextDouble() * 100;
         } else if (type.asNullable() == ClassType.BOOLEAN) {
-            return RANDOM.nextBoolean();
+            // always returns false for boolean, for HEAD operation
+            return false;
         } else if (type == ClassType.STRING) {
             return randomString();
         } else if (type.asNullable() == ClassType.UNIX_TIME_LONG) {

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentMethodMockTestTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentMethodMockTestTemplate.java
@@ -19,9 +19,6 @@ import com.microsoft.typespec.http.client.generator.core.template.example.ModelE
 import com.microsoft.typespec.http.client.generator.core.util.CodeNamer;
 import com.microsoft.typespec.http.client.generator.mgmt.model.clientmodel.examplemodel.FluentMethodMockUnitTest;
 import com.microsoft.typespec.http.client.generator.mgmt.util.FluentUtils;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,6 +27,8 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public class FluentMethodMockTestTemplate
     implements IJavaTemplate<FluentMethodMockTestTemplate.ClientMethodInfo, JavaFile> {
@@ -101,7 +100,7 @@ public class FluentMethodMockTestTemplate
         fluentReturnType.addImportsTo(imports, false);
 
         // create response body with mocked data
-        int statusCode = isCheckExistence? 404 : fluentMethodMockUnitTest.getResponse().getStatusCode();
+        int statusCode = isCheckExistence ? 404 : fluentMethodMockUnitTest.getResponse().getStatusCode();
         Object jsonObject = fluentMethodMockUnitTest.getResponse().getBody();
         ExampleNode verificationNode = fluentMethodMockUnitTest.getResponseVerificationNode();
         String verificationObjectName = fluentMethodMockUnitTest.getResponseVerificationVariableName();
@@ -132,7 +131,8 @@ public class FluentMethodMockTestTemplate
                 "void test" + CodeNamer.toPascalCase(clientMethod.getName()) + "() throws Exception", methodBlock -> {
                     // response
                     if (!isCheckExistence) {
-                        methodBlock.line("String responseStr = " + ClassType.STRING.defaultValueExpression(jsonStr) + ";");
+                        methodBlock
+                            .line("String responseStr = " + ClassType.STRING.defaultValueExpression(jsonStr) + ";");
                         methodBlock.line();
                     }
 
@@ -140,7 +140,7 @@ public class FluentMethodMockTestTemplate
 
                     // prepare mock class
                     methodBlock.line("HttpClient httpClient = response -> Mono.just(new MockHttpResponse(response, "
-                        + statusCode + responseBodyBytes +"));");
+                        + statusCode + responseBodyBytes + "));");
 
                     // initialize manager
                     String exampleMethodName = exampleMethod.getExample().getEntryType().getName();
@@ -154,7 +154,11 @@ public class FluentMethodMockTestTemplate
                     methodBlock.line();
                     // verification
                     if (hasReturnValue) {
-                        assertionVisitor.getAssertions().forEach(methodBlock::line);
+                        if (isCheckExistence) {
+                            methodBlock.line("Assertions.assertFalse(" + verificationObjectName + ")");
+                        } else {
+                            assertionVisitor.getAssertions().forEach(methodBlock::line);
+                        }
                     }
                 });
 

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentMethodMockTestTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentMethodMockTestTemplate.java
@@ -102,7 +102,6 @@ public class FluentMethodMockTestTemplate
         fluentReturnType.addImportsTo(imports, false);
 
         // create response body with mocked data
-        // we'll assert false on checkExistence request afterward
         int statusCode = fluentMethodMockUnitTest.getResponse().getStatusCode();
         Object jsonObject = fluentMethodMockUnitTest.getResponse().getBody();
         ExampleNode verificationNode = fluentMethodMockUnitTest.getResponseVerificationNode();

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentMethodMockTestTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentMethodMockTestTemplate.java
@@ -155,7 +155,7 @@ public class FluentMethodMockTestTemplate
                     // verification
                     if (hasReturnValue) {
                         if (isCheckExistence) {
-                            methodBlock.line("Assertions.assertFalse(" + verificationObjectName + ")");
+                            methodBlock.line("Assertions.assertFalse(" + verificationObjectName + ");");
                         } else {
                             assertionVisitor.getAssertions().forEach(methodBlock::line);
                         }


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/1861#issuecomment-2516596944

generated mock test:
```java
@Test
public void testCheckEntityExistsWithResponse() throws Exception {
    String responseStr = "false";

    HttpClient httpClient
        = response -> Mono.just(new MockHttpResponse(response, 204, responseStr.getBytes(StandardCharsets.UTF_8)));
    ApiManagementManager manager = ApiManagementManager.configure()
        .withHttpClient(httpClient)
        .authenticate(tokenRequestContext -> Mono.just(new AccessToken("this_is_a_token", OffsetDateTime.MAX)),
            new AzureProfile("", "", AzureCloud.AZURE_PUBLIC_CLOUD));

    boolean response = manager.groupUsers()
        .checkEntityExistsWithResponse("sdgktluifiqg", "qcpenob", "ysbeespqbvvaersz", "ufzsautbric",
            com.azure.core.util.Context.NONE)
        .getValue();

    Assertions.assertTrue(response);
}
```

`String ResponseStr = "false"` will be in response body, and can be ignored.