### PR TITLE
[emitter-framework] Add support for ValueExpression

### DIFF
--- a/.chronus/changes/ts-value-expression-2025-3-14-21-19-17.md
+++ b/.chronus/changes/ts-value-expression-2025-3-14-21-19-17.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/emitter-framework"
+---
+
+Add support for rendering a Value Expression

--- a/packages/emitter-framework/src/typescript/components/value-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/value-expression.tsx
@@ -7,13 +7,13 @@ import { Value } from "@typespec/compiler";
  */
 interface ValueExpressionProps {
   /**
-   * The TypeSpec value to be converted to a TypeScript expression.
+   * The TypeSpec value to be converted to a JavaScript expression.
    */
   value: Value;
 }
 
 /**
- * Generates a TypeScript value expression from a TypeSpec value.
+ * Generates a JavaScript value expression from a TypeSpec value.
  * @param props properties for the value expression
  * @returns {@link Children} representing the JavaScript value expression
  */
@@ -32,16 +32,14 @@ export function ValueExpression(props: ValueExpressionProps): Children {
     case "ArrayValue":
       return (
         <ts.ArrayExpression
-          jsValue={props.value.values.map((v) => ValueExpression({ value: v }))}
+          jsValue={props.value.values.map((v) => (
+            <ValueExpression value={v} />
+          ))}
         />
       );
     case "ScalarValue":
-      const { value } = props.value;
-
       if (props.value.value.name === "fromISO") {
-        return ValueExpression({
-          value: value.args[0],
-        });
+        return <ValueExpression value={props.value.value.args[0]} />;
       } else {
         throw new Error("Unsupported scalar constructor: " + props.value.value.name);
       }

--- a/packages/emitter-framework/src/typescript/components/value-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/value-expression.tsx
@@ -22,13 +22,19 @@ export function ValueExpression(props: ValueExpressionProps): Children {
     case "StringValue":
     case "BooleanValue":
     case "NullValue":
-      return ts.ValueExpression({ jsValue: props.value.value });
+      return <ts.ValueExpression jsValue={props.value.value} />;
     case "NumericValue":
-      return ts.ValueExpression({ jsValue: props.value.value.asNumber() });
+      // if its a bigint, we need to add the n suffix
+      if (props.value.value.asNumber()) {
+        return <ts.ValueExpression jsValue={props.value.value.asNumber()} />;
+      }
+      return <ts.ValueExpression jsValue={props.value.value.asBigInt()} />;
     case "ArrayValue":
-      return ts.ArrayExpression({
-        jsValue: props.value.values.map((v) => ValueExpression({ value: v })),
-      });
+      return (
+        <ts.ArrayExpression
+          jsValue={props.value.values.map((v) => ValueExpression({ value: v }))}
+        />
+      );
     case "ScalarValue":
       const { value } = props.value;
 
@@ -46,6 +52,6 @@ export function ValueExpression(props: ValueExpressionProps): Children {
       }
       return <ts.ObjectExpression jsValue={jsProperties} />;
     case "EnumValue":
-      return ts.ValueExpression({ jsValue: props.value.value.value ?? props.value.value.name });
+      return <ts.ValueExpression jsValue={props.value.value.value ?? props.value.value.name} />;
   }
 }

--- a/packages/emitter-framework/src/typescript/components/value-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/value-expression.tsx
@@ -1,0 +1,52 @@
+import { Children } from "@alloy-js/core";
+import * as ts from "@alloy-js/typescript";
+import { Value } from "@typespec/compiler";
+
+/**
+ * Properties for the {@link ValueExpression} component.
+ */
+interface ValueExpressionProps {
+  /**
+   * The TypeSpec value to be converted to a TypeScript expression.
+   */
+  value: Value;
+}
+
+/**
+ * Generates a TypeScript value expression from a TypeSpec value.
+ * @param props properties for the value expression
+ * @returns {@link Children} representing the JavaScript value expression
+ */
+export function ValueExpression(props: ValueExpressionProps): Children {
+  switch (props.value.valueKind) {
+    case "NumericValue":
+      return ts.ValueExpression({ jsValue: props.value.value.asNumber() });
+    case "StringValue":
+    case "BooleanValue":
+    case "NullValue":
+      return ts.ValueExpression({ jsValue: props.value.value });
+    case "ArrayValue":
+      return ts.ArrayExpression({
+        jsValue: props.value.values,
+      });
+    case "ScalarValue":
+      console.log("ScalarValue", props.value);
+      const { value } = props.value;
+
+      if (props.value.value.name === "fromISO") {
+        console.log("fromISO", props.value.value.args[0]);
+        return ts.ValueExpression({
+          jsValue: value.args[0],
+        });
+        // return ValueExpression({
+        //   value: props.value.value.args[0],
+        // });
+      } else {
+        throw new Error("Unsupported scalar constructor: " + props.value.value.name);
+      }
+    case "ObjectValue":
+      return ts.ValueExpression({ jsValue: props.value.properties });
+    case "EnumValue":
+      return ts.ValueExpression({ jsValue: props.value.value.value ?? props.value.value.name });
+  }
+}

--- a/packages/emitter-framework/src/typescript/components/value-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/value-expression.tsx
@@ -24,7 +24,6 @@ export function ValueExpression(props: ValueExpressionProps): Children {
     case "NullValue":
       return <ts.ValueExpression jsValue={props.value.value} />;
     case "NumericValue":
-      // if its a bigint, we need to add the n suffix
       if (props.value.value.asNumber()) {
         return <ts.ValueExpression jsValue={props.value.value.asNumber()} />;
       }

--- a/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
@@ -12,27 +12,6 @@ describe("TypeScript ValueExpression", () => {
     await initEmptyProgram();
   });
 
-  async function testValueExpression(value: Value, expected: string) {
-    const prefix = "const val = ";
-    const res = render(
-      <Output>
-        <SourceFile path="test.ts">
-          {prefix}
-          <ValueExpression value={value} />
-        </SourceFile>
-      </Output>,
-    );
-    const testFile = res.contents.find((file) => file.path === "test.ts");
-
-    assert.exists(testFile, "test.ts file not rendered");
-
-    assert.equal(
-      testFile.contents,
-      `${prefix}${expected}`,
-      "test.ts file contents do not match expected",
-    );
-  }
-
   it("renders strings", async () => {
     const value = $.value.createString("test");
 
@@ -209,3 +188,27 @@ describe("TypeScript ValueExpression", () => {
     );
   });
 });
+
+/**
+ * Helper that renders a value expression and checks the output against the expected value.
+ */
+async function testValueExpression(value: Value, expected: string) {
+  const prefix = "const val = ";
+  const res = render(
+    <Output>
+      <SourceFile path="test.ts">
+        {prefix}
+        <ValueExpression value={value} />
+      </SourceFile>
+    </Output>,
+  );
+  const testFile = res.contents.find((file) => file.path === "test.ts");
+
+  assert.exists(testFile, "test.ts file not rendered");
+
+  assert.equal(
+    testFile.contents,
+    `${prefix}${expected}`,
+    "test.ts file contents do not match expected",
+  );
+}

--- a/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
@@ -219,7 +219,6 @@ async function testValueExpression(value: Value, expected: string) {
 
   assert.exists(testFile, "test.ts file not rendered");
 
-  console.log(testFile.contents);
   assert.equal(
     testFile.contents,
     `${prefix}${expected}`,

--- a/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
@@ -3,95 +3,94 @@ import { dedent } from "@alloy-js/core/testing";
 import { SourceFile } from "@alloy-js/typescript";
 import { EnumValue, Namespace, Numeric, NumericValue, Value } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/experimental/typekit";
-import { assert, beforeAll, describe, expect, it } from "vitest";
+import { assert, beforeAll, expect, it } from "vitest";
 import { ValueExpression } from "../../../src/typescript/components/value-expression.js";
 import { getProgram, initEmptyProgram } from "../test-host.js";
 
-describe("TypeScript ValueExpression", () => {
-  beforeAll(async () => {
-    await initEmptyProgram();
-  });
+beforeAll(async () => {
+  await initEmptyProgram();
+});
 
-  it("renders strings", async () => {
-    const value = $.value.createString("test");
+it("renders strings", async () => {
+  const value = $.value.createString("test");
 
-    await testValueExpression(value, `"test"`);
-  });
+  await testValueExpression(value, `"test"`);
+});
 
-  it("renders integers", async () => {
-    const value = $.value.createNumeric(42);
+it("renders integers", async () => {
+  const value = $.value.createNumeric(42);
 
-    await testValueExpression(value, `42`);
-  });
+  await testValueExpression(value, `42`);
+});
 
-  it("renders decimals", async () => {
-    const value = $.value.createNumeric(42.5);
+it("renders decimals", async () => {
+  const value = $.value.createNumeric(42.5);
 
-    await testValueExpression(value, `42.5`);
-  });
+  await testValueExpression(value, `42.5`);
+});
 
-  it("renders bigints", async () => {
-    const digits = "1234567890123456789012345678901234567890";
-    const value: NumericValue = {
-      entityKind: "Value",
-      valueKind: "NumericValue",
-      value: Numeric(digits),
-    } as NumericValue;
+it("renders bigints", async () => {
+  const digits = "1234567890123456789012345678901234567890";
+  const value: NumericValue = {
+    entityKind: "Value",
+    valueKind: "NumericValue",
+    value: Numeric(digits),
+  } as NumericValue;
 
-    await testValueExpression(value, `${digits}n`);
-  });
+  await testValueExpression(value, `${digits}n`);
+});
 
-  it("renders booleans", async () => {
-    const value = $.value.createBoolean(true);
-    await testValueExpression(value, `true`);
-  });
+it("renders booleans", async () => {
+  const value = $.value.createBoolean(true);
+  await testValueExpression(value, `true`);
+});
 
-  it("renders nulls", async () => {
-    const value = {
-      entityKind: "Value",
-      valueKind: "NullValue",
-      value: null,
-    } as Value;
-    await testValueExpression(value, `null`);
-  });
+it("renders nulls", async () => {
+  const value = {
+    entityKind: "Value",
+    valueKind: "NullValue",
+    value: null,
+  } as Value;
+  await testValueExpression(value, `null`);
+});
 
-  it("renders empty arrays", async () => {
-    // Can be replaced with with TypeKit once #6976 is implemented
-    const value = {
-      entityKind: "Value",
-      valueKind: "ArrayValue",
-      values: [],
-    } as unknown as Value;
-    await testValueExpression(value, `[]`);
-  });
+it("renders empty arrays", async () => {
+  // Can be replaced with with TypeKit once #6976 is implemented
+  const value = {
+    entityKind: "Value",
+    valueKind: "ArrayValue",
+    values: [],
+  } as unknown as Value;
+  await testValueExpression(value, `[]`);
+});
 
-  it("renders arrays with mixed values", async () => {
-    // Can be replaced with with TypeKit once #6976 is implemented
-    const value = {
-      entityKind: "Value",
-      valueKind: "ArrayValue",
-      values: [$.value.createString("foo"), $.value.createNumeric(42), $.value.createBoolean(true)],
-    } as Value;
-    await testValueExpression(value, `["foo", 42, true]`);
-  });
+it("renders arrays with mixed values", async () => {
+  // Can be replaced with with TypeKit once #6976 is implemented
+  const value = {
+    entityKind: "Value",
+    valueKind: "ArrayValue",
+    values: [$.value.createString("foo"), $.value.createNumeric(42), $.value.createBoolean(true)],
+  } as Value;
+  await testValueExpression(value, `["foo", 42, true]`);
+});
 
-  it("renders scalars", async () => {
-    const program = await getProgram(`
+it("renders scalars", async () => {
+  const program = await getProgram(`
       namespace DemoService;
       model DateRange {
         @encode("rfc7231")
         minDate: utcDateTime = utcDateTime.fromISO("2024-02-15T18:36:03Z");
       }
     `);
-    const [namespace] = program.resolveTypeReference("DemoService");
-    const dateRange = (namespace as Namespace).models.get("DateRange");
-    const minDate = dateRange?.properties.get("minDate")?.defaultValue;
-    assert.exists(minDate, "unable to find minDate property");
-    await testValueExpression(minDate, `"2024-02-15T18:36:03Z"`);
-  });
+  const [namespace] = program.resolveTypeReference("DemoService");
+  const dateRange = (namespace as Namespace).models.get("DateRange");
+  const minDate = dateRange?.properties.get("minDate")?.defaultValue;
+  assert.exists(minDate, "unable to find minDate property");
+  await testValueExpression(minDate, `"2024-02-15T18:36:03Z"`);
+});
 
-  it("throws on unsupported scalar", async () => {
-    const program = await getProgram(`
+it("throws on unsupported scalar", async () => {
+  const program = await getProgram(`
       namespace DemoService;
 
       scalar ipv4 extends string {
@@ -103,34 +102,34 @@ describe("TypeScript ValueExpression", () => {
         ip: ipv4;
       }
     `);
-    const [namespace] = program.resolveTypeReference("DemoService");
-    const customScalar = (namespace as Namespace).models.get("IpAddress");
-    assert.exists(customScalar, "unable to find custom scalar");
-    const decorator = customScalar?.decorators.find((d) => d.definition?.name === "@example");
-    assert.exists(decorator?.args[0]?.value, "unable to find example decorator");
-    const value = decorator.args[0].value as Value;
-    await expect(testValueExpression(value, ``)).rejects.toThrow(
-      "Unsupported scalar constructor: fromInt",
-    );
-  });
+  const [namespace] = program.resolveTypeReference("DemoService");
+  const customScalar = (namespace as Namespace).models.get("IpAddress");
+  assert.exists(customScalar, "unable to find custom scalar");
+  const decorator = customScalar?.decorators.find((d) => d.definition?.name === "@example");
+  assert.exists(decorator?.args[0]?.value, "unable to find example decorator");
+  const value = decorator.args[0].value as Value;
+  await expect(testValueExpression(value, ``)).rejects.toThrow(
+    "Unsupported scalar constructor: fromInt",
+  );
+});
 
-  it("renders empty objects", async () => {
-    // Can be replaced with with TypeKit once #6976 is implemented
-    const program = await getProgram(`
+it("renders empty objects", async () => {
+  // Can be replaced with with TypeKit once #6976 is implemented
+  const program = await getProgram(`
       namespace DemoService;
       @example(#{})
       model ObjectValue {};
     `);
-    const [namespace] = program.resolveTypeReference("DemoService");
-    const objectValue = (namespace as Namespace).models.get("ObjectValue");
-    const decorator = objectValue?.decorators.find((d) => d.definition?.name === "@example");
-    assert.exists(decorator?.args[0]?.value, "unable to find example decorator");
-    await testValueExpression(decorator.args[0].value as Value, `{}`);
-  });
+  const [namespace] = program.resolveTypeReference("DemoService");
+  const objectValue = (namespace as Namespace).models.get("ObjectValue");
+  const decorator = objectValue?.decorators.find((d) => d.definition?.name === "@example");
+  assert.exists(decorator?.args[0]?.value, "unable to find example decorator");
+  await testValueExpression(decorator.args[0].value as Value, `{}`);
+});
 
-  it("renders objects with properties", async () => {
-    // Can be replaced with with TypeKit once #6976 is implemented
-    const program = await getProgram(`
+it("renders objects with properties", async () => {
+  // Can be replaced with with TypeKit once #6976 is implemented
+  const program = await getProgram(`
       namespace DemoService;
       @example(#{a: 5, b: "foo", c: true})
       model ObjectValue {
@@ -139,24 +138,24 @@ describe("TypeScript ValueExpression", () => {
         c: boolean;
       };
     `);
-    const [namespace] = program.resolveTypeReference("DemoService");
-    const objectValue = (namespace as Namespace).models.get("ObjectValue");
-    const decorator = objectValue?.decorators.find((d) => d.definition?.name === "@example");
-    assert.exists(decorator?.args[0]?.value, "unable to find example decorator");
-    await testValueExpression(
-      decorator.args[0].value as Value,
-      dedent(`
+  const [namespace] = program.resolveTypeReference("DemoService");
+  const objectValue = (namespace as Namespace).models.get("ObjectValue");
+  const decorator = objectValue?.decorators.find((d) => d.definition?.name === "@example");
+  assert.exists(decorator?.args[0]?.value, "unable to find example decorator");
+  await testValueExpression(
+    decorator.args[0].value as Value,
+    dedent(`
       {
         a: 5,
         b: "foo",
         c: true,
       }`),
-    );
-  });
+  );
+});
 
-  it("renders enums", async () => {
-    // Can be replaced with with TypeKit once #6976 is implemented
-    const program = await getProgram(`
+it("renders enums", async () => {
+  // Can be replaced with with TypeKit once #6976 is implemented
+  const program = await getProgram(`
       namespace DemoService;
       enum Color {
         Red,
@@ -164,29 +163,28 @@ describe("TypeScript ValueExpression", () => {
         Blue
       }
     `);
-    const [namespace] = program.resolveTypeReference("DemoService");
-    const colors = (namespace as Namespace).enums.get("Color");
-    assert.exists(colors, "unable to find Color enum");
-    const red = colors?.members.get("Red");
-    assert.exists(red, "unable to find Red enum member");
-    await testValueExpression(
-      {
-        valueKind: "EnumValue",
-        value: red,
-      } as EnumValue,
-      `"Red"`,
-    );
+  const [namespace] = program.resolveTypeReference("DemoService");
+  const colors = (namespace as Namespace).enums.get("Color");
+  assert.exists(colors, "unable to find Color enum");
+  const red = colors?.members.get("Red");
+  assert.exists(red, "unable to find Red enum member");
+  await testValueExpression(
+    {
+      valueKind: "EnumValue",
+      value: red,
+    } as EnumValue,
+    `"Red"`,
+  );
 
-    const green = colors?.members.get("Green");
-    assert.exists(green, "unable to find Green enum member");
-    await testValueExpression(
-      {
-        valueKind: "EnumValue",
-        value: green,
-      } as EnumValue,
-      `3`,
-    );
-  });
+  const green = colors?.members.get("Green");
+  assert.exists(green, "unable to find Green enum member");
+  await testValueExpression(
+    {
+      valueKind: "EnumValue",
+      value: green,
+    } as EnumValue,
+    `3`,
+  );
 });
 
 /**

--- a/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/value-expression.test.tsx
@@ -1,0 +1,119 @@
+import { Output, render } from "@alloy-js/core";
+import { SourceFile } from "@alloy-js/typescript";
+import { ArrayValue, Namespace, Value } from "@typespec/compiler";
+import { $ } from "@typespec/compiler/experimental/typekit";
+import { format } from "prettier";
+import { assert, describe, expect, it } from "vitest";
+import { ValueExpression } from "../../../src/typescript/components/value-expression.js";
+import { getProgram } from "../test-host.js";
+
+describe("ValueExpression", () => {
+  async function testValueExpression(value: Value, expected: string) {
+    const res = render(
+      <Output>
+        <SourceFile path="test.ts">
+          <ValueExpression value={value} />
+        </SourceFile>
+      </Output>,
+    );
+    const testFile = res.contents.find((file) => file.path === "test.ts");
+    assert(testFile, "test.ts file not rendered");
+    const actualContent = await format(testFile.contents as string, { parser: "typescript" });
+    const expectedContent = await format(expected, {
+      parser: "typescript",
+    });
+    expect(actualContent).toBe(expectedContent);
+  }
+
+  it("handles string value", async () => {
+    // Error: Default typekits may not be used until a program is set in the compiler.
+    // TODO: better way to set this up so I can use typekit?
+    await getProgram(``);
+    const value = $.value.createString("test");
+
+    await testValueExpression(value, `"test"`);
+  });
+
+  it("handles numeric value", async () => {
+    await getProgram(``);
+    const value = $.value.createNumeric(42);
+
+    await testValueExpression(value, `42`);
+  });
+
+  it("handles decimal numeric value", async () => {
+    await getProgram(``);
+    const value = $.value.createNumeric(42.5);
+    await testValueExpression(value, `42.5`);
+  });
+
+  it("handles boolean value", async () => {
+    await getProgram(``);
+    const value = $.value.createBoolean(true);
+    await testValueExpression(value, `true`);
+  });
+
+  it("handles null value", async () => {
+    await getProgram(``);
+    const value: Value = {
+      entityKind: "Value",
+      valueKind: "NullValue",
+      value: null,
+    } as Value;
+    await testValueExpression(value, `null`);
+  });
+
+  it("handles empty array value", async () => {
+    // TODO: is there a better way to create an empty array value?
+    await getProgram(``);
+    const value: ArrayValue = {
+      entityKind: "Value",
+      valueKind: "ArrayValue",
+      values: [],
+      type: {},
+    } as unknown as ArrayValue;
+    await testValueExpression(value, `[]`);
+  });
+
+  it.todo("handles array with mixed values", async () => {
+    await getProgram(``);
+    const value: ArrayValue = {
+      entityKind: "Value",
+      valueKind: "ArrayValue",
+      values: [$.value.createString("foo"), $.value.createNumeric(42), $.value.createBoolean(true)],
+      type: {},
+    } as unknown as ArrayValue;
+    await testValueExpression(value, `["foo", 42, true]`);
+  });
+
+  it("handles fromISO scalar value", async () => {
+    const program = await getProgram(`
+      namespace DemoService;
+      model DateRange {
+        @encode("rfc7231")
+        minDate: utcDateTime = utcDateTime.fromISO("2024-02-15T18:36:03Z");
+      }
+    `);
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const dateRange = (namespace as Namespace).models.get("DateRange");
+    const minDate = dateRange?.properties.get("minDate")?.defaultValue;
+    assert(minDate, "minDate property not found");
+    await testValueExpression(minDate, `fdfd`);
+  });
+
+  it("throws on unsupported scalar constructor", async () => {
+    // TODO: implement test
+  });
+
+  it("handles empty object value", async () => {
+    // TODO: implement test
+  });
+
+  it("handles object with mixed property types", async () => {
+    // TODO: implement test
+  });
+
+  it("throws on unsupported value kind", async () => {
+    // TODO: implement test
+  });
+});

--- a/packages/emitter-framework/test/typescript/test-host.ts
+++ b/packages/emitter-framework/test/typescript/test-host.ts
@@ -39,3 +39,11 @@ export async function getProgram(
   expectDiagnosticEmpty(diagnostics);
   return wrapper.program;
 }
+
+/**
+ * Initializes an empty program in the compiler.
+ * This is useful when you want to initialize the default TypeKits without any code.
+ */
+export async function initEmptyProgram(): Promise<void> {
+  await getProgram("");
+}


### PR DESCRIPTION
This pull request introduces a new feature to add support for rendering a Value Expression in the `@typespec/emitter-framework` package. The key changes include the implementation of the `ValueExpression` component, the addition of comprehensive tests for various value types, and the initialization of an empty program for testing purposes.

### New Feature Implementation:
* [`packages/emitter-framework/src/typescript/components/value-expression.tsx`](diffhunk://#diff-c767f5310b61b469266b95846986ad0b61ac675b975d886af8292a804243cf75R1-R56): Implemented the `ValueExpression` component, which converts a TypeSpec value into a JavaScript expression.

### Testing Enhancements:
* [`packages/emitter-framework/test/typescript/components/value-expression.test.tsx`](diffhunk://#diff-df99d4d0d5d18ddbfb74cda34ed637f99c57829ef71d718ea822d7d3f110e355R1-R236): Added tests to validate the rendering of various value types, including strings, numbers, booleans, nulls, arrays, scalars, objects, and enums.
* [`packages/emitter-framework/test/typescript/test-host.ts`](diffhunk://#diff-25c30ece2977ab4231fab89b603ad2566d5cfa50d83e78996e04da284f30c40eR42-R49): Introduced the `initEmptyProgram` function to initialize an empty program for testing purposes.