### PR TITLE
[Java] Remove azure-json  use in code-model types

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/Message.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/Message.java
@@ -3,12 +3,17 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model;
 
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents a message.
  */
-public class Message {
+public class Message implements JsonSerializable<Message> {
 
     /**
      * Represents a message channel.
@@ -129,5 +134,50 @@ public class Message {
      */
     public void setText(String text) {
         this.text = text;
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        return jsonWriter.writeStartObject()
+            .writeStringField("Channel", channel == null ? null : channel.toString())
+            .writeUntypedField("Details", details)
+            .writeStringField("Text", text)
+            .writeArrayField("Key", key, JsonWriter::writeString)
+            .writeArrayField("Source", source, JsonWriter::writeJson)
+            .writeEndObject();
+    }
+
+    /**
+     * Deserializes a Message instance from the JSON data.
+     *
+     * @param jsonReader The JSON reader to deserialize from.
+     * @return A Message instance deserialized from the JSON data.
+     * @throws IOException If an error occurs during deserialization.
+     */
+    public static Message fromJson(JsonReader jsonReader) throws IOException {
+        return jsonReader.readObject(reader -> {
+            Message message = new Message();
+
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                if ("Channel".equals(fieldName)) {
+                    message.channel = MessageChannel.valueOf(reader.getString());
+                } else if ("Details".equals(fieldName)) {
+                    message.details = reader.readUntyped();
+                } else if ("Text".equals(fieldName)) {
+                    message.text = reader.getString();
+                } else if ("Key".equals(fieldName)) {
+                    message.key = reader.readArray(JsonReader::getString);
+                } else if ("Source".equals(fieldName)) {
+                    message.source = reader.readArray(SourceLocation::fromJson);
+                } else {
+                    reader.skipChildren();
+                }
+            }
+
+            return message;
+        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/Message.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/Message.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents a message.
  */
-public class Message implements JsonSerializable<Message> {
+public class Message {
 
     /**
      * Represents a message channel.
@@ -134,50 +129,5 @@ public class Message implements JsonSerializable<Message> {
      */
     public void setText(String text) {
         this.text = text;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("Channel", channel == null ? null : channel.toString())
-            .writeUntypedField("Details", details)
-            .writeStringField("Text", text)
-            .writeArrayField("Key", key, JsonWriter::writeString)
-            .writeArrayField("Source", source, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Message instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Message instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Message fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            Message message = new Message();
-
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("Channel".equals(fieldName)) {
-                    message.channel = MessageChannel.valueOf(reader.getString());
-                } else if ("Details".equals(fieldName)) {
-                    message.details = reader.readUntyped();
-                } else if ("Text".equals(fieldName)) {
-                    message.text = reader.getString();
-                } else if ("Key".equals(fieldName)) {
-                    message.key = reader.readArray(JsonReader::getString);
-                } else if ("Source".equals(fieldName)) {
-                    message.source = reader.readArray(SourceLocation::fromJson);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return message;
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SmartLocation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SmartLocation.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents a smart location.
  */
-public class SmartLocation implements JsonSerializable<SourceLocation> {
+public class SmartLocation {
     private List<Object> path;
 
     /**
@@ -38,36 +33,5 @@ public class SmartLocation implements JsonSerializable<SourceLocation> {
      */
     public void setPath(List<Object> path) {
         this.path = path;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeArrayField("path", path, JsonWriter::writeUntyped).writeEndObject();
-    }
-
-    /**
-     * Deserializes a SmartLocation instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A SmartLocation instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static SmartLocation fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            SmartLocation smartLocation = new SmartLocation();
-
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("path".equals(fieldName)) {
-                    smartLocation.path = reader.readArray(JsonReader::readUntyped);
-                } else {
-                    reader.skipChildren();;
-                }
-            }
-
-            return smartLocation;
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SmartLocation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SmartLocation.java
@@ -3,12 +3,17 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model;
 
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents a smart location.
  */
-public class SmartLocation {
+public class SmartLocation implements JsonSerializable<SourceLocation> {
     private List<Object> path;
 
     /**
@@ -33,5 +38,36 @@ public class SmartLocation {
      */
     public void setPath(List<Object> path) {
         this.path = path;
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        return jsonWriter.writeStartObject().writeArrayField("path", path, JsonWriter::writeUntyped).writeEndObject();
+    }
+
+    /**
+     * Deserializes a SmartLocation instance from the JSON data.
+     *
+     * @param jsonReader The JSON reader to deserialize from.
+     * @return A SmartLocation instance deserialized from the JSON data.
+     * @throws IOException If an error occurs during deserialization.
+     */
+    public static SmartLocation fromJson(JsonReader jsonReader) throws IOException {
+        return jsonReader.readObject(reader -> {
+            SmartLocation smartLocation = new SmartLocation();
+
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                if ("path".equals(fieldName)) {
+                    smartLocation.path = reader.readArray(JsonReader::readUntyped);
+                } else {
+                    reader.skipChildren();;
+                }
+            }
+
+            return smartLocation;
+        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SourceLocation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SourceLocation.java
@@ -3,16 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonToken;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
-
 /**
  * Represents a source location.
  */
-public class SourceLocation implements JsonSerializable<SourceLocation> {
+public class SourceLocation {
     private String document;
     private SmartLocation position;
 
@@ -56,41 +50,5 @@ public class SourceLocation implements JsonSerializable<SourceLocation> {
      */
     public void setPosition(SmartLocation position) {
         this.position = position;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("document", document)
-            .writeJsonField("position", position)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a SourceLocation instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A SourceLocation instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static SourceLocation fromJson(JsonReader jsonReader) throws IOException {
-        return jsonReader.readObject(reader -> {
-            SourceLocation sourceLocation = new SourceLocation();
-
-            while (reader.nextToken() != JsonToken.END_OBJECT) {
-                String fieldName = reader.getFieldName();
-                reader.nextToken();
-
-                if ("document".equals(fieldName)) {
-                    sourceLocation.document = reader.getString();
-                } else if ("position".equals(fieldName)) {
-                    sourceLocation.position = SmartLocation.fromJson(reader);
-                } else {
-                    reader.skipChildren();
-                }
-            }
-
-            return sourceLocation;
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SourceLocation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SourceLocation.java
@@ -3,10 +3,16 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model;
 
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+import java.io.IOException;
+
 /**
  * Represents a source location.
  */
-public class SourceLocation {
+public class SourceLocation implements JsonSerializable<SourceLocation> {
     private String document;
     private SmartLocation position;
 
@@ -50,5 +56,41 @@ public class SourceLocation {
      */
     public void setPosition(SmartLocation position) {
         this.position = position;
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        return jsonWriter.writeStartObject()
+            .writeStringField("document", document)
+            .writeJsonField("position", position)
+            .writeEndObject();
+    }
+
+    /**
+     * Deserializes a SourceLocation instance from the JSON data.
+     *
+     * @param jsonReader The JSON reader to deserialize from.
+     * @return A SourceLocation instance deserialized from the JSON data.
+     * @throws IOException If an error occurs during deserialization.
+     */
+    public static SourceLocation fromJson(JsonReader jsonReader) throws IOException {
+        return jsonReader.readObject(reader -> {
+            SourceLocation sourceLocation = new SourceLocation();
+
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                if ("document".equals(fieldName)) {
+                    sourceLocation.document = reader.getString();
+                } else if ("position".equals(fieldName)) {
+                    sourceLocation.position = SmartLocation.fromJson(reader);
+                } else {
+                    reader.skipChildren();
+                }
+            }
+
+            return sourceLocation;
+        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/AndSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/AndSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -84,36 +80,5 @@ public class AndSchema extends ComplexSchema {
         }
         AndSchema rhs = ((AndSchema) other);
         return Objects.equals(allOf, rhs.allOf) && Objects.equals(discriminatorValue, rhs.discriminatorValue);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject())
-            .writeArrayField("allOf", allOf, JsonWriter::writeJson)
-            .writeStringField("discriminatorValue", discriminatorValue)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an AndSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An AndSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static AndSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, AndSchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-
-            if ("allOf".equals(fieldName)) {
-                schema.allOf = reader.readArray(ComplexSchema::fromJson);
-            } else if ("discriminatorValue".equals(fieldName)) {
-                schema.discriminatorValue = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/AnySchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/AnySchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * A schema that is non-object, non-complex.
  */
@@ -17,25 +12,5 @@ public class AnySchema extends Schema {
      */
     public AnySchema() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes an AnySchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An AnySchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static AnySchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, AnySchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ApiVersion.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ApiVersion.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -23,7 +18,7 @@ import java.util.Objects;
  * <p>
  * - semver-range style (ie, '^1.0.0' or '~1.0.0' )
  */
-public class ApiVersion implements JsonSerializable<ApiVersion> {
+public class ApiVersion {
     private String version;
     private ApiVersion.Range range;
 
@@ -92,33 +87,6 @@ public class ApiVersion implements JsonSerializable<ApiVersion> {
 
         ApiVersion rhs = ((ApiVersion) other);
         return Objects.equals(version, rhs.version) && Objects.equals(range, rhs.range);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("version", version)
-            .writeStringField("range", range == null ? null : range.toString())
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an ApiVersion instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An ApiVersion instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ApiVersion fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ApiVersion::new, (version, fieldName, reader) -> {
-            if ("version".equals(fieldName)) {
-                version.version = reader.getString();
-            } else if ("range".equals(fieldName)) {
-                version.range = ApiVersion.Range.fromValue(reader.getString());
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ArmIdSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ArmIdSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents an ARM ID schema.
  */
@@ -17,25 +12,5 @@ public class ArmIdSchema extends PrimitiveSchema {
      */
     public ArmIdSchema() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes an ArmIdSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An ArmIdSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ArmIdSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ArmIdSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ArraySchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ArraySchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -124,41 +120,5 @@ public class ArraySchema extends ValueSchema {
             && maxItems == rhs.maxItems
             && uniqueItems == rhs.uniqueItems
             && Objects.equals(this.elementType, rhs.elementType);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeJsonField("elementType", elementType)
-            .writeDoubleField("maxItems", maxItems)
-            .writeDoubleField("minItems", minItems)
-            .writeBooleanField("uniqueItems", uniqueItems)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an ArraySchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An ArraySchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ArraySchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ArraySchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-
-            if ("elementType".equals(fieldName)) {
-                schema.elementType = Schema.fromJson(reader);
-            } else if ("maxItems".equals(fieldName)) {
-                schema.maxItems = reader.getDouble();
-            } else if ("minItems".equals(fieldName)) {
-                schema.minItems = reader.getDouble();
-            } else if ("uniqueItems".equals(fieldName)) {
-                schema.uniqueItems = reader.getBoolean();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/BinarySchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/BinarySchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represent a binary schema.
  */
@@ -17,25 +12,5 @@ public class BinarySchema extends Schema {
      */
     public BinarySchema() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a BinarySchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A BinarySchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static BinarySchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, BinarySchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/BooleanSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/BooleanSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a boolean schema.
  */
@@ -37,25 +32,5 @@ public class BooleanSchema extends PrimitiveSchema {
         }
 
         return other instanceof BooleanSchema;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a BooleanSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A BooleanSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static BooleanSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, BooleanSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ByteArraySchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ByteArraySchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -63,34 +59,6 @@ public class ByteArraySchema extends PrimitiveSchema {
 
         ByteArraySchema rhs = ((ByteArraySchema) other);
         return Objects.equals(format, rhs.format);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject())
-            .writeStringField("format", format == null ? null : format.toString())
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ByteArraySchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ByteArraySchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ByteArraySchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ByteArraySchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-
-            if ("format".equals(fieldName)) {
-                schema.format = ByteArraySchema.Format.fromValue(reader.getString());
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CSharpLanguage.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CSharpLanguage.java
@@ -3,16 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents the C# language.
  */
-public class CSharpLanguage implements JsonSerializable<CSharpLanguage> {
+public class CSharpLanguage {
 
     /**
      * Creates a new instance of the CSharpLanguage class.
@@ -37,21 +31,5 @@ public class CSharpLanguage implements JsonSerializable<CSharpLanguage> {
         }
 
         return other instanceof CSharpLanguage;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeEndObject();
-    }
-
-    /**
-     * Deserializes a CSharpLanguage instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A CSharpLanguage instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static CSharpLanguage fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readEmptyObject(jsonReader, CSharpLanguage::new);
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CharSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CharSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a char schema.
  */
@@ -37,25 +32,5 @@ public class CharSchema extends PrimitiveSchema {
         }
 
         return other instanceof CharSchema;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a CharSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A CharSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static CharSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, CharSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ChoiceSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ChoiceSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -108,48 +104,5 @@ public class ChoiceSchema extends ValueSchema {
         return Objects.equals(lhs.choiceType, rhs.choiceType)
             && Objects.equals(lhs.choices, rhs.choices)
             && Objects.equals(lhs.getLanguage().getJava().getName(), rhs.getLanguage().getJava().getName());
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return writeParentProperties(jsonWriter.writeStartObject()).writeEndObject();
-    }
-
-    JsonWriter writeParentProperties(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter).writeJsonField("choiceType", choiceType)
-            .writeArrayField("choices", choices, JsonWriter::writeJson)
-            .writeStringField("summary", summary);
-    }
-
-    /**
-     * Deserializes a ChoiceSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ChoiceSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ChoiceSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ChoiceSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
-    }
-
-    boolean tryConsumeParentProperties(ChoiceSchema schema, String fieldName, JsonReader reader) throws IOException {
-        if (super.tryConsumeParentProperties(schema, fieldName, reader)) {
-            return true;
-        } else if ("choiceType".equals(fieldName)) {
-            schema.choiceType = Schema.fromJson(reader);
-            return true;
-        } else if ("choices".equals(fieldName)) {
-            schema.choices = reader.readArray(ChoiceValue::fromJson);
-            return true;
-        } else if ("summary".equals(fieldName)) {
-            schema.summary = reader.getString();
-            return true;
-        }
-
-        return false;
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ChoiceValue.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ChoiceValue.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents a choice value.
  */
-public class ChoiceValue implements JsonSerializable<ChoiceValue> {
+public class ChoiceValue {
     private Languages language;
     private String value;
     private DictionaryAny extensions;
@@ -102,35 +97,5 @@ public class ChoiceValue implements JsonSerializable<ChoiceValue> {
 
         ChoiceValue rhs = ((ChoiceValue) other);
         return Objects.equals(this.value, rhs.value);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("language", language)
-            .writeStringField("value", value)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ChoiceValue instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ChoiceValue instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ChoiceValue fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ChoiceValue::new, (value, fieldName, reader) -> {
-            if ("language".equals(fieldName)) {
-                value.language = Languages.fromJson(reader);
-            } else if ("value".equals(fieldName)) {
-                value.value = reader.getString();
-            } else if ("extensions".equals(fieldName)) {
-                value.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Client.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Client.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -171,76 +167,5 @@ public class Client extends Metadata {
 
     public void setParentAccessorPublic(boolean parentAccessorPublic) {
         this.parentAccessorPublic = parentAccessorPublic;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return writeParentProperties(jsonWriter.writeStartObject()).writeEndObject();
-    }
-
-    JsonWriter writeParentProperties(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter).writeStringField("summary", summary)
-            .writeArrayField("operationGroups", operationGroups, JsonWriter::writeJson)
-            .writeArrayField("globalParameters", globalParameters, JsonWriter::writeJson)
-            .writeJsonField("security", security)
-            .writeArrayField("apiVersions", apiVersions, JsonWriter::writeJson)
-            .writeJsonField("serviceVersion", serviceVersion)
-            .writeJsonField("parent", parent)
-            .writeArrayField("subClients", subClients, JsonWriter::writeJson)
-            .writeBooleanField("buildMethodPublic", buildMethodPublic)
-            .writeBooleanField("parentAccessorPublic", parentAccessorPublic);
-    }
-
-    /**
-     * Deserializes a Client instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Client instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Client fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Client::new, (client, fieldName, reader) -> {
-            if (!client.tryConsumeParentProperties(client, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
-    }
-
-    boolean tryConsumeParentProperties(Client client, String fieldName, JsonReader reader) throws IOException {
-        if (super.tryConsumeParentProperties(client, fieldName, reader)) {
-            return true;
-        } else if ("summary".equals(fieldName)) {
-            client.summary = reader.getString();
-            return true;
-        } else if ("operationGroups".equals(fieldName)) {
-            client.operationGroups = reader.readArray(OperationGroup::fromJson);
-            return true;
-        } else if ("globalParameters".equals(fieldName)) {
-            client.globalParameters = reader.readArray(Parameter::fromJson);
-            return true;
-        } else if ("security".equals(fieldName)) {
-            client.security = Security.fromJson(reader);
-            return true;
-        } else if ("apiVersions".equals(fieldName)) {
-            client.apiVersions = reader.readArray(ApiVersion::fromJson);
-            return true;
-        } else if ("serviceVersion".equals(fieldName)) {
-            client.serviceVersion = ServiceVersion.fromJson(reader);
-            return true;
-        } else if ("parent".equals(fieldName)) {
-            client.parent = Client.fromJson(reader);
-            return true;
-        } else if ("subClients".equals(fieldName)) {
-            client.subClients = reader.readArray(Client::fromJson);
-            return true;
-        } else if ("buildMethodPublic".equals(fieldName)) {
-            client.buildMethodPublic = reader.getBoolean();
-            return true;
-        } else if ("parentAccessorPublic".equals(fieldName)) {
-            client.parentAccessorPublic = reader.getBoolean();
-            return true;
-        }
-
-        return false;
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CodeModel.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CodeModel.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -98,41 +94,5 @@ public class CodeModel extends Client {
      */
     public void setTestModel(TestModel testModel) {
         this.testModel = testModel;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeJsonField("info", info)
-            .writeJsonField("schemas", schemas)
-            .writeArrayField("clients", clients, JsonWriter::writeJson)
-            .writeJsonField("testModel", testModel)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a CodeModel instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A CodeModel instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static CodeModel fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, CodeModel::new, (codeModel, fieldName, reader) -> {
-            if (codeModel.tryConsumeParentProperties(codeModel, fieldName, reader)) {
-                return;
-            }
-
-            if ("info".equals(fieldName)) {
-                codeModel.info = Info.fromJson(reader);
-            } else if ("schemas".equals(fieldName)) {
-                codeModel.schemas = Schemas.fromJson(reader);
-            } else if ("clients".equals(fieldName)) {
-                codeModel.clients = reader.readArray(Client::fromJson);
-            } else if ("testModel".equals(fieldName)) {
-                codeModel.testModel = TestModel.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ComplexSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ComplexSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a complex schema (types that can be an object).
  */
@@ -17,25 +12,5 @@ public class ComplexSchema extends Schema {
      */
     public ComplexSchema() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a ComplexSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ComplexSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ComplexSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ComplexSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ConstantSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ConstantSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a constant schema.
  */
@@ -56,32 +51,5 @@ public class ConstantSchema extends Schema {
      */
     public void setValue(ConstantValue value) {
         this.value = value;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("valueType", valueType)
-            .writeJsonField("value", value)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ConstantSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ConstantSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ConstantSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ConstantSchema::new, (schema, fieldName, reader) -> {
-            if ("valueType".equals(fieldName)) {
-                schema.valueType = Schema.fromJson(reader);
-            } else if ("value".equals(fieldName)) {
-                schema.value = ConstantValue.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ConstantValue.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ConstantValue.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents a constant value.
  */
-public class ConstantValue implements JsonSerializable<ConstantValue> {
+public class ConstantValue {
     private Languages language;
     private Object value;
     private DictionaryAny extensions;
@@ -103,35 +98,5 @@ public class ConstantValue implements JsonSerializable<ConstantValue> {
         return Objects.equals(language, rhs.language)
             && Objects.equals(extensions, rhs.extensions)
             && Objects.equals(value, rhs.value);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("language", language)
-            .writeUntypedField("value", value)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ConstantValue instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ConstantValue instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ConstantValue fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ConstantValue::new, (value, fieldName, reader) -> {
-            if ("language".equals(fieldName)) {
-                value.language = Languages.fromJson(reader);
-            } else if ("value".equals(fieldName)) {
-                value.value = reader.readUntyped();
-            } else if ("extensions".equals(fieldName)) {
-                value.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Contact.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Contact.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents a contact.
  */
-public class Contact implements JsonSerializable<Contact> {
+public class Contact {
     private String name;
     private String url;
     private String email;
@@ -123,38 +118,5 @@ public class Contact implements JsonSerializable<Contact> {
             && Objects.equals(extensions, rhs.extensions)
             && Objects.equals(url, rhs.url)
             && Objects.equals(email, rhs.email);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("name", name)
-            .writeStringField("url", url)
-            .writeStringField("email", email)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Constant instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Constant instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Contact fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Contact::new, (contact, fieldName, reader) -> {
-            if ("name".equals(fieldName)) {
-                contact.name = reader.getString();
-            } else if ("url".equals(fieldName)) {
-                contact.url = reader.getString();
-            } else if ("email".equals(fieldName)) {
-                contact.email = reader.getString();
-            } else if ("extensions".equals(fieldName)) {
-                contact.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ConvenienceApi.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ConvenienceApi.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -38,33 +34,5 @@ public class ConvenienceApi extends Metadata {
      */
     public void setRequests(List<Request> requests) {
         this.requests = requests;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject())
-            .writeArrayField("requests", requests, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ConvenienceApi instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ConvenienceApi instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ConvenienceApi fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ConvenienceApi::new, (convenienceApi, fieldName, reader) -> {
-            if (convenienceApi.tryConsumeParentProperties(convenienceApi, fieldName, reader)) {
-                return;
-            }
-
-            if ("requests".equals(fieldName)) {
-                convenienceApi.requests = reader.readArray(Request::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CredentialSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/CredentialSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -104,35 +100,5 @@ public class CredentialSchema extends PrimitiveSchema {
         return Objects.equals(maxLength, rhs.maxLength)
             && Objects.equals(minLength, rhs.minLength)
             && Objects.equals(pattern, rhs.pattern);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeDoubleField("maxLength", maxLength)
-            .writeDoubleField("minLength", minLength)
-            .writeStringField("pattern", pattern)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a CredentialSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A CredentialSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static CredentialSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, CredentialSchema::new, (schema, fieldName, reader) -> {
-            if ("maxLength".equals(fieldName)) {
-                schema.maxLength = reader.getDouble();
-            } else if ("minLength".equals(fieldName)) {
-                schema.minLength = reader.getDouble();
-            } else if ("pattern".equals(fieldName)) {
-                schema.pattern = reader.getString();
-            } else {
-                reader.skipChildren();;
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DateSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DateSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a date value.
  */
@@ -37,25 +32,5 @@ public class DateSchema extends PrimitiveSchema {
         }
 
         return other instanceof DateSchema;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a DateSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A DateSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static DateSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, DateSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DateTimeSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DateTimeSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -63,30 +59,6 @@ public class DateTimeSchema extends PrimitiveSchema {
 
         DateTimeSchema rhs = ((DateTimeSchema) other);
         return format == rhs.format;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("format", format == null ? null : format.toString())
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a DateTimeSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A DateTimeSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static DateTimeSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, DateTimeSchema::new, (schema, fieldName, reader) -> {
-            if ("format".equals(fieldName)) {
-                schema.format = Format.fromValue(reader.getString());
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Deprecation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Deprecation.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -15,7 +10,7 @@ import java.util.Objects;
 /**
  * Represents deprecation information.
  */
-public class Deprecation implements JsonSerializable<Deprecation> {
+public class Deprecation {
     private String message;
     private List<ApiVersion> apiVersions = new ArrayList<>();
 
@@ -84,32 +79,5 @@ public class Deprecation implements JsonSerializable<Deprecation> {
 
         Deprecation rhs = ((Deprecation) other);
         return Objects.equals(message, rhs.message) && Objects.equals(apiVersions, rhs.apiVersions);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("message", message)
-            .writeArrayField("apiVersions", apiVersions, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Deprecation instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Deprecation instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Deprecation fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Deprecation::new, (deprecation, fieldName, reader) -> {
-            if ("message".equals(fieldName)) {
-                deprecation.message = reader.getString();
-            } else if ("apiVersions".equals(fieldName)) {
-                deprecation.apiVersions = reader.readArray(ApiVersion::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DictionaryAny.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DictionaryAny.java
@@ -3,16 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a dictionary of any type.
  */
-public class DictionaryAny implements JsonSerializable<DictionaryAny> {
+public class DictionaryAny {
 
     /**
      * Creates a new instance of the DictionaryAny class.
@@ -37,21 +31,5 @@ public class DictionaryAny implements JsonSerializable<DictionaryAny> {
         }
 
         return other instanceof DictionaryAny;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeEndObject();
-    }
-
-    /**
-     * Deserializes a DictionaryAny instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A DictionaryAny instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static DictionaryAny fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readEmptyObject(jsonReader, DictionaryAny::new);
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DictionaryApiVersion.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DictionaryApiVersion.java
@@ -3,16 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents the version of the dictionary API.
  */
-public class DictionaryApiVersion implements JsonSerializable<DictionaryApiVersion> {
+public class DictionaryApiVersion {
 
     /**
      * Creates a new instance of the DictionaryApiVersion class.
@@ -37,21 +31,5 @@ public class DictionaryApiVersion implements JsonSerializable<DictionaryApiVersi
         }
 
         return other instanceof DictionaryApiVersion;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeEndObject();
-    }
-
-    /**
-     * Deserializes a DictionaryApiVersion instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A DictionaryApiVersion instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static DictionaryApiVersion fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readEmptyObject(jsonReader, DictionaryApiVersion::new);
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DictionarySchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DictionarySchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -83,32 +79,5 @@ public class DictionarySchema extends ComplexSchema {
     @Override
     public int hashCode() {
         return Objects.hash(elementType, nullableItems);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("elementType", elementType)
-            .writeBooleanField("nullableItems", nullableItems)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a DictionarySchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A DictionarySchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static DictionarySchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, DictionarySchema::new, (schema, fieldName, reader) -> {
-            if ("elementType".equals(fieldName)) {
-                schema.elementType = Schema.fromJson(reader);
-            } else if ("nullableItems".equals(fieldName)) {
-                schema.nullableItems = reader.getNullable(JsonReader::getBoolean);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Discriminator.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Discriminator.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Map;
 
 /**
  * Represents a discriminator for polymorphic types.
  */
-public class Discriminator implements JsonSerializable<Discriminator> {
+public class Discriminator {
     private Property property;
     private Map<String, ComplexSchema> immediate;
     private Map<String, ComplexSchema> all;
@@ -76,35 +71,5 @@ public class Discriminator implements JsonSerializable<Discriminator> {
      */
     public void setAll(Map<String, ComplexSchema> all) {
         this.all = all;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("property", property)
-            .writeMapField("immediate", immediate, JsonWriter::writeJson)
-            .writeMapField("all", all, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Discriminator instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Discriminator instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Discriminator fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Discriminator::new, (discriminator, fieldName, reader) -> {
-            if ("property".equals(fieldName)) {
-                discriminator.property = Property.fromJson(reader);
-            } else if ("immediate".equals(fieldName)) {
-                discriminator.immediate = reader.readMap(ComplexSchema::fromJson);
-            } else if ("all".equals(fieldName)) {
-                discriminator.all = reader.readMap(ComplexSchema::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DurationSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/DurationSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -63,30 +59,6 @@ public class DurationSchema extends PrimitiveSchema {
     @Override
     public int hashCode() {
         return Objects.hash(format);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("format", format == null ? null : format.toString())
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a DurationSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A DurationSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static DurationSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, DurationSchema::new, (schema, fieldName, reader) -> {
-            if ("format".equals(fieldName)) {
-                schema.format = Format.fromValue(reader.getString());
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ExternalDocumentation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ExternalDocumentation.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents a reference to external documentation.
  */
-public class ExternalDocumentation implements JsonSerializable<ExternalDocumentation> {
+public class ExternalDocumentation {
     private String description;
     private String url;
     private DictionaryAny extensions;
@@ -104,35 +99,5 @@ public class ExternalDocumentation implements JsonSerializable<ExternalDocumenta
         return Objects.equals(description, rhs.description)
             && Objects.equals(url, rhs.url)
             && Objects.equals(extensions, rhs.extensions);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("description", description)
-            .writeStringField("url", url)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an ExternalDocumentation instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An ExternalDocumentation instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ExternalDocumentation fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ExternalDocumentation::new, (documentation, fieldName, reader) -> {
-            if ("description".equals(fieldName)) {
-                documentation.description = reader.getString();
-            } else if ("url".equals(fieldName)) {
-                documentation.url = reader.getString();
-            } else if ("extensions".equals(fieldName)) {
-                documentation.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/FlagSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/FlagSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -65,29 +61,5 @@ public class FlagSchema extends ValueSchema {
 
         FlagSchema rhs = ((FlagSchema) other);
         return Objects.equals(choices, rhs.choices);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeArrayField("choices", choices, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a FlagSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A FlagSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static FlagSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, FlagSchema::new, (schema, fieldName, reader) -> {
-            if ("choices".equals(fieldName)) {
-                schema.choices = reader.readArray(FlagValue::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/FlagValue.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/FlagValue.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents a flag value.
  */
-public class FlagValue implements JsonSerializable<FlagValue> {
+public class FlagValue {
     private Languages language;
     private double value;
     private DictionaryAny extensions;
@@ -104,35 +99,5 @@ public class FlagValue implements JsonSerializable<FlagValue> {
         return value == rhs.value
             && Objects.equals(language, rhs.language)
             && Objects.equals(extensions, rhs.extensions);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("language", language)
-            .writeDoubleField("value", value)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a FlagValue instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A FlagValue instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static FlagValue fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, FlagValue::new, (value, fieldName, reader) -> {
-            if ("language".equals(fieldName)) {
-                value.language = Languages.fromJson(reader);
-            } else if ("value".equals(fieldName)) {
-                value.value = reader.getDouble();
-            } else if ("extensions".equals(fieldName)) {
-                value.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Header.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Header.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel.XmsExtensions;
-import java.io.IOException;
 
 /**
  * Represents a header.
  */
-public class Header implements JsonSerializable<Header> {
+public class Header {
     private String header;
     private Schema schema;
     private XmsExtensions extensions;
@@ -76,35 +71,5 @@ public class Header implements JsonSerializable<Header> {
      */
     public void setExtensions(XmsExtensions extensions) {
         this.extensions = extensions;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("header", header)
-            .writeJsonField("schema", schema)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Header instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Header instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Header fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Header::new, (header, fieldName, reader) -> {
-            if ("header".equals(fieldName)) {
-                header.header = reader.getString();
-            } else if ("schema".equals(fieldName)) {
-                header.schema = Schema.fromJson(reader);
-            } else if ("extensions".equals(fieldName)) {
-                header.extensions = XmsExtensions.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Info.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Info.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents code model info.
  */
-public class Info implements JsonSerializable<Info> {
+public class Info {
     private String title;
     private String description;
     private String termsOfService;
@@ -186,47 +181,5 @@ public class Info implements JsonSerializable<Info> {
             && Objects.equals(license, rhs.license)
             && Objects.equals(externalDocs, rhs.externalDocs)
             && Objects.equals(extensions, rhs.extensions);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("title", title)
-            .writeStringField("description", description)
-            .writeStringField("termsOfService", termsOfService)
-            .writeJsonField("contact", contact)
-            .writeJsonField("license", license)
-            .writeJsonField("externalDocs", externalDocs)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an Info instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An Info instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Info fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Info::new, (info, fieldName, reader) -> {
-            if ("title".equals(fieldName)) {
-                info.title = reader.getString();
-            } else if ("description".equals(fieldName)) {
-                info.description = reader.getString();
-            } else if ("termsOfService".equals(fieldName)) {
-                info.termsOfService = reader.getString();
-            } else if ("contact".equals(fieldName)) {
-                info.contact = Contact.fromJson(reader);
-            } else if ("license".equals(fieldName)) {
-                info.license = License.fromJson(reader);
-            } else if ("externalDocs".equals(fieldName)) {
-                info.externalDocs = ExternalDocumentation.fromJson(reader);
-            } else if ("extensions".equals(fieldName)) {
-                info.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Language.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Language.java
@@ -3,17 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
-
 /**
  * Represents the per-language metadata.
  */
-public class Language implements JsonSerializable<Language> {
+public class Language {
     private String name;
     private String serializedName;
     private String description;
@@ -157,47 +150,5 @@ public class Language implements JsonSerializable<Language> {
     @Override
     public String toString() {
         return "Language{name='" + name + "', serializedName='" + serializedName + "'}";
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("name", name)
-            .writeStringField("serializedName", serializedName)
-            .writeStringField("description", description)
-            .writeStringField("summary", summary)
-            .writeStringField("namespace", namespace)
-            .writeStringField("crossLanguageDefinitionId", crossLanguageDefinitionId)
-            .writeStringField("comment", comment)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Language instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Language instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Language fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, Language::new, (language, fieldName, reader) -> {
-            if ("name".equals(fieldName)) {
-                language.name = reader.getString();
-            } else if ("serializedName".equals(fieldName)) {
-                language.serializedName = reader.getString();
-            } else if ("description".equals(fieldName)) {
-                language.description = reader.getString();
-            } else if ("summary".equals(fieldName)) {
-                language.summary = reader.getString();
-            } else if ("namespace".equals(fieldName)) {
-                language.namespace = reader.getString();
-            } else if ("crossLanguageDefinitionId".equals(fieldName)) {
-                language.crossLanguageDefinitionId = reader.getString();
-            } else if ("comment".equals(fieldName)) {
-                language.comment = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Languages.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Languages.java
@@ -3,18 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents all languages.
  */
-public class Languages implements JsonSerializable<Languages> {
+public class Languages {
     private Language _default;
     private CSharpLanguage csharp;
     private Language python;
@@ -304,65 +298,5 @@ public class Languages implements JsonSerializable<Languages> {
     @Override
     public String toString() {
         return "Languages{default=" + _default + ", java=" + java + '}';
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("default", _default)
-            .writeJsonField("csharp", csharp)
-            .writeJsonField("python", python)
-            .writeJsonField("ruby", ruby)
-            .writeJsonField("go", go)
-            .writeJsonField("typescript", typescript)
-            .writeJsonField("javascript", javascript)
-            .writeJsonField("powershell", powershell)
-            .writeJsonField("java", java)
-            .writeJsonField("c", c)
-            .writeJsonField("cpp", cpp)
-            .writeJsonField("swift", swift)
-            .writeJsonField("objectivec", objectivec)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Languages instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Languages instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Languages fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, Languages::new, (languages, fieldName, reader) -> {
-            if ("_default".equals(fieldName)) {
-                languages._default = Language.fromJson(reader);
-            } else if ("csharp".equals(fieldName)) {
-                languages.csharp = CSharpLanguage.fromJson(reader);
-            } else if ("python".equals(fieldName)) {
-                languages.python = Language.fromJson(reader);
-            } else if ("ruby".equals(fieldName)) {
-                languages.ruby = Language.fromJson(reader);
-            } else if ("go".equals(fieldName)) {
-                languages.go = Language.fromJson(reader);
-            } else if ("typescript".equals(fieldName)) {
-                languages.typescript = Language.fromJson(reader);
-            } else if ("javascript".equals(fieldName)) {
-                languages.javascript = Language.fromJson(reader);
-            } else if ("powershell".equals(fieldName)) {
-                languages.powershell = Language.fromJson(reader);
-            } else if ("java".equals(fieldName)) {
-                languages.java = Language.fromJson(reader);
-            } else if ("c".equals(fieldName)) {
-                languages.c = Language.fromJson(reader);
-            } else if ("cpp".equals(fieldName)) {
-                languages.cpp = Language.fromJson(reader);
-            } else if ("swift".equals(fieldName)) {
-                languages.swift = Language.fromJson(reader);
-            } else if ("objectivec".equals(fieldName)) {
-                languages.objectivec = Language.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/License.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/License.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents license information.
  */
-public class License implements JsonSerializable<License> {
+public class License {
     private String name;
     private String url;
     private DictionaryAny extensions;
@@ -104,35 +99,5 @@ public class License implements JsonSerializable<License> {
         return Objects.equals(name, rhs.name)
             && Objects.equals(url, rhs.url)
             && Objects.equals(extensions, rhs.extensions);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("name", name)
-            .writeStringField("url", url)
-            .writeJsonField("extensions", extensions)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a License instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A License instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static License fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, License::new, (license, fieldName, reader) -> {
-            if ("name".equals(fieldName)) {
-                license.name = reader.getString();
-            } else if ("url".equals(fieldName)) {
-                license.url = reader.getString();
-            } else if ("extensions".equals(fieldName)) {
-                license.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/LongRunningMetadata.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/LongRunningMetadata.java
@@ -3,16 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents the metadata for long-running operations.
  */
-public class LongRunningMetadata implements JsonSerializable<LongRunningMetadata> {
+public class LongRunningMetadata {
     private ObjectSchema pollResultType;
     private ObjectSchema finalResultType;
     private Metadata pollingStrategy;
@@ -94,38 +88,5 @@ public class LongRunningMetadata implements JsonSerializable<LongRunningMetadata
      */
     public void setFinalResultPropertySerializedName(String finalResultPropertySerializedName) {
         this.finalResultPropertySerializedName = finalResultPropertySerializedName;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("pollResultType", pollResultType)
-            .writeJsonField("finalResultType", finalResultType)
-            .writeJsonField("pollingStrategy", pollingStrategy)
-            .writeStringField("finalResultPropertySerializedName", finalResultPropertySerializedName)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a LongRunningMetadata instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A LongRunningMetadata instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static LongRunningMetadata fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, LongRunningMetadata::new, (lroMetadata, fieldName, reader) -> {
-            if ("pollResultType".equals(fieldName)) {
-                lroMetadata.pollResultType = ObjectSchema.fromJson(reader);
-            } else if ("finalResultType".equals(fieldName)) {
-                lroMetadata.finalResultType = ObjectSchema.fromJson(reader);
-            } else if ("pollingStrategy".equals(fieldName)) {
-                lroMetadata.pollingStrategy = Metadata.fromJson(reader);
-            } else if ("finalResultPropertySerializedName".equals(fieldName)) {
-                lroMetadata.finalResultPropertySerializedName = reader.getFieldName();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Metadata.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Metadata.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel.XmsExtensions;
-import java.io.IOException;
 
 /**
  * Represents metadata.
  */
-public class Metadata implements JsonSerializable<Metadata> {
+public class Metadata {
     private Languages language;
     private Protocols protocol;
     private XmsExtensions extensions;
@@ -76,45 +71,5 @@ public class Metadata implements JsonSerializable<Metadata> {
      */
     public void setExtensions(XmsExtensions extensions) {
         this.extensions = extensions;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return writeParentProperties(jsonWriter.writeStartObject()).writeEndObject();
-    }
-
-    JsonWriter writeParentProperties(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeJsonField("language", language)
-            .writeJsonField("protocol", protocol)
-            .writeJsonField("extensions", extensions);
-    }
-
-    /**
-     * Deserializes a Metadata instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Metadata instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Metadata fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Metadata::new, (metadata, fieldName, reader) -> {
-            if (!metadata.tryConsumeParentProperties(metadata, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
-    }
-
-    boolean tryConsumeParentProperties(Metadata metadata, String fieldName, JsonReader reader) throws IOException {
-        if ("language".equals(fieldName)) {
-            metadata.language = Languages.fromJson(reader);
-            return true;
-        } else if ("protocol".equals(fieldName)) {
-            metadata.protocol = Protocols.fromJson(reader);
-            return true;
-        } else if ("extensions".equals(fieldName)) {
-            metadata.extensions = XmsExtensions.fromJson(reader);
-            return true;
-        }
-        return false;
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/NotSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/NotSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a NOT relationship between schemas.
  */
@@ -36,27 +31,5 @@ public class NotSchema extends Schema {
      */
     public void setNot(Schema not) {
         this.not = not;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeJsonField("not", not).writeEndObject();
-    }
-
-    /**
-     * Deserializes a NotSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A NotSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static NotSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, NotSchema::new, (schema, fieldName, reader) -> {
-            if ("not".equals(fieldName)) {
-                schema.not = Schema.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/NumberSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/NumberSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a Number value.
  */
@@ -150,50 +145,5 @@ public class NumberSchema extends PrimitiveSchema {
      */
     public void setEncode(String encode) {
         this.encode = encode;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeDoubleField("precision", precision)
-            .writeDoubleField("multipleOf", multipleOf)
-            .writeDoubleField("maximum", maximum)
-            .writeBooleanField("exclusiveMaximum", exclusiveMaximum)
-            .writeDoubleField("minimum", minimum)
-            .writeBooleanField("exclusiveMinimum", exclusiveMinimum)
-            .writeStringField("encode", encode)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a NumberSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A NumberSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static NumberSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, NumberSchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-
-            if ("precision".equals(fieldName)) {
-                schema.precision = reader.getDouble();
-            } else if ("multipleOf".equals(fieldName)) {
-                schema.multipleOf = reader.getDouble();
-            } else if ("maximum".equals(fieldName)) {
-                schema.maximum = reader.getDouble();
-            } else if ("exclusiveMaximum".equals(fieldName)) {
-                schema.exclusiveMaximum = reader.getBoolean();
-            } else if ("minimum".equals(fieldName)) {
-                schema.minimum = reader.getDouble();
-            } else if ("exclusiveMinimum".equals(fieldName)) {
-                schema.exclusiveMinimum = reader.getBoolean();
-            } else if ("encode".equals(fieldName)) {
-                schema.encode = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/OAuth2Flow.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/OAuth2Flow.java
@@ -3,16 +3,11 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
-public final class OAuth2Flow implements JsonSerializable<OAuth2Flow> {
+public final class OAuth2Flow {
 
-    public static final class OAuth2Scope implements JsonSerializable<OAuth2Scope> {
+    public static final class OAuth2Scope {
         private String value;
         private String description;
 
@@ -30,26 +25,6 @@ public final class OAuth2Flow implements JsonSerializable<OAuth2Flow> {
 
         public void setDescription(String description) {
             this.description = description;
-        }
-
-        @Override
-        public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-            return jsonWriter.writeStartObject()
-                .writeStringField("value", value)
-                .writeStringField("description", description)
-                .writeEndObject();
-        }
-
-        public static OAuth2Scope fromJson(JsonReader jsonReader) throws IOException {
-            return JsonUtils.readObject(jsonReader, OAuth2Scope::new, (scheme, fieldName, reader) -> {
-                if ("value".equals(fieldName)) {
-                    scheme.value = reader.getString();
-                } else if ("description".equals(fieldName)) {
-                    scheme.description = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            });
         }
     }
 
@@ -97,34 +72,5 @@ public final class OAuth2Flow implements JsonSerializable<OAuth2Flow> {
 
     public void setScopes(List<OAuth2Scope> scopes) {
         this.scopes = scopes;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("type", type)
-            .writeStringField("authorizationUrl", authorizationUrl)
-            .writeStringField("tokenUrl", tokenUrl)
-            .writeStringField("refreshUrl", refreshUrl)
-            .writeArrayField("scopes", scopes, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    public static OAuth2Flow fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, OAuth2Flow::new, (scheme, fieldName, reader) -> {
-            if ("type".equals(fieldName)) {
-                scheme.type = reader.getString();
-            } else if ("authorizationUrl".equals(fieldName)) {
-                scheme.authorizationUrl = reader.getString();
-            } else if ("tokenUrl".equals(fieldName)) {
-                scheme.tokenUrl = reader.getString();
-            } else if ("refreshUrl".equals(fieldName)) {
-                scheme.refreshUrl = reader.getString();
-            } else if ("scopes".equals(fieldName)) {
-                scheme.scopes = reader.readArray(OAuth2Scope::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ODataQuerySchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ODataQuerySchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents an ODataQuery value.
  */
@@ -36,25 +31,5 @@ public class ODataQuerySchema extends Schema {
         }
 
         return other instanceof ODataQuerySchema;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes an ODataQuerySchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An ODataQuerySchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ODataQuerySchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ODataQuerySchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ObjectSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ObjectSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -192,54 +188,5 @@ public class ObjectSchema extends ComplexSchema {
      */
     public void setStronglyTypedHeader(boolean stronglyTypedHeader) {
         this.stronglyTypedHeader = stronglyTypedHeader;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeJsonField("discriminator", discriminator)
-            .writeArrayField("properties", properties, JsonWriter::writeJson)
-            .writeDoubleField("maxProperties", maxProperties)
-            .writeDoubleField("minProperties", minProperties)
-            .writeJsonField("parents", parents)
-            .writeJsonField("children", children)
-            .writeStringField("discriminatorValue", discriminatorValue)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an ObjectSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An ObjectSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ObjectSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ObjectSchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-
-            if ("discriminator".equals(fieldName)) {
-                schema.discriminator = Discriminator.fromJson(reader);
-            } else if ("properties".equals(fieldName)) {
-                schema.properties = reader.readArray(Property::fromJson);
-            } else if ("maxProperties".equals(fieldName)) {
-                schema.maxProperties = reader.getDouble();
-            } else if ("minProperties".equals(fieldName)) {
-                schema.minProperties = reader.getDouble();
-            } else if ("parents".equals(fieldName)) {
-                schema.parents = Relations.fromJson(reader);
-            } else if ("children".equals(fieldName)) {
-                schema.children = Relations.fromJson(reader);
-            } else if ("discriminatorValue".equals(fieldName)) {
-                schema.discriminatorValue = reader.getString();
-            } else if ("flattenedSchema".equals(fieldName)) {
-                schema.flattenedSchema = reader.getBoolean();
-            } else if ("stronglyTypedHeader".equals(fieldName)) {
-                schema.stronglyTypedHeader = reader.getBoolean();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Operation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Operation.java
@@ -4,11 +4,7 @@
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
 import com.azure.core.http.HttpMethod;
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel.XmsExtensions;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -468,86 +464,5 @@ public class Operation extends Metadata {
      */
     public void setInternalApi(Boolean internalApi) {
         this.internalApi = internalApi;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeStringField("operationId", operationId)
-            .writeArrayField("parameters", parameters, JsonWriter::writeJson)
-            .writeArrayField("signatureParameters", signatureParameters, JsonWriter::writeJson)
-            .writeArrayField("requests", requests, JsonWriter::writeJson)
-            .writeArrayField("responses", responses, JsonWriter::writeJson)
-            .writeArrayField("exceptions", exceptions, JsonWriter::writeJson)
-            .writeJsonField("profile", profile)
-            .writeStringField("$key", $key)
-            .writeStringField("description", description)
-            .writeStringField("uid", uid)
-            .writeStringField("summary", summary)
-            .writeArrayField("apiVersions", apiVersions, JsonWriter::writeJson)
-            .writeJsonField("deprecated", deprecated)
-            .writeJsonField("externalDocs", externalDocs)
-            .writeArrayField("specialHeaders", specialHeaders, JsonWriter::writeString)
-            .writeJsonField("lroMetadata", lroMetadata)
-            .writeJsonField("convenienceApi", convenienceApi)
-            .writeBooleanField("generateProtocolApi", generateProtocolApi)
-            .writeBooleanField("internalApi", internalApi)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an Operation instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An Operation instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Operation fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Operation::new, (operation, fieldName, reader) -> {
-            if (operation.tryConsumeParentProperties(operation, fieldName, reader)) {
-                return;
-            }
-
-            if ("operationId".equals(fieldName)) {
-                operation.operationId = reader.getString();
-            } else if ("parameters".equals(fieldName)) {
-                operation.parameters = reader.readArray(Parameter::fromJson);
-            } else if ("signatureParameters".equals(fieldName)) {
-                operation.signatureParameters = reader.readArray(Parameter::fromJson);
-            } else if ("requests".equals(fieldName)) {
-                operation.requests = reader.readArray(Request::fromJson);
-            } else if ("responses".equals(fieldName)) {
-                operation.responses = reader.readArray(Response::fromJson);
-            } else if ("exceptions".equals(fieldName)) {
-                operation.exceptions = reader.readArray(Response::fromJson);
-            } else if ("profile".equals(fieldName)) {
-                operation.profile = DictionaryApiVersion.fromJson(reader);
-            } else if ("$key".equals(fieldName)) {
-                operation.$key = reader.getString();
-            } else if ("description".equals(fieldName)) {
-                operation.description = reader.getString();
-            } else if ("uid".equals(fieldName)) {
-                operation.uid = reader.getString();
-            } else if ("summary".equals(fieldName)) {
-                operation.summary = reader.getString();
-            } else if ("apiVersions".equals(fieldName)) {
-                operation.apiVersions = reader.readArray(ApiVersion::fromJson);
-            } else if ("deprecated".equals(fieldName)) {
-                operation.deprecated = Deprecation.fromJson(reader);
-            } else if ("externalDocs".equals(fieldName)) {
-                operation.externalDocs = ExternalDocumentation.fromJson(reader);
-            } else if ("specialHeaders".equals(fieldName)) {
-                operation.specialHeaders = reader.readArray(JsonReader::getString);
-            } else if ("lroMetadata".equals(fieldName)) {
-                operation.lroMetadata = LongRunningMetadata.fromJson(reader);
-            } else if ("convenienceApi".equals(fieldName)) {
-                operation.convenienceApi = ConvenienceApi.fromJson(reader);
-            } else if ("generateProtocolApi".equals(fieldName)) {
-                operation.generateProtocolApi = reader.getBoolean();
-            } else if ("internalApi".equals(fieldName)) {
-                operation.internalApi = reader.getBoolean();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/OperationGroup.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/OperationGroup.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -76,38 +72,5 @@ public class OperationGroup extends Metadata {
      */
     public void setCodeModel(Client codeModel) {
         this.codeModel = codeModel;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeStringField("$key", $key)
-            .writeArrayField("operations", operations, JsonWriter::writeJson)
-            .writeJsonField("codeModel", codeModel)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an OperationGroup instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An OperationGroup instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static OperationGroup fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, OperationGroup::new, (group, fieldName, reader) -> {
-            if (group.tryConsumeParentProperties(group, fieldName, reader)) {
-                return;
-            }
-
-            if ("$key".equals(fieldName)) {
-                group.$key = reader.getString();
-            } else if ("operations".equals(fieldName)) {
-                group.operations = reader.readArray(Operation::fromJson);
-            } else if ("codeModel".equals(fieldName)) {
-                group.codeModel = CodeModel.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/OrSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/OrSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -64,27 +60,5 @@ public class OrSchema extends ComplexSchema {
 
         OrSchema rhs = (OrSchema) other;
         return Objects.equals(anyOf, rhs.anyOf);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeArrayField("anyOf", anyOf, JsonWriter::writeJson).writeEndObject();
-    }
-
-    /**
-     * Deserializes an OrSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An OrSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static OrSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, OrSchema::new, (schema, fieldName, reader) -> {
-            if ("anyOf".equals(fieldName)) {
-                schema.anyOf = reader.readArray(ObjectSchema::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Parameter.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Parameter.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a discrete input for an operation.
  */
@@ -180,58 +175,6 @@ public class Parameter extends Value {
     @Override
     public void setSummary(String summary) {
         this.summary = summary;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject())
-            .writeStringField("clientDefaultValue", clientDefaultValue)
-            .writeStringField("implementation", implementation == null ? null : implementation.toString())
-            .writeJsonField("operation", operation)
-            .writeBooleanField("flattened", flattened)
-            .writeJsonField("originalParameter", originalParameter)
-            .writeJsonField("groupedBy", groupedBy)
-            .writeJsonField("targetProperty", targetProperty)
-            .writeStringField("origin", origin)
-            .writeStringField("summary", summary)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Parameter instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Parameter instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Parameter fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Parameter::new, (parameter, fieldName, reader) -> {
-            if (parameter.tryConsumeParentProperties(parameter, fieldName, reader)) {
-                return;
-            }
-
-            if ("clientDefaultValue".equals(fieldName)) {
-                parameter.clientDefaultValue = reader.getString();
-            } else if ("implementation".equals(fieldName)) {
-                parameter.implementation = ImplementationLocation.fromValue(reader.getString());
-            } else if ("operation".equals(fieldName)) {
-                parameter.operation = Operation.fromJson(reader);
-            } else if ("flattened".equals(fieldName)) {
-                parameter.flattened = reader.getBoolean();
-            } else if ("originalParameter".equals(fieldName)) {
-                parameter.originalParameter = Parameter.fromJson(reader);
-            } else if ("groupedBy".equals(fieldName)) {
-                parameter.groupedBy = Parameter.fromJson(reader);
-            } else if ("targetProperty".equals(fieldName)) {
-                parameter.targetProperty = Property.fromJson(reader);
-            } else if ("origin".equals(fieldName)) {
-                parameter.origin = reader.getString();
-            } else if ("summary".equals(fieldName)) {
-                parameter.summary = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ParameterGroupSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ParameterGroupSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -64,29 +60,5 @@ public class ParameterGroupSchema extends ComplexSchema {
 
         ParameterGroupSchema rhs = ((ParameterGroupSchema) other);
         return Objects.equals(parameters, rhs.parameters);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeArrayField("parameters", parameters, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ParameterGroupSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ParameterGroupSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ParameterGroupSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ParameterGroupSchema::new, (relations, fieldName, reader) -> {
-            if ("parameters".equals(fieldName)) {
-                relations.parameters = reader.readArray(Parameter::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/PrimitiveSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/PrimitiveSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Schema types that are primitive language values
  */
@@ -17,25 +12,5 @@ public class PrimitiveSchema extends ValueSchema {
      */
     public PrimitiveSchema() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a PrimitiveSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A PrimitiveSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static PrimitiveSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, PrimitiveSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Property.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Property.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -163,50 +159,5 @@ public class Property extends Value {
     @Override
     public void setSummary(String summary) {
         this.summary = summary;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeBooleanField("readOnly", readOnly)
-            .writeStringField("serializedName", serializedName)
-            .writeBooleanField("isDiscriminator", isDiscriminator)
-            .writeArrayField("flattenedNames", flattenedNames, JsonWriter::writeString)
-            .writeArrayField("originalParameter", originalParameter, JsonWriter::writeJson)
-            .writeStringField("clientDefaultValue", clientDefaultValue)
-            .writeStringField("summary", summary)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Property instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Property instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Property fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Property::new, (property, fieldName, reader) -> {
-            if (property.tryConsumeParentProperties(property, fieldName, reader)) {
-                return;
-            }
-
-            if ("readOnly".equals(fieldName)) {
-                property.readOnly = reader.getBoolean();
-            } else if ("serializedName".equals(fieldName)) {
-                property.serializedName = reader.getString();
-            } else if ("isDiscriminator".equals(fieldName)) {
-                property.isDiscriminator = reader.getBoolean();
-            } else if ("flattenedNames".equals(fieldName)) {
-                property.flattenedNames = reader.readArray(JsonReader::getString);
-            } else if ("originalParameter".equals(fieldName)) {
-                property.originalParameter = reader.readArray(Parameter::fromJson);
-            } else if ("clientDefaultValue".equals(fieldName)) {
-                property.clientDefaultValue = reader.getString();
-            } else if ("summary".equals(fieldName)) {
-                property.summary = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Protocol.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Protocol.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents the per-protocol metadata on a given aspect.
  */
-public class Protocol implements JsonSerializable<Protocol> {
+public class Protocol {
     private RequestParameterLocation in;
     private String path;
     private String uri;
@@ -228,59 +223,5 @@ public class Protocol implements JsonSerializable<Protocol> {
      */
     public void setExplode(boolean explode) {
         this.explode = explode;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("in", in == null ? null : in.toString())
-            .writeStringField("path", path)
-            .writeStringField("uri", uri)
-            .writeStringField("method", method)
-            .writeStringField("knownMediaType", knownMediaType == null ? null : knownMediaType.toString())
-            .writeStringField("style", style == null ? null : style.toString())
-            .writeBooleanField("explode", explode)
-            .writeArrayField("mediaTypes", mediaTypes, JsonWriter::writeString)
-            .writeArrayField("servers", servers, JsonWriter::writeJson)
-            .writeArrayField("statusCodes", statusCodes, JsonWriter::writeString)
-            .writeArrayField("headers", headers, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Protocol instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Protocol instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Protocol fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Protocol::new, (protocol, fieldName, reader) -> {
-            if ("in".equals(fieldName)) {
-                protocol.in = RequestParameterLocation.fromValue(reader.getString());
-            } else if ("path".equals(fieldName)) {
-                protocol.path = reader.getString();
-            } else if ("uri".equals(fieldName)) {
-                protocol.uri = reader.getString();
-            } else if ("method".equals(fieldName)) {
-                protocol.method = reader.getString();
-            } else if ("knownMediaType".equals(fieldName)) {
-                protocol.knownMediaType = KnownMediaType.fromValue(reader.getString());
-            } else if ("style".equals(fieldName)) {
-                protocol.style = SerializationStyle.fromValue(reader.getString());
-            } else if ("explode".equals(fieldName)) {
-                protocol.explode = reader.getBoolean();
-            } else if ("mediaTypes".equals(fieldName)) {
-                protocol.mediaTypes = reader.readArray(JsonReader::getString);
-            } else if ("servers".equals(fieldName)) {
-                protocol.servers = reader.readArray(Server::fromJson);
-            } else if ("statusCodes".equals(fieldName)) {
-                protocol.statusCodes = reader.readArray(JsonReader::getString);
-            } else if ("headers".equals(fieldName)) {
-                protocol.headers = reader.readArray(Header::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Protocols.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Protocols.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents custom extensible metadata for individual protocols (ie, HTTP, etc),
  */
-public class Protocols implements JsonSerializable<Protocols> {
+public class Protocols {
     private Protocol http;
     private Protocol amqp;
     private Protocol mqtt;
@@ -124,38 +119,5 @@ public class Protocols implements JsonSerializable<Protocols> {
             && Objects.equals(jsonrpc, rhs.jsonrpc)
             && Objects.equals(amqp, rhs.amqp)
             && Objects.equals(mqtt, rhs.mqtt);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("http", http)
-            .writeJsonField("amqp", amqp)
-            .writeJsonField("mqtt", mqtt)
-            .writeJsonField("jsonrpc", jsonrpc)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Protocols instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Protocols instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Protocols fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Protocols::new, (protocols, fieldName, reader) -> {
-            if ("http".equals(fieldName)) {
-                protocols.http = Protocol.fromJson(reader);
-            } else if ("amqp".equals(fieldName)) {
-                protocols.amqp = Protocol.fromJson(reader);
-            } else if ("mqtt".equals(fieldName)) {
-                protocols.mqtt = Protocol.fromJson(reader);
-            } else if ("jsonrpc".equals(fieldName)) {
-                protocols.jsonrpc = Protocol.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Relations.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Relations.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents relations between schemas.
  */
-public class Relations implements JsonSerializable<Relations> {
+public class Relations {
     private List<Schema> all;
     private List<Schema> immediate;
 
@@ -57,32 +52,5 @@ public class Relations implements JsonSerializable<Relations> {
      */
     public void setImmediate(List<Schema> immediate) {
         this.immediate = immediate;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeArrayField("all", all, JsonWriter::writeJson)
-            .writeArrayField("immediate", immediate, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Relations instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Relations instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Relations fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Relations::new, (relations, fieldName, reader) -> {
-            if ("all".equals(fieldName)) {
-                relations.all = reader.readArray(Schema::fromJson);
-            } else if ("immediate".equals(fieldName)) {
-                relations.immediate = reader.readArray(Schema::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Request.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Request.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,36 +53,5 @@ public class Request extends Metadata {
      */
     public void setSignatureParameters(List<Parameter> signatureParameters) {
         this.signatureParameters = signatureParameters;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject())
-            .writeArrayField("parameters", parameters, JsonWriter::writeJson)
-            .writeArrayField("signatureParameters", signatureParameters, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Request instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Request instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Request fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Request::new, (request, fieldName, reader) -> {
-            if (request.tryConsumeParentProperties(request, fieldName, reader)) {
-                return;
-            }
-
-            if ("parameters".equals(fieldName)) {
-                request.parameters = reader.readArray(Parameter::fromJson);
-            } else if ("signatureParameters".equals(fieldName)) {
-                request.signatureParameters = reader.readArray(Parameter::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Response.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Response.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a response from a service.
  */
@@ -55,44 +50,5 @@ public class Response extends Metadata {
      */
     public void setBinary(Boolean binary) {
         this.binary = binary;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return writeParentProperties(jsonWriter.writeStartObject()).writeEndObject();
-    }
-
-    JsonWriter writeParentProperties(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter).writeJsonField("schema", schema)
-            .writeBooleanField("binary", binary);
-    }
-
-    /**
-     * Deserializes a Response instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Response instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Response fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Response::new, (response, fieldName, reader) -> {
-            if (!response.tryConsumeParentProperties(response, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
-    }
-
-    boolean tryConsumeParentProperties(Response response, String fieldName, JsonReader reader) throws IOException {
-        if (super.tryConsumeParentProperties(response, fieldName, reader)) {
-            return true;
-        } else if ("schema".equals(fieldName)) {
-            response.schema = Schema.fromJson(reader);
-            return true;
-        } else if ("binary".equals(fieldName)) {
-            response.binary = reader.getNullable(JsonReader::getBoolean);
-            return true;
-        }
-
-        return false;
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ScenarioStep.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ScenarioStep.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Map;
 
 /**
  * Represents a step in a scenario.
  */
-public class ScenarioStep implements JsonSerializable<ScenarioStep> {
+public class ScenarioStep {
     private TestScenarioStepType type;
     private String operationId;
     private String exampleFile;
@@ -133,44 +128,5 @@ public class ScenarioStep implements JsonSerializable<ScenarioStep> {
      */
     public void setRequestParameters(Map<String, Object> requestParameters) {
         this.requestParameters = requestParameters;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("type", type == null ? null : type.toString())
-            .writeStringField("operationId", operationId)
-            .writeStringField("exampleFile", exampleFile)
-            .writeStringField("exampleName", exampleName)
-            .writeMapField("requestParameters", requestParameters, JsonWriter::writeUntyped)
-            .writeStringField("description", description)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ScenarioStep instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ScenarioStep instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ScenarioStep fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ScenarioStep::new, (step, fieldName, reader) -> {
-            if ("type".equals(fieldName)) {
-                step.type = TestScenarioStepType.fromValue(reader.getString());
-            } else if ("operationId".equals(fieldName)) {
-                step.operationId = reader.getString();
-            } else if ("exampleFile".equals(fieldName)) {
-                step.exampleFile = reader.getString();
-            } else if ("exampleName".equals(fieldName)) {
-                step.exampleName = reader.getString();
-            } else if ("requestParameters".equals(fieldName)) {
-                step.requestParameters = reader.readMap(JsonReader::readUntyped);
-            } else if ("description".equals(fieldName)) {
-                step.description = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ScenarioTest.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ScenarioTest.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -19,7 +14,7 @@ import java.util.Map;
  * Api Scenario Definition Reference
  * </a>
  */
-public class ScenarioTest implements JsonSerializable<ScenarioTest> {
+public class ScenarioTest {
     private String filePath;
     private List<String> requiredVariables;
     private Map<String, String> requiredVariablesDefault;
@@ -140,44 +135,5 @@ public class ScenarioTest implements JsonSerializable<ScenarioTest> {
      */
     public void setUseArmTemplate(Boolean useArmTemplate) {
         this.useArmTemplate = useArmTemplate;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("_filePath", filePath)
-            .writeArrayField("requiredVariables", requiredVariables, JsonWriter::writeString)
-            .writeMapField("requiredVariablesDefault", requiredVariablesDefault, JsonWriter::writeString)
-            .writeArrayField("scenarios", scenarios, JsonWriter::writeJson)
-            .writeStringField("scope", scope == null ? null : scope.toString())
-            .writeBooleanField("useArmTemplate", useArmTemplate)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a ScenarioTest instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ScenarioTest instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ScenarioTest fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ScenarioTest::new, (test, fieldName, reader) -> {
-            if ("_filePath".equals(fieldName)) {
-                test.filePath = reader.getString();
-            } else if ("requiredVariables".equals(fieldName)) {
-                test.requiredVariables = reader.readArray(JsonReader::getString);
-            } else if ("requiredVariablesDefault".equals(fieldName)) {
-                test.requiredVariablesDefault = reader.readMap(JsonReader::getString);
-            } else if ("scenarios".equals(fieldName)) {
-                test.scenarios = reader.readArray(TestScenario::fromJson);
-            } else if ("scope".equals(fieldName)) {
-                test.scope = ScenarioTestScope.fromValue(reader.getString());
-            } else if ("useArmTemplate".equals(fieldName)) {
-                test.useArmTemplate = reader.getNullable(JsonReader::getBoolean);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Schema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Schema.java
@@ -3,13 +3,8 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -274,92 +269,6 @@ public class Schema extends Metadata {
 
     public boolean isXmlWrapped() {
         return serialization != null && serialization.getXml() != null && serialization.getXml().isWrapped();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return writeParentProperties(jsonWriter.writeStartObject()).writeEndObject();
-    }
-
-    JsonWriter writeParentProperties(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter).writeStringField("type", type == null ? null : type.toString())
-            .writeStringField("summary", summary)
-            .writeUntypedField("example", example)
-            .writeUntypedField("defaultValue", defaultValue)
-            .writeJsonField("serialization", serialization)
-            .writeArrayField("serializationFormats", serializationFormats, JsonWriter::writeString)
-            .writeArrayField("usage", usage,
-                (writer, element) -> writer.writeString(element == null ? null : element.toString()))
-            .writeStringField("uid", uid)
-            .writeStringField("$key", $key)
-            .writeStringField("description", description)
-            .writeArrayField("apiVersions", apiVersions, JsonWriter::writeJson)
-            .writeJsonField("deprecated", deprecated)
-            .writeJsonField("externalDocs", externalDocs);
-    }
-
-    /**
-     * Deserializes a Schema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Schema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Schema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Schema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
-    }
-
-    boolean tryConsumeParentProperties(Schema schema, String fieldName, JsonReader reader) throws IOException {
-        if (super.tryConsumeParentProperties(schema, fieldName, reader)) {
-            return true;
-        } else if ("type".equals(fieldName)) {
-            schema.type = Schema.AllSchemaTypes.fromValue(reader.getString());
-            return true;
-        } else if ("summary".equals(fieldName)) {
-            schema.summary = reader.getString();
-            return true;
-        } else if ("example".equals(fieldName)) {
-            schema.example = reader.readUntyped();
-            return true;
-        } else if ("defaultValue".equals(fieldName)) {
-            schema.defaultValue = reader.readUntyped();
-            return true;
-        } else if ("serialization".equals(fieldName)) {
-            schema.serialization = SerializationFormats.fromJson(reader);
-            return true;
-        } else if ("serializationFormats".equals(fieldName)) {
-            List<String> formats = reader.readArray(JsonReader::getString);
-            schema.serializationFormats = formats == null ? null : new HashSet<>(formats);
-            return true;
-        } else if ("usage".equals(fieldName)) {
-            List<SchemaContext> usage = reader.readArray(element -> SchemaContext.fromValue(element.getString()));
-            schema.usage = usage == null ? null : new HashSet<>(usage);
-            return true;
-        } else if ("uid".equals(fieldName)) {
-            schema.uid = reader.getString();
-            return true;
-        } else if ("$key".equals(fieldName)) {
-            schema.$key = reader.getString();
-            return true;
-        } else if ("description".equals(fieldName)) {
-            schema.description = reader.getString();
-            return true;
-        } else if ("apiVersions".equals(fieldName)) {
-            schema.apiVersions = reader.readArray(ApiVersion::fromJson);
-            return true;
-        } else if ("deprecated".equals(fieldName)) {
-            schema.deprecated = Deprecation.fromJson(reader);
-            return true;
-        } else if ("externalDocs".equals(fieldName)) {
-            schema.externalDocs = ExternalDocumentation.fromJson(reader);
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SchemaResponse.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SchemaResponse.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a response from a service.
  */
@@ -36,32 +31,5 @@ public class SchemaResponse extends Response {
      */
     public void setSchema(Schema schema) {
         this.schema = schema;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeJsonField("schema", schema)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a SchemaResponse instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A SchemaResponse instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static SchemaResponse fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, SchemaResponse::new, (response, fieldName, reader) -> {
-            if (response.tryConsumeParentProperties(response, fieldName, reader)) {
-                return;
-            }
-
-            if ("schema".equals(fieldName)) {
-                response.schema = Schema.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Schemas.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Schemas.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Represents the full set of schemas for a given service, categorized into convenient collections.
  */
-public class Schemas implements JsonSerializable<Schemas> {
+public class Schemas {
     private List<ArraySchema> arrays = new ArrayList<>();
     private List<DictionarySchema> dictionaries = new ArrayList<>();
     private List<BinarySchema> binaries = new ArrayList<>();
@@ -552,110 +547,5 @@ public class Schemas implements JsonSerializable<Schemas> {
      */
     public void setBinaries(List<BinarySchema> binaries) {
         this.binaries = binaries;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeArrayField("arrays", arrays, JsonWriter::writeJson)
-            .writeArrayField("dictionaries", dictionaries, JsonWriter::writeJson)
-            .writeArrayField("binaries", binaries, JsonWriter::writeJson)
-            .writeArrayField("groups", groups, JsonWriter::writeJson)
-            .writeArrayField("booleans", booleans, JsonWriter::writeJson)
-            .writeArrayField("numbers", numbers, JsonWriter::writeJson)
-            .writeArrayField("objects", objects, JsonWriter::writeJson)
-            .writeArrayField("strings", strings, JsonWriter::writeJson)
-            .writeArrayField("unixtimes", unixtimes, JsonWriter::writeJson)
-            .writeArrayField("byteArrays", byteArrays, JsonWriter::writeJson)
-            .writeArrayField("streams", streams, JsonWriter::writeJson)
-            .writeArrayField("chars", chars, JsonWriter::writeJson)
-            .writeArrayField("dates", dates, JsonWriter::writeJson)
-            .writeArrayField("dateTimes", dateTimes, JsonWriter::writeJson)
-            .writeArrayField("durations", durations, JsonWriter::writeJson)
-            .writeArrayField("uuids", uuids, JsonWriter::writeJson)
-            .writeArrayField("uris", uris, JsonWriter::writeJson)
-            .writeArrayField("credentials", credentials, JsonWriter::writeJson)
-            .writeArrayField("odataQueries", odataQueries, JsonWriter::writeJson)
-            .writeArrayField("choices", choices, JsonWriter::writeJson)
-            .writeArrayField("sealedChoices", sealedChoices, JsonWriter::writeJson)
-            .writeArrayField("flags", flags, JsonWriter::writeJson)
-            .writeArrayField("constants", constants, JsonWriter::writeJson)
-            .writeArrayField("ands", ands, JsonWriter::writeJson)
-            .writeArrayField("ors", ors, JsonWriter::writeJson)
-            .writeArrayField("xors", xors, JsonWriter::writeJson)
-            .writeArrayField("unknowns", unknowns, JsonWriter::writeJson)
-            .writeArrayField("parameterGroups", parameterGroups, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Schemas instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Schemas instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Schemas fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Schemas::new, (schemas, fieldName, reader) -> {
-            if ("arrays".equals(fieldName)) {
-                schemas.arrays = reader.readArray(ArraySchema::fromJson);
-            } else if ("dictionaries".equals(fieldName)) {
-                schemas.dictionaries = reader.readArray(DictionarySchema::fromJson);
-            } else if ("binaries".equals(fieldName)) {
-                schemas.binaries = reader.readArray(BinarySchema::fromJson);
-            } else if ("groups".equals(fieldName)) {
-                schemas.groups = reader.readArray(ObjectSchema::fromJson);
-            } else if ("booleans".equals(fieldName)) {
-                schemas.booleans = reader.readArray(BooleanSchema::fromJson);
-            } else if ("numbers".equals(fieldName)) {
-                schemas.numbers = reader.readArray(NumberSchema::fromJson);
-            } else if ("objects".equals(fieldName)) {
-                schemas.objects = reader.readArray(ObjectSchema::fromJson);
-            } else if ("strings".equals(fieldName)) {
-                schemas.strings = reader.readArray(StringSchema::fromJson);
-            } else if ("unixtimes".equals(fieldName)) {
-                schemas.unixtimes = reader.readArray(UnixTimeSchema::fromJson);
-            } else if ("byteArrays".equals(fieldName)) {
-                schemas.byteArrays = reader.readArray(ByteArraySchema::fromJson);
-            } else if ("streams".equals(fieldName)) {
-                schemas.streams = reader.readArray(Schema::fromJson);
-            } else if ("chars".equals(fieldName)) {
-                schemas.chars = reader.readArray(CharSchema::fromJson);
-            } else if ("dates".equals(fieldName)) {
-                schemas.dates = reader.readArray(DateSchema::fromJson);
-            } else if ("dateTimes".equals(fieldName)) {
-                schemas.dateTimes = reader.readArray(DateTimeSchema::fromJson);
-            } else if ("durations".equals(fieldName)) {
-                schemas.durations = reader.readArray(DurationSchema::fromJson);
-            } else if ("uuids".equals(fieldName)) {
-                schemas.uuids = reader.readArray(UuidSchema::fromJson);
-            } else if ("uris".equals(fieldName)) {
-                schemas.uris = reader.readArray(UriSchema::fromJson);
-            } else if ("credentials".equals(fieldName)) {
-                schemas.credentials = reader.readArray(CredentialSchema::fromJson);
-            } else if ("odataQueries".equals(fieldName)) {
-                schemas.odataQueries = reader.readArray(ODataQuerySchema::fromJson);
-            } else if ("choices".equals(fieldName)) {
-                schemas.choices = reader.readArray(ChoiceSchema::fromJson);
-            } else if ("sealedChoices".equals(fieldName)) {
-                schemas.sealedChoices = reader.readArray(SealedChoiceSchema::fromJson);
-            } else if ("flags".equals(fieldName)) {
-                schemas.flags = reader.readArray(FlagSchema::fromJson);
-            } else if ("constants".equals(fieldName)) {
-                schemas.constants = reader.readArray(ConstantSchema::fromJson);
-            } else if ("ands".equals(fieldName)) {
-                schemas.ands = reader.readArray(AndSchema::fromJson);
-            } else if ("ors".equals(fieldName)) {
-                schemas.ors = reader.readArray(OrSchema::fromJson);
-            } else if ("xors".equals(fieldName)) {
-                schemas.xors = reader.readArray(XorSchema::fromJson);
-            } else if ("unknowns".equals(fieldName)) {
-                schemas.unknowns = reader.readArray(Schema::fromJson);
-            } else if ("parameterGroups".equals(fieldName)) {
-                schemas.parameterGroups = reader.readArray(ParameterGroupSchema::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Scheme.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Scheme.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -16,7 +11,7 @@ import java.util.Set;
 /**
  * Represents a security scheme.
  */
-public class Scheme implements JsonSerializable<Scheme> {
+public class Scheme {
     private Scheme.SecuritySchemeType type;
     // OAuth2
     private Set<String> scopes = new HashSet<>();
@@ -133,46 +128,6 @@ public class Scheme implements JsonSerializable<Scheme> {
      */
     public void setPrefix(String prefix) {
         this.prefix = prefix;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("type", type == null ? null : type.toString())
-            .writeArrayField("scopes", scopes, JsonWriter::writeString)
-            .writeStringField("name", name)
-            .writeStringField("in", in)
-            .writeStringField("prefix", prefix)
-            .writeArrayField("flows", flows, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Scheme instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Scheme instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Scheme fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Scheme::new, (scheme, fieldName, reader) -> {
-            if ("type".equals(fieldName)) {
-                scheme.type = SecuritySchemeType.fromValue(reader.getString());
-            } else if ("scopes".equals(fieldName)) {
-                List<String> scopes = reader.readArray(JsonReader::getString);
-                scheme.scopes = scopes == null ? null : new HashSet<>(scopes);
-            } else if ("name".equals(fieldName)) {
-                scheme.name = reader.getString();
-            } else if ("in".equals(fieldName)) {
-                scheme.in = reader.getString();
-            } else if ("prefix".equals(fieldName)) {
-                scheme.prefix = reader.getString();
-            } else if ("flows".equals(fieldName)) {
-                scheme.flows = reader.readArray(OAuth2Flow::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SealedChoiceSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SealedChoiceSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a choice of several values (ie, an 'enum').
  */
@@ -40,25 +35,5 @@ public class SealedChoiceSchema extends ChoiceSchema {
         }
 
         return sharedEquals(this, (SealedChoiceSchema) other);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a SealedChoiceSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A SealedChoiceSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static SealedChoiceSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, SealedChoiceSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Security.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Security.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Represents security information.
  */
-public class Security implements JsonSerializable<Security> {
+public class Security {
     private boolean authenticationRequired;
     private List<Scheme> schemes = new ArrayList<>();
 
@@ -58,32 +53,5 @@ public class Security implements JsonSerializable<Security> {
      */
     public void setSchemes(List<Scheme> schemes) {
         this.schemes = schemes;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeBooleanField("authenticationRequired", authenticationRequired)
-            .writeArrayField("schemes", schemes, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Security instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Security instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Security fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Security::new, (security, fieldName, reader) -> {
-            if ("authenticationRequired".equals(fieldName)) {
-                security.authenticationRequired = reader.getBoolean();
-            } else if ("schemes".equals(fieldName)) {
-                security.schemes = reader.readArray(Scheme::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SerializationFormat.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SerializationFormat.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents a serialization format.
  */
-public class SerializationFormat implements JsonSerializable<SerializationFormat> {
+public class SerializationFormat {
     private DictionaryAny extensions;
 
     /**
@@ -63,27 +58,5 @@ public class SerializationFormat implements JsonSerializable<SerializationFormat
 
         SerializationFormat rhs = ((SerializationFormat) other);
         return Objects.equals(extensions, rhs.extensions);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeJsonField("extensions", extensions).writeEndObject();
-    }
-
-    /**
-     * Deserializes a SerializationFormat instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A SerializationFormat instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static SerializationFormat fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, SerializationFormat::new, (format, fieldName, reader) -> {
-            if ("extensions".equals(fieldName)) {
-                format.extensions = DictionaryAny.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SerializationFormats.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/SerializationFormats.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
  * Represents individual serialization formats.
  */
-public class SerializationFormats implements JsonSerializable<SerializationFormats> {
+public class SerializationFormats {
     private SerializationFormat json;
     private XmlSerializationFormat xml;
     private SerializationFormat protobuf;
@@ -102,35 +97,5 @@ public class SerializationFormats implements JsonSerializable<SerializationForma
 
         SerializationFormats rhs = ((SerializationFormats) other);
         return Objects.equals(json, rhs.json) && Objects.equals(protobuf, rhs.protobuf) && Objects.equals(xml, rhs.xml);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("json", json)
-            .writeJsonField("xml", xml)
-            .writeJsonField("protobuf", protobuf)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a SerializationFormats instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A SerializationFormats instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static SerializationFormats fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, SerializationFormats::new, (formats, fieldName, reader) -> {
-            if ("json".equals(fieldName)) {
-                formats.json = SerializationFormat.fromJson(reader);
-            } else if ("xml".equals(fieldName)) {
-                formats.xml = XmlSerializationFormat.fromJson(reader);
-            } else if ("protobuf".equals(fieldName)) {
-                formats.protobuf = SerializationFormat.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Server.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Server.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents a server.
  */
-public class Server implements JsonSerializable<Server> {
+public class Server {
     private String url;
     private Languages language;
     private List<Value> variables;
@@ -76,35 +71,5 @@ public class Server implements JsonSerializable<Server> {
      */
     public void setVariables(List<Value> variables) {
         this.variables = variables;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("url", url)
-            .writeJsonField("language", language)
-            .writeArrayField("variables", variables, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a Server instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Server instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Server fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Server::new, (server, fieldName, reader) -> {
-            if ("url".equals(fieldName)) {
-                server.url = reader.getString();
-            } else if ("language".equals(fieldName)) {
-                server.language = Languages.fromJson(reader);
-            } else if ("variables".equals(fieldName)) {
-                server.variables = reader.readArray(Value::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ServiceVersion.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ServiceVersion.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a service version.
  */
@@ -17,25 +12,5 @@ public class ServiceVersion extends Metadata {
      */
     public ServiceVersion() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a ServiceVersion instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ServiceVersion instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ServiceVersion fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ServiceVersion::new, (serviceVersion, fieldName, reader) -> {
-            if (!serviceVersion.tryConsumeParentProperties(serviceVersion, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/StreamResponse.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/StreamResponse.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a stream response.
  */
@@ -26,25 +21,5 @@ public class StreamResponse extends Response {
      */
     public boolean isStream() {
         return true;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a StreamResponse instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A StreamResponse instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static StreamResponse fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, StreamResponse::new, (response, fieldName, reader) -> {
-            if (!response.tryConsumeParentProperties(response, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/StringSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/StringSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -101,37 +97,5 @@ public class StringSchema extends PrimitiveSchema {
 
         StringSchema rhs = ((StringSchema) other);
         return maxLength == rhs.maxLength && minLength == rhs.minLength && Objects.equals(pattern, rhs.pattern);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeDoubleField("maxLength", maxLength)
-            .writeDoubleField("minLength", minLength)
-            .writeStringField("pattern", pattern)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a StringSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A StringSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static StringSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, StringSchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-            if ("maxLength".equals(fieldName)) {
-                schema.maxLength = reader.getDouble();
-            } else if ("minLength".equals(fieldName)) {
-                schema.minLength = reader.getDouble();
-            } else if ("pattern".equals(fieldName)) {
-                schema.pattern = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/TestModel.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/TestModel.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents a test model.
  */
-public class TestModel implements JsonSerializable<TestModel> {
+public class TestModel {
     private List<ScenarioTest> scenarioTests;
 
     /**
@@ -38,29 +33,5 @@ public class TestModel implements JsonSerializable<TestModel> {
      */
     public void setScenarioTests(List<ScenarioTest> scenarioTests) {
         this.scenarioTests = scenarioTests;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeArrayField("scenarioTests", scenarioTests, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a TestModel instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A TestModel instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static TestModel fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, TestModel::new, (model, fieldName, reader) -> {
-            if ("scenarioTests".equals(fieldName)) {
-                model.scenarioTests = reader.readArray(ScenarioTest::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/TestScenario.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/TestScenario.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Represents a test scenario.
  */
-public class TestScenario implements JsonSerializable<TestScenario> {
+public class TestScenario {
     private String description;
     private List<String> requiredVariables;
     private Map<String, String> requiredVariablesDefault;
@@ -135,44 +130,5 @@ public class TestScenario implements JsonSerializable<TestScenario> {
      */
     public void setResolvedSteps(List<ScenarioStep> resolvedSteps) {
         this.resolvedSteps = resolvedSteps;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("description", description)
-            .writeArrayField("requiredVariables", requiredVariables, JsonWriter::writeString)
-            .writeMapField("requiredVariablesDefault", requiredVariablesDefault, JsonWriter::writeString)
-            .writeStringField("scenario", scenario)
-            .writeBooleanField("shareScope", shareScope)
-            .writeArrayField("_resolvedSteps", resolvedSteps, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a TestScenario instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A TestScenario instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static TestScenario fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, TestScenario::new, (scenario, fieldName, reader) -> {
-            if ("description".equals(fieldName)) {
-                scenario.description = reader.getString();
-            } else if ("requiredVariables".equals(fieldName)) {
-                scenario.requiredVariables = reader.readArray(JsonReader::getString);
-            } else if ("requiredVariablesDefault".equals(fieldName)) {
-                scenario.requiredVariablesDefault = reader.readMap(JsonReader::getString);
-            } else if ("scenario".equals(fieldName)) {
-                scenario.scenario = reader.getString();
-            } else if ("shareScope".equals(fieldName)) {
-                scenario.shareScope = reader.getNullable(JsonReader::getBoolean);
-            } else if ("_resolvedSteps".equals(fieldName)) {
-                scenario.resolvedSteps = reader.readArray(ScenarioStep::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/TimeSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/TimeSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a time schema.
  */
@@ -17,25 +12,5 @@ public class TimeSchema extends PrimitiveSchema {
      */
     public TimeSchema() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a TimeSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A TimeSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static TimeSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, TimeSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/UnixTimeSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/UnixTimeSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a UnixTime value.
  */
@@ -37,25 +32,5 @@ public class UnixTimeSchema extends PrimitiveSchema {
         }
 
         return other instanceof UnixTimeSchema;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a UnixTimeSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A UnixTimeSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static UnixTimeSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, UnixTimeSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/UriSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/UriSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -101,38 +97,5 @@ public class UriSchema extends PrimitiveSchema {
 
         UriSchema rhs = ((UriSchema) other);
         return maxLength == rhs.maxLength && minLength == rhs.minLength && Objects.equals(pattern, rhs.pattern);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject()).writeDoubleField("maxLength", maxLength)
-            .writeDoubleField("minLength", minLength)
-            .writeStringField("pattern", pattern)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a UriSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A UriSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static UriSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, UriSchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-
-            if ("maxLength".equals(fieldName)) {
-                schema.maxLength = reader.getDouble();
-            } else if ("minLength".equals(fieldName)) {
-                schema.minLength = reader.getDouble();
-            } else if ("pattern".equals(fieldName)) {
-                schema.pattern = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/UuidSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/UuidSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Represents a Uuid value.
  */
@@ -37,25 +32,5 @@ public class UuidSchema extends PrimitiveSchema {
         }
 
         return other instanceof UuidSchema;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a UuidSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A UuidSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static UuidSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, UuidSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Value.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/Value.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -229,76 +225,5 @@ public class Value extends Metadata {
      */
     public void setNullable(boolean nullable) {
         this.nullable = nullable;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return writeParentProperties(jsonWriter.writeStartObject()).writeEndObject();
-    }
-
-    JsonWriter writeParentProperties(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter).writeJsonField("schema", schema)
-            .writeBooleanField("required", required)
-            .writeBooleanField("nullable", nullable)
-            .writeStringField("$key", $key)
-            .writeStringField("description", description)
-            .writeStringField("uid", uid)
-            .writeStringField("summary", summary)
-            .writeArrayField("apiVersions", apiVersions, JsonWriter::writeJson)
-            .writeJsonField("deprecated", deprecated)
-            .writeJsonField("externalDocs", externalDocs);
-    }
-
-    /**
-     * Deserializes a Value instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A Value instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static Value fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, Value::new, (value, fieldName, reader) -> {
-            if (!value.tryConsumeParentProperties(value, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
-    }
-
-    boolean tryConsumeParentProperties(Value value, String fieldName, JsonReader reader) throws IOException {
-        if (super.tryConsumeParentProperties(value, fieldName, reader)) {
-            return true;
-        } else if ("schema".equals(fieldName)) {
-            value.schema = Schema.fromJson(reader);
-            return true;
-        } else if ("required".equals(fieldName)) {
-            value.required = reader.getBoolean();
-            return true;
-        } else if ("nullable".equals(fieldName)) {
-            value.nullable = reader.getBoolean();
-            return true;
-        } else if ("$key".equals(fieldName)) {
-            value.$key = reader.getString();
-            return true;
-        } else if ("description".equals(fieldName)) {
-            value.description = reader.getString();
-            return true;
-        } else if ("uid".equals(fieldName)) {
-            value.uid = reader.getString();
-            return true;
-        } else if ("summary".equals(fieldName)) {
-            value.summary = reader.getString();
-            return true;
-        } else if ("apiVersions".equals(fieldName)) {
-            value.apiVersions = reader.readArray(ApiVersion::fromJson);
-            return true;
-        } else if ("deprecated".equals(fieldName)) {
-            value.deprecated = Deprecation.fromJson(reader);
-            return true;
-        } else if ("externalDocs".equals(fieldName)) {
-            value.externalDocs = ExternalDocumentation.fromJson(reader);
-            return true;
-        }
-
-        return false;
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ValueSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/ValueSchema.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
-
 /**
  * Schema types that are non-object or complex types.
  */
@@ -17,25 +12,5 @@ public class ValueSchema extends Schema {
      */
     public ValueSchema() {
         super();
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.toJson(jsonWriter);
-    }
-
-    /**
-     * Deserializes a ValueSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A ValueSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static ValueSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, ValueSchema::new, (schema, fieldName, reader) -> {
-            if (!schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/XmlSerializationFormat.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/XmlSerializationFormat.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -163,47 +159,5 @@ public class XmlSerializationFormat extends SerializationFormat {
             && wrapped == rhs.wrapped
             && Objects.equals(prefix, rhs.prefix)
             && text == rhs.text;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("extensions", getExtensions())
-            .writeStringField("name", name)
-            .writeStringField("namespace", namespace)
-            .writeStringField("prefix", prefix)
-            .writeBooleanField("attribute", attribute)
-            .writeBooleanField("wrapped", wrapped)
-            .writeBooleanField("text", text)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a XmlSerializationFormat instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A XmlSerializationFormat instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmlSerializationFormat fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, XmlSerializationFormat::new, (format, fieldName, reader) -> {
-            if ("extensions".equals(fieldName)) {
-                format.setExtensions(DictionaryAny.fromJson(reader));
-            } else if ("name".equals(fieldName)) {
-                format.name = reader.getString();
-            } else if ("namespace".equals(fieldName)) {
-                format.namespace = reader.getString();
-            } else if ("prefix".equals(fieldName)) {
-                format.prefix = reader.getString();
-            } else if ("attribute".equals(fieldName)) {
-                format.attribute = reader.getBoolean();
-            } else if ("wrapped".equals(fieldName)) {
-                format.wrapped = reader.getBoolean();
-            } else if ("text".equals(fieldName)) {
-                format.text = reader.getBoolean();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/XorSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/codemodel/XorSchema.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.codemodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -65,33 +61,5 @@ public class XorSchema extends ComplexSchema {
 
         XorSchema rhs = ((XorSchema) other);
         return Objects.equals(oneOf, rhs.oneOf);
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return super.writeParentProperties(jsonWriter.writeStartObject())
-            .writeArrayField("oneOf", oneOf, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes a XorSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return A XorSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XorSchema fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, XorSchema::new, (schema, fieldName, reader) -> {
-            if (schema.tryConsumeParentProperties(schema, fieldName, reader)) {
-                return;
-            }
-
-            if ("oneOf".equals(fieldName)) {
-                schema.oneOf = reader.readArray(Schema::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/AllowedResource.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/AllowedResource.java
@@ -3,18 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents a resource that is allowed to be accessed.
  */
-public class AllowedResource implements JsonSerializable<AllowedResource> {
+public class AllowedResource {
     private List<String> scopes;
     private String type;
 
@@ -58,32 +52,5 @@ public class AllowedResource implements JsonSerializable<AllowedResource> {
      */
     public void setType(String type) {
         this.type = type;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeArrayField("scopes", scopes, JsonWriter::writeString)
-            .writeStringField("type", type)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an AllowedResource instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An AllowedResource instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static AllowedResource fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, AllowedResource::new, (allowedResource, fieldName, reader) -> {
-            if ("scopes".equals(fieldName)) {
-                allowedResource.scopes = reader.readArray(JsonReader::getString);
-            } else if ("type".equals(fieldName)) {
-                allowedResource.type = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/PageableContinuationToken.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/PageableContinuationToken.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Header;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Parameter;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Property;
-import java.io.IOException;
 import java.util.List;
 
-public class PageableContinuationToken implements JsonSerializable<PageableContinuationToken> {
+public class PageableContinuationToken {
 
     private Parameter parameter;
     private List<Property> responseProperty;
@@ -41,29 +36,5 @@ public class PageableContinuationToken implements JsonSerializable<PageableConti
 
     public void setResponseHeader(Header responseHeader) {
         this.responseHeader = responseHeader;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("parameter", parameter)
-            .writeArrayField("responseProperty", responseProperty, JsonWriter::writeJson)
-            .writeJsonField("responseHeader", responseHeader)
-            .writeEndObject();
-    }
-
-    public static PageableContinuationToken fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, PageableContinuationToken::new,
-            (continuationToken, fieldName, reader) -> {
-                if ("parameter".equals(fieldName)) {
-                    continuationToken.parameter = Parameter.fromJson(jsonReader);
-                } else if ("responseProperty".equals(fieldName)) {
-                    continuationToken.responseProperty = reader.readArray(Property::fromJson);
-                } else if ("responseHeader".equals(fieldName)) {
-                    continuationToken.responseHeader = Header.fromJson(jsonReader);
-                } else {
-                    reader.skipChildren();
-                }
-            });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsArmIdDetails.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsArmIdDetails.java
@@ -3,18 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents the details of an ARM ID.
  */
-public class XmsArmIdDetails implements JsonSerializable<XmsArmIdDetails> {
+public class XmsArmIdDetails {
     private List<AllowedResource> allowedResources;
 
     /**
@@ -39,29 +33,5 @@ public class XmsArmIdDetails implements JsonSerializable<XmsArmIdDetails> {
      */
     public void setAllowedResources(List<AllowedResource> allowedResources) {
         this.allowedResources = allowedResources;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeArrayField("allowedResources", allowedResources, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an XmsArmIdDetails instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An XmsArmIdDetails instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmsArmIdDetails fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, XmsArmIdDetails::new, (xmsArmIdDetails, fieldName, reader) -> {
-            if ("allowedResources".equals(fieldName)) {
-                xmsArmIdDetails.allowedResources = reader.readArray(AllowedResource::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsEnum.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsEnum.java
@@ -3,18 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents an enum.
  */
-public class XmsEnum implements JsonSerializable<XmsEnum> {
+public class XmsEnum {
     private String name;
     private boolean modelAsString = false;
     private List<Value> values;
@@ -79,40 +73,10 @@ public class XmsEnum implements JsonSerializable<XmsEnum> {
         this.values = values;
     }
 
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("name", name)
-            .writeBooleanField("modelAsString", modelAsString)
-            .writeArrayField("values", values, JsonWriter::writeJson)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an XmsEnum instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An XmsEnum instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmsEnum fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, XmsEnum::new, (xmsEnum, fieldName, reader) -> {
-            if ("name".equals(fieldName)) {
-                xmsEnum.name = reader.getString();
-            } else if ("modelAsString".equals(fieldName)) {
-                xmsEnum.modelAsString = reader.getBoolean();
-            } else if ("values".equals(fieldName)) {
-                xmsEnum.values = reader.readArray(Value::fromJson);
-            } else {
-                reader.skipChildren();
-            }
-        });
-    }
-
     /**
      * Represents a value of the enum.
      */
-    public static class Value implements JsonSerializable<Value> {
+    public static class Value {
         private String value;
         private String description;
         private String name;
@@ -175,36 +139,6 @@ public class XmsEnum implements JsonSerializable<XmsEnum> {
          */
         public void setName(String name) {
             this.name = name;
-        }
-
-        @Override
-        public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-            return jsonWriter.writeStartObject()
-                .writeStringField("value", value)
-                .writeStringField("description", description)
-                .writeStringField("name", name)
-                .writeEndObject();
-        }
-
-        /**
-         * Deserializes a Value instance from the JSON data.
-         *
-         * @param jsonReader The JSON reader to deserialize from.
-         * @return A Value instance deserialized from the JSON data.
-         * @throws IOException If an error occurs during deserialization.
-         */
-        public static Value fromJson(JsonReader jsonReader) throws IOException {
-            return readObject(jsonReader, Value::new, (value, fieldName, reader) -> {
-                if ("value".equals(fieldName)) {
-                    value.value = reader.getString();
-                } else if ("description".equals(fieldName)) {
-                    value.description = reader.getString();
-                } else if ("name".equals(fieldName)) {
-                    value.name = reader.getString();
-                } else {
-                    reader.skipChildren();
-                }
-            });
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsExamples.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsExamples.java
@@ -3,18 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
 import java.util.Map;
 
 /**
  * Represents the examples of a model.
  */
-public class XmsExamples implements JsonSerializable<XmsExamples> {
+public class XmsExamples {
     private Map<String, Object> examples;
 
     /**
@@ -39,29 +33,5 @@ public class XmsExamples implements JsonSerializable<XmsExamples> {
      */
     public void setExamples(Map<String, Object> examples) {
         this.examples = examples;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeMapField("examples", examples, JsonWriter::writeUntyped)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an XmsExamples instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An XmsExamples instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmsExamples fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, XmsExamples::new, (xmsExamples, fieldName, reader) -> {
-            if ("examples".equals(fieldName)) {
-                xmsExamples.examples = reader.readMap(JsonReader::readUntyped);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsExtensions.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsExtensions.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
-import java.io.IOException;
 import java.util.List;
 
 /**
  * Represents the x-ms-extensions of a model.
  */
-public class XmsExtensions implements JsonSerializable<XmsExtensions> {
+public class XmsExtensions {
     private XmsEnum xmsEnum;
     private String xmsClientName;
     private XmsPageable xmsPageable;
@@ -324,74 +319,5 @@ public class XmsExtensions implements JsonSerializable<XmsExtensions> {
      */
     public void setXmsVersioningAdded(List<String> xmsVersioningAdded) {
         this.xmsVersioningAdded = xmsVersioningAdded;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeJsonField("xmsEnum", xmsEnum)
-            .writeStringField("xmsClientName", xmsClientName)
-            .writeJsonField("xmsPageable", xmsPageable)
-            .writeBooleanField("xmsSkipUrlEncoding", xmsSkipUrlEncoding)
-            .writeBooleanField("xmsClientFlatten", xmsClientFlatten)
-            .writeBooleanField("xmsLongRunningOperation", xmsLongRunningOperation)
-            .writeJsonField("xmsLongRunningOperationOptions", xmsLongRunningOperationOptions)
-            .writeBooleanField("xmsFlattened", xmsFlattened)
-            .writeBooleanField("xmsAzureResource", xmsAzureResource)
-            .writeArrayField("xmsMutability", xmsMutability, JsonWriter::writeString)
-            .writeStringField("xmsHeaderCollectionPrefix", xmsHeaderCollectionPrefix)
-            .writeJsonField("xmsInternalAutorestAnonymousSchema", xmsInternalAutorestAnonymousSchema)
-            .writeJsonField("xmsArmIdDetails", xmsArmIdDetails)
-            .writeJsonField("xmsExamples", xmsExamples)
-            .writeBooleanField("xmsSecret", xmsSecret)
-            .writeArrayField("xmsVersioningAdded", xmsVersioningAdded, JsonWriter::writeString)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an XmsExtensions instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An XmsExtensions instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmsExtensions fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, XmsExtensions::new, (extensions, fieldName, reader) -> {
-            if ("xmsEnum".equals(fieldName)) {
-                extensions.xmsEnum = XmsEnum.fromJson(reader);
-            } else if ("xmsClientName".equals(fieldName)) {
-                extensions.xmsClientName = reader.getString();
-            } else if ("xmsPageable".equals(fieldName)) {
-                extensions.xmsPageable = XmsPageable.fromJson(reader);
-            } else if ("xmsSkipUrlEncoding".equals(fieldName)) {
-                extensions.xmsSkipUrlEncoding = reader.getBoolean();
-            } else if ("xmsClientFlatten".equals(fieldName)) {
-                extensions.xmsClientFlatten = reader.getBoolean();
-            } else if ("xmsLongRunningOperation".equals(fieldName)) {
-                extensions.xmsLongRunningOperation = reader.getBoolean();
-            } else if ("xmsLongRunningOperationOptions".equals(fieldName)) {
-                extensions.xmsLongRunningOperationOptions = XmsLongRunningOperationOptions.fromJson(reader);
-            } else if ("xmsFlattened".equals(fieldName)) {
-                extensions.xmsFlattened = reader.getBoolean();
-            } else if ("xmsAzureResource".equals(fieldName)) {
-                extensions.xmsAzureResource = reader.getBoolean();
-            } else if ("xmsMutability".equals(fieldName)) {
-                extensions.xmsMutability = reader.readArray(JsonReader::getString);
-            } else if ("xmsHeaderCollectionPrefix".equals(fieldName)) {
-                extensions.xmsHeaderCollectionPrefix = reader.getString();
-            } else if ("xmsInternalAutorestAnonymousSchema".equals(fieldName)) {
-                extensions.xmsInternalAutorestAnonymousSchema = XmsInternalAutorestAnonymousSchema.fromJson(reader);
-            } else if ("xmsArmIdDetails".equals(fieldName)) {
-                extensions.xmsArmIdDetails = XmsArmIdDetails.fromJson(reader);
-            } else if ("xmsExamples".equals(fieldName)) {
-                extensions.xmsExamples = XmsExamples.fromJson(reader);
-            } else if ("xmsSecret".equals(fieldName)) {
-                extensions.xmsSecret = reader.getNullable(JsonReader::getBoolean);
-            } else if ("xmsVersioningAdded".equals(fieldName)) {
-                extensions.xmsVersioningAdded = reader.readArray(JsonReader::getString);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsInternalAutorestAnonymousSchema.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsInternalAutorestAnonymousSchema.java
@@ -3,17 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
-
 /**
  * Represents an anonymous schema.
  */
-public class XmsInternalAutorestAnonymousSchema implements JsonSerializable<XmsInternalAutorestAnonymousSchema> {
+public class XmsInternalAutorestAnonymousSchema {
     private boolean anonymous = true;
 
     /**
@@ -38,27 +31,5 @@ public class XmsInternalAutorestAnonymousSchema implements JsonSerializable<XmsI
      */
     public void setAnonymous(boolean anonymous) {
         this.anonymous = anonymous;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeBooleanField("anonymous", anonymous).writeEndObject();
-    }
-
-    /**
-     * Deserializes an XmsInternalAutorestAnonymousSchema instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An XmsInternalAutorestAnonymousSchema instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmsInternalAutorestAnonymousSchema fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, XmsInternalAutorestAnonymousSchema::new, (anonymousSchema, fieldName, reader) -> {
-            if ("anonymous".equals(fieldName)) {
-                anonymousSchema.anonymous = reader.getBoolean();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsLongRunningOperationOptions.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsLongRunningOperationOptions.java
@@ -3,17 +3,10 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import static com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils.readObject;
-
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import java.io.IOException;
-
 /**
  * Represents the options for a long-running operation.
  */
-public class XmsLongRunningOperationOptions implements JsonSerializable<XmsLongRunningOperationOptions> {
+public class XmsLongRunningOperationOptions {
     // azure-async-operation
     // location
     // original-uri
@@ -41,27 +34,5 @@ public class XmsLongRunningOperationOptions implements JsonSerializable<XmsLongR
      */
     public void setFinalStateVia(String finalStateVia) {
         this.finalStateVia = finalStateVia;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject().writeStringField("finalStateVia", finalStateVia).writeEndObject();
-    }
-
-    /**
-     * Deserializes an XmsLongRunningOperationOptions instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An XmsLongRunningOperationOptions instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmsLongRunningOperationOptions fromJson(JsonReader jsonReader) throws IOException {
-        return readObject(jsonReader, XmsLongRunningOperationOptions::new, (lroOptions, fieldName, reader) -> {
-            if ("finalStateVia".equals(fieldName)) {
-                lroOptions.finalStateVia = reader.getString();
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsPageable.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/extensionmodel/XmsPageable.java
@@ -3,17 +3,12 @@
 
 package com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel;
 
-import com.azure.json.JsonReader;
-import com.azure.json.JsonSerializable;
-import com.azure.json.JsonWriter;
-import com.microsoft.typespec.http.client.generator.core.extension.base.util.JsonUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Operation;
-import java.io.IOException;
 
 /**
  * Represents the pageable settings of a model.
  */
-public class XmsPageable implements JsonSerializable<XmsPageable> {
+public class XmsPageable {
     private String itemName = "value";
     private String nextLinkName;
     private String operationName;
@@ -106,41 +101,5 @@ public class XmsPageable implements JsonSerializable<XmsPageable> {
      */
     public void setNextOperation(Operation nextOperation) {
         this.nextOperation = nextOperation;
-    }
-
-    @Override
-    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
-        return jsonWriter.writeStartObject()
-            .writeStringField("itemName", itemName)
-            .writeStringField("nextLinkName", nextLinkName)
-            .writeStringField("operationName", operationName)
-            .writeJsonField("continuationToken", continuationToken)
-            .writeJsonField("nextOperation", nextOperation)
-            .writeEndObject();
-    }
-
-    /**
-     * Deserializes an XmsPageable instance from the JSON data.
-     *
-     * @param jsonReader The JSON reader to deserialize from.
-     * @return An XmsPageable instance deserialized from the JSON data.
-     * @throws IOException If an error occurs during deserialization.
-     */
-    public static XmsPageable fromJson(JsonReader jsonReader) throws IOException {
-        return JsonUtils.readObject(jsonReader, XmsPageable::new, (pageable, fieldName, reader) -> {
-            if ("itemName".equals(fieldName)) {
-                pageable.itemName = reader.getString();
-            } else if ("nextLinkName".equals(fieldName)) {
-                pageable.nextLinkName = reader.getString();
-            } else if ("operationName".equals(fieldName)) {
-                pageable.operationName = reader.getString();
-            } else if ("continuationToken".equals(fieldName)) {
-                pageable.continuationToken = PageableContinuationToken.fromJson(reader);
-            } else if ("nextOperation".equals(fieldName)) {
-                pageable.nextOperation = Operation.fromJson(reader);
-            } else {
-                reader.skipChildren();
-            }
-        });
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/Preprocessor.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/Preprocessor.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.core.preprocessor;
 
-import com.azure.json.JsonProviders;
-import com.azure.json.JsonReader;
 import com.azure.json.ReadValueCallback;
 import com.microsoft.typespec.http.client.generator.core.extension.base.util.FileUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.jsonrpc.Connection;
@@ -87,14 +85,8 @@ public class Preprocessor extends NewPlugin {
 
         CodeModel codeModel;
         try {
-            if (!file.startsWith("{")) {
-                // YAML
-                codeModel = yamlMapper.loadAs(file, CodeModel.class);
-            } else {
-                try (JsonReader jsonReader = JsonProviders.createReader(file)) {
-                    codeModel = CodeModel.fromJson(jsonReader);
-                }
-            }
+            // YAML
+            codeModel = yamlMapper.loadAs(file, CodeModel.class);
         } catch (Exception e) {
             System.err.println("Got an error " + e.getMessage());
             connection.sendError(1, 500, "Cannot parse input into code model: " + e.getMessage());

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/FluentNamer.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/FluentNamer.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.typespec.http.client.generator.mgmt;
 
-import com.azure.json.JsonProviders;
-import com.azure.json.JsonReader;
 import com.microsoft.typespec.http.client.generator.core.extension.base.util.FileUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.jsonrpc.Connection;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.CodeModel;
@@ -95,13 +93,7 @@ public class FluentNamer extends Preprocessor {
     }
 
     private CodeModel loadCodeModel(String file) throws IOException {
-        if (!file.startsWith("{")) {
-            return yamlMapper.loadAs(file, CodeModel.class);
-        } else {
-            try (JsonReader jsonReader = JsonProviders.createReader(file)) {
-                return CodeModel.fromJson(jsonReader);
-            }
-        }
+        return yamlMapper.loadAs(file, CodeModel.class);
     }
 
     private Yaml createYaml() {


### PR DESCRIPTION
The code model is serialized and deserialized as YAML. So, the use of azure-json and implementations of its contracts in code model types can be removed. This simplifies maintenance by removing the need to synchronize serde handling when adding or removing code model properties.

The autorest validation pr is [here](https://github.com/Azure/autorest.java/pull/3077).