### PR TITLE
Add back emitter-extension-path

### DIFF
--- a/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/packages/http-client-csharp/emitter/src/emitter.ts
@@ -98,7 +98,8 @@ export async function $onEmit(context: EmitContext<CSharpEmitterOptions>) {
       );
       logger.info(`Checking if ${csProjFile} exists`);
 
-      const projectRoot = findProjectRoot(dirname(fileURLToPath(import.meta.url)));
+      const emitterPath = options["emitter-extension-path"] ?? import.meta.url;
+      const projectRoot = findProjectRoot(dirname(fileURLToPath(emitterPath)));
       const generatorPath = resolvePath(
         projectRoot + "/dist/generator/Microsoft.TypeSpec.Generator.dll",
       );

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -17,6 +17,7 @@ export interface CSharpEmitterOptions {
   logLevel?: LoggerLevel;
   "disable-xml-docs"?: boolean;
   "generator-name"?: string;
+  "emitter-extension-path"?: string;
   "update-code-model"?: (model: CodeModel) => CodeModel;
   "sdk-context-options"?: CreateSdkContextOptions;
   "generate-protocol-methods"?: boolean;
@@ -96,6 +97,12 @@ export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = 
       nullable: true,
       description:
         "The name of the generator. By default this is set to `ScmCodeModelGenerator`. Generator authors can set this to the name of a generator that inherits from `ScmCodeModelGenerator`.",
+    },
+    "emitter-extension-path": {
+      type: "string",
+      nullable: true,
+      description:
+        "Allows emitter authors to specify the path to a custom emitter package, allowing you to extend the emitter behavior. This should be set to `import.meta.url` if you are using a custom emitter.",
     },
     "update-code-model": {
       type: "object",

--- a/packages/http-client-csharp/readme.md
+++ b/packages/http-client-csharp/readme.md
@@ -104,6 +104,12 @@ Set to `true` to disable XML documentation generation. The default value is `fal
 
 The name of the generator. By default this is set to `ScmCodeModelGenerator`. Generator authors can set this to the name of a generator that inherits from `ScmCodeModelGenerator`.
 
+### `emitter-extension-path`
+
+**Type:** `string`
+
+Allows emitter authors to specify the path to a custom emitter package, allowing you to extend the emitter behavior. This should be set to `import.meta.url` if you are using a custom emitter.
+
 ### `update-code-model`
 
 **Type:** `object`

--- a/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
@@ -91,6 +91,12 @@ Set to `true` to disable XML documentation generation. The default value is `fal
 
 The name of the generator. By default this is set to `ScmCodeModelGenerator`. Generator authors can set this to the name of a generator that inherits from `ScmCodeModelGenerator`.
 
+### `emitter-extension-path`
+
+**Type:** `string`
+
+Allows emitter authors to specify the path to a custom emitter package, allowing you to extend the emitter behavior. This should be set to `import.meta.url` if you are using a custom emitter.
+
 ### `update-code-model`
 
 **Type:** `object`


### PR DESCRIPTION
Turns out we do still need this option for extending emitters.