### PR TITLE
Fix telemetryClient initialization crash issue

### DIFF
--- a/.chronus/changes/fix7020-2025-3-17-9-35-27.md
+++ b/.chronus/changes/fix7020-2025-3-17-9-35-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - typespec-vscode
+---
+
+Fix crash when initialize telemetry client

--- a/packages/typespec-vscode/src/telemetry/telemetry-client.ts
+++ b/packages/typespec-vscode/src/telemetry/telemetry-client.ts
@@ -43,8 +43,14 @@ export class TelemetryClient {
       );
       this._client = undefined;
     } else {
-      // has to convert the TelemetryReporter to any, otherwise it will report error: This expression is not constructable.
-      this._client = new (TelemetryReporter as any)(key);
+      try {
+        this._client = new TelemetryReporter.default(key);
+      } catch (err) {
+        this.logErrorWhenLoggingTelemetry(
+          `Failed to initialize telemetry client with key, error: ${inspect(err)}`,
+        );
+        this._client = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/microsoft/typespec/issues/7020

After adopt esbuild to build the library, the rollup changed, it will crash when use `TelemetryReporter` as constructor to initialize telemetry client. So update to use `TelemetryReporter.default` to refer to the `TelemetryReporter` class and construct the instance. And apply try-catch so that it will not crash the whole process when exception occur during telemetry client initialization.