### PR TITLE
[emitter-framework] Backfill missing tests

### DIFF
--- a/.chronus/changes/interface-method-update-2025-3-17-22-56-57.md
+++ b/.chronus/changes/interface-method-update-2025-3-17-22-56-57.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/emitter-framework"
+---
+
+Backfill tests for interface method

--- a/packages/emitter-framework/src/typescript/components/interface-method.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-method.tsx
@@ -41,10 +41,10 @@ export function InterfaceMethod(props: Readonly<InterfaceMethodProps>) {
   return (
     <ts.InterfaceMethod
       {...forwardProps}
+      {...updateProps}
       name={name}
       returnType={returnType}
       parameters={allParameters}
-      {...updateProps}
     />
   );
 }

--- a/packages/emitter-framework/src/typescript/components/interface-method.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-method.tsx
@@ -29,9 +29,7 @@ export function InterfaceMethod(props: Readonly<InterfaceMethodProps>) {
     ["returnType", "parameters"],
   );
 
-  const name = props.name
-    ? props.name
-    : ts.useTSNamePolicy().getName(efProps.type.name, "function");
+  const name = props.name ?? ts.useTSNamePolicy().getName(efProps.type.name, "function");
   const returnType = props.returnType ?? <TypeExpression type={getReturnType(efProps.type)} />;
   const allParameters = buildParameterDescriptors(efProps.type.parameters, {
     params: props.parameters,

--- a/packages/emitter-framework/test/typescript/components/interface-method.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-method.test.tsx
@@ -93,4 +93,142 @@ describe("interface methods with a `type` prop", () => {
       `,
     );
   });
+
+  it("can prepend extra parameters with raw params provided", async () => {
+    const { getName } = (await runner.compile(`
+      @test op getName(id: string): string;
+    `)) as { getName: Operation };
+
+    const res = render(
+      <Output>
+        <SourceFile path="test.ts">
+          <InterfaceDeclaration name="basicInterface">
+            <InterfaceMethod
+              type={getName}
+              parametersMode="prepend"
+              parameters={[{ name: "foo", type: "string" }]}
+            />
+          </InterfaceDeclaration>
+        </SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+        interface basicInterface {
+          getName(foo: string, id: string): string
+        }
+      `,
+    );
+  });
+
+  it("can replace parameters with raw params provided", async () => {
+    const { getName } = (await runner.compile(`
+      @test op getName(id: string): string;
+    `)) as { getName: Operation };
+
+    const res = render(
+      <Output>
+        <SourceFile path="test.ts">
+          <InterfaceDeclaration name="basicInterface">
+            <InterfaceMethod
+              type={getName}
+              parametersMode="replace"
+              parameters={[
+                { name: "foo", type: "string" },
+                { name: "bar", type: "number" },
+              ]}
+            />
+          </InterfaceDeclaration>
+        </SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+        interface basicInterface {
+          getName(foo: string, bar: number): string
+        }
+      `,
+    );
+  });
+
+  it("can override return type", async () => {
+    const { getName } = (await runner.compile(`
+      @test op getName(id: string): string;
+    `)) as { getName: Operation };
+
+    const res = render(
+      <Output>
+        <SourceFile path="test.ts">
+          <InterfaceDeclaration name="basicInterface">
+            <InterfaceMethod type={getName} returnType="Promise<Record<string, unknown>>" />
+          </InterfaceDeclaration>
+        </SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+        interface basicInterface {
+          getName(id: string): Promise<Record<string, unknown>>
+        }
+      `,
+    );
+  });
+
+  it("can override method name", async () => {
+    const { getName } = (await runner.compile(`
+      @test op getName(id: string): string;
+    `)) as { getName: Operation };
+
+    const res = render(
+      <Output>
+        <SourceFile path="test.ts">
+          <InterfaceDeclaration name="basicInterface">
+            <InterfaceMethod type={getName} name="getNameCustom" />
+          </InterfaceDeclaration>
+        </SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+        interface basicInterface {
+          getNameCustom(id: string): string
+        }
+      `,
+    );
+  });
+});
+
+describe("interface methods without a `type` prop", () => {
+  it("renders a plain interface method", async () => {
+    const res = render(
+      <Output>
+        <SourceFile path="test.ts">
+          <InterfaceDeclaration name="basicInterface">
+            <InterfaceMethod
+              name="plainMethod"
+              parameters={[{ name: "param1", type: "string" }]}
+              returnType="number"
+            />
+          </InterfaceDeclaration>
+        </SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+        interface basicInterface {
+          plainMethod(param1: string): number
+        }
+      `,
+    );
+  });
 });

--- a/packages/emitter-framework/test/typescript/components/interface-method.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-method.test.tsx
@@ -65,5 +65,32 @@ describe("interface methods with a `type` prop", () => {
     );
   });
 
-  it.todo("can append extra parameters with raw params provided", async () => {});
+  it("can append extra parameters with raw params provided", async () => {
+    const { getName } = (await runner.compile(`
+      @test op getName(id: string): string;
+    `)) as { getName: Operation };
+
+    const res = render(
+      <Output>
+        <SourceFile path="test.ts">
+          <InterfaceDeclaration name="basicInterface">
+            <InterfaceMethod
+              type={getName}
+              parametersMode="append"
+              parameters={[{ name: "foo", type: "string" }]}
+            />
+          </InterfaceDeclaration>
+        </SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+        interface basicInterface {
+          getName(id: string, foo: string): string
+        }
+      `,
+    );
+  });
 });

--- a/packages/emitter-framework/test/typescript/components/interface-method.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-method.test.tsx
@@ -15,7 +15,7 @@ describe("interface methods with a `type` prop", () => {
     runner = await createEmitterFrameworkTestRunner();
   });
 
-  it("creates a interface member", async () => {
+  it("creates a interface method", async () => {
     const { getName } = (await runner.compile(`
       @test op getName(id: string): string;
     `)) as { getName: Operation };


### PR DESCRIPTION
#7017 added support for interface methods. This PR follows up with backfilling
some of the missing tests
