### PR TITLE
Skip emitter-extension-path for configuration

### DIFF
--- a/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/packages/http-client-csharp/emitter/src/emitter.ts
@@ -152,6 +152,7 @@ export function createConfiguration(
     "api-version",
     "generate-protocol-methods",
     "generate-convenience-methods",
+    "emitter-extension-path",
   ];
   const derivedOptions = Object.fromEntries(
     Object.entries(options).filter(([key]) => !skipKeys.includes(key)),


### PR DESCRIPTION
options["emitter-extension-path"] varies based on the running location, we need to skip it for configuration.