### PR TITLE
[compiler] $.type.isError returns true for error models

### DIFF
--- a/.chronus/changes/typekit-fixes-2025-3-21-16-18-50.md
+++ b/.chronus/changes/typekit-fixes-2025-3-21-16-18-50.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fixes an issue where isError was returning false for error models

--- a/.chronus/changes/typekit-fixes-2025-3-21-16-18-50.md
+++ b/.chronus/changes/typekit-fixes-2025-3-21-16-18-50.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/compiler"
 ---
 
-Fixes an issue where isError was returning false for error models
+Fixes an issue where isError was checking for error types instead of error models.

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../core/intrinsic-type-state.js";
 import { isErrorType, isNeverType } from "../../../core/type-utils.js";
 import { Enum, Model, Scalar, Union, type Type } from "../../../core/types.js";
-import { getDoc, getSummary } from "../../../lib/decorators.js";
+import { getDoc, getSummary, isErrorModel } from "../../../lib/decorators.js";
 import { resolveEncodedName } from "../../../lib/encoded-names.js";
 import { defineKit } from "../define-kit.js";
 import { copyMap } from "../utils.js";
@@ -214,7 +214,7 @@ defineKit<TypekitExtension>({
       return clone;
     },
     isError(type) {
-      return isErrorType(type);
+      return isErrorType(type) || isErrorModel(this.program, type);
     },
     getEncodedName(type, encoding) {
       return resolveEncodedName(this.program, type, encoding);

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -36,7 +36,7 @@ export interface TypeTypekit {
    * Checks if a type is decorated with `@error`
    * @param type The type to check.
    */
-  isError(type: Type): boolean;
+  isError(type: Type): asserts type is Model;
   /**
    * Get the name of this type in the specified encoding.
    */

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -33,7 +33,7 @@ export interface TypeTypekit {
    */
   finishType(type: Type): void;
   /**
-   * Checks if a type is decorated with \@error
+   * Checks if a type is decorated with `@error`
    * @param type The type to check.
    */
   isError(type: Type): boolean;

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -13,7 +13,7 @@ import {
   getMinValue,
   getMinValueExclusive,
 } from "../../../core/intrinsic-type-state.js";
-import { isErrorType, isNeverType } from "../../../core/type-utils.js";
+import { isNeverType } from "../../../core/type-utils.js";
 import { Enum, Model, Scalar, Union, type Type } from "../../../core/types.js";
 import { getDoc, getSummary, isErrorModel } from "../../../lib/decorators.js";
 import { resolveEncodedName } from "../../../lib/encoded-names.js";
@@ -214,7 +214,7 @@ defineKit<TypekitExtension>({
       return clone;
     },
     isError(type) {
-      return isErrorType(type) || isErrorModel(this.program, type);
+      return isErrorModel(this.program, type);
     },
     getEncodedName(type, encoding) {
       return resolveEncodedName(this.program, type, encoding);

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -33,7 +33,7 @@ export interface TypeTypekit {
    */
   finishType(type: Type): void;
   /**
-   * Checks if a type is decorated with @error
+   * Checks if a type is decorated with \@error
    * @param type The type to check.
    */
   isError(type: Type): boolean;

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -36,7 +36,7 @@ export interface TypeTypekit {
    * Checks if a type is decorated with `@error`
    * @param type The type to check.
    */
-  isError(type: Type): asserts type is Model;
+  isError(type: Type): type is Model;
   /**
    * Get the name of this type in the specified encoding.
    */

--- a/packages/compiler/test/experimental/typekit/type.test.ts
+++ b/packages/compiler/test/experimental/typekit/type.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { Enum, ErrorType, Model, Scalar, Union } from "../../../src/core/types.js";
+import { Enum, Model, Scalar, Union } from "../../../src/core/types.js";
 import { $ } from "../../../src/experimental/typekit/index.js";
 import { isTemplateInstance } from "../../../src/index.js";
-import { createContextMock, getTypes } from "./utils.js";
+import { getTypes } from "./utils.js";
 
 it("should clone a model", async () => {
   const {
@@ -262,34 +262,22 @@ describe("minValueExclusive and maxValueExclusive", () => {
   });
 });
 
-describe("isError", () => {
-  it("is true for intrinsic errors", async () => {
-    const error: ErrorType = {
-      kind: "Intrinsic",
-      name: "ErrorType",
-      entityKind: "Type",
-      isFinished: true,
-    };
-
-    const { program } = await createContextMock();
-
-    expect($(program).type.isError(error)).toBe(true);
-  });
-
-  it("is true for @error models", async () => {
-    const {
-      Foo,
-      context: { program },
-    } = await getTypes(
-      `
+it("isError can check if a type is an error model", async () => {
+  const {
+    Foo,
+    Error,
+    context: { program },
+  } = await getTypes(
+    `
       @error
-      model Foo {
+      model Error {
         props: string;
       }
+      model Foo {}
       `,
-      ["Foo"],
-    );
+    ["Foo", "Error"],
+  );
 
-    expect($(program).type.isError(Foo)).toBe(true);
-  });
+  expect($(program).type.isError(Error)).toBe(true);
+  expect($(program).type.isError(Foo)).toBe(false);
 });

--- a/packages/compiler/test/experimental/typekit/type.test.ts
+++ b/packages/compiler/test/experimental/typekit/type.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { Enum, Model, Scalar, Union } from "../../../src/core/types.js";
+import { Enum, ErrorType, Model, Scalar, Union } from "../../../src/core/types.js";
 import { $ } from "../../../src/experimental/typekit/index.js";
 import { isTemplateInstance } from "../../../src/index.js";
-import { getTypes } from "./utils.js";
+import { createContextMock, getTypes } from "./utils.js";
 
 it("should clone a model", async () => {
   const {
@@ -259,5 +259,37 @@ describe("minValueExclusive and maxValueExclusive", () => {
 
     expect(max).toBe(55);
     expect(min).toBe(15);
+  });
+});
+
+describe("isError", () => {
+  it("is true for intristic errors", async () => {
+    const error: ErrorType = {
+      kind: "Intrinsic",
+      name: "ErrorType",
+      entityKind: "Type",
+      isFinished: true,
+    };
+
+    const { program } = await createContextMock();
+
+    expect($(program).type.isError(error)).toBe(true);
+  });
+
+  it("is true for @error models", async () => {
+    const {
+      Foo,
+      context: { program },
+    } = await getTypes(
+      `
+      @error
+      model Foo {
+        props: string;
+      }
+      `,
+      ["Foo"],
+    );
+
+    expect($(program).type.isError(Foo)).toBe(true);
   });
 });

--- a/packages/compiler/test/experimental/typekit/type.test.ts
+++ b/packages/compiler/test/experimental/typekit/type.test.ts
@@ -263,7 +263,7 @@ describe("minValueExclusive and maxValueExclusive", () => {
 });
 
 describe("isError", () => {
-  it("is true for intristic errors", async () => {
+  it("is true for intrinsic errors", async () => {
     const error: ErrorType = {
       kind: "Intrinsic",
       name: "ErrorType",


### PR DESCRIPTION
`$.type.isError` should return true for error models (models decorated with `@error`), but not for built-in errors.

Fixes #6939