### PR TITLE
1882: `utcDateTime` defaults to Protobuf.WellKnown.Timestamp

### DIFF
--- a/packages/protobuf/src/ast.ts
+++ b/packages/protobuf/src/ast.ts
@@ -122,6 +122,16 @@ export type ProtoScalar = [typeof $scalar, ScalarName];
 export type ProtoType = ProtoScalar | ProtoRef | ProtoMap;
 
 /**
+ * A wrapped `ProtoType`. If the `protoType` is a `ProtoRef` requiring an
+ * import, then the import `source` should be provided. Otherwise, it should
+ * be undefined.
+ */
+export type ProtoTypeInfo = {
+  protoType: ProtoType;
+  source?: string;
+};
+
+/**
  * Create a scalar type by name.
  */
 export function scalar(t: ScalarName): ProtoScalar {


### PR DESCRIPTION
This makes `TypeSpec.utcDateTime` default to `Protobuf.WellKnown.Timestamp` by mapping `utcDateTime` to `ref("google.prototype.Timestamp")` making sure to import "google/protobuf/timestamp.proto".

This required the creation of a new type `ProtoTypeInfo` wrapping a `ProtoType` with `source` info to communicate to `addType` that this particular scalar is actually a reference that needs to be imported.