### PR TITLE
[compiler] Add typekit support to check if a type is in a namespace

### DIFF
--- a/.chronus/changes/type-in-namespace-2025-3-23-17-11-6.md
+++ b/.chronus/changes/type-in-namespace-2025-3-23-17-11-6.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Adds TypeKit support for type.inNamespace to check namespace membership

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -304,19 +304,11 @@ defineKit<TypekitExtension>({
         case "UnionVariant":
           return this.type.inNamespace(type.union, namespace);
         default:
+          if ("namespace" in type && type.namespace) {
+            return this.type.inNamespace(type.namespace, namespace);
+          }
           return false;
       }
-      // if (type === namespace) {
-      //   return true;
-      // }
-      // if ("namespace" in type && type.namespace) {
-      //   return this.type.inNamespace(type.namespace, namespace);
-      // }
-
-      // if (type.kind === "Operation" && type.interface) {
-      //   return this.type.inNamespace(type.interface, namespace);
-      // }
-      // return false;
     },
   },
 });

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -287,7 +287,7 @@ defineKit<TypekitExtension>({
           } else if (type.model) {
             return this.type.inNamespace(type.model, namespace);
           }
-          return false;
+          break;
         case "EnumMember":
           return this.type.inNamespace(type.enum, namespace);
         case "UnionVariant":
@@ -298,13 +298,16 @@ defineKit<TypekitExtension>({
           } else if (type.namespace) {
             return this.type.inNamespace(type.namespace, namespace);
           }
-          return false;
+          break;
         default:
           if ("namespace" in type && type.namespace) {
             return this.type.inNamespace(type.namespace, namespace);
           }
-          return false;
+          break;
       }
+
+      // If we got this far, the type does not belong to the namespace
+      return false;
     },
   },
 });

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -1,4 +1,4 @@
-import { compilerAssert, ignoreDiagnostics } from "../../../core/diagnostics.js";
+import { ignoreDiagnostics } from "../../../core/diagnostics.js";
 import { getDiscriminatedUnion } from "../../../core/helpers/discriminator-utils.js";
 import { getLocationContext } from "../../../core/helpers/location-context.js";
 import {
@@ -282,9 +282,6 @@ defineKit<TypekitExtension>({
       return getLocationContext(this.program, type).type === "project";
     },
     inNamespace(type: Type, namespace: Namespace): boolean {
-      compilerAssert(type !== undefined, "parameter 'type' is undefined");
-      compilerAssert(namespace !== undefined, "parameter 'namespace' is undefined");
-
       // A namespace is always in itself
       if (type === namespace) {
         return true;
@@ -293,9 +290,7 @@ defineKit<TypekitExtension>({
       // Handle types with known containers
       switch (type.kind) {
         case "ModelProperty":
-          if (type.sourceProperty) {
-            return this.type.inNamespace(type.sourceProperty, namespace);
-          } else if (type.model) {
+          if (type.model) {
             return this.type.inNamespace(type.model, namespace);
           }
           break;

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -275,38 +275,36 @@ defineKit<TypekitExtension>({
       return getLocationContext(this.program, type).type === "project";
     },
     inNamespace(type: Type, namespace: Namespace): boolean {
+      // A namespace is always in itself
       if (type === namespace) {
         return true;
       }
 
-      // Handle types that can be sourced from other types
-      if (type.kind === "ModelProperty") {
-        return type.sourceProperty
-          ? this.type.inNamespace(type.sourceProperty, namespace)
-          : type.model
-            ? this.type.inNamespace(type.model, namespace)
-            : false;
+      switch (type.kind) {
+        case "ModelProperty":
+          if (type.sourceProperty) {
+            return this.type.inNamespace(type.sourceProperty, namespace);
+          } else if (type.model) {
+            return this.type.inNamespace(type.model, namespace);
+          }
+          return false;
+        case "EnumMember":
+          return this.type.inNamespace(type.enum, namespace);
+        case "UnionVariant":
+          return this.type.inNamespace(type.union, namespace);
+        case "Operation":
+          if (type.interface) {
+            return this.type.inNamespace(type.interface, namespace);
+          } else if (type.namespace) {
+            return this.type.inNamespace(type.namespace, namespace);
+          }
+          return false;
+        default:
+          if ("namespace" in type && type.namespace) {
+            return this.type.inNamespace(type.namespace, namespace);
+          }
+          return false;
       }
-
-      // Handle members of container types
-      if (type.kind === "EnumMember") {
-        return this.type.inNamespace(type.enum, namespace);
-      }
-      if (type.kind === "UnionVariant") {
-        return this.type.inNamespace(type.union, namespace);
-      }
-
-      // Handle namespace-containing types
-      if (type.kind === "Operation" && type.interface) {
-        return this.type.inNamespace(type.interface, namespace);
-      }
-
-      // Handle any type with a namespace property
-      if ("namespace" in type && type.namespace) {
-        return this.type.inNamespace(type.namespace, namespace);
-      }
-
-      return false;
     },
   },
 });

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -122,6 +122,13 @@ export interface TypeTypekit {
    */
   isUserDefined(type: Type): boolean;
 
+  /**
+   * Checks if the given type is in the given namespace (directly or indirectly) by walking up the type's namespace chain.
+   *
+   * @param type The type to check.
+   * @param namespace The namespace to check membership against.
+   * @returns True if the type is in the namespace, false otherwise.
+   */
   inNamespace(type: Type, namespace: Namespace): boolean;
 }
 

--- a/packages/compiler/test/experimental/typekit/type.test.ts
+++ b/packages/compiler/test/experimental/typekit/type.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Enum, Model, Scalar, Union } from "../../../src/core/types.js";
+import { Enum, Model, Namespace, Scalar, Union } from "../../../src/core/types.js";
 import { $ } from "../../../src/experimental/typekit/index.js";
 import { isTemplateInstance } from "../../../src/index.js";
 import { getTypes } from "./utils.js";
@@ -280,4 +280,150 @@ it("isError can check if a type is an error model", async () => {
 
   expect($(program).type.isError(Error)).toBe(true);
   expect($(program).type.isError(Foo)).toBe(false);
+});
+
+describe("inNamespace", () => {
+  it("checks that a namespace belongs to itself", async () => {
+    const {
+      Root,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace Root {}
+      `,
+      ["Root"],
+    );
+    expect($(program).type.inNamespace(Root, Root as Namespace)).toBe(true);
+  });
+
+  it("checks direct namespace membership", async () => {
+    const {
+      Root,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace Root {
+        namespace Child1 {
+          namespace Child2 {}
+        }
+      }
+      `,
+      ["Root"],
+    );
+
+    const child1 = (Root as Namespace).namespaces.get("Child1")!;
+    const child2 = child1.namespaces.get("Child2")!;
+    expect($(program).type.inNamespace(child1, Root as Namespace)).toBe(true);
+    expect($(program).type.inNamespace(child2, Root as Namespace)).toBe(true);
+    expect($(program).type.inNamespace(child1, child2 as Namespace)).toBe(false);
+  });
+
+  it("checks model property namespace membership", async () => {
+    const {
+      Root,
+      Outside,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace Root {
+        model Inside {
+          prop: string;
+        }
+      }
+
+      model Outside extends Root.Inside {
+        prop: string;
+      }
+      `,
+      ["Root", "Inside", "Outside"],
+    );
+
+    const model1 = (Root as Namespace).models.get("Inside")!;
+    expect(model1).toBeDefined();
+    const prop1 = model1.properties.get("prop")!;
+    expect(prop1).toBeDefined();
+
+    const prop2 = (Outside as Model).properties.get("prop")!;
+
+    expect($(program).type.inNamespace(prop1, Root as Namespace)).toBe(true);
+    expect($(program).type.inNamespace(prop2, Root as Namespace)).toBe(false);
+  });
+
+  it("checks enum member namespace membership", async () => {
+    const {
+      Root,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace Root {
+        enum Test {
+          A,
+          B
+        }
+      }
+      `,
+      ["Root"],
+    );
+
+    const enum1 = (Root as Namespace).enums.get("Test")!;
+    const enumMember = enum1.members.get("A")!;
+    expect($(program).type.inNamespace(enumMember, Root as Namespace)).toBe(true);
+  });
+
+  it("checks union variant namespace membership", async () => {
+    const {
+      Root,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace Root {
+        union Test {
+          A: string,
+          B: int32
+        }
+      }
+      `,
+      ["Root"],
+    );
+
+    const union = (Root as Namespace).unions.get("Test")!;
+    const variant = union.variants.get("A")!;
+    expect(variant).toBeDefined();
+    expect($(program).type.inNamespace(variant, Root as Namespace)).toBe(true);
+  });
+
+  it("checks interface operation namespace membership", async () => {
+    const {
+      Root,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace Root {
+        interface Test {
+          op myOp(): void;
+        }
+      }
+      `,
+      ["Root"],
+    );
+
+    const test = (Root as Namespace).interfaces.get("Test")!;
+    const operation = test.operations.get("myOp")!;
+    expect($(program).type.inNamespace(operation, Root as Namespace)).toBe(true);
+  });
+
+  it("returns false for types without namespace", async () => {
+    const {
+      MyNamespace,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace MyNamespace { }
+      `,
+      ["MyNamespace"],
+    );
+
+    const stringLiteral = $(program).literal.create("test");
+    expect($(program).type.inNamespace(stringLiteral, MyNamespace as Namespace)).toBe(false);
+  });
 });

--- a/packages/compiler/test/experimental/typekit/type.test.ts
+++ b/packages/compiler/test/experimental/typekit/type.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { Enum, Model, Namespace, Scalar, Union } from "../../../src/core/types.js";
 import { $ } from "../../../src/experimental/typekit/index.js";
 import { isTemplateInstance } from "../../../src/index.js";
-import { createContextMock, getTypes } from "./utils.js";
+import { getTypes } from "./utils.js";
 
 it("should clone a model", async () => {
   const {
@@ -438,33 +438,6 @@ describe("inNamespace", () => {
     expect($(program).type.inNamespace(operation!, Root as Namespace)).toBe(true);
   });
 
-  it("checks namespace membership via source property", async () => {
-    const {
-      Root,
-      Derived,
-      context: { program },
-    } = await getTypes(
-      `
-      namespace Root {
-        model Base {
-          propA: string;
-        }
-
-      }
-
-      model Derived is Root.Base {
-        propB: string;
-      }
-      `,
-      ["Root", "Derived"],
-    );
-
-    const inheritedProp = (Derived as Model).properties.get("propA");
-    expect(inheritedProp).toBeDefined();
-
-    expect($(program).type.inNamespace(inheritedProp!, Root as Namespace)).toBe(true);
-  });
-
   it("returns false for types outside the namespace", async () => {
     const {
       Root,
@@ -498,20 +471,5 @@ describe("inNamespace", () => {
 
     const stringLiteral = $(program).literal.create("test");
     expect($(program).type.inNamespace(stringLiteral, MyNamespace as Namespace)).toBe(false);
-  });
-
-  it("throws a useful error if type is undefined", async () => {
-    const { program } = await createContextMock();
-    expect(() => $(program).type.inNamespace(undefined as any, undefined as any)).toThrowError(
-      /parameter 'type'/,
-    );
-  });
-
-  it("throws a useful error if namespace is undefined", async () => {
-    const { program } = await createContextMock();
-    const type = $(program).literal.create("test");
-    expect(() => $(program).type.inNamespace(type, undefined as any)).toThrowError(
-      /parameter 'namespace'/,
-    );
   });
 });

--- a/packages/compiler/test/experimental/typekit/type.test.ts
+++ b/packages/compiler/test/experimental/typekit/type.test.ts
@@ -412,6 +412,22 @@ describe("inNamespace", () => {
     expect($(program).type.inNamespace(operation, Root as Namespace)).toBe(true);
   });
 
+  it("checks operations namespace membership", async () => {
+    const {
+      Root,
+      context: { program },
+    } = await getTypes(
+      `
+      namespace Root {
+        op myOp(): void;
+      }
+      `,
+      ["Root"],
+    );
+    const operation = (Root as Namespace).operations.get("myOp")!;
+    expect($(program).type.inNamespace(operation, Root as Namespace)).toBe(true);
+  });
+
   it("returns false for types without namespace", async () => {
     const {
       MyNamespace,


### PR DESCRIPTION
This pull request introduces a new feature to the `@typespec/compiler` package, adding support for checking namespace membership using a new `inNamespace` method. The changes include updates to the core type system, implementation of the feature, and extensive test coverage to ensure correctness.


Added a new `inNamespace` method to the `Type` TypeKit to determine if a type belongs to a specific namespace. This method handles various type scenarios, including models, enums, unions, and operations. (`packages/compiler/src/experimental/typekit/kits/type.ts`, [[1]](diffhunk://#diff-aaa7a0cba000f6acff7c2734746e5f87fcfd7676ee6ff0b49bbe11385194f854R124-R125) [[2]](diffhunk://#diff-aaa7a0cba000f6acff7c2734746e5f87fcfd7676ee6ff0b49bbe11385194f854R277-R313)


Resolves #7036