### PR TITLE
[compiler] Add typekit support for creating a union from an array of children

### DIFF
--- a/.chronus/changes/union-from-children-2025-3-23-20-26-20.md
+++ b/.chronus/changes/union-from-children-2025-3-23-20-26-20.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Add typekit support for creating a union from an array of children

--- a/packages/compiler/src/experimental/typekit/kits/union.ts
+++ b/packages/compiler/src/experimental/typekit/kits/union.ts
@@ -50,7 +50,13 @@ export interface UnionKit {
    */
   create(desc: UnionDescriptor): Union;
   /**
-   * Create a union type from an array of types.
+   * Create an anonymous union type from an array of types.
+   *
+   * @param children The types to create a union from.
+   *
+   * Any API documentation will be rendered and preserved in the resulting union.
+   *
+   * No other decorators are copied from the enum to the union.
    */
   create(children: Type[]): Union;
 
@@ -64,7 +70,8 @@ export interface UnionKit {
    * For member without an explicit value, the member name is used as the value.
    *
    * Any API documentation will be rendered and preserved in the resulting union.
-   * - No other decorators are copied from the enum to the union.
+   *
+   * No other decorators are copied from the enum to the union.
    */
   createFromEnum(type: Enum): Union;
 

--- a/packages/compiler/test/experimental/typekit/union.test.ts
+++ b/packages/compiler/test/experimental/typekit/union.test.ts
@@ -35,7 +35,7 @@ it("can create a union from array of types", async () => {
     context: { program },
   } = await getTypes(
     `
-    @doc("foo")
+    @doc("docs for foo")
     model Foo {}
     model Bar {}
     scalar Qux extends string;
@@ -50,12 +50,20 @@ it("can create a union from array of types", async () => {
   expect(union.expression).toBe(true);
   expect(union.variants.size).toBe(4);
 
-  // Ensure docs are copied
-  // Variants are ordered in order that they appear in source.
-  const firstVariant = union.variants.values().next().value;
-  expect(firstVariant).toBeDefined();
+  const variants = Array.from(union.variants.values());
+  const fooVariant = variants.find((v) => v.type === Foo);
+  expect(fooVariant).toBeDefined();
+  // Check if the documentation is preserved
+  expect(getDoc(program, fooVariant!)).toBe("docs for foo");
 
-  expect(getDoc(program, firstVariant!)).toBe("foo");
+  const barVariant = variants.find((v) => v.type === Bar);
+  expect(barVariant).toBeDefined();
+
+  const quxVariant = variants.find((v) => v.type === Qux);
+  expect(quxVariant).toBeDefined();
+
+  const fooBarVariant = variants.find((v) => v.type === FooBar);
+  expect(fooBarVariant).toBeDefined();
 });
 
 it("can check if the union is extensible", async () => {

--- a/packages/compiler/test/experimental/typekit/union.test.ts
+++ b/packages/compiler/test/experimental/typekit/union.test.ts
@@ -26,6 +26,38 @@ it("can create a union", async () => {
   expect((union.variants.get("bye")?.type as StringLiteral).value).toBe("Goodbye");
 });
 
+it("can create a union from array of types", async () => {
+  const {
+    Foo,
+    Bar,
+    Qux,
+    FooBar,
+    context: { program },
+  } = await getTypes(
+    `
+    @doc("foo")
+    model Foo {}
+    model Bar {}
+    scalar Qux extends string;
+    alias FooBar = Foo | Bar;
+    `,
+    ["Foo", "Bar", "Qux", "FooBar"],
+  );
+  const union = $(program).union.create([Foo, Bar, Qux, FooBar]);
+  expect(union).toBeDefined();
+
+  expect(union.kind).toBe("Union");
+  expect(union.expression).toBe(true);
+  expect(union.variants.size).toBe(4);
+
+  // Ensure docs are copied
+  // Variants are ordered in order that they appear in source.
+  const firstVariant = union.variants.values().next().value;
+  expect(firstVariant).toBeDefined();
+
+  expect(getDoc(program, firstVariant!)).toBe("foo");
+});
+
 it("can check if the union is extensible", async () => {
   const {
     Foo,


### PR DESCRIPTION
This pull request enhances the `UnionKit` functionality by introducing support for creating unions from an array of types

### Enhancements to `UnionKit`:

* Added a simpler overload to the `create` method in the `UnionKit` interface to allow creating unions from an array of types without providing a descriptor. This method ensures that API documentation is preserved for each type in the resulting union. (`packages/compiler/src/experimental/typekit/kits/union.ts`, [packages/compiler/src/experimental/typekit/kits/union.tsR52-R61](diffhunk://#diff-816f871c71805aac443a8098fd22d351885f675fe6d39297f9217f423118f3b3R52-R61))
* Refactored the `create` method implementation to handle both `UnionDescriptor` and an array of types. When provided with an array, it constructs a `UnionDescriptor` while preserving documentation and applying appropriate decorators. (`packages/compiler/src/experimental/typekit/kits/union.ts`, [packages/compiler/src/experimental/typekit/kits/union.tsL121-R168](diffhunk://#diff-816f871c71805aac443a8098fd22d351885f675fe6d39297f9217f423118f3b3L121-R168))

Resolves #6958
