### PR TITLE
[typekits] adds isAssignableTo kits

### DIFF
--- a/.chronus/changes/typekits-is-assignable-to-2025-3-23-14-36-58.md
+++ b/.chronus/changes/typekits-is-assignable-to-2025-3-23-14-36-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Adds `$.type.isAssignableTo`, `$.value.isAssignableTo` and `$.entity.isAssignableTo` typekits. Also registers `$.resolve` typekit

--- a/packages/compiler/src/experimental/typekit/kits/entity.ts
+++ b/packages/compiler/src/experimental/typekit/kits/entity.ts
@@ -1,0 +1,33 @@
+import type { Entity, Node } from "../../../core/types.js";
+import { createDiagnosable, Diagnosable } from "../create-diagnosable.js";
+import { defineKit } from "../define-kit.js";
+
+/** @experimental */
+export interface EntityKit {
+  /**
+   * Check if the source type can be assigned to the target.
+   * @param source Source type
+   * @param target Target type
+   * @param diagnosticTarget Target for the diagnostic
+   */
+  isAssignableTo: Diagnosable<
+    (source: Entity, target: Entity, diagnosticTarget?: Entity | Node) => boolean
+  >;
+}
+
+interface TypekitExtension {
+  /** @experimental */
+  entity: EntityKit;
+}
+
+declare module "../define-kit.js" {
+  interface Typekit extends TypekitExtension {}
+}
+
+defineKit<TypekitExtension>({
+  entity: {
+    isAssignableTo: createDiagnosable(function (source, target, diagnosticTarget) {
+      return this.program.checker.isTypeAssignableTo(source, target, diagnosticTarget ?? source);
+    }),
+  },
+});

--- a/packages/compiler/src/experimental/typekit/kits/index.ts
+++ b/packages/compiler/src/experimental/typekit/kits/index.ts
@@ -1,5 +1,6 @@
 export * from "./array.js";
 export * from "./builtin.js";
+export * from "./entity.js";
 export * from "./enum-member.js";
 export * from "./enum.js";
 export * from "./literal.js";
@@ -7,6 +8,7 @@ export * from "./model-property.js";
 export * from "./model.js";
 export * from "./operation.js";
 export * from "./record.js";
+export * from "./resolve.js";
 export * from "./scalar.js";
 export * from "./tuple.js";
 export * from "./type.js";

--- a/packages/compiler/src/experimental/typekit/kits/type.ts
+++ b/packages/compiler/src/experimental/typekit/kits/type.ts
@@ -14,9 +14,10 @@ import {
   getMinValueExclusive,
 } from "../../../core/intrinsic-type-state.js";
 import { isNeverType } from "../../../core/type-utils.js";
-import { Enum, Model, Scalar, Union, type Type } from "../../../core/types.js";
+import { Entity, Enum, Model, Node, Scalar, Union, type Type } from "../../../core/types.js";
 import { getDoc, getSummary, isErrorModel } from "../../../lib/decorators.js";
 import { resolveEncodedName } from "../../../lib/encoded-names.js";
+import { createDiagnosable, Diagnosable } from "../create-diagnosable.js";
 import { defineKit } from "../define-kit.js";
 import { copyMap } from "../utils.js";
 import { getPlausibleName } from "../utils/get-plausible-name.js";
@@ -121,6 +122,16 @@ export interface TypeTypekit {
    * @returns True if the type is a user defined type, false otherwise.
    */
   isUserDefined(type: Type): boolean;
+
+  /**
+   * Check if the source type can be assigned to the target.
+   * @param source Source type
+   * @param target Target type
+   * @param diagnosticTarget Target for the diagnostic
+   */
+  isAssignableTo: Diagnosable<
+    (source: Type, target: Entity, diagnosticTarget?: Entity | Node) => boolean
+  >;
 }
 
 interface TypekitExtension {
@@ -272,5 +283,8 @@ defineKit<TypekitExtension>({
     isUserDefined(type) {
       return getLocationContext(this.program, type).type === "project";
     },
+    isAssignableTo: createDiagnosable(function (source, target, diagnosticTarget) {
+      return this.program.checker.isTypeAssignableTo(source, target, diagnosticTarget ?? source);
+    }),
   },
 });

--- a/packages/compiler/src/experimental/typekit/kits/value.ts
+++ b/packages/compiler/src/experimental/typekit/kits/value.ts
@@ -2,7 +2,9 @@ import { Numeric } from "../../../core/numeric.js";
 import type {
   ArrayValue,
   BooleanValue,
+  Entity,
   EnumValue,
+  Node,
   NullValue,
   NumericValue,
   ObjectValue,
@@ -10,6 +12,7 @@ import type {
   StringValue,
   Value,
 } from "../../../core/types.js";
+import { createDiagnosable, Diagnosable } from "../create-diagnosable.js";
 import { defineKit } from "../define-kit.js";
 
 /** @experimental */
@@ -94,6 +97,16 @@ export interface ValueKit {
   isBoolean(type: Value): type is BooleanValue;
 
   is(type: { valueKind: string }): type is Value;
+
+  /**
+   * Check if the source type can be assigned to the target.
+   * @param source Source type
+   * @param target Target type
+   * @param diagnosticTarget Target for the diagnostic
+   */
+  isAssignableTo: Diagnosable<
+    (source: Value, target: Entity, diagnosticTarget?: Entity | Node) => boolean
+  >;
 }
 
 interface TypekitExtension {
@@ -185,5 +198,8 @@ defineKit<TypekitExtension>({
     isScalar(type) {
       return type.valueKind === "ScalarValue";
     },
+    isAssignableTo: createDiagnosable(function (source, target, diagnosticTarget) {
+      return this.program.checker.isTypeAssignableTo(source, target, diagnosticTarget ?? source);
+    }),
   },
 });

--- a/packages/compiler/test/experimental/typekit/entity.test.ts
+++ b/packages/compiler/test/experimental/typekit/entity.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { $ } from "../../../src/experimental/typekit/index.js";
+import { Model } from "../../../src/index.js";
+import { expectDiagnosticEmpty, expectDiagnostics } from "../../../src/testing/expect.js";
+import { getAssignables } from "./utils.js";
+
+describe("$.entity.isAssignableTo", () => {
+  it("validates MixedParameterConstraint against Type", async () => {
+    const { sourceProp, program } = await getAssignables({ source: "string" });
+    expect(sourceProp.entityKind).toBe("MixedParameterConstraint");
+
+    const tk = $(program);
+    expect(tk.entity.isAssignableTo(sourceProp, tk.builtin.string)).toBe(true);
+    expect(tk.entity.isAssignableTo(sourceProp, tk.builtin.int8)).toBe(false);
+  });
+
+  it("validates MixedParameterConstraint against Value", async () => {
+    const { sourceProp, program } = await getAssignables({ source: `"foo"` });
+    expect(sourceProp.entityKind).toBe("MixedParameterConstraint");
+
+    const tk = $(program);
+    // Can't actually assign to a value.
+    expect(tk.entity.isAssignableTo(sourceProp, tk.value.create("foo"))).toBe(false);
+  });
+
+  it("validates MixedParameterConstraint against MixedParameterConstraint", async () => {
+    const { sourceProp, targetProp, program } = await getAssignables({
+      source: `"foo"`,
+      target: "string",
+    });
+    expect(sourceProp.entityKind).toBe("MixedParameterConstraint");
+    expect(targetProp.entityKind).toBe("MixedParameterConstraint");
+
+    const tk = $(program);
+    expect(tk.entity.isAssignableTo(sourceProp, targetProp)).toBe(true);
+    expect(tk.entity.isAssignableTo(targetProp, sourceProp)).toBe(false);
+  });
+
+  it("validates MixedParameterConstraint against Indeterminate", async () => {
+    const {
+      sourceProp,
+      targetProp: invalidSourceProp,
+      program,
+      types: { Instance },
+    } = await getAssignables({
+      source: `"foo"`,
+      target: "string",
+      code: `
+        model Template<A extends string> { field: A }
+        @test model Instance is Template<"foo">;
+      `,
+    });
+    expect(sourceProp.entityKind).toBe("MixedParameterConstraint");
+    const indeterminate = (Instance as Model).sourceModels[0].model!.templateMapper!.args[0];
+    expect(indeterminate.entityKind).toBe("Indeterminate");
+
+    const tk = $(program);
+    expect(tk.entity.isAssignableTo(sourceProp, indeterminate)).toBe(true);
+    expect(tk.entity.isAssignableTo(invalidSourceProp, indeterminate)).toBe(false);
+  });
+
+  it("validates Indeterminate against Type", async () => {
+    const {
+      program,
+      types: { Instance },
+    } = await getAssignables({
+      code: `
+        model Template<A extends string> { field: A }
+        @test model Instance is Template<"foo">;
+      `,
+    });
+    const indeterminate = (Instance as Model).sourceModels[0].model!.templateMapper!.args[0];
+    expect(indeterminate.entityKind).toBe("Indeterminate");
+
+    const tk = $(program);
+    expect(tk.entity.isAssignableTo(indeterminate, tk.builtin.string)).toBe(true);
+    expect(tk.entity.isAssignableTo(indeterminate, tk.builtin.int8)).toBe(false);
+  });
+
+  it("validates Indeterminate against Value", async () => {
+    const {
+      program,
+      types: { Instance },
+    } = await getAssignables({
+      code: `
+        model Template<A extends string> { field: A }
+        @test model Instance is Template<"foo">;
+      `,
+    });
+    const indeterminate = (Instance as Model).sourceModels[0].model!.templateMapper!.args[0];
+    expect(indeterminate.entityKind).toBe("Indeterminate");
+
+    const tk = $(program);
+    // Can't actually assign to a value.
+    expect(tk.entity.isAssignableTo(indeterminate, tk.value.create("foo"))).toBe(false);
+  });
+
+  it("validates Indeterminate against MixedParameterConstraint", async () => {
+    const {
+      sourceProp: invalidTargetProp,
+      targetProp,
+      program,
+      types: { Instance },
+    } = await getAssignables({
+      target: "valueof string",
+      source: "int8",
+      code: `
+        model Template<A extends string> { field: A }
+        @test model Instance is Template<"foo">;
+      `,
+    });
+    const indeterminate = (Instance as Model).sourceModels[0].model!.templateMapper!.args[0];
+    expect(indeterminate.entityKind).toBe("Indeterminate");
+
+    const tk = $(program);
+    expect(tk.entity.isAssignableTo(indeterminate, targetProp)).toBe(true);
+    expect(tk.entity.isAssignableTo(indeterminate, invalidTargetProp)).toBe(false);
+  });
+
+  it("validates Indeterminate against Indeterminate", async () => {
+    const {
+      program,
+      types: { Instance },
+    } = await getAssignables({
+      target: "valueof string",
+      code: `
+        model Template<A extends string> { field: A }
+        @test model Instance is Template<"foo">;
+      `,
+    });
+    const indeterminate = (Instance as Model).sourceModels[0].model!.templateMapper!.args[0];
+    expect(indeterminate.entityKind).toBe("Indeterminate");
+
+    const tk = $(program);
+    expect(tk.entity.isAssignableTo(indeterminate, indeterminate)).toBe(true);
+  });
+
+  it("emits diagnostic when assigning incompatible types", async () => {
+    const { program } = await getAssignables({});
+
+    const tk = $(program);
+    const invalidTest = tk.entity.isAssignableTo.withDiagnostics(
+      tk.literal.create("foo"),
+      tk.builtin.boolean,
+    );
+    expect(invalidTest[0]).toBe(false);
+    expectDiagnostics(invalidTest[1], { code: "unassignable" });
+
+    const validTest = tk.entity.isAssignableTo.withDiagnostics(
+      tk.literal.create("foo"),
+      tk.builtin.string,
+    );
+    expect(validTest[0]).toBe(true);
+    expectDiagnosticEmpty(validTest[1]);
+  });
+});

--- a/packages/compiler/test/experimental/typekit/resolve.test.ts
+++ b/packages/compiler/test/experimental/typekit/resolve.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, expect, it } from "vitest";
-import { IntrinsicType } from "../../../src/core/types.js"; // Corrected path
-import { $ } from "../../../src/experimental/typekit/index.js"; // Corrected path
-import "../../../src/experimental/typekit/kits/resolve.js"; // Corrected path
+import { IntrinsicType } from "../../../src/core/types.js";
+import { $ } from "../../../src/experimental/typekit/index.js";
 import { createTestHost } from "../../../src/testing/test-host.js";
 import { createTestWrapper } from "../../../src/testing/test-utils.js";
 import { BasicTestRunner } from "../../../src/testing/types.js";

--- a/packages/compiler/test/experimental/typekit/value.test.ts
+++ b/packages/compiler/test/experimental/typekit/value.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { $ } from "../../../src/experimental/typekit/index.js";
+import { Model } from "../../../src/index.js";
+import { expectDiagnosticEmpty, expectDiagnostics } from "../../../src/testing/expect.js";
+import { getAssignables } from "./utils.js";
+
+describe("isAssignableTo", () => {
+  it("validates against Type", async () => {
+    const { program } = await getAssignables({});
+
+    const tk = $(program);
+    // Can't actually assign a value to a type.
+    expect(tk.value.isAssignableTo(tk.value.create("foo"), tk.builtin.string)).toBe(false);
+  });
+
+  it("validates against Value", async () => {
+    const { program } = await getAssignables({});
+
+    const tk = $(program);
+    // Can't actually assign a value to a value.
+    expect(tk.value.isAssignableTo(tk.value.create("foo"), tk.value.create("foo"))).toBe(false);
+  });
+
+  it("validates against MixedParameterConstraint", async () => {
+    const { targetProp, program } = await getAssignables({ target: "valueof string" });
+    expect(targetProp.entityKind).toBe("MixedParameterConstraint");
+
+    const tk = $(program);
+    expect(tk.value.isAssignableTo(tk.value.create("foo"), targetProp)).toBe(true);
+    expect(tk.value.isAssignableTo(tk.value.create(123), targetProp)).toBe(false);
+  });
+
+  it("validates against Indeterminate", async () => {
+    const {
+      program,
+      types: { Instance },
+    } = await getAssignables({
+      code: `
+        model Template<A extends string> { field: A }
+        @test model Instance is Template<"foo">;
+      `,
+    });
+    const indeterminate = (Instance as Model).sourceModels[0].model!.templateMapper!.args[0];
+    expect(indeterminate.entityKind).toBe("Indeterminate");
+
+    const tk = $(program);
+    // Can't actually assign a value to an indeterminate.
+    expect(tk.value.isAssignableTo(tk.value.create("foo"), indeterminate)).toBe(false);
+  });
+
+  it("emits diagnostic when assigning incompatible values", async () => {
+    const { targetProp, program } = await getAssignables({ target: "valueof string" });
+    expect(targetProp.entityKind).toBe("MixedParameterConstraint");
+
+    const tk = $(program);
+    const invalidTest = tk.value.isAssignableTo.withDiagnostics(tk.value.create(123), targetProp);
+    expect(invalidTest[0]).toBe(false);
+    expectDiagnostics(invalidTest[1], { code: "unassignable" });
+    const validTest = tk.value.isAssignableTo.withDiagnostics(tk.value.create("foo"), targetProp);
+    expect(validTest[0]).toBe(true);
+    expectDiagnosticEmpty(validTest[1]);
+  });
+});


### PR DESCRIPTION
Fixes #7086 

Added the `isAssignableTo` kits to `$.type`, `$.value`, and a new `$.entity`. 

Can also see an argument for just having `$.assignable` or `$.relation.isAssignableTo`