### PR TITLE
Update BinaryContentHelperDefinition to use RequestContentApi

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/BinaryContentHelperDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/BinaryContentHelperDefinition.cs
@@ -21,7 +21,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private const string _fromDictionaryName = "FromDictionary";
         private const string _fromObjectName = "FromObject";
 
-        private readonly CSharpType _requestBodyType = typeof(BinaryContent);
+        private readonly CSharpType _requestBodyType =
+            ScmCodeModelGenerator.Instance.TypeFactory.RequestContentApi.RequestContentType;
 
         private readonly MethodSignatureModifiers _methodModifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/ClientPipelineApiTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Linq;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Expressions;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/ClientResponseApiTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/ClientResponseApiTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/HttpMessageApiTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/HttpMessageApiTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.ClientModel.Primitives;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/RequestContentApiTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Abstractions/RequestContentApiTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Statements;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Abstractions
+{
+    public class RequestContentApiTests
+    {
+        [Test]
+        public void BinaryContentHelperMethodsUseCorrectReturnType()
+        {
+            MockHelpers.LoadMockGenerator(requestContentApi: TestRequestContentApi.Instance);
+            var binaryContentHelper = new BinaryContentHelperDefinition();
+
+            foreach (var method in binaryContentHelper.Methods)
+            {
+                Assert.IsNotNull(method);
+                Assert.IsNotNull(method.Signature.ReturnType);
+                Assert.IsTrue(method.Signature.ReturnType!.Equals(typeof(string)));
+            }
+        }
+
+        private record TestRequestContentApi : RequestContentApi
+        {
+            private static TestRequestContentApi? _instance;
+            internal static TestRequestContentApi Instance => _instance ??= new();
+            public TestRequestContentApi(ValueExpression original) : base(typeof(string), original)
+            {
+            }
+            private TestRequestContentApi() : base(typeof(string), Empty)
+            {
+            }
+
+            public override CSharpType RequestContentType => new CSharpType(typeof(string));
+            public override RequestContentApi FromExpression(ValueExpression original) =>
+                new TestRequestContentApi(original);
+
+            public override RequestContentApi ToExpression() => this;
+            public override MethodBodyStatement[] Create(ValueExpression argument)
+                => [Original.Invoke("FakeCreate", argument).Terminate()];
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestHelpers/MockHelpers.cs
@@ -58,6 +58,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
             ClientResponseApi? clientResponseApi = null,
             ClientPipelineApi? clientPipelineApi = null,
             HttpMessageApi? httpMessageApi = null,
+            RequestContentApi? requestContentApi = null,
             Func<InputAuth>? auth = null)
         {
             IReadOnlyList<string> inputNsApiVersions = apiVersions?.Invoke() ?? [];
@@ -126,6 +127,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
             if (httpMessageApi is not null)
             {
                 mockTypeFactory.Setup(p => p.HttpMessageApi).Returns(httpMessageApi);
+            }
+
+            if (requestContentApi is not null)
+            {
+                mockTypeFactory.Setup(p => p.RequestContentApi).Returns(requestContentApi);
             }
 
             if (createInputLibrary is not null)


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/49450