### PR TITLE
http-client-java, bug fix, use final in immutable Headers class

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ModelTemplate.java
@@ -664,7 +664,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         addGeneratedAnnotation(classBlock);
         addFieldAnnotations(model, property, classBlock, settings);
 
-        if (ClientModelUtil.includePropertyInConstructor(property, settings) || property.isConstant()) {
+        if (model.isStronglyTypedHeader() && ClientModelUtil.isImmutableOutputModel(model, settings)) {
+            // a shortcut for Headers class
+            classBlock.privateFinalMemberVariable(fieldSignature);
+        } else if (ClientModelUtil.includePropertyInConstructor(property, settings) || property.isConstant()) {
             classBlock.privateFinalMemberVariable(fieldSignature);
         } else {
             classBlock.privateMemberVariable(fieldSignature);

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/util/ModelTemplateHeaderHelper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/util/ModelTemplateHeaderHelper.java
@@ -209,8 +209,11 @@ public final class ModelTemplateHeaderHelper {
 
         // String is special as the setter is null safe for it, unlike other nullable types.
         if (needsNullGuarding) {
-            javaBlock.ifBlock(property.getName() + " != null",
-                ifBlock -> ifBlock.line("this." + property.getName() + " = " + setter + ";"));
+            javaBlock
+                .ifBlock(property.getName() + " != null",
+                    ifBlock -> ifBlock.line("this." + property.getName() + " = " + setter + ";"))
+                .elseBlock(elseBlock -> elseBlock.line(
+                    "this." + property.getName() + " = " + property.getClientType().defaultValueExpression() + ";"));
         } else {
             javaBlock.line("this." + property.getName() + " = " + setter + ";");
         }


### PR DESCRIPTION
The problem is due to that the `##Headers` class would be an output only class (as this is contracted by codegen as a model for output headers).

And in outputImmutable setting, codegen will not generate "setter" method.

Then the class variable required to be marked as `final`.

And then it would require the constructor always initialized the variable (even it is just `null`).

(I didn't add test case, to avoid conflicting with Srikanta's PR)

Sample code
```java
@Immutable
public final class TopLevelArmResourceInterfacesActionHeaders {
    /*
     * The Retry-After property.
     */
    private final Integer retryAfter;

    /*
     * The location property.
     */
    private final String location;

    // HttpHeaders containing the raw property values.
    /**
     * Creates an instance of TopLevelArmResourceInterfacesActionHeaders class.
     * 
     * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
     */
    public TopLevelArmResourceInterfacesActionHeaders(HttpHeaders rawHeaders) {
        String retryAfter = rawHeaders.getValue(HttpHeaderName.RETRY_AFTER);
        if (retryAfter != null) {
            this.retryAfter = Integer.parseInt(retryAfter);
        } else {
            this.retryAfter = null;
        }
        this.location = rawHeaders.getValue(HttpHeaderName.LOCATION);
    }

    ...
```

basically, the change is the
`final` in `private final Integer retryAfter;`
and
`this.retryAfter = null;` in `else`.

---

This change should not affect vanilla or mgmt from Swagger, because above scenario only apply when `--output-model-immutable`.