### PR TITLE
`explode` defaults to `true` for query parameters

### DIFF
--- a/packages/http-client-js/test/scenarios/encoding/query_bytes.md
+++ b/packages/http-client-js/test/scenarios/encoding/query_bytes.md
@@ -23,7 +23,7 @@ export async function defaultEncoding(
   value: Uint8Array,
   options?: DefaultEncodingOptions,
 ): Promise<void> {
-  const path = parse("/default{?value}").expand({
+  const path = parse("/default{?value*}").expand({
     value: encodeUint8Array(value, "base64url")!,
   });
   const httpRequestOptions = {

--- a/packages/http-client-js/test/scenarios/encoding/query_date.md
+++ b/packages/http-client-js/test/scenarios/encoding/query_date.md
@@ -23,7 +23,7 @@ export async function defaultEncoding(
   value: Date,
   options?: DefaultEncodingOptions,
 ): Promise<void> {
-  const path = parse("/default{?value}").expand({
+  const path = parse("/default{?value*}").expand({
     value: dateRfc3339Serializer(value),
   });
   const httpRequestOptions = {
@@ -65,7 +65,7 @@ export async function defaultEncoding(
   client: TestClientContext,
   options?: DefaultEncodingOptions,
 ): Promise<void> {
-  const path = parse("/default{?value}").expand({
+  const path = parse("/default{?value*}").expand({
     ...(options?.value && { value: dateRfc3339Serializer(options.value) }),
   });
   const httpRequestOptions = {
@@ -109,7 +109,7 @@ export async function get(
   value: Date,
   options?: GetOptions,
 ): Promise<void> {
-  const path = parse("/default{?value}").expand({
+  const path = parse("/default{?value*}").expand({
     value: dateRfc3339Serializer(value),
   });
   const httpRequestOptions = {
@@ -153,7 +153,7 @@ export async function get(
   value: Date,
   options?: GetOptions,
 ): Promise<void> {
-  const path = parse("/default{?value}").expand({
+  const path = parse("/default{?value*}").expand({
     value: dateRfc7231Serializer(value),
   });
   const httpRequestOptions = {
@@ -197,7 +197,7 @@ export async function get(
   value: Date,
   options?: GetOptions,
 ): Promise<void> {
-  const path = parse("/default{?value}").expand({
+  const path = parse("/default{?value*}").expand({
     value: dateUnixTimestampSerializer(value),
   });
   const httpRequestOptions = {

--- a/packages/http-client-js/test/scenarios/http-operations/basic-request.md
+++ b/packages/http-client-js/test/scenarios/http-operations/basic-request.md
@@ -75,7 +75,7 @@ export async function read(
   name: string,
   options?: ReadOptions,
 ): Promise<void> {
-  const path = parse("/widgets/{id}{?foo}").expand({
+  const path = parse("/widgets/{id}{?foo*}").expand({
     id: id,
     foo: foo,
   });

--- a/packages/http-client-js/test/scenarios/http-operations/paging.md
+++ b/packages/http-client-js/test/scenarios/http-operations/paging.md
@@ -51,7 +51,7 @@ export function link(
 
 ```ts src/api/testClientOperations.ts function linkSend
 async function linkSend(client: TestClientContext, filter: string, options?: Record<string, any>) {
-  const path = parse("/link{?filter,nextToken}").expand({
+  const path = parse("/link{?filter*,nextToken*}").expand({
     filter: filter,
     ...(options?.nextToken && { nextToken: options.nextToken }),
   });
@@ -173,7 +173,7 @@ export function link(
 
 ```ts src/api/testClientOperations.ts function linkSend
 async function linkSend(client: TestClientContext, filter: string, options?: Record<string, any>) {
-  const path = parse("/link{?filter,maxPageSize}").expand({
+  const path = parse("/link{?filter*,maxPageSize*}").expand({
     filter: filter,
     ...(options?.maxPageSize && { maxPageSize: options.maxPageSize }),
   });

--- a/packages/http-client-js/test/scenarios/http-operations/with-parameters.md
+++ b/packages/http-client-js/test/scenarios/http-operations/with-parameters.md
@@ -37,7 +37,7 @@ export async function read(
   name: string,
   options?: ReadOptions,
 ): Promise<void> {
-  const path = parse("/widgets/{id}{?foo}").expand({
+  const path = parse("/widgets/{id}{?foo*}").expand({
     id: id,
     foo: foo,
   });

--- a/packages/http-client-js/test/scenarios/operation-parameters/only_required.md
+++ b/packages/http-client-js/test/scenarios/operation-parameters/only_required.md
@@ -18,7 +18,7 @@ export async function getWithParams(
   age: number,
   options?: GetWithParamsOptions,
 ): Promise<number> {
-  const path = parse("/{?name,age}").expand({
+  const path = parse("/{?name*,age*}").expand({
     name: name,
     age: age,
   });

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -169,7 +169,8 @@ export function resolveQueryOptionsWithDefaults(
   options: QueryOptions & { name: string },
 ): Required<QueryOptions> {
   return {
-    explode: options.explode ?? false,
+    // For query parameters(style: form) the default is explode: true https://spec.openapis.org/oas/v3.0.2#fixed-fields-9
+    explode: options.explode ?? true,
     name: options.name,
   };
 }

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -277,14 +277,25 @@ describe("http: decorators", () => {
       strictEqual(getQueryParamName(runner.program, select), "$select");
     });
 
-    it("specify explode: true", async () => {
+    it("don't specify explode", async () => {
       const { selects } = await runner.compile(`
-        op test(@test @query(#{ explode: true }) selects: string[]): string;
+        op test(@test @query selects: string[]): string;
       `);
       expect(getQueryParamOptions(runner.program, selects)).toEqual({
         type: "query",
         name: "selects",
         explode: true,
+      });
+    });
+
+    it("specify explode: false", async () => {
+      const { selects } = await runner.compile(`
+        op test(@test @query(#{ explode: false }) selects: string[]): string;
+      `);
+      expect(getQueryParamOptions(runner.program, selects)).toEqual({
+        type: "query",
+        name: "selects",
+        explode: false,
       });
     });
   });

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -572,16 +572,17 @@ describe("uri template", () => {
       [`@path(#{style: "fragment"}) one: string`, "/foo/{#one}"],
       [`@path(#{style: "path"}) one: string`, "/foo/{/one}"],
       ["@path(#{allowReserved: true, explode: true}) one: string", "/foo/{+one*}"],
-      ["@query one: string", "/foo{?one}"],
+      ["@query one: string", "/foo{?one*}"],
       ["@query(#{explode: true}) one: string", "/foo{?one*}"],
+      ["@query(#{explode: false}) one: string", "/foo{?one}"],
       [
         "@query(#{explode: true}) one: string, @query(#{explode: true}) two: string",
         "/foo{?one*,two*}",
       ],
 
       // cspell:ignore Atwo Dtwo
-      [`@query("one:two") one: string`, "/foo{?one%3Atwo}"],
-      [`@query("one-two") one: string`, "/foo{?one%2Dtwo}"],
+      [`@query("one:two") one: string`, "/foo{?one%3Atwo*}"],
+      [`@query("one-two") one: string`, "/foo{?one%2Dtwo*}"],
     ])("%s -> %s", async (param, expectedUri) => {
       const op = await getOp(`@route("/foo") op foo(${param}): void;`);
       expect(op.uriTemplate).toEqual(expectedUri);

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1542,9 +1542,9 @@ function createOAPIEmitter(
   function getQueryParameterAttributes(httpProperty: HttpProperty & { kind: "query" }) {
     const attributes: { style?: string; explode?: boolean } = {};
 
-    if (httpProperty.options.explode !== true) {
+    if (httpProperty.options.explode === false) {
       // For query parameters(style: form) the default is explode: true https://spec.openapis.org/oas/v3.0.2#fixed-fields-9
-      attributes.explode = true;
+      attributes.explode = false;
     }
     const style = getParameterStyle(httpProperty.property);
     if (style) {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1544,7 +1544,7 @@ function createOAPIEmitter(
 
     if (httpProperty.options.explode !== true) {
       // For query parameters(style: form) the default is explode: true https://spec.openapis.org/oas/v3.0.2#fixed-fields-9
-      attributes.explode = false;
+      attributes.explode = true;
     }
     const style = getParameterStyle(httpProperty.property);
     if (style) {

--- a/packages/openapi3/test/metadata.test.ts
+++ b/packages/openapi3/test/metadata.test.ts
@@ -663,7 +663,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
         "Parameters.q": {
           name: "q",
           in: "query",
-          explode: false,
           required: true,
           schema: { type: "string" },
         },
@@ -731,7 +730,6 @@ worksFor(["3.0.0", "3.1.0"], ({ openApiFor }) => {
               name: "q",
               in: "query",
               required: true,
-              explode: false,
               schema: { type: "string" },
             },
             {

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -40,7 +40,6 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
         `op test(@query @encode(${encoding}) myParam: string[]): void;`,
       );
       expect(param).toMatchObject({
-        explode: false,
         style: style,
       });
       expect(param.schema).toStrictEqual({
@@ -94,7 +93,6 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
       deepStrictEqual(res.paths["/"].get.parameters[0], {
         in: "query",
         name: "id",
-        explode: false,
         required: true,
         schema: {
           type: "string",

--- a/packages/openapi3/test/shared-routes.test.ts
+++ b/packages/openapi3/test/shared-routes.test.ts
@@ -70,7 +70,6 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
       {
         in: "query",
         name: "resourceGroup",
-        explode: false,
         required: false,
         schema: {
           type: "string",
@@ -79,7 +78,6 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
       {
         in: "query",
         name: "foo",
-        explode: false,
         required: true,
         schema: {
           type: "string",
@@ -88,7 +86,6 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
       {
         in: "query",
         name: "subscription",
-        explode: false,
         required: false,
         schema: {
           type: "string",
@@ -133,7 +130,6 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
       {
         in: "query",
         name: "filter",
-        explode: false,
         required: true,
         schema: {
           type: "string",
@@ -180,7 +176,6 @@ worksFor(["3.0.0", "3.1.0"], ({ diagnoseOpenApiFor, openApiFor }) => {
         name: "filter",
         in: "query",
         required: false,
-        explode: false,
         schema: {
           type: "string",
           enum: ["resourceGroup"],

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -583,9 +583,11 @@ describe("uri template", () => {
       [`@path(#{style: "fragment"}) one: string`, "/foo/{#one}"],
       [`@path(#{style: "path"}) one: string`, "/foo/{/one}"],
       ["@path(#{allowReserved: true, explode: true}) one: string", "/foo/{+one*}"],
-      ["@query one: string", "/foo{?one}"],
+      ["@query one: string", "/foo{?one*}"],
+      ["@query(#{explode: true}) one: string", "/foo{?one*}"],
+      ["@query(#{explode: false}) one: string", "/foo{?one}"],
       // cspell:ignore Atwo
-      [`@query("one:two") one: string`, "/foo{?one%3Atwo}"],
+      [`@query("one:two") one: string`, "/foo{?one%3Atwo*}"],
     ])("%s -> %s", async (param, expectedUri) => {
       const op = await getOp(`@route("/foo") interface Test {@autoRoute op foo(${param}): void;}`);
       expect(op.uriTemplate).toEqual(expectedUri);

--- a/packages/samples/specs/visibility/visibility.tsp
+++ b/packages/samples/specs/visibility/visibility.tsp
@@ -62,7 +62,7 @@ namespace Hello {
   @get op read(
     @path id: string,
 
-    @query(#{ explode: true })
+    @query(#{ explode: false })
     fieldMask: string[],
   ): ReadablePerson;
   @post op create(@body person: WritablePerson): ReadablePerson;

--- a/packages/samples/test/output/grpc-library-example/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/grpc-library-example/@typespec/openapi3/openapi.yaml
@@ -270,7 +270,6 @@ components:
       schema:
         type: integer
         format: int32
-      explode: true
     ListRequestBase.page_token:
       name: page_token
       in: query
@@ -282,7 +281,6 @@ components:
         returned from the previous call to `ListShelves` method.
       schema:
         type: string
-      explode: true
     MergeShelvesRequest.name:
       name: name
       in: path

--- a/packages/samples/test/output/grpc-library-example/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/grpc-library-example/@typespec/openapi3/openapi.yaml
@@ -270,7 +270,7 @@ components:
       schema:
         type: integer
         format: int32
-      explode: false
+      explode: true
     ListRequestBase.page_token:
       name: page_token
       in: query
@@ -282,7 +282,7 @@ components:
         returned from the previous call to `ListShelves` method.
       schema:
         type: string
-      explode: false
+      explode: true
     MergeShelvesRequest.name:
       name: name
       in: path

--- a/packages/samples/test/output/nullable/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/nullable/@typespec/openapi3/openapi.yaml
@@ -14,7 +14,7 @@ paths:
           schema:
             type: string
             nullable: true
-          explode: false
+          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/nullable/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/nullable/@typespec/openapi3/openapi.yaml
@@ -14,7 +14,6 @@ paths:
           schema:
             type: string
             nullable: true
-          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/optional/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/optional/@typespec/openapi3/openapi.yaml
@@ -14,7 +14,6 @@ paths:
           schema:
             type: string
             default: defaultQueryString
-          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/optional/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/optional/@typespec/openapi3/openapi.yaml
@@ -14,7 +14,7 @@ paths:
           schema:
             type: string
             default: defaultQueryString
-          explode: false
+          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/param-decorators/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/param-decorators/@typespec/openapi3/openapi.yaml
@@ -23,7 +23,6 @@ paths:
             format: int32
             minimum: 0
             maximum: 10
-          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/param-decorators/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/param-decorators/@typespec/openapi3/openapi.yaml
@@ -23,7 +23,7 @@ paths:
             format: int32
             minimum: 0
             maximum: 10
-          explode: false
+          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/petstore/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/petstore/@typespec/openapi3/openapi.yaml
@@ -15,7 +15,7 @@ paths:
           required: false
           schema:
             type: string
-          explode: false
+          explode: true
       responses:
         '200':
           description: The request has succeeded.
@@ -104,7 +104,7 @@ paths:
           required: true
           schema:
             type: string
-          explode: false
+          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/petstore/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/petstore/@typespec/openapi3/openapi.yaml
@@ -15,7 +15,6 @@ paths:
           required: false
           schema:
             type: string
-          explode: true
       responses:
         '200':
           description: The request has succeeded.
@@ -104,7 +103,6 @@ paths:
           required: true
           schema:
             type: string
-          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/rest/petstore/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/rest/petstore/@typespec/openapi3/openapi.yaml
@@ -459,7 +459,6 @@ paths:
           required: true
           schema:
             type: string
-          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/rest/petstore/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/rest/petstore/@typespec/openapi3/openapi.yaml
@@ -459,7 +459,7 @@ paths:
           required: true
           schema:
             type: string
-          explode: false
+          explode: true
       responses:
         '200':
           description: The request has succeeded.

--- a/packages/samples/test/output/todoApp/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/todoApp/@typespec/openapi3/openapi.yaml
@@ -301,7 +301,7 @@ components:
         type: integer
         format: int32
         default: 50
-      explode: false
+      explode: true
     TodoItems.PaginationControls.offset:
       name: offset
       in: query
@@ -311,7 +311,7 @@ components:
         type: integer
         format: int32
         default: 0
-      explode: false
+      explode: true
   schemas:
     ApiError:
       type: object

--- a/packages/samples/test/output/todoApp/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/todoApp/@typespec/openapi3/openapi.yaml
@@ -301,7 +301,6 @@ components:
         type: integer
         format: int32
         default: 50
-      explode: true
     TodoItems.PaginationControls.offset:
       name: offset
       in: query
@@ -311,7 +310,6 @@ components:
         type: integer
         format: int32
         default: 0
-      explode: true
   schemas:
     ApiError:
       type: object

--- a/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
+++ b/packages/samples/test/output/visibility/@typespec/openapi3/openapi.yaml
@@ -86,6 +86,7 @@ paths:
             type: array
             items:
               type: string
+          explode: false
       responses:
         '200':
           description: The request has succeeded.


### PR DESCRIPTION
From https://github.com/microsoft/typespec/pull/4167, the default value of `explode` in the query parameter has become `false`.

However, according to the OpenAPI v3 specification, the default value of `explode` in the query parameter is `true`.

* [https://swagger.io/docs/specification/v3_0/serialization/#query-parameters](https://swagger.io/docs/specification/v3_0/serialization/#query-parameters:~:text=The%20default%20serialization%20method%20is%20style%3A%20form%20and%20explode%3A%20true.)
* [https://spec.openapis.org/oas/v3.0.2#fixed-fields-9](https://spec.openapis.org/oas/v3.0.2#fixed-fields-9:~:text=parameters%20this%20property%20has%20no%20effect.-,When%20style%20is%20form%2C%20the%20default%20value%20is%20true,-.%20For%20all%20other%20styles%2C%20the%20default)

Actually, the code comment says that `For query parameters(style: form) the default is explode: true` as opposed to the implementation.
https://github.com/microsoft/typespec/blob/f5fbe0ade19a80f15b1475bee6ea7584c72cdbda/packages/openapi3/src/openapi.ts#L1545-L1548

Therefore, I changed the default value of `explode` to `true` in this PR.