### PR TITLE
[compiler] Add nesting and scalar handling for getPlausibleName

### DIFF
--- a/.chronus/changes/get-plausible-name-fixes-2025-3-28-17-12-25.md
+++ b/.chronus/changes/get-plausible-name-fixes-2025-3-28-17-12-25.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fixes handling of nested templates in getPlausibleName

--- a/packages/compiler/src/typekit/utils/get-plausible-name.ts
+++ b/packages/compiler/src/typekit/utils/get-plausible-name.ts
@@ -5,7 +5,7 @@ import { Enum, Interface, Model, Scalar, Union } from "../../core/types.js";
  * Get a plausible name for the given type.
  * @experimental
  */
-export function getPlausibleName(type: Model | Union | Enum | Scalar | Interface) {
+export function getPlausibleName(type: Model | Union | Enum | Scalar | Interface): string {
   let name = type.name;
 
   if (!name) {
@@ -13,7 +13,21 @@ export function getPlausibleName(type: Model | Union | Enum | Scalar | Interface
   }
 
   if (isTemplateInstance(type)) {
-    const namePrefix = type.templateMapper.args.map((a) => ("name" in a && a.name) || "").join("_");
+    const namePrefix = type.templateMapper.args
+      .map((a) => {
+        if (a.entityKind === "Type") {
+          switch (a.kind) {
+            case "Model":
+            case "Interface":
+            case "Enum":
+            case "Scalar":
+            case "Union":
+              return getPlausibleName(a);
+          }
+        }
+        return "name" in a ? a.name : "";
+      })
+      .join("_");
     name = `${namePrefix}${name}`;
   }
 

--- a/packages/compiler/src/typekit/utils/get-plausible-name.ts
+++ b/packages/compiler/src/typekit/utils/get-plausible-name.ts
@@ -6,25 +6,20 @@ import { Enum, Interface, Model, Scalar, Union } from "../../core/types.js";
  * @experimental
  */
 export function getPlausibleName(type: Model | Union | Enum | Scalar | Interface): string {
-  let name = type.name;
-
-  if (!name) {
-    name = "TypeExpression"; // TODO: Implement automatic name generation based on the type context
-  }
-
-  if (type.kind === "Scalar") {
-    name = `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
-  }
+  let name = type.name ?? "TypeExpression";
 
   if (isTemplateInstance(type)) {
     const namePrefix = type.templateMapper.args
       .map((a) => {
         if (a.entityKind === "Type") {
           switch (a.kind) {
+            case "Scalar":
+              // Box<scalar> is not a scalar so capital case naming convention applies
+              const name = getPlausibleName(a);
+              return name.charAt(0).toUpperCase() + name.slice(1);
             case "Model":
             case "Interface":
             case "Enum":
-            case "Scalar":
             case "Union":
               return getPlausibleName(a);
           }

--- a/packages/compiler/src/typekit/utils/get-plausible-name.ts
+++ b/packages/compiler/src/typekit/utils/get-plausible-name.ts
@@ -12,6 +12,10 @@ export function getPlausibleName(type: Model | Union | Enum | Scalar | Interface
     name = "TypeExpression"; // TODO: Implement automatic name generation based on the type context
   }
 
+  if (type.kind === "Scalar") {
+    name = `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+  }
+
   if (isTemplateInstance(type)) {
     const namePrefix = type.templateMapper.args
       .map((a) => {

--- a/packages/compiler/test/typekit/type.test.ts
+++ b/packages/compiler/test/typekit/type.test.ts
@@ -85,6 +85,34 @@ describe("getPlausibleName", () => {
     expect(isTemplateInstance(Foo2)).toBe(true);
     expect($(program).type.getPlausibleName(Foo2)).toBe("Qux_BazFoo");
   });
+
+  it("returns a generated name for anonymous arrays", async () => {
+    const {
+      Bar,
+      context: { program },
+    } = await getTypes(
+      `
+      model Foo<T> {t: T};
+      model Box<T> {t: T};
+      @test model Bar {
+        stringArrayArray: Array<Array<string>>;
+        stringFoo: Foo<string>;
+        boxFoo: Box<Foo<string>>;
+      }
+      `,
+      ["Bar"],
+    );
+
+    const stringArrayArray = (Bar as Model).properties.get("stringArrayArray")!.type as Model;
+    const stringFoo = (Bar as Model).properties.get("stringFoo")!.type as Model;
+    const boxFoo = (Bar as Model).properties.get("boxFoo")!.type as Model;
+    expect(isTemplateInstance(stringArrayArray)).toBe(true);
+    expect($(program).type.getPlausibleName(stringArrayArray)).toBe("StringArrayArray");
+    expect(isTemplateInstance(stringFoo)).toBe(true);
+    expect($(program).type.getPlausibleName(stringFoo)).toBe("StringFoo");
+    expect(isTemplateInstance(boxFoo)).toBe(true);
+    expect($(program).type.getPlausibleName(boxFoo)).toBe("StringFooBox");
+  });
 });
 
 describe("minValue and maxValue", () => {

--- a/packages/compiler/test/typekit/type.test.ts
+++ b/packages/compiler/test/typekit/type.test.ts
@@ -86,7 +86,26 @@ describe("getPlausibleName", () => {
     expect($(program).type.getPlausibleName(Foo2)).toBe("Qux_BazFoo");
   });
 
-  it("returns a generated name for anonymous arrays", async () => {
+  it("returns a generated name for templated scalars", async () => {
+    const {
+      Bar,
+      context: { program },
+    } = await getTypes(
+      `
+      scalar myInt extends int32;
+      @test model Bar {
+        myIntArray: Array<myInt>;
+      }
+      `,
+      ["Bar"],
+    );
+
+    const int32Array = (Bar as Model).properties.get("myIntArray")!.type as Model;
+    expect(isTemplateInstance(int32Array)).toBe(true);
+    expect($(program).type.getPlausibleName(int32Array)).toBe("MyIntArray");
+  });
+
+  it("returns a generated name for various nesting levels", async () => {
     const {
       Bar,
       context: { program },

--- a/packages/compiler/test/typekit/type.test.ts
+++ b/packages/compiler/test/typekit/type.test.ts
@@ -86,7 +86,7 @@ describe("getPlausibleName", () => {
     expect($(program).type.getPlausibleName(Foo2)).toBe("Qux_BazFoo");
   });
 
-  it("returns a generated name for templated scalars", async () => {
+  it("handles scalars correctly", async () => {
     const {
       Bar,
       context: { program },
@@ -95,14 +95,19 @@ describe("getPlausibleName", () => {
       scalar myInt extends int32;
       @test model Bar {
         myIntArray: Array<myInt>;
+        myInt: myInt;
       }
       `,
       ["Bar"],
     );
 
-    const int32Array = (Bar as Model).properties.get("myIntArray")!.type as Model;
-    expect(isTemplateInstance(int32Array)).toBe(true);
-    expect($(program).type.getPlausibleName(int32Array)).toBe("MyIntArray");
+    const myIntArray = (Bar as Model).properties.get("myIntArray")!.type as Model;
+    expect(isTemplateInstance(myIntArray)).toBe(true);
+    expect($(program).type.getPlausibleName(myIntArray)).toBe("MyIntArray");
+
+    const myInt = (Bar as Model).properties.get("myInt")!.type as Scalar;
+    expect(isTemplateInstance(myInt)).toBe(false);
+    expect($(program).type.getPlausibleName(myInt)).toBe("myInt");
   });
 
   it("returns a generated name for various nesting levels", async () => {


### PR DESCRIPTION
Fixes a few known cases where `getPlausibleName` is not providing the right result

Few examples:

```typespec
      model Foo<T> {t: T};
      model Box<T> {t: T};
      scalar myInt extends int32;
      @test model Bar {
        stringArrayArray: Array<Array<string>>;
        stringFoo: Foo<string>;
        boxFoo: Box<Foo<string>>;
        int32Array: Array<myInt>;
      }
```

|field|type|before|after|
|-----|----|-----------|-----|
|stringArrayArray|`Array<Array<string>>`|ArrayArray|StringArrayArray|
|stringFoo|`Foo<string>`|stringFoo|StringFoo|
|boxFoo|`Box<Foo<string>>`|FooBox|StringFooBox|
|int32Array|`Array<myInt>`|myIntArray|MyIntArray|


Resolves #6961