### PR TITLE
http-client-java, copilot-instruction for "Update package for latest compiler"

### DIFF
--- a/packages/http-client-java/.github/copilot-instructions.md
+++ b/packages/http-client-java/.github/copilot-instructions.md
@@ -5,18 +5,18 @@
 # Update Package for Latest Dependencies
 
 Steps:
+
 1. Run `ncu -u` on "package.json" in root and in both "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders.
 2. Update `peerDependencies` in root "package.json", according to the versions in `devDependencies`.
 3. Update `override` in the other 2 "package.json", according to the versions in root "package.json".
 4. Save the files, and run `npm install` in root, so that "package-lock.json" would be updated.
 
-Developer may need to run `Geenrate.ps1` in "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders, to update the e2e spector tests.
+Developer may need to run `Generate.ps1` in "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders, to update the e2e spector tests.
 
 # Update Package and Prepare for Minor/Patch Release
 
-Execute "Update Package for Latest Dependencies".
+Steps:
 
-Then
 1. Bump minor/patch version of `@typespec/http-client-java` in the 3 "package.json".
 2. Save the file, and run `npm install` in root, so that "package-lock.json" would be updated.
 

--- a/packages/http-client-java/.github/copilot-instructions.md
+++ b/packages/http-client-java/.github/copilot-instructions.md
@@ -2,13 +2,22 @@
 
 ---
 
-# Update package for latest compiler
+# Update Package for Latest Dependencies
 
 Steps:
 1. Run `ncu -u` on "package.json" in root and in both "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders.
-2. Bump the minor version of `@typespec/http-client-java` in the 3 "package.json".
-3. Update `peerDependencies` in root "package.json", according to the versions in `devDependencies`.
-4. Update `override` in the other 2 "package.json", according to the versions in root "package.json".
-5. Run `Geenrate.ps1` in "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders.
+2. Update `peerDependencies` in root "package.json", according to the versions in `devDependencies`.
+3. Update `override` in the other 2 "package.json", according to the versions in root "package.json".
+4. Save the files, and run `npm install` in root, so that "package-lock.json" would be updated.
+
+Developer may need to run `Geenrate.ps1` in "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders, to update the e2e spector tests.
+
+# Update Package and Prepare for Minor/Patch Release
+
+Execute "Update Package for Latest Dependencies".
+
+Then
+1. Bump minor/patch version of `@typespec/http-client-java` in the 3 "package.json".
+2. Save the file, and run `npm install` in root, so that "package-lock.json" would be updated.
 
 The [publish to NPM](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7294) would be automatically triggered, after the PR is merged.

--- a/packages/http-client-java/.github/copilot-instructions.md
+++ b/packages/http-client-java/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+> **Scope**: These instructions apply **only** to the `packages/http-client-java` sub-project in this monorepo. Use them whenever Copilot generates code, tests, commit messages, or pull request descriptions for the emitter. If Copilot is used in other sub-projects, these rules do not apply unless stated otherwise.
+
+---
+
+# Update package for latest compiler
+
+Steps:
+1. Run `ncu -u` on "package.json" in root and in both "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders.
+2. Bump the minor version of `@typespec/http-client-java` in the 3 "package.json".
+3. Update `peerDependencies` in root "package.json", according to the versions in `devDependencies`.
+4. Update `override` in the other 2 "package.json", according to the versions in root "package.json".
+5. Run `Geenrate.ps1` in "generator/http-client-generator-clientcore-test" and "generator/http-client-generator-test" folders.
+
+The [publish to NPM](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7294) would be automatically triggered, after the PR is merged.


### PR DESCRIPTION
Typically use "Claude" model in code-insider, in agent mode.

The "Update Package for Latest Dependencies" instruction works fine (when this be simple). Result PR https://github.com/microsoft/typespec/pull/7159 . 

I've also tried the "prepare patch release" instruction. Seems OK.

"Save the files" (the last step of  "Update Package for Latest Dependencies" and "Update Package and Prepare for Minor/Patch Release") needs to be done by dev.

---

similar file in js https://github.com/microsoft/typespec/blob/main/packages/http-client-js/.github/copilot-instructions.md