### PR TITLE
Fix the .tsp for the Spector test to specify base64url encoding

### DIFF
--- a/.chronus/changes/fix-spector-encode-base64url-2025-3-29-14-28-9.md
+++ b/.chronus/changes/fix-spector-encode-base64url-2025-3-29-14-28-9.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/http-specs"
+---
+
+Fixed the `@encode` value for `/encode/bytes/body/response/base64url` to explicitly specify `base64url`.

--- a/packages/http-specs/specs/encode/bytes/main.tsp
+++ b/packages/http-specs/specs/encode/bytes/main.tsp
@@ -366,6 +366,7 @@ namespace ResponseBody {
     contentType: "application/json";
 
     @body
+    @encode(BytesKnownEncoding.base64url)
     body: base64urlBytes;
   };
 }


### PR DESCRIPTION
Without that line, the emitter returns `"base64"` as a value of `SdkType.encode`, NOT `"base64url"`.

If the intent was to use the default, then maybe the `op base64()` on the line 348 shouldn't be specifying `@encode`, but not this one.

Or, the tcgc should have a different default value, but from what I currently see, the default appears to be `"base64"`, not `"base64url"`.

Either way, this fixes the spec, and now we can generate the correct code to pass the test.

You may have a question - if this value has been incorrect all along, how come that C# and Java emitters pass this test? (but C++, Go and Python are still failing). And I think that is because Java and C# use a function that does not complain when you ask it to decode base64 value, but give it base64url, i.e. it can do both. In C++, the function that we use is going to throw if you give it base64-encoded and not base64-encoded value, so in our case the test was throwing an exception.

It is still a bit strange - on line 12 there is the following definition:
```tsp
@encode(BytesKnownEncoding.base64url)
scalar base64urlBytes extends bytes;
```

However, somehow in this specific case, for body, the value that tcgc gives us is `base64` and not `base64url`. It does not seem to create problems in all other contexts/test cases. But there (repsonse body), it does. Could it be dues to a bug in tcgc/decorator?

Either way, this does fix the test, regardless of whether it is due to tcgc bug or not.