### PR TITLE
[emitter-framework] Use custom refkey

### DIFF
--- a/.chronus/changes/refkey-prefix-2025-3-29-15-27-8.md
+++ b/.chronus/changes/refkey-prefix-2025-3-29-15-27-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/emitter-framework"
+---
+
+Add prefix to all emitter-framework owned refkeys

--- a/packages/emitter-framework/src/typescript/components/class-method.tsx
+++ b/packages/emitter-framework/src/typescript/components/class-method.tsx
@@ -1,7 +1,7 @@
-import { refkey as getRefkey } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { Operation } from "@typespec/compiler";
 import { buildParameterDescriptors, getReturnType } from "../utils/operation.js";
+import { efRefkey } from "../utils/refkey.js";
 import { TypeExpression } from "./type-expression.jsx";
 
 export interface ClassMethodPropsWithType extends Omit<ts.ClassMethodProps, "name"> {
@@ -17,7 +17,7 @@ export function ClassMethod(props: ClassMethodProps) {
     return <ts.ClassMethod {...props} />;
   }
 
-  const refkey = props.refkey ?? getRefkey(props.type, "method");
+  const refkey = props.refkey ?? efRefkey(props.type, "method");
 
   const name = props.name ? props.name : ts.useTSNamePolicy().getName(props.type.name, "function");
   const returnType =

--- a/packages/emitter-framework/src/typescript/components/enum-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/enum-declaration.tsx
@@ -3,6 +3,7 @@ import * as ts from "@alloy-js/typescript";
 import { Enum, EnumMember as TspEnumMember, Union } from "@typespec/compiler";
 import { useTsp } from "../../core/context/tsp-context.js";
 import { reportDiagnostic } from "../../lib.js";
+import { efRefkey } from "../utils/refkey.js";
 
 export interface EnumDeclarationProps extends Omit<ts.TypeDeclarationProps, "name"> {
   name?: string;
@@ -31,7 +32,7 @@ export function EnumDeclaration(props: EnumDeclarationProps) {
   return (
     <ts.EnumDeclaration
       name={name}
-      refkey={ay.refkey(props.type)}
+      refkey={efRefkey(props.type)}
       default={props.default}
       export={props.export}
     >
@@ -41,7 +42,7 @@ export function EnumDeclaration(props: EnumDeclarationProps) {
             <EnumMember
               type={value}
               refkey={
-                $.union.is(props.type) ? ay.refkey(props.type.variants.get(key)) : ay.refkey(value)
+                $.union.is(props.type) ? efRefkey(props.type.variants.get(key)) : efRefkey(value)
               }
             />
           );
@@ -61,7 +62,7 @@ export function EnumMember(props: EnumMemberProps) {
     <ts.EnumMember
       name={props.type.name}
       jsValue={props.type.value ?? props.type.name}
-      refkey={ay.refkey(props.refkey ?? props.type)}
+      refkey={props.refkey ?? efRefkey(props.type)}
     />
   );
 }

--- a/packages/emitter-framework/src/typescript/components/function-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/function-declaration.tsx
@@ -1,7 +1,7 @@
-import { refkey as getRefkey } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { Model, Operation } from "@typespec/compiler";
 import { buildParameterDescriptors, getReturnType } from "../utils/operation.js";
+import { efRefkey } from "../utils/refkey.js";
 import { TypeExpression } from "./type-expression.js";
 
 export interface FunctionDeclarationPropsWithType
@@ -25,7 +25,7 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
     return <ts.FunctionDeclaration {...props} />;
   }
 
-  const refkey = props.refkey ?? getRefkey(props.type);
+  const refkey = props.refkey ?? efRefkey(props.type);
 
   let name = props.name ? props.name : ts.useTSNamePolicy().getName(props.type.name, "function");
 

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -1,5 +1,5 @@
 import * as ay from "@alloy-js/core";
-import { Children, refkey as getRefkey, mapJoin } from "@alloy-js/core";
+import { Children, mapJoin } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import {
   Interface,
@@ -13,6 +13,7 @@ import { Typekit } from "@typespec/compiler/experimental/typekit";
 import { createRekeyableMap } from "@typespec/compiler/utils";
 import { useTsp } from "../../core/context/tsp-context.js";
 import { reportDiagnostic } from "../../lib.js";
+import { efRefkey } from "../utils/refkey.js";
 import { InterfaceMember } from "./interface-member.js";
 import { TypeExpression } from "./type-expression.jsx";
 export interface TypedInterfaceDeclarationProps extends Omit<ts.InterfaceDeclarationProps, "name"> {
@@ -41,7 +42,7 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
 
   name = namePolicy.getName(name, "interface");
 
-  const refkey = props.refkey ?? getRefkey(props.type);
+  const refkey = props.refkey ?? efRefkey(props.type);
 
   const extendsType = props.extends ?? getExtendsType($, props.type);
 
@@ -92,7 +93,7 @@ function getExtendsType($: Typekit, type: Model | Interface): Children | undefin
       // Instead of extending we need to create an envelope property
       // do nothing here.
     } else {
-      extending.push(getRefkey(type.baseModel));
+      extending.push(efRefkey(type.baseModel));
     }
   }
 

--- a/packages/emitter-framework/src/typescript/components/static-serializers.tsx
+++ b/packages/emitter-framework/src/typescript/components/static-serializers.tsx
@@ -1,7 +1,8 @@
-import { code, refkey } from "@alloy-js/core";
+import { code } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
+import { efRefkey } from "../utils/refkey.js";
 
-export const DateRfc3339SerializerRefkey = refkey();
+export const DateRfc3339SerializerRefkey = efRefkey();
 export function DateRfc3339Serializer() {
   return (
     <ts.FunctionDeclaration
@@ -22,7 +23,7 @@ export function DateRfc3339Serializer() {
   );
 }
 
-export const DateRfc7231SerializerRefkey = refkey();
+export const DateRfc7231SerializerRefkey = efRefkey();
 export function DateRfc7231Serializer() {
   return (
     <ts.FunctionDeclaration
@@ -43,7 +44,7 @@ export function DateRfc7231Serializer() {
   );
 }
 
-export const DateDeserializerRefkey = refkey();
+export const DateDeserializerRefkey = efRefkey();
 export function DateDeserializer() {
   return (
     <ts.FunctionDeclaration
@@ -64,7 +65,7 @@ export function DateDeserializer() {
   );
 }
 
-export const DateUnixTimestampDeserializerRefkey = refkey();
+export const DateUnixTimestampDeserializerRefkey = efRefkey();
 export function DateUnixTimestampDeserializer() {
   return (
     <ts.FunctionDeclaration
@@ -85,7 +86,7 @@ export function DateUnixTimestampDeserializer() {
   );
 }
 
-export const DateRfc7231DeserializerRefkey = refkey();
+export const DateRfc7231DeserializerRefkey = efRefkey();
 export function DateRfc7231Deserializer() {
   return (
     <ts.FunctionDeclaration
@@ -106,7 +107,7 @@ export function DateRfc7231Deserializer() {
   );
 }
 
-export const DateUnixTimestampSerializerRefkey = refkey();
+export const DateUnixTimestampSerializerRefkey = efRefkey();
 export function DateUnixTimestampSerializer() {
   return (
     <ts.FunctionDeclaration
@@ -127,7 +128,7 @@ export function DateUnixTimestampSerializer() {
   );
 }
 
-export const RecordSerializerRefkey = refkey();
+export const RecordSerializerRefkey = efRefkey();
 export function RecordSerializer() {
   const recordType = `Record<string, any>`;
   const convertFnType = `(item: any) => any`;
@@ -160,7 +161,7 @@ export function RecordSerializer() {
   );
 }
 
-export const ArraySerializerRefkey = refkey();
+export const ArraySerializerRefkey = efRefkey();
 export function ArraySerializer() {
   const arrayType = `any[]`;
   const convertFnType = `(item: any) => any`;

--- a/packages/emitter-framework/src/typescript/components/type-alias-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/type-alias-declaration.tsx
@@ -1,8 +1,8 @@
-import { refkey as getRefkey } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { Type } from "@typespec/compiler";
 import { useTsp } from "../../core/context/tsp-context.js";
 import { reportDiagnostic } from "../../lib.js";
+import { efRefkey } from "../utils/refkey.js";
 import { TypeExpression } from "./type-expression.jsx";
 
 export interface TypedAliasDeclarationProps extends Omit<ts.TypeDeclarationProps, "name"> {
@@ -32,7 +32,7 @@ export function TypeAliasDeclaration(props: TypeAliasDeclarationProps) {
 
   const name = ts.useTSNamePolicy().getName(originalName, "type");
   return (
-    <ts.TypeDeclaration {...props} name={name} refkey={props.refkey ?? getRefkey(props.type)}>
+    <ts.TypeDeclaration {...props} name={name} refkey={props.refkey ?? efRefkey(props.type)}>
       <TypeExpression type={props.type} noReference />
       {props.children}
     </ts.TypeDeclaration>

--- a/packages/emitter-framework/src/typescript/components/type-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/type-expression.tsx
@@ -1,10 +1,11 @@
-import { For, refkey } from "@alloy-js/core";
+import { For } from "@alloy-js/core";
 import { Reference, ValueExpression } from "@alloy-js/typescript";
 import { IntrinsicType, Model, Scalar, Type } from "@typespec/compiler";
 import { Typekit } from "@typespec/compiler/experimental/typekit";
 import "@typespec/http/experimental/typekit";
 import { useTsp } from "../../core/context/tsp-context.js";
 import { reportTypescriptDiagnostic } from "../../typescript/lib.js";
+import { efRefkey } from "../utils/refkey.js";
 import { ArrayExpression } from "./array-expression.js";
 import { FunctionType } from "./function-type.js";
 import { InterfaceExpression } from "./interface-declaration.js";
@@ -28,7 +29,7 @@ export function TypeExpression(props: TypeExpressionProps) {
   if (!props.noReference && isDeclaration($, type)) {
     // todo: probably need abstraction around deciding what's a declaration in the output
     // (it may not correspond to things which are declarations in TypeSpec?)
-    return <Reference refkey={refkey(type)} />;
+    return <Reference refkey={efRefkey(type)} />;
     //throw new Error("Reference not implemented");
   }
 

--- a/packages/emitter-framework/src/typescript/components/type-transform.tsx
+++ b/packages/emitter-framework/src/typescript/components/type-transform.tsx
@@ -1,4 +1,4 @@
-import { Children, code, For, mapJoin, Refkey, refkey } from "@alloy-js/core";
+import { Children, code, For, mapJoin, Refkey } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import {
   Discriminator,
@@ -14,6 +14,7 @@ import { createRekeyableMap } from "@typespec/compiler/utils";
 import { useTsp } from "../../core/context/tsp-context.js";
 import { reportDiagnostic } from "../../lib.js";
 import { reportTypescriptDiagnostic } from "../../typescript/lib.js";
+import { efRefkey } from "../utils/refkey.js";
 import {
   ArraySerializerRefkey,
   DateDeserializerRefkey,
@@ -118,7 +119,7 @@ export function TypeTransformDeclaration(props: TypeTransformProps) {
   const functionSuffix = props.target === "application" ? "ToApplication" : "ToTransport";
   const functionName = props.name ? props.name : `${baseName}${functionSuffix}`;
   const itemType =
-    props.target === "application" ? "any" : <ts.Reference refkey={refkey(props.type)} />;
+    props.target === "application" ? "any" : <ts.Reference refkey={efRefkey(props.type)} />;
 
   let transformExpression: Children;
   if ($.model.is(props.type)) {
@@ -145,7 +146,7 @@ export function TypeTransformDeclaration(props: TypeTransformProps) {
     });
   }
 
-  const returnType = props.target === "application" ? refkey(props.type) : "any";
+  const returnType = props.target === "application" ? efRefkey(props.type) : "any";
 
   const ref = props.refkey ?? getTypeTransformerRefkey(props.type, props.target);
 
@@ -169,7 +170,7 @@ export function TypeTransformDeclaration(props: TypeTransformProps) {
  * @returns the refkey for the TypeTransformer function
  */
 export function getTypeTransformerRefkey(type: Type, target: "application" | "transport") {
-  return refkey(type, target);
+  return efRefkey(type, target);
 }
 
 export interface ModelTransformExpressionProps {
@@ -356,7 +357,7 @@ export function TypeTransformCall(props: TypeTransformCallProps): Children {
   }
   let itemName: Children = itemPath.join(".");
   if (props.castInput) {
-    itemName = code`${itemName} as ${refkey(props.type)}`;
+    itemName = code`${itemName} as ${efRefkey(props.type)}`;
   }
   const transformType = collapsedProperty?.type ?? props.type;
   if ($.model.is(transformType) && $.array.is(transformType)) {

--- a/packages/emitter-framework/src/typescript/components/union-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-declaration.tsx
@@ -1,8 +1,8 @@
-import { refkey as getRefkey } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { Enum, Union } from "@typespec/compiler";
 import { useTsp } from "../../core/context/tsp-context.js";
 import { reportDiagnostic } from "../../lib.js";
+import { efRefkey } from "../utils/refkey.js";
 import { UnionExpression } from "./union-expression.js";
 
 export interface TypedUnionDeclarationProps extends Omit<ts.TypeDeclarationProps, "name"> {
@@ -19,7 +19,7 @@ export function UnionDeclaration(props: UnionDeclarationProps) {
   }
 
   const { type, ...coreProps } = props;
-  const refkey = coreProps.refkey ?? getRefkey(type);
+  const refkey = coreProps.refkey ?? efRefkey(type);
 
   const originalName = coreProps.name ?? type.name;
 

--- a/packages/emitter-framework/src/typescript/utils/index.ts
+++ b/packages/emitter-framework/src/typescript/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./operation.js";
+export * from "./refkey.js";

--- a/packages/emitter-framework/src/typescript/utils/refkey.ts
+++ b/packages/emitter-framework/src/typescript/utils/refkey.ts
@@ -1,0 +1,18 @@
+import { refkey as ayRefkey } from "@alloy-js/core";
+
+export const refKeyPrefix = Symbol.for("emitter-framework:typescript");
+
+/**
+ * A wrapper around `refkey` that uses a custom symbol to avoid collisions with
+ * other libraries that use `refkey`.
+ *
+ * @remarks
+ *
+ * The underlying `refkey` function is called with the {@link refKeyPrefix} symbol as the first argument.
+ *
+ * @param args The arguments to pass to `refkey`.
+ * @returns A `Refkey` object that can be used to identify the value.
+ */
+export function efRefkey(...args: unknown[]) {
+  return ayRefkey(refKeyPrefix, ...args);
+}

--- a/packages/emitter-framework/test/typescript/components/enum-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/enum-declaration.test.tsx
@@ -1,9 +1,10 @@
-import { List, refkey, StatementList } from "@alloy-js/core";
+import { List, StatementList } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
 import { Enum, Union } from "@typespec/compiler";
 import { describe, expect, it } from "vitest";
 import { TspContext } from "../../../src/core/index.js";
 import { EnumDeclaration } from "../../../src/typescript/components/enum-declaration.js";
+import { efRefkey } from "../../../src/typescript/utils/refkey.js";
 import { getEmitOutput } from "../../utils.js";
 
 describe("Typescript Enum Declaration", () => {
@@ -75,8 +76,8 @@ describe("Typescript Enum Declaration", () => {
           <List hardline>
             <EnumDeclaration type={Foo} />
             <StatementList>
-              {refkey(Foo)}
-              {refkey(Foo.members.get("one"))}
+              {efRefkey(Foo)}
+              {efRefkey(Foo.members.get("one"))}
             </StatementList>
           </List>
         </TspContext.Provider>
@@ -110,8 +111,8 @@ describe("Typescript Enum Declaration", () => {
           <List hardline>
             <EnumDeclaration type={Foo} />
             <StatementList>
-              {refkey(Foo)}
-              {refkey(Foo.variants.get("one"))}
+              {efRefkey(Foo)}
+              {efRefkey(Foo.variants.get("one"))}
             </StatementList>
           </List>
         </TspContext.Provider>


### PR DESCRIPTION
When a default refkey is created by emitter-framework it normally uses the
`type` prop as the key. That is a bit too generic and can lead to refkey
collisions (is my understanding).

Each emitter-framework based emitter could use its own refkey function which
prepends a unique symbol and avoid name collisions.
