### PR TITLE
API additions in support of tracing

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProvider.cs
@@ -7,19 +7,22 @@ using Microsoft.TypeSpec.Generator.Statements;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 {
-    internal class ScmMethodProvider : MethodProvider
+    public class ScmMethodProvider : MethodProvider
     {
         public ScmMethodProvider(
             MethodSignature signature,
             MethodBodyStatement bodyStatements,
             TypeProvider enclosingType,
             XmlDocProvider? xmlDocProvider = default,
-            TypeProvider? collectionDefinition = default)
+            TypeProvider? collectionDefinition = default,
+            bool isProtocolMethod = false)
             : base(signature, bodyStatements, enclosingType, xmlDocProvider)
         {
             CollectionDefinition = collectionDefinition;
+            IsProtocolMethod = isProtocolMethod;
         }
 
         internal TypeProvider? CollectionDefinition { get; }
+        public bool IsProtocolMethod { get; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -533,7 +533,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             var protocolMethod =
-                new ScmMethodProvider(methodSignature, methodBody, EnclosingType, collectionDefinition: collection);
+                new ScmMethodProvider(methodSignature, methodBody, EnclosingType, collectionDefinition: collection, isProtocolMethod: true);
 
             // XmlDocs will be null if the method isn't public
             if (protocolMethod.XmlDocs != null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ScmLibraryVisitor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ScmLibraryVisitor.cs
@@ -21,5 +21,20 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
         {
             return clientProvider;
         }
+
+        protected override MethodProvider? VisitMethod(MethodProvider method)
+        {
+            if (method is ScmMethodProvider scmMethod)
+            {
+                return VisitMethod(scmMethod);
+            }
+
+            return base.VisitMethod(method);
+        }
+
+        protected internal virtual ScmMethodProvider? VisitMethod(ScmMethodProvider method)
+        {
+            return method;
+        }
     }
 }


### PR DESCRIPTION
This PR introduces some API additions in support of enabling tracing via a visitor.

Example usage: https://github.com/Azure/azure-sdk-for-net/pull/49691
contributes to: https://github.com/Azure/azure-sdk-for-net/issues/49589