### PR TITLE
Format tspconfig.yaml, skip files with known formatting, show a summary at the end

### DIFF
--- a/.chronus/changes/formatter-improvements-2025-3-30-15-31-26.md
+++ b/.chronus/changes/formatter-improvements-2025-3-30-15-31-26.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Add support for formatting `tspconfig.yaml` with `tsp format`

--- a/.chronus/changes/formatter-improvements-2025-3-30-15-31-27.md
+++ b/.chronus/changes/formatter-improvements-2025-3-30-15-31-27.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+`tsp format` only formats files it knows about and ignores other. Allowing a more generic glob pattern `tsp format .` or `tsp format "**/*"`

--- a/packages/compiler/src/core/cli/actions/format.ts
+++ b/packages/compiler/src/core/cli/actions/format.ts
@@ -57,7 +57,10 @@ async function format(host: CliCompilerHost, args: FormatArgs) {
       exclude: args["exclude"],
     });
     const msg = [
-      formattedCount(result.formatted),
+      result.formatted.length > 0 ? formattedCount(result.formatted) : undefined,
+      result.alreadyFormatted.length > 0
+        ? alreadyFormattedCount(result.alreadyFormatted)
+        : undefined,
       result.ignored.length > 0 ? ignoredCount(result.ignored) : undefined,
       result.errored.length > 0 ? errorCount(result.errored) : undefined,
     ]
@@ -79,6 +82,9 @@ async function format(host: CliCompilerHost, args: FormatArgs) {
 
 function formattedCount(files: readonly string[]): string {
   return pc.green(`${files.length} formatted`);
+}
+function alreadyFormattedCount(files: readonly string[]): string {
+  return pc.green(`${files.length} already formatted`);
 }
 function needsFormatCount(files: readonly string[]): string {
   return pc.yellow(`${files.length} need format`);

--- a/packages/compiler/src/core/cli/actions/format.ts
+++ b/packages/compiler/src/core/cli/actions/format.ts
@@ -33,18 +33,18 @@ async function check(host: CliCompilerHost, args: FormatArgs) {
 
     if (result.needsFormat.length > 0 || result.errored.length > 0) {
       const msg = [
-        needsFormatCount(result.needsFormat),
-        result.errored.length > 0 ? errorCount(result.errored) : undefined,
-        formattedCount(result.formatted),
-        result.ignored.length > 0 ? ignoredCount(result.ignored) : undefined,
+        needsFormatText(result.needsFormat),
+        result.errored.length > 0 ? errorText(result.errored) : undefined,
+        formattedText(result.formatted),
+        result.ignored.length > 0 ? ignoredText(result.ignored) : undefined,
       ];
 
       task.warn(msg.filter((x) => x).join(", "));
       process.exit(1);
     } else {
       const msg = [
-        formattedCount(result.formatted),
-        result.ignored.length > 0 ? ignoredCount(result.ignored) : undefined,
+        formattedText(result.formatted),
+        result.ignored.length > 0 ? ignoredText(result.ignored) : undefined,
       ];
       task.succeed(msg.filter((x) => x).join(", "));
     }
@@ -57,12 +57,10 @@ async function format(host: CliCompilerHost, args: FormatArgs) {
       exclude: args["exclude"],
     });
     const msg = [
-      result.formatted.length > 0 ? formattedCount(result.formatted) : undefined,
-      result.alreadyFormatted.length > 0
-        ? alreadyFormattedCount(result.alreadyFormatted)
-        : undefined,
-      result.ignored.length > 0 ? ignoredCount(result.ignored) : undefined,
-      result.errored.length > 0 ? errorCount(result.errored) : undefined,
+      result.formatted.length > 0 ? formattedText(result.formatted) : undefined,
+      result.alreadyFormatted.length > 0 ? unchangedText(result.alreadyFormatted) : undefined,
+      result.ignored.length > 0 ? ignoredText(result.ignored) : undefined,
+      result.errored.length > 0 ? errorText(result.errored) : undefined,
     ]
       .filter((x) => x)
       .join(", ");
@@ -80,18 +78,18 @@ async function format(host: CliCompilerHost, args: FormatArgs) {
   });
 }
 
-function formattedCount(files: readonly string[]): string {
+function formattedText(files: readonly string[]): string {
   return pc.green(`${files.length} formatted`);
 }
-function alreadyFormattedCount(files: readonly string[]): string {
-  return pc.green(`${files.length} already formatted`);
+function unchangedText(files: readonly string[]): string {
+  return pc.green(`${files.length} unchanged`);
 }
-function needsFormatCount(files: readonly string[]): string {
+function needsFormatText(files: readonly string[]): string {
   return pc.yellow(`${files.length} need format`);
 }
-function ignoredCount(files: readonly string[]): string {
+function ignoredText(files: readonly string[]): string {
   return pc.gray(`${files.length} ignored`);
 }
-function errorCount(errored: readonly [string, Diagnostic][]): string {
+function errorText(errored: readonly [string, Diagnostic][]): string {
   return pc.red(`${errored.length} error${errored.length > 1 ? "s" : ""}`);
 }

--- a/packages/compiler/src/core/cli/actions/format.ts
+++ b/packages/compiler/src/core/cli/actions/format.ts
@@ -1,5 +1,6 @@
+import pc from "picocolors";
 import { logDiagnostics } from "../../diagnostics.js";
-import { findUnformattedTypeSpecFiles, formatTypeSpecFiles } from "../../formatter-fs.js";
+import { findUnformattedTypeSpecFiles, formatFiles } from "../../formatter-fs.js";
 import { CliCompilerHost } from "../types.js";
 
 export interface FormatArgs {
@@ -15,22 +16,39 @@ export async function formatAction(host: CliCompilerHost, args: FormatArgs) {
       debug: args.debug,
     });
     if (unformatted.length > 0) {
-      // eslint-disable-next-line no-console
-      console.log(`Found ${unformatted.length} unformatted files:`);
+      log(`Found ${unformatted.length} unformatted files:`);
       for (const file of unformatted) {
-        // eslint-disable-next-line no-console
-        console.log(` - ${file}`);
+        log(` - ${file}`);
       }
       process.exit(1);
     }
   } else {
-    const [_, diagnostics] = await formatTypeSpecFiles(args["include"], {
+    const result = await formatFiles(args["include"], {
       exclude: args["exclude"],
       debug: args.debug,
     });
-    if (diagnostics.length > 0) {
-      logDiagnostics(diagnostics, host.logSink);
+    const results = [pc.green(`${result.formattedFiles.length} formatted`)];
+    if (result.ignoredFiles.length > 0) {
+      results.push(pc.gray(`${result.ignoredFiles.length} ignored`));
+    }
+    if (result.erroredFiles.length > 0) {
+      logDiagnostics(
+        result.erroredFiles.map((x) => x[1]),
+        host.logSink,
+      );
+      results.push(
+        pc.red(`${result.erroredFiles.length} error${result.erroredFiles.length > 1 ? "s" : ""}`),
+      );
+    }
+    log(`${results.join(", ")}`);
+
+    if (result.erroredFiles.length > 0) {
       process.exit(1);
     }
   }
+}
+
+function log(message: string) {
+  // eslint-disable-next-line no-console
+  console.log(message);
 }

--- a/packages/compiler/src/core/cli/actions/format.ts
+++ b/packages/compiler/src/core/cli/actions/format.ts
@@ -1,6 +1,7 @@
 import pc from "picocolors";
 import { logDiagnostics } from "../../diagnostics.js";
-import { findUnformattedTypeSpecFiles, formatFiles } from "../../formatter-fs.js";
+import { checkFilesFormat, formatFiles } from "../../formatter-fs.js";
+import { Diagnostic } from "../../types.js";
 import { CliCompilerHost } from "../types.js";
 
 export interface FormatArgs {
@@ -9,46 +10,82 @@ export interface FormatArgs {
   debug?: boolean;
   check?: boolean;
 }
+
 export async function formatAction(host: CliCompilerHost, args: FormatArgs) {
   if (args["check"]) {
-    const unformatted = await findUnformattedTypeSpecFiles(args["include"], {
-      exclude: args["exclude"],
-      debug: args.debug,
-    });
-    if (unformatted.length > 0) {
-      log(`Found ${unformatted.length} unformatted files:`);
-      for (const file of unformatted) {
-        log(` - ${file}`);
-      }
-      process.exit(1);
-    }
+    await check(host, args);
   } else {
-    const result = await formatFiles(args["include"], {
-      exclude: args["exclude"],
-      debug: args.debug,
-    });
-    const results = [pc.green(`${result.formattedFiles.length} formatted`)];
-    if (result.ignoredFiles.length > 0) {
-      results.push(pc.gray(`${result.ignoredFiles.length} ignored`));
-    }
-    if (result.erroredFiles.length > 0) {
-      logDiagnostics(
-        result.erroredFiles.map((x) => x[1]),
-        host.logSink,
-      );
-      results.push(
-        pc.red(`${result.erroredFiles.length} error${result.erroredFiles.length > 1 ? "s" : ""}`),
-      );
-    }
-    log(`${results.join(", ")}`);
-
-    if (result.erroredFiles.length > 0) {
-      process.exit(1);
-    }
+    await format(host, args);
   }
 }
 
-function log(message: string) {
-  // eslint-disable-next-line no-console
-  console.log(message);
+async function check(host: CliCompilerHost, args: FormatArgs) {
+  await host.logger.trackAction("Checking format", "", async (task) => {
+    const result = await checkFilesFormat(args["include"], {
+      exclude: args["exclude"],
+    });
+    if (result.errored.length > 0) {
+      logDiagnostics(
+        result.errored.map((x) => x[1]),
+        host.logSink,
+      );
+    }
+
+    if (result.needsFormat.length > 0 || result.errored.length > 0) {
+      const msg = [
+        needsFormatCount(result.needsFormat),
+        result.errored.length > 0 ? errorCount(result.errored) : undefined,
+        formattedCount(result.formatted),
+        result.ignored.length > 0 ? ignoredCount(result.ignored) : undefined,
+      ];
+
+      task.warn(msg.filter((x) => x).join(", "));
+      process.exit(1);
+    } else {
+      const msg = [
+        formattedCount(result.formatted),
+        result.ignored.length > 0 ? ignoredCount(result.ignored) : undefined,
+      ];
+      task.succeed(msg.filter((x) => x).join(", "));
+    }
+  });
+}
+
+async function format(host: CliCompilerHost, args: FormatArgs) {
+  await host.logger.trackAction("Formatting", "", async (task) => {
+    const result = await formatFiles(args["include"], {
+      exclude: args["exclude"],
+    });
+    const msg = [
+      formattedCount(result.formatted),
+      result.ignored.length > 0 ? ignoredCount(result.ignored) : undefined,
+      result.errored.length > 0 ? errorCount(result.errored) : undefined,
+    ]
+      .filter((x) => x)
+      .join(", ");
+
+    if (result.errored.length > 0) {
+      logDiagnostics(
+        result.errored.map((x) => x[1]),
+        host.logSink,
+      );
+      task.warn(msg);
+      process.exit(1);
+    } else {
+      task.succeed(msg);
+    }
+  });
+}
+
+function formattedCount(files: readonly string[]): string {
+  return pc.green(`${files.length} formatted`);
+}
+function needsFormatCount(files: readonly string[]): string {
+  return pc.yellow(`${files.length} need format`);
+}
+function ignoredCount(files: readonly string[]): string {
+  return pc.gray(`${files.length} ignored`);
+}
+function errorCount(errored: readonly [string, Diagnostic][]): string {
+  return pc.red(`${errored.length} error${errored.length > 1 ? "s" : ""}`);
 }

--- a/packages/compiler/src/core/formatter.ts
+++ b/packages/compiler/src/core/formatter.ts
@@ -1,9 +1,60 @@
 import type { Options } from "prettier";
-import { check, format } from "prettier/standalone";
+import YamlPlugin from "prettier/plugins/yaml.js";
+import { check, format as prettierFormat } from "prettier/standalone";
 import * as typespecPrettierPlugin from "../formatter/index.js";
+import { getAnyExtensionFromPath } from "./path-utils.js";
 
+export type Formatter = "typespec" | "tspconfig";
+
+/**
+ * Get the formatter name for the given filename
+ * @param filename The filename to check
+ */
+export function getFormatterFromFilename(filename: string): Formatter | undefined {
+  const ext = getAnyExtensionFromPath(filename);
+  if (filename.endsWith("tspconfig.yaml")) {
+    return "tspconfig";
+  }
+  switch (ext) {
+    case ".tsp":
+      return "typespec";
+  }
+  return undefined;
+}
+
+/**
+ * Format the code with the given formatter
+ * @param code The code to format
+ * @param formatter The formatter to use
+ * @param prettierConfig Optional config for prettier
+ * @returns The formatted code
+ * @throws PrettierParserError if the code is not valid
+ */
+export async function format(
+  code: string,
+  formatter: Formatter,
+  prettierConfig?: Options,
+): Promise<string> {
+  switch (formatter) {
+    case "typespec":
+      return formatTypeSpec(code, prettierConfig);
+    case "tspconfig":
+      return await prettierFormat(code, {
+        ...prettierConfig,
+        parser: "yaml",
+        plugins: [YamlPlugin],
+      });
+  }
+}
+
+/**
+ * Format TypeSpec code
+ * @param code Code to format
+ * @param prettierConfig Optional config for prettier.
+ * @returns Formatted code
+ */
 export async function formatTypeSpec(code: string, prettierConfig?: Options): Promise<string> {
-  const output = await format(code, {
+  const output = await prettierFormat(code, {
     ...prettierConfig,
     parser: "typespec",
     plugins: [typespecPrettierPlugin],

--- a/packages/compiler/src/core/formatter.ts
+++ b/packages/compiler/src/core/formatter.ts
@@ -35,11 +35,40 @@ export async function format(
   formatter: Formatter,
   prettierConfig?: Options,
 ): Promise<string> {
+  return runFormatter(prettierFormat, code, formatter, prettierConfig);
+}
+
+/**
+ * Check the given code is correctly formatted with the given formatter
+ * @param code The code to check the format of
+ * @param formatter The formatter to use
+ * @param prettierConfig Optional config for prettier
+ * @returns true if the code is formatted correctly
+ * @throws PrettierParserError if the code is not valid
+ */
+export async function checkFormat(
+  code: string,
+  formatter: Formatter,
+  prettierConfig?: Options,
+): Promise<boolean> {
+  return runFormatter(check, code, formatter, prettierConfig);
+}
+
+async function runFormatter<T>(
+  fn: (code: string, options?: Options) => Promise<T>,
+  code: string,
+  formatter: Formatter,
+  prettierConfig?: Options,
+): Promise<T> {
   switch (formatter) {
     case "typespec":
-      return formatTypeSpec(code, prettierConfig);
+      return fn(code, {
+        ...prettierConfig,
+        parser: "typespec",
+        plugins: [typespecPrettierPlugin],
+      });
     case "tspconfig":
-      return await prettierFormat(code, {
+      return await fn(code, {
         ...prettierConfig,
         parser: "yaml",
         plugins: [YamlPlugin],


### PR DESCRIPTION
This improve the formatter in 3 ways
1. Add support for formatting tspconfig.yaml fix #7173
1. Just skip the files that it doesn't know to format if they were included in the glob pattern
2. Show a summary of what it did at the end + progress bar


### Format
- formatted with some files having parsing issues
![image](https://github.com/user-attachments/assets/f122424e-1d98-431c-aa05-e371fa135490)

- all files already formatted
![image](https://github.com/user-attachments/assets/b9fee57f-462d-4798-b3f5-f40419341ba6)

- files formatted
![image](https://github.com/user-attachments/assets/5c1695a1-fcff-4e7a-865d-aa123847458d)

### Check
![image](https://github.com/user-attachments/assets/4355e70c-fcff-4c47-982e-16a9c0b80ca8)

- With no errors

![image](https://github.com/user-attachments/assets/22cb59c4-4676-4e6f-a4d2-c3c348773dfd)
