### PR TITLE
More api additions for tracing

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -233,6 +233,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         public PropertyProvider PipelineProperty { get; }
         public FieldProvider EndpointField { get; }
 
+        public IReadOnlyList<ClientProvider> SubClients => _subClients.Value;
+
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", $"{Name}.cs");
 
         protected override string BuildName() => _inputClient.Name.ToCleanName();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         public TypeProvider EnclosingType { get; }
 
-        internal string? OriginalName { get; init; }
+        public string? OriginalName { get; internal init; }
 
         internal Lazy<NamedTypeSymbolProvider?>? CustomProvider { get; init; }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -374,6 +374,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 _relativeFilePath = relativeFilePath;
             }
+
+            // Rebuild the canonical view
+            _canonicalView = new(BuildCanonicalView);
         }
         public IReadOnlyList<EnumTypeMember> EnumValues => _enumValues ??= BuildEnumValues();
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/MethodProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/MethodProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -47,6 +47,27 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
                 null,
                 $"",
                 [new ParameterProvider("input", $"", typeof(Stream))]));
+        }
+
+        [Test]
+        public void TestUpdate()
+        {
+            MockHelpers.LoadMockGenerator();
+            var typeProvider = new TestTypeProvider();
+            var methodProvider = new MethodProvider(
+                new MethodSignature("Test", $"", MethodSignatureModifiers.Public, null, $"", []),
+                Throw(Null), typeProvider);
+            // add the method to the type provider
+            typeProvider.Update(methods: [methodProvider]);
+
+            // now update the method and check if the type provider reflects the change
+            methodProvider.Update(new MethodSignature("Updated", $"", MethodSignatureModifiers.Public, null, $"", []));
+            var updatedMethods = typeProvider.CanonicalView.Methods;
+            Assert.IsNotNull(updatedMethods);
+            Assert.AreEqual(1, updatedMethods!.Count);
+
+            var updatedMethod = updatedMethods[0];
+            Assert.AreEqual("Updated", updatedMethod.Signature.Name);
         }
 
         private class TestTypeProvider : TypeProvider

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Snippets;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Providers
+{
+    public class TypeProviderTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator();
+        }
+
+        [Test]
+        public void TestUpdateCanonicalView()
+        {
+            var typeProvider = new TestTypeProvider();
+            var methodProvider = new MethodProvider(
+                new MethodSignature("Test", $"", MethodSignatureModifiers.Public, null, $"", []),
+                Snippet.Throw(Snippet.Null), typeProvider);
+
+            typeProvider.Update(methods: [methodProvider]);
+            var updatedMethods = typeProvider.CanonicalView.Methods;
+            Assert.IsNotNull(updatedMethods);
+            Assert.AreEqual(1, updatedMethods!.Count);
+            Assert.AreEqual(methodProvider, updatedMethods[0]);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds more API additions of support of enabling tracing via the visitor APIs.

consumed in: https://github.com/Azure/azure-sdk-for-net/pull/49691

contributes to https://github.com/Azure/azure-sdk-for-net/issues/49589