### PR TITLE
Fix perf regression client e2e 

### DIFF
--- a/.chronus/changes/fix-perf-regression-client-js-e2e-2025-3-30-20-31-39.md
+++ b/.chronus/changes/fix-perf-regression-client-js-e2e-2025-3-30-20-31-39.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/http-client-js"
+---
+
+Fix perf regression client e2e and extra perf gain with compiler api

--- a/packages/http-client-js/eng/scripts/emit-e2e.js
+++ b/packages/http-client-js/eng/scripts/emit-e2e.js
@@ -161,16 +161,6 @@ async function processFile(file, options) {
       outputDir,
     ]);
 
-    if (spinner) spinner.text = `Transpiling with Babel: ${relativePath}`;
-    await runCommand("npx", [
-      "babel",
-      outputDir,
-      "-d",
-      `dist/${outputDir}`,
-      "--extensions",
-      ".ts,.tsx",
-    ]);
-
     if (spinner) spinner.text = `Formatting with Prettier: ${relativePath}`;
     await runCommand("npx", ["prettier", outputDir, "--write"]);
 


### PR DESCRIPTION
@joseharriaga  found this and doesn't do anything. Because babel is not installed anymore with the alloy cli the npx command tries to install the package(I think) slowing down the e2e generation from ~35s to ~150s