### PR TITLE
change $.model.getSpreadType to $.model.getIndexType

### DIFF
--- a/.chronus/changes/tk-rm-get-spread-2025-4-1-12-13-58.md
+++ b/.chronus/changes/tk-rm-get-spread-2025-4-1-12-13-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Replaces `$.model.getSpreadType` with `$.model.getIndexType` to better reflect what it actually being returned. `getSpreadType` did not actually return a list of spread types, but the model's indexer type instead.

--- a/.chronus/changes/tk-rm-get-spread-2025-4-1-12-29-44.md
+++ b/.chronus/changes/tk-rm-get-spread-2025-4-1-12-29-44.md
@@ -1,0 +1,8 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/emitter-framework"
+  - "@typespec/http-client-js"
+---
+
+Update to use getIndexType instead of getSpreadType

--- a/packages/compiler/src/typekit/kits/model.ts
+++ b/packages/compiler/src/typekit/kits/model.ts
@@ -143,7 +143,7 @@ declare module "../define-kit.js" {
   interface Typekit extends TypekitExtension {}
 }
 
-const spreadCache = new Map<Model, Model>();
+const indexCache = new Map<Model, Model>();
 defineKit<TypekitExtension>({
   model: {
     create(desc) {
@@ -173,8 +173,8 @@ defineKit<TypekitExtension>({
       return getEffectiveModelType(this.program, model, filter);
     },
     getIndexType(model) {
-      if (spreadCache.has(model)) {
-        return spreadCache.get(model);
+      if (indexCache.has(model)) {
+        return indexCache.get(model);
       }
 
       if (!model.indexer) {
@@ -183,13 +183,13 @@ defineKit<TypekitExtension>({
 
       if (model.indexer.key.name === "string") {
         const record = this.record.create(model.indexer.value);
-        spreadCache.set(model, record);
+        indexCache.set(model, record);
         return record;
       }
 
       if (model.indexer.key.name === "integer") {
         const array = this.array.create(model.indexer.value);
-        spreadCache.set(model, array);
+        indexCache.set(model, array);
         return array;
       }
 

--- a/packages/compiler/src/typekit/kits/model.ts
+++ b/packages/compiler/src/typekit/kits/model.ts
@@ -235,9 +235,9 @@ defineKit<TypekitExtension>({
       }
 
       // model MyModel { ...Record<>} should be model with additional properties
-      const spread = this.model.getIndexType(model);
-      if (spread && this.record.is(spread)) {
-        return spread;
+      const indexType = this.model.getIndexType(model);
+      if (indexType && this.record.is(indexType)) {
+        return indexType;
       }
 
       if (model.baseModel) {

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -96,15 +96,15 @@ function getExtendsType($: Typekit, type: Model | Interface): Children | undefin
     }
   }
 
-  const spreadType = $.model.getSpreadType(type);
-  if (spreadType) {
+  const indexType = $.model.getIndexType(type);
+  if (indexType) {
     // When extending a record we need to override the element type to be unknown to avoid type errors
-    if ($.record.is(spreadType)) {
+    if ($.record.is(indexType)) {
       // Here we are in the additional properties land.
       // Instead of extending we need to create an envelope property
       // do nothing here.
     } else {
-      extending.push(<TypeExpression type={spreadType} />);
+      extending.push(<TypeExpression type={indexType} />);
     }
   }
 

--- a/packages/emitter-framework/src/typescript/components/type-transform.tsx
+++ b/packages/emitter-framework/src/typescript/components/type-transform.tsx
@@ -198,7 +198,7 @@ export function ModelTransformExpression(props: ModelTransformExpressionProps) {
     });
   }
 
-  if ($.model.getSpreadType(props.type)) {
+  if ($.model.getIndexType(props.type)) {
     reportTypescriptDiagnostic($.program, {
       code: "typescript-spread-model-transformation-nyi",
       target: props.type,

--- a/packages/http-client-js/src/components/transforms/json/json-model-transform.tsx
+++ b/packages/http-client-js/src/components/transforms/json/json-model-transform.tsx
@@ -86,14 +86,14 @@ export function JsonModelTransformDeclaration(
     { name: "input_", type: inputType, refkey: inputRef, optional: true },
   ];
 
-  const spread = $.model.getSpreadType(props.type);
-  const hasAdditionalProperties = spread && $.model.is(spread) && $.record.is(spread);
+  const indexType = $.model.getIndexType(props.type);
+  const hasAdditionalProperties = indexType && $.record.is(indexType);
 
   const declarationRefkey = getJsonModelTransformRefkey(props.type, props.target);
   return (
     <>
       {hasAdditionalProperties ? (
-        <JsonRecordTransformDeclaration target={props.target} type={spread} />
+        <JsonRecordTransformDeclaration target={props.target} type={indexType} />
       ) : null}
       <JsonTransformDiscriminatorDeclaration type={props.type} target={props.target} />
       <ts.FunctionDeclaration


### PR DESCRIPTION
What `getSpreadType` returned is actually the `model.indexer.value` wrapped in a `Record` or `Array` model, depending on what the `model.indexer.key` is. This is different than whatever is spread.

2 examples of how this is different:
- Multiple records: `model Foo { ...Record<string>; ...Record<int8>; }` has an indexer value that is the union of `string | int8`.
- Excludes non-indexed types: `model Foo { ...Bar }` would not return the `Bar` type as expected by the typekit name.

## Just remove getSpreadType instead of rename it?
I considered just removing getSpreadType but there are a few benefits to having `getIndexType`
- No need to check the `model.indexer.key.name` to determine if the indexer was sourced from an `Array` or `Record` type.
- `getIndexType` supports caching, so the `Record`/`Array` type is only created once per model when needed, instead of every time it's requested. Given types can be used as refkeys in alloy this seems like a useful feature.