### PR TITLE
Remove dates from blog posts and URL slugs

### DIFF
--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -27,6 +27,8 @@ export const collections = {
     type: "content",
     // Type-check frontmatter using a schema
     schema: z.object({
+      slug: z.string().optional(),
+      redirect_slug: z.string().optional(),
       title: z.string(),
       description: z.string(),
       image: z.string().optional(),

--- a/website/src/content/blog/2024-04-25-introducing/blog.md
+++ b/website/src/content/blog/2024-04-25-introducing/blog.md
@@ -1,5 +1,6 @@
 ---
-slug: 2024-04-25-introducing
+slug: introducing
+redirect_slug: 2024-04-25-introducing
 title: "Introducing TypeSpec: A New Language for API-Centric Development"
 image: ./intro.png
 description: Over last few years, we've been hard at work on https://typespec.io/, a modern API definition language. This language is designed to meet the evolving needs of API developers, architects, and managers in an environment where the delivery of consistently high-quality APIs and related experiences is becoming increasingly complex and critical.

--- a/website/src/content/blog/2024-11-04-typespec-at-lseg/blog.md
+++ b/website/src/content/blog/2024-11-04-typespec-at-lseg/blog.md
@@ -1,8 +1,9 @@
 ---
-slug: 2024-11-04-typespec-at-lseg
+slug: typespec-at-lseg
+redirect_slug: 2024-11-04-typespec-at-lseg
 title: "Enhancing API design at the London Stock Exchange Group"
 image: ./tsp_lseg_360x360.png
-description: In the fast-paced world of financial services, having consistent and efficient APIs and SDKs is crucial. At Microsoft, we’ve been working closely with LSEG (London Stock Exchange Group) to streamline their development process using TypeSpec. This collaboration has been very beneficial and educational for both sides, and we’re excited to share our insights with you.
+description: In the fast-paced world of financial services, having consistent and efficient APIs and SDKs is crucial. At Microsoft, we've been working closely with LSEG (London Stock Exchange Group) to streamline their development process using TypeSpec. This collaboration has been very beneficial and educational for both sides, and we're excited to share our insights with you.
 publishDate: 2024-11-04
 authors:
   - name: Mario Guerra

--- a/website/src/content/blog/2025-03-31-typespec-1-0-release/typespec_1_0_release.md
+++ b/website/src/content/blog/2025-03-31-typespec-1-0-release/typespec_1_0_release.md
@@ -1,13 +1,14 @@
 ---
-slug: 2025-03-31-typespec-1-0-release
+slug: typespec-1-0-RC-release
+redirect_slug: 2025-03-31-typespec-1-0-release
 title: "TypeSpec 1.0-RC: Design Faster Today, Scale Easier Tomorrow"
 image: ./TypeSpec_1_0_RC.png
 description: "The TypeSpec 1.0 Release Candidate is here! This open-source project, created by Microsoft and released to the community, brings a powerful yet concise API modeling language that supports API-first development, streamlining the generation of server code, client libraries, schemas, and documentation from a single source of truth."
 publishDate: 2025-04-02
-author:
-  name: Mario Guerra
-  title: Senior Product Manager @ Microsoft
-authorAvatar: assets/img/authors/mario_guerra.png
+authors:
+  - name: Mario Guerra
+    title: Senior Product Manager @ Microsoft
+    avatar: assets/img/authors/mario_guerra.png
 tags:
   - release
   - announcement

--- a/website/src/layouts/blog-post.astro
+++ b/website/src/layouts/blog-post.astro
@@ -3,12 +3,11 @@ import type { CollectionEntry } from "astro:content";
 import BaseLayout from "./base-layout.astro";
 import { resolveBlogImagePath } from "../pages/blog/resolve-image";
 import { resolveAuthorAvatar } from "../utils/resolve-author-avatar";
-import { format } from "date-fns/format";
 import { Image } from "astro:assets";
 import BlogAuthor from "../components/BlogAuthor.astro";
 
 type Props = CollectionEntry<"blog">["data"];
-const { title, image: relativeImage, publishDate, author, authorAvatar, authors } = Astro.props;
+const { title, image: relativeImage, author, authorAvatar, authors } = Astro.props;
 const image = relativeImage && (await resolveBlogImagePath(Astro.params.slug ?? "", relativeImage));
 // Fixed height value for all images
 const fixedHeight = 360;

--- a/website/src/layouts/blog-post.astro
+++ b/website/src/layouts/blog-post.astro
@@ -62,12 +62,6 @@ const authorsWithAvatars = await Promise.all(
   .title h1 {
     margin: 0 0 0.5em 0;
   }
-  .date {
-    display: block;
-    padding: 1rem;
-    font-size: var(--fontSizeBase400);
-    color: var(--colorNeutralForeground1);
-  }
   .last-updated-on {
     font-style: italic;
   }
@@ -85,9 +79,6 @@ const authorsWithAvatars = await Promise.all(
     </div>
     <div class="prose">
       <div class="title">
-        <time class="date" datetime={publishDate.toISOString()}>
-          {format(publishDate, "MMMM d, yyyy")}
-        </time>
         <h1>{title}</h1>
         <hr />
       </div>

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -4,14 +4,43 @@ import BlogPost from "../../layouts/blog-post.astro";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
-  return posts.map((post) => ({
-    params: { slug: post.slug },
-    props: post,
-  }));
-}
-type Props = CollectionEntry<"blog">;
 
-const post = Astro.props;
+  // Create paths for all posts using their main slug
+  const mainPaths = posts.map((post) => {
+    // Get the proper slug to use - prioritize data.slug, then post.slug
+    const mainSlug = post.data.slug || post.slug;
+
+    return {
+      params: { slug: mainSlug },
+      props: { post, isRedirect: false },
+    };
+  });
+
+  // Create redirect paths for posts that have a redirect_slug
+  const redirectPaths = posts
+    .filter(
+      (post) =>
+        post.data.redirect_slug && post.data.redirect_slug !== (post.data.slug || post.slug),
+    )
+    .map((post) => ({
+      params: { slug: post.data.redirect_slug },
+      props: { post, isRedirect: true },
+    }));
+
+  return [...mainPaths, ...redirectPaths];
+}
+
+const { post, isRedirect } = Astro.props;
+
+// Get the proper slug to use - prioritize data.slug, then post.slug
+const mainSlug = post.data.slug || post.slug;
+
+// If this is a redirect path, redirect to the actual post URL
+// Include trailing slash since trailingSlash is set to always
+if (isRedirect) {
+  return Astro.redirect(`/blog/${mainSlug}/`);
+}
+
 const { Content } = await post.render();
 ---
 

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -35,10 +35,8 @@ const { post, isRedirect } = Astro.props;
 // If this is a redirect path, redirect to the actual post URL
 // Include trailing slash since trailingSlash is set to always
 if (isRedirect) {
-  // Get the proper slug to use - prioritize data.slug, then post.slug
-  // Define it directly in the if block to make TypeScript recognize it's being used
-  const redirectTarget = `/blog/${post.data.slug || post.slug}/`;
-  return Astro.redirect(redirectTarget);
+  // Perform the redirect directly without creating an intermediate variable
+  return Astro.redirect(`/blog/${post.data.slug || post.slug}/`);
 }
 
 const { Content } = await post.render();

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { type CollectionEntry, getCollection } from "astro:content";
+import { getCollection } from "astro:content";
 import BlogPost from "../../layouts/blog-post.astro";
 
 export async function getStaticPaths() {
@@ -32,13 +32,13 @@ export async function getStaticPaths() {
 
 const { post, isRedirect } = Astro.props;
 
-// Get the proper slug to use - prioritize data.slug, then post.slug
-const mainSlug = post.data.slug || post.slug;
-
 // If this is a redirect path, redirect to the actual post URL
 // Include trailing slash since trailingSlash is set to always
 if (isRedirect) {
-  return Astro.redirect(`/blog/${mainSlug}/`);
+  // Get the proper slug to use - prioritize data.slug, then post.slug
+  // Define it directly in the if block to make TypeScript recognize it's being used
+  const redirectTarget = `/blog/${post.data.slug || post.slug}/`;
+  return Astro.redirect(redirectTarget);
 }
 
 const { Content } = await post.render();

--- a/website/src/pages/blog/_BlogPostPreview.astro
+++ b/website/src/pages/blog/_BlogPostPreview.astro
@@ -1,7 +1,6 @@
 ---
 import Card from "@site/src/components/card.astro";
 import { resolveBlogImagePath } from "@site/src/pages/blog/resolve-image";
-import { format } from "date-fns";
 import { Image } from "astro:assets";
 import Link from "@typespec/astro-utils/components/link.astro";
 

--- a/website/src/pages/blog/_BlogPostPreview.astro
+++ b/website/src/pages/blog/_BlogPostPreview.astro
@@ -36,13 +36,6 @@ const image = post.data.image && (await resolveBlogImagePath(post.slug, post.dat
   .link:hover {
     outline: solid var(--colorBrandForeground1);
   }
-  .date {
-    display: block;
-    padding: 1rem;
-    text-align: left;
-    font-size: var(--fontSizeBase500);
-    border-bottom: 1px solid var(--colorNeutralStroke3);
-  }
 
   .image {
     margin: auto;
@@ -99,11 +92,6 @@ const image = post.data.image && (await resolveBlogImagePath(post.slug, post.dat
 <article aria-labelledby={post.slug}>
   <Link class="link" href={`/blog/${post.slug}/`} data-astro-prefetch>
     <Card noPadding>
-      <header>
-        <time class="date" datetime={post.data.publishDate.toISOString()}>
-          {format(post.data.publishDate, "MMMM d, yyyy")}
-        </time>
-      </header>
       <div class="image-container">
         {image && <Image class="image" src={image} alt="" loading={imageLoading} />}
       </div>

--- a/website/src/pages/blog/_BlogPostPreview.astro
+++ b/website/src/pages/blog/_BlogPostPreview.astro
@@ -7,8 +7,10 @@ import Link from "@typespec/astro-utils/components/link.astro";
 
 export type Props = {
   post: {
-    slug: string;
+    slug?: string;
     data: {
+      slug?: string;
+      redirect_slug?: string;
       title: string;
       description: string;
       publishDate: Date;
@@ -20,7 +22,11 @@ export type Props = {
 
 const { post, imageLoading } = Astro.props;
 
-const image = post.data.image && (await resolveBlogImagePath(post.slug, post.data.image));
+// Get the actual slug to use - prioritize data.slug, then post.slug, then fallback to data.redirect_slug
+const postSlug = post.data.slug || post.slug || post.data.redirect_slug || "";
+
+// Use the determined slug for image resolution
+const image = post.data.image && (await resolveBlogImagePath(postSlug, post.data.image));
 ---
 
 <style>
@@ -89,15 +95,15 @@ const image = post.data.image && (await resolveBlogImagePath(post.slug, post.dat
     background: var(--colorNeutralBackground2);
   }
 </style>
-<article aria-labelledby={post.slug}>
-  <Link class="link" href={`/blog/${post.slug}/`} data-astro-prefetch>
+<article aria-labelledby={postSlug}>
+  <Link class="link" href={`/blog/${postSlug}/`} data-astro-prefetch>
     <Card noPadding>
       <div class="image-container">
         {image && <Image class="image" src={image} alt="" loading={imageLoading} />}
       </div>
 
       <div class="content">
-        <h3 class="heading-4 md:heading-3" id={post.slug}>
+        <h3 class="heading-4 md:heading-3" id={postSlug}>
           {post.data.title}
         </h3>
         <p class="text-astro-gray-200">{post.data.description}</p>

--- a/website/src/pages/blog/resolve-image.ts
+++ b/website/src/pages/blog/resolve-image.ts
@@ -1,19 +1,47 @@
+import type { ImageMetadata } from "astro";
+import { getCollection } from "astro:content";
 import { join, normalize } from "path/posix";
 
 const allImages = import.meta.glob<{ default: ImageMetadata }>(
   "../../content/blog/**/*.{png,jpg,jpeg,webp}",
 );
 
-export async function resolveBlogImagePath(slug: string, relativeImage: string) {
-  const path = normalize(join("../../content/blog/", slug, relativeImage));
+export async function resolveBlogImagePath(
+  slug: string,
+  relativeImage: string,
+): Promise<ImageMetadata> {
+  // If no slug provided, we can't resolve the image
+  if (!slug) {
+    throw new Error(`Cannot resolve image path without a slug`);
+  }
 
-  const imageImporter = allImages[path];
+  // First, try the direct path using dated directory structure
+  // This covers the case where slug is the dated slug OR where slug is the new format but matches a directory name
+  const directPath = normalize(join("../../content/blog/", slug, relativeImage));
+  let imageImporter = allImages[directPath];
 
   if (!imageImporter) {
-    throw new Error(`Image not found: ${path}`);
+    // If direct path didn't work, try to find the post by slug or redirect_slug
+    const posts = await getCollection("blog");
+
+    // Find the post that matches either the slug or redirect_slug
+    const post = posts.find(
+      (post) => post.data.slug === slug || post.data.redirect_slug === slug || post.slug === slug,
+    );
+
+    if (post) {
+      // Use the collection entry's id which contains the directory name with date
+      // Collection entry id looks like: "2024-04-25-introducing/blog.md"
+      const dirWithDate = post.id.split("/")[0];
+      const path = normalize(join("../../content/blog/", dirWithDate, relativeImage));
+      imageImporter = allImages[path];
+    }
+  }
+
+  if (!imageImporter) {
+    throw new Error(`Image not found for slug "${slug}" and path "${relativeImage}"`);
   }
 
   const { default: image } = await imageImporter();
-
   return image;
 }


### PR DESCRIPTION
As suggested by Lori, I'm removing dates from our posts in order to keep the content looking more evergreen. I also added support for blog post URL redirects so links to the original blog post URLs will still resolve properly.