### PR TITLE
Revert "Bump @azure/identity from 4.8.0 to 4.9.1"

### DIFF
--- a/packages/bundle-uploader/package.json
+++ b/packages/bundle-uploader/package.json
@@ -37,7 +37,7 @@
     "!dist/test/**"
   ],
   "dependencies": {
-    "@azure/identity": "~4.9.1",
+    "@azure/identity": "~4.8.0",
     "@azure/storage-blob": "~12.27.0",
     "@pnpm/workspace.find-packages": "^1000.0.17",
     "@typespec/bundler": "workspace:^",

--- a/packages/spec-coverage-sdk/package.json
+++ b/packages/spec-coverage-sdk/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/microsoft/typespec#readme",
   "dependencies": {
-    "@azure/identity": "~4.9.1",
+    "@azure/identity": "~4.8.0",
     "@azure/storage-blob": "~12.27.0",
     "@types/node": "~22.13.11"
   },

--- a/packages/spector/package.json
+++ b/packages/spector/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/microsoft/typespec#readme",
   "dependencies": {
-    "@azure/identity": "~4.9.1",
+    "@azure/identity": "~4.8.0",
     "@types/js-yaml": "^4.0.5",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.8.3)
       '@astrojs/starlight':
         specifier: ^0.32.4
-        version: 0.32.6(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
+        version: 0.32.6(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       '@expressive-code/core':
         specifier: ^0.40.2
         version: 0.40.2
@@ -153,7 +153,7 @@ importers:
         version: link:../playground
       astro-expressive-code:
         specifier: ^0.40.2
-        version: 0.40.2(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
+        version: 0.40.2(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -169,7 +169,7 @@ importers:
         version: 18.3.20
       astro:
         specifier: ^5.5.6
-        version: 5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+        version: 5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
 
   packages/best-practices:
     devDependencies:
@@ -201,8 +201,8 @@ importers:
   packages/bundle-uploader:
     dependencies:
       '@azure/identity':
-        specifier: ~4.9.1
-        version: 4.9.1
+        specifier: ~4.8.0
+        version: 4.8.0
       '@azure/storage-blob':
         specifier: ~12.27.0
         version: 12.27.0
@@ -1849,8 +1849,8 @@ importers:
   packages/spec-coverage-sdk:
     dependencies:
       '@azure/identity':
-        specifier: ~4.9.1
-        version: 4.9.1
+        specifier: ~4.8.0
+        version: 4.8.0
       '@azure/storage-blob':
         specifier: ~12.27.0
         version: 12.27.0
@@ -1920,8 +1920,8 @@ importers:
   packages/spector:
     dependencies:
       '@azure/identity':
-        specifier: ~4.9.1
-        version: 4.9.1
+        specifier: ~4.8.0
+        version: 4.8.0
       '@types/js-yaml':
         specifier: ^4.0.5
         version: 4.0.9
@@ -2390,7 +2390,7 @@ importers:
         version: 4.2.7(@types/node@22.13.17)(@types/react-dom@18.3.7(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.19.4)(yaml@2.7.1)
       '@astrojs/starlight':
         specifier: ^0.32.4
-        version: 0.32.6(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
+        version: 0.32.6(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       '@docsearch/css':
         specifier: ^3.9.0
         version: 3.9.0
@@ -2414,10 +2414,10 @@ importers:
         version: link:../packages/playground
       astro:
         specifier: ^5.5.6
-        version: 5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+        version: 5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       astro-rehype-relative-markdown-links:
         specifier: ^0.18.1
-        version: 0.18.1(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
+        version: 0.18.1(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2514,7 +2514,7 @@ importers:
         version: link:../packages/xml
       astro-expressive-code:
         specifier: ^0.40.2
-        version: 0.40.2(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
+        version: 0.40.2(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       rehype-mermaid:
         specifier: ^3.0.0
         version: 3.0.0(playwright@1.52.0)
@@ -2783,10 +2783,6 @@ packages:
     resolution: {integrity: sha512-/wGw8fJ4mdpJ1Cum7s1S+VQyXt1ihwKLzfabS1O/RDADnmzVc01dHn44qD0BvGH6KlZNzOMW95tEpKqhkCChPA==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-client@1.9.4':
-    resolution: {integrity: sha512-f7IxTD15Qdux30s2qFARH+JxgwxWLG2Rlr4oSkPGuLWm+1p5y1+C04XGLA0vmX6EtqfutmjvpNmAfgwVIS5hpw==}
-    engines: {node: '>=18.0.0'}
-
   '@azure/core-http-compat@2.2.0':
     resolution: {integrity: sha512-1kW8ZhN0CfbNOG6C688z5uh2yrzALE7dDXHiR9dY4vt+EbhGZQSbjDa5bQd2rf3X2pdWMsXbqbArxUyeNdvtmg==}
     engines: {node: '>=18.0.0'}
@@ -2803,10 +2799,6 @@ packages:
     resolution: {integrity: sha512-zHeoI3NCs53lLBbWNzQycjnYKsA1CVKlnzSNuSFcUDwBp8HHVObePxrM7HaX+Ha5Ks639H7chNC9HOaIhNS03w==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-rest-pipeline@1.20.0':
-    resolution: {integrity: sha512-ASoP8uqZBS3H/8N8at/XwFr6vYrRP3syTK0EUjDXQy0Y1/AUS+QeIRThKmTNJO2RggvBBxaXDPM7YoIwDGeA0g==}
-    engines: {node: '>=18.0.0'}
-
   '@azure/core-tracing@1.2.0':
     resolution: {integrity: sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==}
     engines: {node: '>=18.0.0'}
@@ -2815,24 +2807,16 @@ packages:
     resolution: {integrity: sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-util@1.12.0':
-    resolution: {integrity: sha512-13IyjTQgABPARvG90+N2dXpC+hwp466XCdQXPCRlbWHgd3SJd5Q1VvaBGv6k1BIa4MQm6hAF1UBU1m8QUxV8sQ==}
-    engines: {node: '>=18.0.0'}
-
   '@azure/core-xml@1.4.5':
     resolution: {integrity: sha512-gT4H8mTaSXRz7eGTuQyq1aIJnJqeXzpOe9Ay7Z3FrCouer14CbV3VzjnJrNrQfbBpGBLO9oy8BmrY75A0p53cA==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/identity@4.9.1':
-    resolution: {integrity: sha512-986D7Cf1AOwYqSDtO/FnMAyk/Jc8qpftkGsxuehoh4F85MhQ4fICBGX/44+X1y78lN4Sqib3Bsoaoh/FvOGgmg==}
+  '@azure/identity@4.8.0':
+    resolution: {integrity: sha512-l9ALUGHtFB/JfsqmA+9iYAp2a+cCwdNO/cyIr2y7nJLJsz1aae6qVP8XxT7Kbudg0IQRSIMXj0+iivFdbD1xPA==}
     engines: {node: '>=18.0.0'}
 
   '@azure/logger@1.1.4':
     resolution: {integrity: sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@azure/logger@1.2.0':
-    resolution: {integrity: sha512-0hKEzLhpw+ZTAfNJyRrn6s+V0nDWzXk9OjBr2TiGIu0OfMr5s2V4FpKLTAK3Ca5r5OKLbf4hkOGDPyiRjie/jA==}
     engines: {node: '>=18.0.0'}
 
   '@azure/msal-browser@4.11.1':
@@ -6425,10 +6409,6 @@ packages:
     resolution: {integrity: sha512-3zI/d10N4D0L0MQVNTLp9PhhY49Wtg9iYZcb+rWxA4Ii9eJigpamCXjGaH7SkrhQ4+5w++ad7TP64tQzUvRDQA==}
     engines: {node: '>=18.0.0'}
 
-  '@typespec/ts-http-runtime@0.2.2':
-    resolution: {integrity: sha512-Gz/Sm64+Sq/vklJu1tt9t+4R2lvnud8NbTD/ZfpZtMiUX7YeVpCA8j6NSW8ptwcoLL+NmYANwqP8DV0q/bwl2w==}
-    engines: {node: '>=18.0.0'}
-
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -9777,8 +9757,14 @@ packages:
   jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
 
+  jwa@2.0.0:
+    resolution: {integrity: sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==}
+
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
@@ -12008,6 +11994,10 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stoppable@1.1.0:
+    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
+    engines: {node: '>=4', npm: '>=6'}
+
   storybook@8.6.12:
     resolution: {integrity: sha512-Z/nWYEHBTLK1ZBtAWdhxC0l5zf7ioJ7G4+zYqtTdYeb67gTnxNj80gehf8o8QY9L2zA2+eyMRGLC2V5fI7Z3Tw==}
     hasBin: true
@@ -13740,12 +13730,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.2.6(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))':
+  '@astrojs/mdx@4.2.6(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.1
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      astro: 5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -13792,16 +13782,16 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.24.3
 
-  '@astrojs/starlight@0.32.6(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))':
+  '@astrojs/starlight@0.32.6(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))':
     dependencies:
-      '@astrojs/mdx': 4.2.6(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
+      '@astrojs/mdx': 4.2.6(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       '@astrojs/sitemap': 3.3.1
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
-      astro-expressive-code: 0.40.2(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
+      astro: 5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      astro-expressive-code: 0.40.2(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -13846,31 +13836,17 @@ snapshots:
   '@azure/core-auth@1.9.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0
+      '@azure/core-util': 1.11.0
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@azure/core-client@1.9.3':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.20.0
+      '@azure/core-rest-pipeline': 1.19.1
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/core-client@1.9.4':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.20.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -13878,19 +13854,17 @@ snapshots:
   '@azure/core-http-compat@2.2.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.20.0
+      '@azure/core-client': 1.9.3
+      '@azure/core-rest-pipeline': 1.19.1
     transitivePeerDependencies:
       - supports-color
 
   '@azure/core-lro@2.7.2':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@azure/core-paging@1.6.2':
     dependencies:
@@ -13901,22 +13875,10 @@ snapshots:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/core-rest-pipeline@1.20.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
-      '@typespec/ts-http-runtime': 0.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -13930,31 +13892,26 @@ snapshots:
       '@azure/abort-controller': 2.1.2
       tslib: 2.8.1
 
-  '@azure/core-util@1.12.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/core-xml@1.4.5':
     dependencies:
       fast-xml-parser: 5.2.1
       tslib: 2.8.1
 
-  '@azure/identity@4.9.1':
+  '@azure/identity@4.8.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.20.0
+      '@azure/core-client': 1.9.3
+      '@azure/core-rest-pipeline': 1.19.1
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
       '@azure/msal-browser': 4.11.1
       '@azure/msal-node': 3.5.2
+      events: 3.3.0
+      jws: 4.0.0
       open: 10.1.2
+      stoppable: 1.1.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -13962,13 +13919,6 @@ snapshots:
   '@azure/logger@1.1.4':
     dependencies:
       tslib: 2.8.1
-
-  '@azure/logger@1.2.0':
-    dependencies:
-      '@typespec/ts-http-runtime': 0.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@azure/msal-browser@4.11.1':
     dependencies:
@@ -18969,14 +18919,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typespec/ts-http-runtime@0.2.2':
-    dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.3.4(vite@6.3.4(@types/node@22.13.17)(tsx@4.19.4)(yaml@2.7.1))':
@@ -19230,7 +19172,7 @@ snapshots:
 
   '@vscode/vsce@3.3.2':
     dependencies:
-      '@azure/identity': 4.9.1
+      '@azure/identity': 4.8.0
       '@vscode/vsce-sign': 2.0.5
       azure-devops-node-api: 12.5.0
       chalk: 2.4.2
@@ -19996,14 +19938,14 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.40.2(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)):
+  astro-expressive-code@0.40.2(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)):
     dependencies:
-      astro: 5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      astro: 5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       rehype-expressive-code: 0.40.2
 
-  astro-rehype-relative-markdown-links@0.18.1(astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)):
+  astro-rehype-relative-markdown-links@0.18.1(astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)):
     dependencies:
-      astro: 5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      astro: 5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       catch-unknown: 2.0.0
       debug: 4.4.0(supports-color@8.1.1)
       github-slugger: 2.0.0
@@ -20015,7 +19957,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@5.7.10(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1):
+  astro@5.7.10(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)(@types/node@22.13.17)(encoding@0.1.13)(rollup@4.40.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1):
     dependencies:
       '@astrojs/compiler': 2.12.0
       '@astrojs/internal-helpers': 0.6.1
@@ -20066,7 +20008,7 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.4.1
       unist-util-visit: 5.0.0
-      unstorage: 1.16.0(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0)
+      unstorage: 1.16.0(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0)
       vfile: 6.0.3
       vite: 6.3.4(@types/node@22.13.17)(tsx@4.19.4)(yaml@2.7.1)
       vitefu: 1.0.6(vite@6.3.4(@types/node@22.13.17)(tsx@4.19.4)(yaml@2.7.1))
@@ -23302,9 +23244,20 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
+  jwa@2.0.0:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
   jws@3.2.2:
     dependencies:
       jwa: 1.4.1
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.0
       safe-buffer: 5.2.1
 
   katex@0.16.22:
@@ -26184,6 +26137,8 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  stoppable@1.1.0: {}
+
   storybook@8.6.12(prettier@3.5.3):
     dependencies:
       '@storybook/core': 8.6.12(prettier@3.5.3)(storybook@8.6.12(prettier@3.5.3))
@@ -26917,7 +26872,7 @@ snapshots:
       acorn: 8.14.1
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.16.0(@azure/identity@4.9.1)(@azure/storage-blob@12.27.0):
+  unstorage@1.16.0(@azure/identity@4.8.0)(@azure/storage-blob@12.27.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -26928,7 +26883,7 @@ snapshots:
       ofetch: 1.4.1
       ufo: 1.6.1
     optionalDependencies:
-      '@azure/identity': 4.9.1
+      '@azure/identity': 4.8.0
       '@azure/storage-blob': 12.27.0
 
   update-browserslist-db@1.1.3(browserslist@4.24.4):


### PR DESCRIPTION
Reverts microsoft/typespec#7212

Breaks storage upload

Api calls return this now 
```
 body: {
    Code: 'AuthenticationFailed',
    Message: 'Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.\n' +
      'RequestId:73864bc5-601e-005b-7ea4-bb2585000000\n' +
      'Time:2025-05-02T20:55:14.8499091Z',
    AuthenticationErrorDetail: 'Authentication scheme Bearer is not supported in this version.'
  }
```