### PR TITLE
[openapi3:converter] Add support for converting inline schemas using `allOf`

### DIFF
--- a/.chronus/changes/feat-tsp-openapi3-support-allof-2025-4-3-13-30-47.md
+++ b/.chronus/changes/feat-tsp-openapi3-support-allof-2025-4-3-13-30-47.md
@@ -4,6 +4,4 @@ packages:
   - "@typespec/openapi3"
 ---
 
-Add support for OpenAPI's 'allOf' schema composition when converting to TypeSpec.
-
-It enables combining multiple schemas into a single type, supporting inheritance and property aggregation.
+[OpenAPI -> tsp] Add support for converting inline schemas using allOf

--- a/.chronus/changes/feat-tsp-openapi3-support-allof-2025-4-3-13-30-47.md
+++ b/.chronus/changes/feat-tsp-openapi3-support-allof-2025-4-3-13-30-47.md
@@ -1,0 +1,9 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Add support for OpenAPI's 'allOf' schema composition when converting to TypeSpec.
+
+It enables combining multiple schemas into a single type, supporting inheritance and property aggregation.

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
@@ -79,6 +79,8 @@ export class SchemaToExpressionGenerator {
       type = getEnum(schema.enum);
     } else if (schema.anyOf) {
       type = this.getAnyOfType(schema, callingScope);
+    } else if (schema.allOf) {
+      type = this.getAllOfType(schema, callingScope);
     } else if (schema.type === "array") {
       type = this.generateArrayType(schema, callingScope);
     } else if (schema.type === "boolean") {
@@ -104,6 +106,43 @@ export class SchemaToExpressionGenerator {
     }
 
     return type;
+  }
+
+  private getAllOfType(schema: OpenAPI3Schema, callingScope: string[]): string {
+    const requiredProps: string[] = schema.required || [];
+    let properties: Record<string, Refable<OpenAPI3Schema>> = {};
+    const baseTypes: string[] = [];
+
+    for (const member of schema.allOf || []) {
+      if ("$ref" in member) {
+        // If it's a $ref, process it as inheritance/extension and add to the list
+        baseTypes.push(this.getRefName(member.$ref, callingScope));
+      } else if (member.properties) {
+        properties = { ...properties, ...member.properties };
+        if (member.required) {
+          requiredProps.push(...member.required);
+        }
+      }
+    }
+
+    const props: string[] = [];
+    for (const name of Object.keys(properties)) {
+      const isOptional = !requiredProps.includes(name) ? "?" : "";
+      props.push(
+        `${printIdentifier(name)}${isOptional}: ${this.generateTypeFromRefableSchema(properties[name], callingScope)}`
+      );
+    }
+
+    if (baseTypes.length > 0 && props.length > 0) {
+      // When there are both inherited types and properties
+      return `${baseTypes.join(" & ")} & {${props.join("; ")}}`;
+    } else if (baseTypes.length > 0) {
+      // When there are only inherited types
+      return baseTypes.join(" & ");
+    } else {
+      // When there are only properties
+      return `{${props.join("; ")}}`;
+    }
   }
 
   private getAnyOfType(schema: OpenAPI3Schema, callingScope: string[]): string {

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
@@ -129,7 +129,7 @@ export class SchemaToExpressionGenerator {
     for (const name of Object.keys(properties)) {
       const isOptional = !requiredProps.includes(name) ? "?" : "";
       props.push(
-        `${printIdentifier(name)}${isOptional}: ${this.generateTypeFromRefableSchema(properties[name], callingScope)}`
+        `${printIdentifier(name)}${isOptional}: ${this.generateTypeFromRefableSchema(properties[name], callingScope)}`,
       );
     }
 

--- a/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
@@ -141,6 +141,87 @@ const testScenarios: TestScenario[] = [
     },
     expected: `Model | boolean | "foo" | "bar"`,
   },
+  // allOf
+  {
+    schema: {
+      allOf: [
+        { $ref: "#/Path/To/BaseModel" },
+        { $ref: "#/Path/To/MixinModel" },
+      ],
+    },
+    expected: "BaseModel & MixinModel",
+  },
+  {
+    schema: {
+      allOf: [
+        { $ref: "#/Path/To/BaseModel" },
+        {
+          type: "object",
+          properties: {
+            foo: { type: "string" },
+            bar: { type: "boolean" },
+          }
+        },
+      ],
+    },
+    expected: "BaseModel & {foo?: string; bar?: boolean}",
+  },
+  {
+    schema: {
+      allOf: [
+        { $ref: "#/Path/To/BaseModel" },
+        {
+          type: "object",
+          required: ["foo"],
+          properties: {
+            foo: { type: "string" },
+            bar: { type: "boolean" },
+          }
+        },
+      ],
+    },
+    expected: "BaseModel & {foo: string; bar?: boolean}",
+  },
+  {
+    schema: {
+      allOf: [
+        {
+          type: "object",
+          properties: {
+            prop1: { type: "string" },
+          }
+        },
+        {
+          type: "object",
+          properties: {
+            prop2: { type: "number" },
+          }
+        },
+      ],
+    },
+    expected: "{prop1?: string; prop2?: numeric}",
+  },
+  {
+    schema: {
+      allOf: [
+        {
+          type: "object",
+          required: ["prop1"],
+          properties: {
+            prop1: { type: "string" },
+          }
+        },
+        {
+          type: "object",
+          required: ["prop2"],
+          properties: {
+            prop2: { type: "number" },
+          }
+        },
+      ],
+    },
+    expected: "{prop1: string; prop2: numeric}",
+  },
   // fallthrough
   { schema: {}, expected: "unknown" },
 ];

--- a/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
@@ -144,10 +144,7 @@ const testScenarios: TestScenario[] = [
   // allOf
   {
     schema: {
-      allOf: [
-        { $ref: "#/Path/To/BaseModel" },
-        { $ref: "#/Path/To/MixinModel" },
-      ],
+      allOf: [{ $ref: "#/Path/To/BaseModel" }, { $ref: "#/Path/To/MixinModel" }],
     },
     expected: "BaseModel & MixinModel",
   },
@@ -155,16 +152,17 @@ const testScenarios: TestScenario[] = [
     schema: {
       allOf: [
         { $ref: "#/Path/To/BaseModel" },
+        { $ref: "#/Path/To/MixinModel" },
         {
           type: "object",
           properties: {
             foo: { type: "string" },
             bar: { type: "boolean" },
-          }
+          },
         },
       ],
     },
-    expected: "BaseModel & {foo?: string; bar?: boolean}",
+    expected: "BaseModel & MixinModel & {foo?: string; bar?: boolean}",
   },
   {
     schema: {
@@ -176,7 +174,7 @@ const testScenarios: TestScenario[] = [
           properties: {
             foo: { type: "string" },
             bar: { type: "boolean" },
-          }
+          },
         },
       ],
     },
@@ -187,40 +185,20 @@ const testScenarios: TestScenario[] = [
       allOf: [
         {
           type: "object",
-          properties: {
-            prop1: { type: "string" },
-          }
-        },
-        {
-          type: "object",
-          properties: {
-            prop2: { type: "number" },
-          }
-        },
-      ],
-    },
-    expected: "{prop1?: string; prop2?: numeric}",
-  },
-  {
-    schema: {
-      allOf: [
-        {
-          type: "object",
           required: ["prop1"],
           properties: {
             prop1: { type: "string" },
-          }
+          },
         },
         {
           type: "object",
-          required: ["prop2"],
           properties: {
             prop2: { type: "number" },
-          }
+          },
         },
       ],
     },
-    expected: "{prop1: string; prop2: numeric}",
+    expected: "{prop1: string; prop2?: numeric}",
   },
   // fallthrough
   { schema: {}, expected: "unknown" },

--- a/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
@@ -193,15 +193,46 @@ const testScenarios: TestScenario[] = [
         {
           type: "object",
           properties: {
-            prop2: { type: "number" },
+            prop2: {
+              allOf: [
+                { $ref: "#/Path/To/BaseModel" },
+                { $ref: "#/Path/To/MixinModel" },
+                {
+                  type: "object",
+                  properties: {
+                    foo: { type: "string" },
+                    bar: { type: "boolean" },
+                  },
+                },
+              ],
+            },
           },
         },
       ],
     },
-    expected: "{prop1: string; prop2?: numeric}",
+    expected: "{prop1: string; prop2?: BaseModel & MixinModel & {foo?: string; bar?: boolean}}",
+  },
+  {
+    schema: {
+      type: "object",
+      properties: {
+        emptyProp: { type: "object" },
+      },
+    },
+    expected: "{emptyProp?: {}}",
   },
   // fallthrough
   { schema: {}, expected: "unknown" },
+  {
+    schema: {
+      type: "object",
+      required: ["missingTypeProp"],
+      properties: {
+        missingTypeProp: { properties: { foo: { type: "string" } } },
+      },
+    },
+    expected: "{missingTypeProp: unknown}",
+  },
 ];
 
 describe("tsp-openapi: generate-type", () => {

--- a/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
@@ -199,6 +199,7 @@ const testScenarios: TestScenario[] = [
                 { $ref: "#/Path/To/MixinModel" },
                 {
                   type: "object",
+                  required: ["foo"],
                   properties: {
                     foo: { type: "string" },
                     bar: { type: "boolean" },
@@ -210,7 +211,7 @@ const testScenarios: TestScenario[] = [
         },
       ],
     },
-    expected: "{prop1: string; prop2?: BaseModel & MixinModel & {foo?: string; bar?: boolean}}",
+    expected: "{prop1: string; prop2?: BaseModel & MixinModel & {foo: string; bar?: boolean}}",
   },
   {
     schema: {


### PR DESCRIPTION
# Add support for converting inline schemas using `allOf`

## Overview
This PR adds support for the OpenAPI 'allOf' keyword when converting OpenAPI 3.0 documents to TypeSpec. The implementation handles schema composition patterns, converting them to appropriate TypeSpec type expressions.

## Implementation Details
- Added a new `getAllOfType` method in the `SchemaToExpressionGenerator` class
- Handles different schema composition scenarios:
  - Multiple $ref references (converted to TypeSpec intersection types using `&`)
  - Combination of $ref and object properties

## Testing
Added test cases to `generate-type.test.ts` covering various scenarios:
- Basic type intersection with multiple $refs
- Mixed $ref and inline property objects
- Multiple property objects composition