### PR TITLE
Remove version property from service option model that was deprecated and removed in 1.0-rc.0

### DIFF
--- a/.chronus/changes/remove-service-from-type-2025-4-4-20-20-4.md
+++ b/.chronus/changes/remove-service-from-type-2025-4-4-20-20-4.md
@@ -1,0 +1,9 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Remove `version` property on `ServiceOptions` passed to `@service` decorator. That handling of that option was removed in `1.0.0-rc.0` where it was previously deprecated.
+If wanting to specify version in an OpenAPI document use the `@OpenAPI.info` decorator from the `@typespec/openapi` library

--- a/packages/compiler/generated-defs/TypeSpec.ts
+++ b/packages/compiler/generated-defs/TypeSpec.ts
@@ -16,7 +16,6 @@ import type {
 
 export interface ServiceOptions {
   readonly title?: string;
-  readonly version?: string;
 }
 
 export interface DiscriminatedOptions {

--- a/packages/compiler/lib/std/decorators.tsp
+++ b/packages/compiler/lib/std/decorators.tsp
@@ -63,11 +63,6 @@ model ServiceOptions {
    * Title of the service.
    */
   title?: string;
-
-  /**
-   * Version of the service.
-   */
-  version?: string;
 }
 
 /**

--- a/packages/openapi/test/decorators.test.ts
+++ b/packages/openapi/test/decorators.test.ts
@@ -294,7 +294,6 @@ describe("openapi: decorators", () => {
         #suppress "deprecated" "Test"
         @service(#{ 
           title: "Service API", 
-          version: "2.0.0" 
         })
         @summary("My summary")
         @info(#{

--- a/website/src/content/docs/docs/standard-library/built-in-data-types.md
+++ b/website/src/content/docs/docs/standard-library/built-in-data-types.md
@@ -398,7 +398,6 @@ model ServiceOptions
 | Name | Type | Description |
 |------|------|-------------|
 | title? | [`string`](#string) | Title of the service. |
-| version? | [`string`](#string) | Version of the service. |
 
 ### `Update` {#Update}
 


### PR DESCRIPTION
fix #7220
That property was deprecated and then removed in 1.0-rc.0 but missed it in the model used for service options