### PR TITLE
[hsjs] add missing shebang to scaffolding CLI

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-scaffold-shebang-2025-4-5-17-37-22.md
+++ b/.chronus/changes/witemple-msft-hsjs-scaffold-shebang-2025-4-5-17-37-22.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Added a missing shebang line to `hsjs-scaffold` for better platform compatibility.

--- a/packages/http-server-js/cmd/hsjs-scaffold.mjs
+++ b/packages/http-server-js/cmd/hsjs-scaffold.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { main } from "../dist/src/scripts/scaffold/bin.mjs";
 
 main().catch(function onScaffoldError(error) {


### PR DESCRIPTION
This was an oversight when the CLI shim was added instead of just pointing the scaffolding bin entry to the compiled `.mts` file. 