### PR TITLE
[http] Fix diagnostic for PatchOptions.implicitOptionality referring a non-existing property

### DIFF
--- a/.chronus/changes/fix-implicit-optionality-diagnostic-2025-4-7-3-41-57.md
+++ b/.chronus/changes/fix-implicit-optionality-diagnostic-2025-4-7-3-41-57.md
@@ -1,0 +1,8 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http"
+---
+
+Fix diagnostic for `PatchOptions.implicitOptionality`, which refers a non-existing property and the incorrect value.
+To keep the old behavior, you will need to use `@patch(#{ implicitOptionality: true })` instead.

--- a/packages/http/src/lib.ts
+++ b/packages/http/src/lib.ts
@@ -198,7 +198,7 @@ export const $lib = createTypeSpecLibrary({
     "patch-implicit-optional": {
       severity: "warning",
       messages: {
-        default: `Patch operation stopped applying an implicit optional transform to the body in 1.0.0. Use @patch(#{implicitOptionality: false}) to restore the old behavior.`,
+        default: `Patch operation stopped applying an implicit optional transform to the body in 1.0.0. Use @patch(#{implicitOptionality: true}) to restore the old behavior.`,
       },
     },
     "merge-patch-contains-null": {

--- a/packages/http/src/lib.ts
+++ b/packages/http/src/lib.ts
@@ -198,7 +198,7 @@ export const $lib = createTypeSpecLibrary({
     "patch-implicit-optional": {
       severity: "warning",
       messages: {
-        default: `Patch operation stopped applying an implicit optional transform to the body in 1.0.0. Use @patch(#{implicitOptional: false}) to restore the old behavior.`,
+        default: `Patch operation stopped applying an implicit optional transform to the body in 1.0.0. Use @patch(#{implicitOptionality: false}) to restore the old behavior.`,
       },
     },
     "merge-patch-contains-null": {


### PR DESCRIPTION
Replaced `implicitOptional` with `implicitOptionality` to refer the existing property.