### PR TITLE
Update CreateModel and CreateModelCore return type to TypeProvider

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -534,12 +534,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // For convenience methods, use the service method parameters
             var inputParameters = methodType is MethodType.Convenience ? serviceMethod.Parameters : operation.Parameters;
 
-            ModelProvider? spreadSource = null;
+            TypeProvider? spreadSource = null;
             if (methodType == MethodType.Convenience)
             {
                 InputParameter? inputOperationSpreadParameter = operation.Parameters.FirstOrDefault(p => p.Kind.HasFlag(InputParameterKind.Spread));
                 spreadSource = inputOperationSpreadParameter != null
-                    ? ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(GetSpreadParameterModel(inputOperationSpreadParameter)) as ModelProvider
+                    ? ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(GetSpreadParameterModel(inputOperationSpreadParameter))
                     : null;
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -539,7 +539,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 InputParameter? inputOperationSpreadParameter = operation.Parameters.FirstOrDefault(p => p.Kind.HasFlag(InputParameterKind.Spread));
                 spreadSource = inputOperationSpreadParameter != null
-                    ? ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(GetSpreadParameterModel(inputOperationSpreadParameter))
+                    ? ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(GetSpreadParameterModel(inputOperationSpreadParameter)) as ModelProvider
                     : null;
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -338,11 +338,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             List<ValueExpression> conversions = new List<ValueExpression>();
             bool addedSpreadSource = false;
 
-            ModelProvider? bodyModel = null;
+            TypeProvider? bodyModel = null;
             InputParameter? methodBodyParameter = ServiceMethod.Parameters.FirstOrDefault(p => p.Location == InputRequestLocation.Body);
             if (methodBodyParameter?.Type is InputModelType model)
             {
-                bodyModel = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(model) as ModelProvider;
+                bodyModel = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(model);
             }
 
             foreach (var param in ConvenienceMethodParameters)
@@ -422,7 +422,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         }
 
         private (List<ValueExpression> RequiredParameters, List<ValueExpression> OptionalParameters)?
-            GetNonBodyModelPropertiesConversions(ParameterProvider bodyParam, ModelProvider bodyModel)
+            GetNonBodyModelPropertiesConversions(ParameterProvider bodyParam, TypeProvider bodyModel)
         {
             // Extract non-body properties from the body model
             var nonBodyProperties = bodyModel.CanonicalView.Properties

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -342,7 +342,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             InputParameter? methodBodyParameter = ServiceMethod.Parameters.FirstOrDefault(p => p.Location == InputRequestLocation.Body);
             if (methodBodyParameter?.Type is InputModelType model)
             {
-                bodyModel = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(model);
+                bodyModel = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(model) as ModelProvider;
             }
 
             foreach (var param in ConvenienceMethodParameters)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/ModelCustomizationTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             var modelTypeProvider = mockGenerator.Object.OutputLibrary.TypeProviders.FirstOrDefault(t => t is ModelProvider && t.Name == "MockInputModel");
             Assert.IsNotNull(modelTypeProvider);
 
-            var baseModelTypeProvider = (modelTypeProvider as ModelProvider)?.BaseModelProvider;
+            var baseModelTypeProvider = (modelTypeProvider as ModelProvider)?.BaseTypeProvider as ModelProvider;
             Assert.IsNotNull(baseModelTypeProvider);
             var customCodeView = baseModelTypeProvider!.CustomCodeView;
             Assert.IsNotNull(customCodeView);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/LibraryVisitor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/LibraryVisitor.cs
@@ -110,7 +110,7 @@ namespace Microsoft.TypeSpec.Generator
         /// <param name="model">The original input model.</param>
         /// <param name="type">The current conversion.</param>
         /// <returns>Null if it should be removed otherwise the modified version of the <see cref="ModelProvider"/>.</returns>
-        protected internal virtual ModelProvider? PreVisitModel(InputModelType model, ModelProvider? type)
+        protected internal virtual TypeProvider? PreVisitModel(InputModelType model, TypeProvider? type)
         {
             return type;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var methods = new List<MethodProvider>(_models.Count());
             foreach (var model in _models)
             {
-                var modelProvider = CodeModelGenerator.Instance.TypeFactory.CreateModel(model);
+                var modelProvider = CodeModelGenerator.Instance.TypeFactory.CreateModel(model) as ModelProvider;
 
                 if (modelProvider is null)
                     continue;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -111,9 +111,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
             return [.. derivedModels];
         }
-        internal override TypeProvider? BaseTypeProvider => BaseModelProvider;
+        public override TypeProvider? BaseTypeProvider => BaseModelProvider;
 
-        public ModelProvider? BaseModelProvider
+        internal ModelProvider? BaseModelProvider
             => _baseModelProvider ??= (_baseTypeProvider?.Value is ModelProvider baseModelProvider ? baseModelProvider : null);
         private FieldProvider? RawDataField => _rawDataField ??= BuildRawDataField();
         private List<FieldProvider> AdditionalPropertyFields => _additionalPropertyFields ??= BuildAdditionalPropertyFields();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -92,7 +92,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             // add discriminated subtypes
             foreach (var subtype in _inputModel.DiscriminatedSubtypes)
             {
-                var model = CodeModelGenerator.Instance.TypeFactory.CreateModel(subtype.Value);
+                var model = CodeModelGenerator.Instance.TypeFactory.CreateModel(subtype.Value) as ModelProvider;
                 if (model != null)
                 {
                     derivedModels.Add(model);
@@ -102,7 +102,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             // add derived models
             foreach (var derivedModel in _inputModel.DerivedModels)
             {
-                var model = CodeModelGenerator.Instance.TypeFactory.CreateModel(derivedModel);
+                var model = CodeModelGenerator.Instance.TypeFactory.CreateModel(derivedModel) as ModelProvider;
                 if (model != null)
                 {
                     derivedModels.Add(model);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -170,7 +170,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             return modifiers;
         }
 
-        internal virtual TypeProvider? BaseTypeProvider => null;
+        public virtual TypeProvider? BaseTypeProvider => null;
 
         protected virtual CSharpType? GetBaseType() => null;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -141,23 +141,23 @@ namespace Microsoft.TypeSpec.Generator
         /// </summary>
         /// <param name="model">The <see cref="InputModelType"/> to convert.</param>
         /// <returns>An instance of <see cref="TypeProvider"/>.</returns>
-        public ModelProvider? CreateModel(InputModelType model)
+        public TypeProvider? CreateModel(InputModelType model)
         {
             if (CSharpToModelProvider.TryGetValue(model, out var modelProvider))
                 return modelProvider;
 
-            modelProvider = CreateModelCore(model);
+            modelProvider = CreateModelCore(model) as ModelProvider;
 
             foreach (var visitor in Visitors)
             {
-                modelProvider = visitor.PreVisitModel(model, modelProvider);
+                modelProvider = visitor.PreVisitModel(model, modelProvider as ModelProvider);
             }
 
             CSharpToModelProvider.Add(model, modelProvider);
             return modelProvider;
         }
 
-        protected virtual ModelProvider? CreateModelCore(InputModelType model) => new ModelProvider(model);
+        protected virtual TypeProvider? CreateModelCore(InputModelType model) => new ModelProvider(model);
 
         /// <summary>
         /// Factory method for creating a <see cref="TypeProvider"/> based on an <see cref="InputEnumType"> <paramref name="enumType"/>.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -150,7 +150,7 @@ namespace Microsoft.TypeSpec.Generator
 
             foreach (var visitor in Visitors)
             {
-                modelProvider = visitor.PreVisitModel(model, modelProvider as ModelProvider);
+                modelProvider = visitor.PreVisitModel(model, modelProvider) as ModelProvider;
             }
 
             CSharpToModelProvider.Add(model, modelProvider);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/InputLibraryVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/InputLibraryVisitorTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
             {
                 _cleanupReference = cleanupReference;
             }
-            protected internal override ModelProvider? PreVisitModel(InputModelType inputModel, ModelProvider? typeProvider)
+            protected internal override TypeProvider? PreVisitModel(InputModelType inputModel, TypeProvider? typeProvider)
             {
                 if (inputModel.Name == "Model1")
                 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/MockHelpers.cs
@@ -88,7 +88,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
 
             if (createModelCore != null)
             {
-                mockTypeFactory.Protected().Setup<ModelProvider?>("CreateModelCore", ItExpr.IsAny<InputModelType>()).Returns((InputModelType inputModel) => createModelCore.Invoke(inputModel));
+                mockTypeFactory.Protected().Setup<TypeProvider?>("CreateModelCore", ItExpr.IsAny<InputModelType>()).Returns((InputModelType inputModel) => createModelCore.Invoke(inputModel));
             }
 
             if (createEnumCore != null)


### PR DESCRIPTION
- Update `CreateModel` and `CreateModelCore` return type to `TypeProvider`
- Update `PreVisitModel` to use `TypeProvider`
- Update `TypeProvider.BaseTypeProvider` to be public and `ModelProvider.BaseModelProvider` to internal