### PR TITLE
[http-client-java] mgmt, remove `@Generated` annotation

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentStreamStyleSerializationModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentStreamStyleSerializationModelTemplate.java
@@ -7,10 +7,12 @@ import com.azure.core.util.CoreUtils;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModel;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModelProperty;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModelPropertyReference;
+import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaContext;
 import com.microsoft.typespec.http.client.generator.core.template.StreamSerializationModelTemplate;
 import com.microsoft.typespec.http.client.generator.mgmt.model.arm.ErrorClientModel;
 import com.microsoft.typespec.http.client.generator.mgmt.util.FluentUtils;
 import java.util.List;
+import java.util.Set;
 
 public class FluentStreamStyleSerializationModelTemplate extends StreamSerializationModelTemplate {
     private static final FluentModelTemplate FLUENT_MODEL_TEMPLATE = FluentModelTemplate.getInstance();
@@ -50,5 +52,13 @@ public class FluentStreamStyleSerializationModelTemplate extends StreamSerializa
     @Override
     protected List<ClientModelPropertyReference> getClientModelPropertyReferences(ClientModel model) {
         return FLUENT_MODEL_TEMPLATE.getClientModelPropertyReferences(model);
+    }
+
+    @Override
+    protected void addGeneratedImport(Set<String> imports) {
+    }
+
+    @Override
+    protected void addGeneratedAnnotation(JavaContext classBlock) {
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/fluent/models/ConfidentialResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/fluent/models/ConfidentialResourceInner.java
@@ -6,7 +6,6 @@ package azure.resourcemanager.commonproperties.fluent.models;
 
 import azure.resourcemanager.commonproperties.models.ConfidentialResourceProperties;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -23,37 +22,31 @@ public final class ConfidentialResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private ConfidentialResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of ConfidentialResourceInner class.
      */
-    @Generated
     public ConfidentialResourceInner() {
     }
 
@@ -62,7 +55,6 @@ public final class ConfidentialResourceInner extends Resource {
      * 
      * @return the properties value.
      */
-    @Generated
     public ConfidentialResourceProperties properties() {
         return this.properties;
     }
@@ -73,7 +65,6 @@ public final class ConfidentialResourceInner extends Resource {
      * @param properties the properties value to set.
      * @return the ConfidentialResourceInner object itself.
      */
-    @Generated
     public ConfidentialResourceInner withProperties(ConfidentialResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -84,7 +75,6 @@ public final class ConfidentialResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -94,7 +84,6 @@ public final class ConfidentialResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -105,7 +94,6 @@ public final class ConfidentialResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -116,7 +104,6 @@ public final class ConfidentialResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -125,7 +112,6 @@ public final class ConfidentialResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public ConfidentialResourceInner withLocation(String location) {
         super.withLocation(location);
@@ -135,7 +121,6 @@ public final class ConfidentialResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public ConfidentialResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/fluent/models/ManagedIdentityTrackedResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/fluent/models/ManagedIdentityTrackedResourceInner.java
@@ -7,7 +7,6 @@ package azure.resourcemanager.commonproperties.fluent.models;
 import azure.resourcemanager.commonproperties.models.ManagedIdentityTrackedResourceProperties;
 import azure.resourcemanager.commonproperties.models.ManagedServiceIdentity;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -24,43 +23,36 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private ManagedIdentityTrackedResourceProperties properties;
 
     /*
      * The managed service identities assigned to this resource.
      */
-    @Generated
     private ManagedServiceIdentity identity;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of ManagedIdentityTrackedResourceInner class.
      */
-    @Generated
     public ManagedIdentityTrackedResourceInner() {
     }
 
@@ -69,7 +61,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * 
      * @return the properties value.
      */
-    @Generated
     public ManagedIdentityTrackedResourceProperties properties() {
         return this.properties;
     }
@@ -80,7 +71,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * @param properties the properties value to set.
      * @return the ManagedIdentityTrackedResourceInner object itself.
      */
-    @Generated
     public ManagedIdentityTrackedResourceInner withProperties(ManagedIdentityTrackedResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -91,7 +81,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * 
      * @return the identity value.
      */
-    @Generated
     public ManagedServiceIdentity identity() {
         return this.identity;
     }
@@ -102,7 +91,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * @param identity the identity value to set.
      * @return the ManagedIdentityTrackedResourceInner object itself.
      */
-    @Generated
     public ManagedIdentityTrackedResourceInner withIdentity(ManagedServiceIdentity identity) {
         this.identity = identity;
         return this;
@@ -113,7 +101,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -123,7 +110,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -134,7 +120,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -145,7 +130,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -154,7 +138,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public ManagedIdentityTrackedResourceInner withLocation(String location) {
         super.withLocation(location);
@@ -164,7 +147,6 @@ public final class ManagedIdentityTrackedResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public ManagedIdentityTrackedResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ApiError.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ApiError.java
@@ -4,7 +4,6 @@
 
 package azure.resourcemanager.commonproperties.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.management.exception.AdditionalInfo;
 import com.azure.core.management.exception.ManagementError;
@@ -22,43 +21,36 @@ public final class ApiError extends ManagementError {
     /*
      * The Api inner error
      */
-    @Generated
     private InnerError innererror;
 
     /*
      * Additional info for the error.
      */
-    @Generated
     private List<AdditionalInfo> additionalInfo;
 
     /*
      * Details for the error.
      */
-    @Generated
     private List<ManagementError> details;
 
     /*
      * The target of the error.
      */
-    @Generated
     private String target;
 
     /*
      * The error message parsed from the body of the http error response.
      */
-    @Generated
     private String message;
 
     /*
      * The error code parsed from the body of the http error response.
      */
-    @Generated
     private String code;
 
     /**
      * Creates an instance of ApiError class.
      */
-    @Generated
     private ApiError() {
     }
 
@@ -67,7 +59,6 @@ public final class ApiError extends ManagementError {
      * 
      * @return the innererror value.
      */
-    @Generated
     public InnerError getInnererror() {
         return this.innererror;
     }
@@ -77,7 +68,6 @@ public final class ApiError extends ManagementError {
      * 
      * @return the additionalInfo value.
      */
-    @Generated
     @Override
     public List<AdditionalInfo> getAdditionalInfo() {
         return this.additionalInfo;
@@ -88,7 +78,6 @@ public final class ApiError extends ManagementError {
      * 
      * @return the details value.
      */
-    @Generated
     @Override
     public List<ManagementError> getDetails() {
         return this.details;
@@ -99,7 +88,6 @@ public final class ApiError extends ManagementError {
      * 
      * @return the target value.
      */
-    @Generated
     @Override
     public String getTarget() {
         return this.target;
@@ -110,7 +98,6 @@ public final class ApiError extends ManagementError {
      * 
      * @return the message value.
      */
-    @Generated
     @Override
     public String getMessage() {
         return this.message;
@@ -121,7 +108,6 @@ public final class ApiError extends ManagementError {
      * 
      * @return the code value.
      */
-    @Generated
     @Override
     public String getCode() {
         return this.code;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ConfidentialResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ConfidentialResourceProperties.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.commonproperties.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,19 +20,16 @@ public final class ConfidentialResourceProperties implements JsonSerializable<Co
     /*
      * The status of the last operation.
      */
-    @Generated
     private String provisioningState;
 
     /*
      * The username property.
      */
-    @Generated
     private String username;
 
     /**
      * Creates an instance of ConfidentialResourceProperties class.
      */
-    @Generated
     public ConfidentialResourceProperties() {
     }
 
@@ -42,7 +38,6 @@ public final class ConfidentialResourceProperties implements JsonSerializable<Co
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public String provisioningState() {
         return this.provisioningState;
     }
@@ -52,7 +47,6 @@ public final class ConfidentialResourceProperties implements JsonSerializable<Co
      * 
      * @return the username value.
      */
-    @Generated
     public String username() {
         return this.username;
     }
@@ -63,7 +57,6 @@ public final class ConfidentialResourceProperties implements JsonSerializable<Co
      * @param username the username value to set.
      * @return the ConfidentialResourceProperties object itself.
      */
-    @Generated
     public ConfidentialResourceProperties withUsername(String username) {
         this.username = username;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/InnerError.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/InnerError.java
@@ -4,7 +4,6 @@
 
 package azure.resourcemanager.commonproperties.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,19 +19,16 @@ public final class InnerError implements JsonSerializable<InnerError> {
     /*
      * The exception type.
      */
-    @Generated
     private String exceptiontype;
 
     /*
      * The internal error message or exception dump.
      */
-    @Generated
     private String errordetail;
 
     /**
      * Creates an instance of InnerError class.
      */
-    @Generated
     private InnerError() {
     }
 
@@ -41,7 +37,6 @@ public final class InnerError implements JsonSerializable<InnerError> {
      * 
      * @return the exceptiontype value.
      */
-    @Generated
     public String exceptiontype() {
         return this.exceptiontype;
     }
@@ -51,7 +46,6 @@ public final class InnerError implements JsonSerializable<InnerError> {
      * 
      * @return the errordetail value.
      */
-    @Generated
     public String errordetail() {
         return this.errordetail;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ManagedIdentityTrackedResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ManagedIdentityTrackedResourceProperties.java
@@ -4,7 +4,6 @@
 
 package azure.resourcemanager.commonproperties.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,13 +20,11 @@ public final class ManagedIdentityTrackedResourceProperties
     /*
      * The status of the last operation.
      */
-    @Generated
     private String provisioningState;
 
     /**
      * Creates an instance of ManagedIdentityTrackedResourceProperties class.
      */
-    @Generated
     public ManagedIdentityTrackedResourceProperties() {
     }
 
@@ -36,7 +33,6 @@ public final class ManagedIdentityTrackedResourceProperties
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public String provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ManagedServiceIdentity.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/ManagedServiceIdentity.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.commonproperties.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -23,32 +22,27 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * The service principal ID of the system assigned identity. This property will only be provided for a system
      * assigned identity.
      */
-    @Generated
     private String principalId;
 
     /*
      * The tenant ID of the system assigned identity. This property will only be provided for a system assigned
      * identity.
      */
-    @Generated
     private String tenantId;
 
     /*
      * The type of managed identity assigned to this resource.
      */
-    @Generated
     private ManagedServiceIdentityType type;
 
     /*
      * The identities assigned to this resource by the user.
      */
-    @Generated
     private Map<String, UserAssignedIdentity> userAssignedIdentities;
 
     /**
      * Creates an instance of ManagedServiceIdentity class.
      */
-    @Generated
     public ManagedServiceIdentity() {
     }
 
@@ -58,7 +52,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the principalId value.
      */
-    @Generated
     public String principalId() {
         return this.principalId;
     }
@@ -69,7 +62,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the tenantId value.
      */
-    @Generated
     public String tenantId() {
         return this.tenantId;
     }
@@ -79,7 +71,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the type value.
      */
-    @Generated
     public ManagedServiceIdentityType type() {
         return this.type;
     }
@@ -90,7 +81,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * @param type the type value to set.
      * @return the ManagedServiceIdentity object itself.
      */
-    @Generated
     public ManagedServiceIdentity withType(ManagedServiceIdentityType type) {
         this.type = type;
         return this;
@@ -101,7 +91,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the userAssignedIdentities value.
      */
-    @Generated
     public Map<String, UserAssignedIdentity> userAssignedIdentities() {
         return this.userAssignedIdentities;
     }
@@ -112,7 +101,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * @param userAssignedIdentities the userAssignedIdentities value to set.
      * @return the ManagedServiceIdentity object itself.
      */
-    @Generated
     public ManagedServiceIdentity withUserAssignedIdentities(Map<String, UserAssignedIdentity> userAssignedIdentities) {
         this.userAssignedIdentities = userAssignedIdentities;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/UserAssignedIdentity.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/models/UserAssignedIdentity.java
@@ -4,7 +4,6 @@
 
 package azure.resourcemanager.commonproperties.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,19 +19,16 @@ public final class UserAssignedIdentity implements JsonSerializable<UserAssigned
     /*
      * The principal ID of the assigned identity.
      */
-    @Generated
     private String principalId;
 
     /*
      * The client ID of the assigned identity.
      */
-    @Generated
     private String clientId;
 
     /**
      * Creates an instance of UserAssignedIdentity class.
      */
-    @Generated
     public UserAssignedIdentity() {
     }
 
@@ -41,7 +37,6 @@ public final class UserAssignedIdentity implements JsonSerializable<UserAssigned
      * 
      * @return the principalId value.
      */
-    @Generated
     public String principalId() {
         return this.principalId;
     }
@@ -51,7 +46,6 @@ public final class UserAssignedIdentity implements JsonSerializable<UserAssigned
      * 
      * @return the clientId value.
      */
-    @Generated
     public String clientId() {
         return this.clientId;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/nonresource/fluent/models/NonResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/nonresource/fluent/models/NonResourceInner.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.nonresource.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,25 +19,21 @@ public final class NonResourceInner implements JsonSerializable<NonResourceInner
     /*
      * An id.
      */
-    @Generated
     private String id;
 
     /*
      * A name.
      */
-    @Generated
     private String name;
 
     /*
      * A type.
      */
-    @Generated
     private String type;
 
     /**
      * Creates an instance of NonResourceInner class.
      */
-    @Generated
     public NonResourceInner() {
     }
 
@@ -47,7 +42,6 @@ public final class NonResourceInner implements JsonSerializable<NonResourceInner
      * 
      * @return the id value.
      */
-    @Generated
     public String id() {
         return this.id;
     }
@@ -58,7 +52,6 @@ public final class NonResourceInner implements JsonSerializable<NonResourceInner
      * @param id the id value to set.
      * @return the NonResourceInner object itself.
      */
-    @Generated
     public NonResourceInner withId(String id) {
         this.id = id;
         return this;
@@ -69,7 +62,6 @@ public final class NonResourceInner implements JsonSerializable<NonResourceInner
      * 
      * @return the name value.
      */
-    @Generated
     public String name() {
         return this.name;
     }
@@ -80,7 +72,6 @@ public final class NonResourceInner implements JsonSerializable<NonResourceInner
      * @param name the name value to set.
      * @return the NonResourceInner object itself.
      */
-    @Generated
     public NonResourceInner withName(String name) {
         this.name = name;
         return this;
@@ -91,7 +82,6 @@ public final class NonResourceInner implements JsonSerializable<NonResourceInner
      * 
      * @return the type value.
      */
-    @Generated
     public String type() {
         return this.type;
     }
@@ -102,7 +92,6 @@ public final class NonResourceInner implements JsonSerializable<NonResourceInner
      * @param type the type value to set.
      * @return the NonResourceInner object itself.
      */
-    @Generated
     public NonResourceInner withType(String type) {
         this.type = type;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/CheckNameAvailabilityResponseInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/CheckNameAvailabilityResponseInner.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.operationtemplates.fluent.models;
 
 import azure.resourcemanager.operationtemplates.models.CheckNameAvailabilityReason;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,25 +20,21 @@ public final class CheckNameAvailabilityResponseInner implements JsonSerializabl
     /*
      * Indicates if the resource name is available.
      */
-    @Generated
     private Boolean nameAvailable;
 
     /*
      * The reason why the given name is not available.
      */
-    @Generated
     private CheckNameAvailabilityReason reason;
 
     /*
      * Detailed reason why the given name is not available.
      */
-    @Generated
     private String message;
 
     /**
      * Creates an instance of CheckNameAvailabilityResponseInner class.
      */
-    @Generated
     private CheckNameAvailabilityResponseInner() {
     }
 
@@ -48,7 +43,6 @@ public final class CheckNameAvailabilityResponseInner implements JsonSerializabl
      * 
      * @return the nameAvailable value.
      */
-    @Generated
     public Boolean nameAvailable() {
         return this.nameAvailable;
     }
@@ -58,7 +52,6 @@ public final class CheckNameAvailabilityResponseInner implements JsonSerializabl
      * 
      * @return the reason value.
      */
-    @Generated
     public CheckNameAvailabilityReason reason() {
         return this.reason;
     }
@@ -68,7 +61,6 @@ public final class CheckNameAvailabilityResponseInner implements JsonSerializabl
      * 
      * @return the message value.
      */
-    @Generated
     public String message() {
         return this.message;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/ExportResultInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/ExportResultInner.java
@@ -4,7 +4,6 @@
 
 package azure.resourcemanager.operationtemplates.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -21,13 +20,11 @@ public final class ExportResultInner implements JsonSerializable<ExportResultInn
     /*
      * Content of the exported order.
      */
-    @Generated
     private String content;
 
     /**
      * Creates an instance of ExportResultInner class.
      */
-    @Generated
     private ExportResultInner() {
     }
 
@@ -36,7 +33,6 @@ public final class ExportResultInner implements JsonSerializable<ExportResultInn
      * 
      * @return the content value.
      */
-    @Generated
     public String content() {
         return this.content;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/OperationInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/OperationInner.java
@@ -7,7 +7,6 @@ package azure.resourcemanager.operationtemplates.fluent.models;
 import azure.resourcemanager.operationtemplates.models.ActionType;
 import azure.resourcemanager.operationtemplates.models.OperationDisplay;
 import azure.resourcemanager.operationtemplates.models.Origin;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -26,39 +25,33 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * The name of the operation, as per Resource-Based Access Control (RBAC). Examples:
      * "Microsoft.Compute/virtualMachines/write", "Microsoft.Compute/virtualMachines/capture/action"
      */
-    @Generated
     private String name;
 
     /*
      * Whether the operation applies to data-plane. This is "true" for data-plane operations and "false" for Azure
      * Resource Manager/control-plane operations.
      */
-    @Generated
     private Boolean isDataAction;
 
     /*
      * Localized display information for this particular operation.
      */
-    @Generated
     private OperationDisplay display;
 
     /*
      * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default
      * value is "user,system"
      */
-    @Generated
     private Origin origin;
 
     /*
      * Extensible enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
      */
-    @Generated
     private ActionType actionType;
 
     /**
      * Creates an instance of OperationInner class.
      */
-    @Generated
     private OperationInner() {
     }
 
@@ -68,7 +61,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the name value.
      */
-    @Generated
     public String name() {
         return this.name;
     }
@@ -79,7 +71,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the isDataAction value.
      */
-    @Generated
     public Boolean isDataAction() {
         return this.isDataAction;
     }
@@ -89,7 +80,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the display value.
      */
-    @Generated
     public OperationDisplay display() {
         return this.display;
     }
@@ -100,7 +90,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the origin value.
      */
-    @Generated
     public Origin origin() {
         return this.origin;
     }
@@ -111,7 +100,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the actionType value.
      */
-    @Generated
     public ActionType actionType() {
         return this.actionType;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/OrderInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/fluent/models/OrderInner.java
@@ -6,7 +6,6 @@ package azure.resourcemanager.operationtemplates.fluent.models;
 
 import azure.resourcemanager.operationtemplates.models.OrderProperties;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -23,37 +22,31 @@ public final class OrderInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private OrderProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of OrderInner class.
      */
-    @Generated
     public OrderInner() {
     }
 
@@ -62,7 +55,6 @@ public final class OrderInner extends Resource {
      * 
      * @return the properties value.
      */
-    @Generated
     public OrderProperties properties() {
         return this.properties;
     }
@@ -73,7 +65,6 @@ public final class OrderInner extends Resource {
      * @param properties the properties value to set.
      * @return the OrderInner object itself.
      */
-    @Generated
     public OrderInner withProperties(OrderProperties properties) {
         this.properties = properties;
         return this;
@@ -84,7 +75,6 @@ public final class OrderInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -94,7 +84,6 @@ public final class OrderInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -105,7 +94,6 @@ public final class OrderInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -116,7 +104,6 @@ public final class OrderInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -125,7 +112,6 @@ public final class OrderInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public OrderInner withLocation(String location) {
         super.withLocation(location);
@@ -135,7 +121,6 @@ public final class OrderInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public OrderInner withTags(Map<String, String> tags) {
         super.withTags(tags);

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/implementation/models/OperationListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/implementation/models/OperationListResult.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.operationtemplates.implementation.models;
 
 import azure.resourcemanager.operationtemplates.fluent.models.OperationInner;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -24,19 +23,16 @@ public final class OperationListResult implements JsonSerializable<OperationList
     /*
      * The Operation items on this page
      */
-    @Generated
     private List<OperationInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of OperationListResult class.
      */
-    @Generated
     private OperationListResult() {
     }
 
@@ -45,7 +41,6 @@ public final class OperationListResult implements JsonSerializable<OperationList
      * 
      * @return the value value.
      */
-    @Generated
     public List<OperationInner> value() {
         return this.value;
     }
@@ -55,7 +50,6 @@ public final class OperationListResult implements JsonSerializable<OperationList
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/CheckNameAvailabilityRequest.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/CheckNameAvailabilityRequest.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.operationtemplates.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public final class CheckNameAvailabilityRequest implements JsonSerializable<Chec
     /*
      * The name of the resource for which availability needs to be checked.
      */
-    @Generated
     private String name;
 
     /*
      * The resource type.
      */
-    @Generated
     private String type;
 
     /**
      * Creates an instance of CheckNameAvailabilityRequest class.
      */
-    @Generated
     public CheckNameAvailabilityRequest() {
     }
 
@@ -41,7 +37,6 @@ public final class CheckNameAvailabilityRequest implements JsonSerializable<Chec
      * 
      * @return the name value.
      */
-    @Generated
     public String name() {
         return this.name;
     }
@@ -52,7 +47,6 @@ public final class CheckNameAvailabilityRequest implements JsonSerializable<Chec
      * @param name the name value to set.
      * @return the CheckNameAvailabilityRequest object itself.
      */
-    @Generated
     public CheckNameAvailabilityRequest withName(String name) {
         this.name = name;
         return this;
@@ -63,7 +57,6 @@ public final class CheckNameAvailabilityRequest implements JsonSerializable<Chec
      * 
      * @return the type value.
      */
-    @Generated
     public String type() {
         return this.type;
     }
@@ -74,7 +67,6 @@ public final class CheckNameAvailabilityRequest implements JsonSerializable<Chec
      * @param type the type value to set.
      * @return the CheckNameAvailabilityRequest object itself.
      */
-    @Generated
     public CheckNameAvailabilityRequest withType(String type) {
         this.type = type;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/ExportRequest.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/ExportRequest.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.operationtemplates.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,13 +20,11 @@ public final class ExportRequest implements JsonSerializable<ExportRequest> {
     /*
      * Format of the exported order.
      */
-    @Generated
     private String format;
 
     /**
      * Creates an instance of ExportRequest class.
      */
-    @Generated
     public ExportRequest() {
     }
 
@@ -36,7 +33,6 @@ public final class ExportRequest implements JsonSerializable<ExportRequest> {
      * 
      * @return the format value.
      */
-    @Generated
     public String format() {
         return this.format;
     }
@@ -47,7 +43,6 @@ public final class ExportRequest implements JsonSerializable<ExportRequest> {
      * @param format the format value to set.
      * @return the ExportRequest object itself.
      */
-    @Generated
     public ExportRequest withFormat(String format) {
         this.format = format;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/OperationDisplay.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/OperationDisplay.java
@@ -4,7 +4,6 @@
 
 package azure.resourcemanager.operationtemplates.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,33 +20,28 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or
      * "Microsoft Compute".
      */
-    @Generated
     private String provider;
 
     /*
      * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or
      * "Job Schedule Collections".
      */
-    @Generated
     private String resource;
 
     /*
      * The concise, localized friendly name for the operation; suitable for dropdowns. E.g.
      * "Create or Update Virtual Machine", "Restart Virtual Machine".
      */
-    @Generated
     private String operation;
 
     /*
      * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
      */
-    @Generated
     private String description;
 
     /**
      * Creates an instance of OperationDisplay class.
      */
-    @Generated
     private OperationDisplay() {
     }
 
@@ -57,7 +51,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the provider value.
      */
-    @Generated
     public String provider() {
         return this.provider;
     }
@@ -68,7 +61,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the resource value.
      */
-    @Generated
     public String resource() {
         return this.resource;
     }
@@ -79,7 +71,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the operation value.
      */
-    @Generated
     public String operation() {
         return this.operation;
     }
@@ -90,7 +81,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/OrderProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/models/OrderProperties.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.operationtemplates.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,25 +20,21 @@ public final class OrderProperties implements JsonSerializable<OrderProperties> 
     /*
      * The product ID of the order.
      */
-    @Generated
     private String productId;
 
     /*
      * Amount of the product.
      */
-    @Generated
     private int amount;
 
     /*
      * The provisioning state of the product.
      */
-    @Generated
     private String provisioningState;
 
     /**
      * Creates an instance of OrderProperties class.
      */
-    @Generated
     public OrderProperties() {
     }
 
@@ -48,7 +43,6 @@ public final class OrderProperties implements JsonSerializable<OrderProperties> 
      * 
      * @return the productId value.
      */
-    @Generated
     public String productId() {
         return this.productId;
     }
@@ -59,7 +53,6 @@ public final class OrderProperties implements JsonSerializable<OrderProperties> 
      * @param productId the productId value to set.
      * @return the OrderProperties object itself.
      */
-    @Generated
     public OrderProperties withProductId(String productId) {
         this.productId = productId;
         return this;
@@ -70,7 +63,6 @@ public final class OrderProperties implements JsonSerializable<OrderProperties> 
      * 
      * @return the amount value.
      */
-    @Generated
     public int amount() {
         return this.amount;
     }
@@ -81,7 +73,6 @@ public final class OrderProperties implements JsonSerializable<OrderProperties> 
      * @param amount the amount value to set.
      * @return the OrderProperties object itself.
      */
-    @Generated
     public OrderProperties withAmount(int amount) {
         this.amount = amount;
         return this;
@@ -92,7 +83,6 @@ public final class OrderProperties implements JsonSerializable<OrderProperties> 
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public String provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/ExtensionsResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/ExtensionsResourceInner.java
@@ -6,7 +6,6 @@ package azure.resourcemanager.resources.fluent.models;
 
 import azure.resourcemanager.resources.models.ExtensionsResourceProperties;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.ProxyResource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -22,37 +21,31 @@ public final class ExtensionsResourceInner extends ProxyResource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private ExtensionsResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of ExtensionsResourceInner class.
      */
-    @Generated
     public ExtensionsResourceInner() {
     }
 
@@ -61,7 +54,6 @@ public final class ExtensionsResourceInner extends ProxyResource {
      * 
      * @return the properties value.
      */
-    @Generated
     public ExtensionsResourceProperties properties() {
         return this.properties;
     }
@@ -72,7 +64,6 @@ public final class ExtensionsResourceInner extends ProxyResource {
      * @param properties the properties value to set.
      * @return the ExtensionsResourceInner object itself.
      */
-    @Generated
     public ExtensionsResourceInner withProperties(ExtensionsResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -83,7 +74,6 @@ public final class ExtensionsResourceInner extends ProxyResource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -93,7 +83,6 @@ public final class ExtensionsResourceInner extends ProxyResource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -104,7 +93,6 @@ public final class ExtensionsResourceInner extends ProxyResource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -115,7 +103,6 @@ public final class ExtensionsResourceInner extends ProxyResource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/LocationResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/LocationResourceInner.java
@@ -6,7 +6,6 @@ package azure.resourcemanager.resources.fluent.models;
 
 import azure.resourcemanager.resources.models.LocationResourceProperties;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.ProxyResource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -22,37 +21,31 @@ public final class LocationResourceInner extends ProxyResource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private LocationResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of LocationResourceInner class.
      */
-    @Generated
     public LocationResourceInner() {
     }
 
@@ -61,7 +54,6 @@ public final class LocationResourceInner extends ProxyResource {
      * 
      * @return the properties value.
      */
-    @Generated
     public LocationResourceProperties properties() {
         return this.properties;
     }
@@ -72,7 +64,6 @@ public final class LocationResourceInner extends ProxyResource {
      * @param properties the properties value to set.
      * @return the LocationResourceInner object itself.
      */
-    @Generated
     public LocationResourceInner withProperties(LocationResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -83,7 +74,6 @@ public final class LocationResourceInner extends ProxyResource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -93,7 +83,6 @@ public final class LocationResourceInner extends ProxyResource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -104,7 +93,6 @@ public final class LocationResourceInner extends ProxyResource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -115,7 +103,6 @@ public final class LocationResourceInner extends ProxyResource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/NestedProxyResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/NestedProxyResourceInner.java
@@ -6,7 +6,6 @@ package azure.resourcemanager.resources.fluent.models;
 
 import azure.resourcemanager.resources.models.NestedProxyResourceProperties;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.ProxyResource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -22,37 +21,31 @@ public final class NestedProxyResourceInner extends ProxyResource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private NestedProxyResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of NestedProxyResourceInner class.
      */
-    @Generated
     public NestedProxyResourceInner() {
     }
 
@@ -61,7 +54,6 @@ public final class NestedProxyResourceInner extends ProxyResource {
      * 
      * @return the properties value.
      */
-    @Generated
     public NestedProxyResourceProperties properties() {
         return this.properties;
     }
@@ -72,7 +64,6 @@ public final class NestedProxyResourceInner extends ProxyResource {
      * @param properties the properties value to set.
      * @return the NestedProxyResourceInner object itself.
      */
-    @Generated
     public NestedProxyResourceInner withProperties(NestedProxyResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -83,7 +74,6 @@ public final class NestedProxyResourceInner extends ProxyResource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -93,7 +83,6 @@ public final class NestedProxyResourceInner extends ProxyResource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -104,7 +93,6 @@ public final class NestedProxyResourceInner extends ProxyResource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -115,7 +103,6 @@ public final class NestedProxyResourceInner extends ProxyResource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/SingletonTrackedResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/SingletonTrackedResourceInner.java
@@ -6,7 +6,6 @@ package azure.resourcemanager.resources.fluent.models;
 
 import azure.resourcemanager.resources.models.SingletonTrackedResourceProperties;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -23,37 +22,31 @@ public final class SingletonTrackedResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private SingletonTrackedResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of SingletonTrackedResourceInner class.
      */
-    @Generated
     public SingletonTrackedResourceInner() {
     }
 
@@ -62,7 +55,6 @@ public final class SingletonTrackedResourceInner extends Resource {
      * 
      * @return the properties value.
      */
-    @Generated
     public SingletonTrackedResourceProperties properties() {
         return this.properties;
     }
@@ -73,7 +65,6 @@ public final class SingletonTrackedResourceInner extends Resource {
      * @param properties the properties value to set.
      * @return the SingletonTrackedResourceInner object itself.
      */
-    @Generated
     public SingletonTrackedResourceInner withProperties(SingletonTrackedResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -84,7 +75,6 @@ public final class SingletonTrackedResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -94,7 +84,6 @@ public final class SingletonTrackedResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -105,7 +94,6 @@ public final class SingletonTrackedResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -116,7 +104,6 @@ public final class SingletonTrackedResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -125,7 +112,6 @@ public final class SingletonTrackedResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public SingletonTrackedResourceInner withLocation(String location) {
         super.withLocation(location);
@@ -135,7 +121,6 @@ public final class SingletonTrackedResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public SingletonTrackedResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/TopLevelTrackedResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/fluent/models/TopLevelTrackedResourceInner.java
@@ -6,7 +6,6 @@ package azure.resourcemanager.resources.fluent.models;
 
 import azure.resourcemanager.resources.models.TopLevelTrackedResourceProperties;
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -23,37 +22,31 @@ public final class TopLevelTrackedResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private TopLevelTrackedResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of TopLevelTrackedResourceInner class.
      */
-    @Generated
     public TopLevelTrackedResourceInner() {
     }
 
@@ -62,7 +55,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
      * 
      * @return the properties value.
      */
-    @Generated
     public TopLevelTrackedResourceProperties properties() {
         return this.properties;
     }
@@ -73,7 +65,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
      * @param properties the properties value to set.
      * @return the TopLevelTrackedResourceInner object itself.
      */
-    @Generated
     public TopLevelTrackedResourceInner withProperties(TopLevelTrackedResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -84,7 +75,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -94,7 +84,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -105,7 +94,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -116,7 +104,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -125,7 +112,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public TopLevelTrackedResourceInner withLocation(String location) {
         super.withLocation(location);
@@ -135,7 +121,6 @@ public final class TopLevelTrackedResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public TopLevelTrackedResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/ExtensionsResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/ExtensionsResourceListResult.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.implementation.models;
 
 import azure.resourcemanager.resources.fluent.models.ExtensionsResourceInner;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class ExtensionsResourceListResult implements JsonSerializable<Exte
     /*
      * The ExtensionsResource items on this page
      */
-    @Generated
     private List<ExtensionsResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of ExtensionsResourceListResult class.
      */
-    @Generated
     private ExtensionsResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class ExtensionsResourceListResult implements JsonSerializable<Exte
      * 
      * @return the value value.
      */
-    @Generated
     public List<ExtensionsResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class ExtensionsResourceListResult implements JsonSerializable<Exte
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/LocationResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/LocationResourceListResult.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.implementation.models;
 
 import azure.resourcemanager.resources.fluent.models.LocationResourceInner;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class LocationResourceListResult implements JsonSerializable<Locati
     /*
      * The LocationResource items on this page
      */
-    @Generated
     private List<LocationResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of LocationResourceListResult class.
      */
-    @Generated
     private LocationResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class LocationResourceListResult implements JsonSerializable<Locati
      * 
      * @return the value value.
      */
-    @Generated
     public List<LocationResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class LocationResourceListResult implements JsonSerializable<Locati
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/NestedProxyResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/NestedProxyResourceListResult.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.implementation.models;
 
 import azure.resourcemanager.resources.fluent.models.NestedProxyResourceInner;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class NestedProxyResourceListResult implements JsonSerializable<Nes
     /*
      * The NestedProxyResource items on this page
      */
-    @Generated
     private List<NestedProxyResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of NestedProxyResourceListResult class.
      */
-    @Generated
     private NestedProxyResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class NestedProxyResourceListResult implements JsonSerializable<Nes
      * 
      * @return the value value.
      */
-    @Generated
     public List<NestedProxyResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class NestedProxyResourceListResult implements JsonSerializable<Nes
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/SingletonTrackedResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/SingletonTrackedResourceListResult.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.implementation.models;
 
 import azure.resourcemanager.resources.fluent.models.SingletonTrackedResourceInner;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class SingletonTrackedResourceListResult implements JsonSerializabl
     /*
      * The SingletonTrackedResource items on this page
      */
-    @Generated
     private List<SingletonTrackedResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of SingletonTrackedResourceListResult class.
      */
-    @Generated
     private SingletonTrackedResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class SingletonTrackedResourceListResult implements JsonSerializabl
      * 
      * @return the value value.
      */
-    @Generated
     public List<SingletonTrackedResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class SingletonTrackedResourceListResult implements JsonSerializabl
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/TopLevelTrackedResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/models/TopLevelTrackedResourceListResult.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.implementation.models;
 
 import azure.resourcemanager.resources.fluent.models.TopLevelTrackedResourceInner;
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class TopLevelTrackedResourceListResult implements JsonSerializable
     /*
      * The TopLevelTrackedResource items on this page
      */
-    @Generated
     private List<TopLevelTrackedResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of TopLevelTrackedResourceListResult class.
      */
-    @Generated
     private TopLevelTrackedResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class TopLevelTrackedResourceListResult implements JsonSerializable
      * 
      * @return the value value.
      */
-    @Generated
     public List<TopLevelTrackedResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class TopLevelTrackedResourceListResult implements JsonSerializable
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/ExtensionsResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/ExtensionsResourceProperties.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public final class ExtensionsResourceProperties implements JsonSerializable<Exte
     /*
      * The description of the resource.
      */
-    @Generated
     private String description;
 
     /*
      * The status of the last operation.
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /**
      * Creates an instance of ExtensionsResourceProperties class.
      */
-    @Generated
     public ExtensionsResourceProperties() {
     }
 
@@ -41,7 +37,6 @@ public final class ExtensionsResourceProperties implements JsonSerializable<Exte
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }
@@ -52,7 +47,6 @@ public final class ExtensionsResourceProperties implements JsonSerializable<Exte
      * @param description the description value to set.
      * @return the ExtensionsResourceProperties object itself.
      */
-    @Generated
     public ExtensionsResourceProperties withDescription(String description) {
         this.description = description;
         return this;
@@ -63,7 +57,6 @@ public final class ExtensionsResourceProperties implements JsonSerializable<Exte
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/LocationResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/LocationResourceProperties.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public final class LocationResourceProperties implements JsonSerializable<Locati
     /*
      * The description of the resource.
      */
-    @Generated
     private String description;
 
     /*
      * The status of the last operation.
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /**
      * Creates an instance of LocationResourceProperties class.
      */
-    @Generated
     public LocationResourceProperties() {
     }
 
@@ -41,7 +37,6 @@ public final class LocationResourceProperties implements JsonSerializable<Locati
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }
@@ -52,7 +47,6 @@ public final class LocationResourceProperties implements JsonSerializable<Locati
      * @param description the description value to set.
      * @return the LocationResourceProperties object itself.
      */
-    @Generated
     public LocationResourceProperties withDescription(String description) {
         this.description = description;
         return this;
@@ -63,7 +57,6 @@ public final class LocationResourceProperties implements JsonSerializable<Locati
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/NestedProxyResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/NestedProxyResourceProperties.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public final class NestedProxyResourceProperties implements JsonSerializable<Nes
     /*
      * Provisioning State of the nested child Resource
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /*
      * Nested resource description.
      */
-    @Generated
     private String description;
 
     /**
      * Creates an instance of NestedProxyResourceProperties class.
      */
-    @Generated
     public NestedProxyResourceProperties() {
     }
 
@@ -41,7 +37,6 @@ public final class NestedProxyResourceProperties implements JsonSerializable<Nes
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }
@@ -51,7 +46,6 @@ public final class NestedProxyResourceProperties implements JsonSerializable<Nes
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }
@@ -62,7 +56,6 @@ public final class NestedProxyResourceProperties implements JsonSerializable<Nes
      * @param description the description value to set.
      * @return the NestedProxyResourceProperties object itself.
      */
-    @Generated
     public NestedProxyResourceProperties withDescription(String description) {
         this.description = description;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/NotificationDetails.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/NotificationDetails.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,19 +20,16 @@ public final class NotificationDetails implements JsonSerializable<NotificationD
     /*
      * The notification message.
      */
-    @Generated
     private String message;
 
     /*
      * If true, the notification is urgent.
      */
-    @Generated
     private boolean urgent;
 
     /**
      * Creates an instance of NotificationDetails class.
      */
-    @Generated
     public NotificationDetails() {
     }
 
@@ -42,7 +38,6 @@ public final class NotificationDetails implements JsonSerializable<NotificationD
      * 
      * @return the message value.
      */
-    @Generated
     public String message() {
         return this.message;
     }
@@ -53,7 +48,6 @@ public final class NotificationDetails implements JsonSerializable<NotificationD
      * @param message the message value to set.
      * @return the NotificationDetails object itself.
      */
-    @Generated
     public NotificationDetails withMessage(String message) {
         this.message = message;
         return this;
@@ -64,7 +58,6 @@ public final class NotificationDetails implements JsonSerializable<NotificationD
      * 
      * @return the urgent value.
      */
-    @Generated
     public boolean urgent() {
         return this.urgent;
     }
@@ -75,7 +68,6 @@ public final class NotificationDetails implements JsonSerializable<NotificationD
      * @param urgent the urgent value to set.
      * @return the NotificationDetails object itself.
      */
-    @Generated
     public NotificationDetails withUrgent(boolean urgent) {
         this.urgent = urgent;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/SingletonTrackedResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/SingletonTrackedResourceProperties.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public final class SingletonTrackedResourceProperties implements JsonSerializabl
     /*
      * The status of the last operation.
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /*
      * The description of the resource.
      */
-    @Generated
     private String description;
 
     /**
      * Creates an instance of SingletonTrackedResourceProperties class.
      */
-    @Generated
     public SingletonTrackedResourceProperties() {
     }
 
@@ -41,7 +37,6 @@ public final class SingletonTrackedResourceProperties implements JsonSerializabl
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }
@@ -51,7 +46,6 @@ public final class SingletonTrackedResourceProperties implements JsonSerializabl
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }
@@ -62,7 +56,6 @@ public final class SingletonTrackedResourceProperties implements JsonSerializabl
      * @param description the description value to set.
      * @return the SingletonTrackedResourceProperties object itself.
      */
-    @Generated
     public SingletonTrackedResourceProperties withDescription(String description) {
         this.description = description;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/TopLevelTrackedResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/models/TopLevelTrackedResourceProperties.java
@@ -5,7 +5,6 @@
 package azure.resourcemanager.resources.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public final class TopLevelTrackedResourceProperties implements JsonSerializable
     /*
      * The status of the last operation.
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /*
      * The description of the resource.
      */
-    @Generated
     private String description;
 
     /**
      * Creates an instance of TopLevelTrackedResourceProperties class.
      */
-    @Generated
     public TopLevelTrackedResourceProperties() {
     }
 
@@ -41,7 +37,6 @@ public final class TopLevelTrackedResourceProperties implements JsonSerializable
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }
@@ -51,7 +46,6 @@ public final class TopLevelTrackedResourceProperties implements JsonSerializable
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }
@@ -62,7 +56,6 @@ public final class TopLevelTrackedResourceProperties implements JsonSerializable
      * @param description the description value to set.
      * @return the TopLevelTrackedResourceProperties object itself.
      */
-    @Generated
     public TopLevelTrackedResourceProperties withDescription(String description) {
         this.description = description;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ChildExtensionResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ChildExtensionResourceInner.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.ProxyResource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -22,37 +21,31 @@ public final class ChildExtensionResourceInner extends ProxyResource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private ChildExtensionResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of ChildExtensionResourceInner class.
      */
-    @Generated
     public ChildExtensionResourceInner() {
     }
 
@@ -61,7 +54,6 @@ public final class ChildExtensionResourceInner extends ProxyResource {
      * 
      * @return the properties value.
      */
-    @Generated
     public ChildExtensionResourceProperties properties() {
         return this.properties;
     }
@@ -72,7 +64,6 @@ public final class ChildExtensionResourceInner extends ProxyResource {
      * @param properties the properties value to set.
      * @return the ChildExtensionResourceInner object itself.
      */
-    @Generated
     public ChildExtensionResourceInner withProperties(ChildExtensionResourceProperties properties) {
         this.properties = properties;
         return this;
@@ -83,7 +74,6 @@ public final class ChildExtensionResourceInner extends ProxyResource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -93,7 +83,6 @@ public final class ChildExtensionResourceInner extends ProxyResource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -104,7 +93,6 @@ public final class ChildExtensionResourceInner extends ProxyResource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -115,7 +103,6 @@ public final class ChildExtensionResourceInner extends ProxyResource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ChildResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ChildResourceInner.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -23,37 +22,31 @@ public final class ChildResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private ChildResourceProperties innerProperties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of ChildResourceInner class.
      */
-    @Generated
     public ChildResourceInner() {
     }
 
@@ -62,7 +55,6 @@ public final class ChildResourceInner extends Resource {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private ChildResourceProperties innerProperties() {
         return this.innerProperties;
     }
@@ -72,7 +64,6 @@ public final class ChildResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -82,7 +73,6 @@ public final class ChildResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -93,7 +83,6 @@ public final class ChildResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -104,7 +93,6 @@ public final class ChildResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -113,7 +101,6 @@ public final class ChildResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public ChildResourceInner withLocation(String location) {
         super.withLocation(location);
@@ -123,7 +110,6 @@ public final class ChildResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public ChildResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);
@@ -135,7 +121,6 @@ public final class ChildResourceInner extends Resource {
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.innerProperties() == null ? null : this.innerProperties().provisioningState();
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ChildResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ChildResourceProperties.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,13 +20,11 @@ public final class ChildResourceProperties implements JsonSerializable<ChildReso
     /*
      * Provisioning State of Top Level Arm Resource
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /**
      * Creates an instance of ChildResourceProperties class.
      */
-    @Generated
     public ChildResourceProperties() {
     }
 
@@ -36,7 +33,6 @@ public final class ChildResourceProperties implements JsonSerializable<ChildReso
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/CustomTemplateResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/CustomTemplateResourceInner.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -28,43 +27,36 @@ public final class CustomTemplateResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private CustomTemplateResourceProperties innerProperties;
 
     /*
      * Managed identity.
      */
-    @Generated
     private ManagedServiceIdentity identity;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of CustomTemplateResourceInner class.
      */
-    @Generated
     public CustomTemplateResourceInner() {
     }
 
@@ -73,7 +65,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private CustomTemplateResourceProperties innerProperties() {
         return this.innerProperties;
     }
@@ -83,7 +74,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the identity value.
      */
-    @Generated
     public ManagedServiceIdentity identity() {
         return this.identity;
     }
@@ -94,7 +84,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * @param identity the identity value to set.
      * @return the CustomTemplateResourceInner object itself.
      */
-    @Generated
     public CustomTemplateResourceInner withIdentity(ManagedServiceIdentity identity) {
         this.identity = identity;
         return this;
@@ -105,7 +94,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -115,7 +103,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -126,7 +113,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -137,7 +123,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -146,7 +131,6 @@ public final class CustomTemplateResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public CustomTemplateResourceInner withLocation(String location) {
         super.withLocation(location);
@@ -156,7 +140,6 @@ public final class CustomTemplateResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public CustomTemplateResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);
@@ -168,7 +151,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.innerProperties() == null ? null : this.innerProperties().provisioningState();
     }
@@ -178,7 +160,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the dog value.
      */
-    @Generated
     public Dog dog() {
         return this.innerProperties() == null ? null : this.innerProperties().dog();
     }
@@ -189,7 +170,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * @param dog the dog value to set.
      * @return the CustomTemplateResourceInner object itself.
      */
-    @Generated
     public CustomTemplateResourceInner withDog(Dog dog) {
         if (this.innerProperties() == null) {
             this.innerProperties = new CustomTemplateResourceProperties();
@@ -203,7 +183,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the namedEmptyModel value.
      */
-    @Generated
     public EmptyModel namedEmptyModel() {
         return this.innerProperties() == null ? null : this.innerProperties().namedEmptyModel();
     }
@@ -214,7 +193,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * @param namedEmptyModel the namedEmptyModel value to set.
      * @return the CustomTemplateResourceInner object itself.
      */
-    @Generated
     public CustomTemplateResourceInner withNamedEmptyModel(EmptyModel namedEmptyModel) {
         if (this.innerProperties() == null) {
             this.innerProperties = new CustomTemplateResourceProperties();
@@ -228,7 +206,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the anonymousEmptyModel value.
      */
-    @Generated
     public CustomTemplateResourcePropertiesAnonymousEmptyModel anonymousEmptyModel() {
         return this.innerProperties() == null ? null : this.innerProperties().anonymousEmptyModel();
     }
@@ -239,7 +216,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * @param anonymousEmptyModel the anonymousEmptyModel value to set.
      * @return the CustomTemplateResourceInner object itself.
      */
-    @Generated
     public CustomTemplateResourceInner
         withAnonymousEmptyModel(CustomTemplateResourcePropertiesAnonymousEmptyModel anonymousEmptyModel) {
         if (this.innerProperties() == null) {
@@ -254,7 +230,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * 
      * @return the priority value.
      */
-    @Generated
     public PriorityModel priority() {
         return this.innerProperties() == null ? null : this.innerProperties().priority();
     }
@@ -265,7 +240,6 @@ public final class CustomTemplateResourceInner extends Resource {
      * @param priority the priority value to set.
      * @return the CustomTemplateResourceInner object itself.
      */
-    @Generated
     public CustomTemplateResourceInner withPriority(PriorityModel priority) {
         if (this.innerProperties() == null) {
             this.innerProperties = new CustomTemplateResourceProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/CustomTemplateResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/CustomTemplateResourceProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -26,37 +25,31 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
     /*
      * The status of the last operation.
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /*
      * The dog property.
      */
-    @Generated
     private Dog dog;
 
     /*
      * The namedEmptyModel property.
      */
-    @Generated
     private EmptyModel namedEmptyModel;
 
     /*
      * The anonymousEmptyModel property.
      */
-    @Generated
     private CustomTemplateResourcePropertiesAnonymousEmptyModel anonymousEmptyModel;
 
     /*
      * The priority property.
      */
-    @Generated
     private PriorityModel priority;
 
     /**
      * Creates an instance of CustomTemplateResourceProperties class.
      */
-    @Generated
     public CustomTemplateResourceProperties() {
     }
 
@@ -65,7 +58,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }
@@ -75,7 +67,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * 
      * @return the dog value.
      */
-    @Generated
     public Dog dog() {
         return this.dog;
     }
@@ -86,7 +77,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * @param dog the dog value to set.
      * @return the CustomTemplateResourceProperties object itself.
      */
-    @Generated
     public CustomTemplateResourceProperties withDog(Dog dog) {
         this.dog = dog;
         return this;
@@ -97,7 +87,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * 
      * @return the namedEmptyModel value.
      */
-    @Generated
     public EmptyModel namedEmptyModel() {
         return this.namedEmptyModel;
     }
@@ -108,7 +97,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * @param namedEmptyModel the namedEmptyModel value to set.
      * @return the CustomTemplateResourceProperties object itself.
      */
-    @Generated
     public CustomTemplateResourceProperties withNamedEmptyModel(EmptyModel namedEmptyModel) {
         this.namedEmptyModel = namedEmptyModel;
         return this;
@@ -119,7 +107,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * 
      * @return the anonymousEmptyModel value.
      */
-    @Generated
     public CustomTemplateResourcePropertiesAnonymousEmptyModel anonymousEmptyModel() {
         return this.anonymousEmptyModel;
     }
@@ -130,7 +117,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * @param anonymousEmptyModel the anonymousEmptyModel value to set.
      * @return the CustomTemplateResourceProperties object itself.
      */
-    @Generated
     public CustomTemplateResourceProperties
         withAnonymousEmptyModel(CustomTemplateResourcePropertiesAnonymousEmptyModel anonymousEmptyModel) {
         this.anonymousEmptyModel = anonymousEmptyModel;
@@ -142,7 +128,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * 
      * @return the priority value.
      */
-    @Generated
     public PriorityModel priority() {
         return this.priority;
     }
@@ -153,7 +138,6 @@ public final class CustomTemplateResourceProperties implements JsonSerializable<
      * @param priority the priority value to set.
      * @return the CustomTemplateResourceProperties object itself.
      */
-    @Generated
     public CustomTemplateResourceProperties withPriority(PriorityModel priority) {
         this.priority = priority;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ManagedMaintenanceWindowStatusContentProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ManagedMaintenanceWindowStatusContentProperties.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,13 +20,11 @@ public final class ManagedMaintenanceWindowStatusContentProperties
     /*
      * The status of the last operation.
      */
-    @Generated
     private String provisioningState;
 
     /**
      * Creates an instance of ManagedMaintenanceWindowStatusContentProperties class.
      */
-    @Generated
     private ManagedMaintenanceWindowStatusContentProperties() {
     }
 
@@ -36,7 +33,6 @@ public final class ManagedMaintenanceWindowStatusContentProperties
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public String provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ManagedMaintenanceWindowStatusInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ManagedMaintenanceWindowStatusInner.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
@@ -22,37 +21,31 @@ public final class ManagedMaintenanceWindowStatusInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private ManagedMaintenanceWindowStatusContentProperties innerProperties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of ManagedMaintenanceWindowStatusInner class.
      */
-    @Generated
     private ManagedMaintenanceWindowStatusInner() {
     }
 
@@ -61,7 +54,6 @@ public final class ManagedMaintenanceWindowStatusInner extends Resource {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private ManagedMaintenanceWindowStatusContentProperties innerProperties() {
         return this.innerProperties;
     }
@@ -71,7 +63,6 @@ public final class ManagedMaintenanceWindowStatusInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -81,7 +72,6 @@ public final class ManagedMaintenanceWindowStatusInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -92,7 +82,6 @@ public final class ManagedMaintenanceWindowStatusInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -103,7 +92,6 @@ public final class ManagedMaintenanceWindowStatusInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -114,7 +102,6 @@ public final class ManagedMaintenanceWindowStatusInner extends Resource {
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public String provisioningState() {
         return this.innerProperties() == null ? null : this.innerProperties().provisioningState();
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ModelInterfaceDifferentNameProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ModelInterfaceDifferentNameProperties.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,13 +20,11 @@ public final class ModelInterfaceDifferentNameProperties
     /*
      * The status of the last operation.
      */
-    @Generated
     private String provisioningState;
 
     /**
      * Creates an instance of ModelInterfaceDifferentNameProperties class.
      */
-    @Generated
     private ModelInterfaceDifferentNameProperties() {
     }
 
@@ -36,7 +33,6 @@ public final class ModelInterfaceDifferentNameProperties
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public String provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ModelInterfaceSameNameInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ModelInterfaceSameNameInner.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
@@ -22,37 +21,31 @@ public final class ModelInterfaceSameNameInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private ModelInterfaceDifferentNameProperties innerProperties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of ModelInterfaceSameNameInner class.
      */
-    @Generated
     private ModelInterfaceSameNameInner() {
     }
 
@@ -61,7 +54,6 @@ public final class ModelInterfaceSameNameInner extends Resource {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private ModelInterfaceDifferentNameProperties innerProperties() {
         return this.innerProperties;
     }
@@ -71,7 +63,6 @@ public final class ModelInterfaceSameNameInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -81,7 +72,6 @@ public final class ModelInterfaceSameNameInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -92,7 +82,6 @@ public final class ModelInterfaceSameNameInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -103,7 +92,6 @@ public final class ModelInterfaceSameNameInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -114,7 +102,6 @@ public final class ModelInterfaceSameNameInner extends Resource {
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public String provisioningState() {
         return this.innerProperties() == null ? null : this.innerProperties().provisioningState();
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/OperationInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/OperationInner.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -26,39 +25,33 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * The name of the operation, as per Resource-Based Access Control (RBAC). Examples:
      * "Microsoft.Compute/virtualMachines/write", "Microsoft.Compute/virtualMachines/capture/action"
      */
-    @Generated
     private String name;
 
     /*
      * Whether the operation applies to data-plane. This is "true" for data-plane operations and "false" for Azure
      * Resource Manager/control-plane operations.
      */
-    @Generated
     private Boolean isDataAction;
 
     /*
      * Localized display information for this particular operation.
      */
-    @Generated
     private OperationDisplay display;
 
     /*
      * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default
      * value is "user,system"
      */
-    @Generated
     private Origin origin;
 
     /*
      * Extensible enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
      */
-    @Generated
     private ActionType actionType;
 
     /**
      * Creates an instance of OperationInner class.
      */
-    @Generated
     private OperationInner() {
     }
 
@@ -68,7 +61,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the name value.
      */
-    @Generated
     public String name() {
         return this.name;
     }
@@ -79,7 +71,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the isDataAction value.
      */
-    @Generated
     public Boolean isDataAction() {
         return this.isDataAction;
     }
@@ -89,7 +80,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the display value.
      */
-    @Generated
     public OperationDisplay display() {
         return this.display;
     }
@@ -100,7 +90,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the origin value.
      */
-    @Generated
     public Origin origin() {
         return this.origin;
     }
@@ -111,7 +100,6 @@ public final class OperationInner implements JsonSerializable<OperationInner> {
      * 
      * @return the actionType value.
      */
-    @Generated
     public ActionType actionType() {
         return this.actionType;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ResultInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/ResultInner.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,13 +19,11 @@ public final class ResultInner implements JsonSerializable<ResultInner> {
     /*
      * The reason property.
      */
-    @Generated
     private String reason;
 
     /**
      * Creates an instance of ResultInner class.
      */
-    @Generated
     private ResultInner() {
     }
 
@@ -35,7 +32,6 @@ public final class ResultInner implements JsonSerializable<ResultInner> {
      * 
      * @return the reason value.
      */
-    @Generated
     public String reason() {
         return this.reason;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/TopLevelArmResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/TopLevelArmResourceInner.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
 import com.azure.json.JsonReader;
@@ -25,37 +24,31 @@ public final class TopLevelArmResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private TopLevelArmResourceProperties innerProperties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of TopLevelArmResourceInner class.
      */
-    @Generated
     public TopLevelArmResourceInner() {
     }
 
@@ -64,7 +57,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private TopLevelArmResourceProperties innerProperties() {
         return this.innerProperties;
     }
@@ -74,7 +66,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -84,7 +75,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -95,7 +85,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -106,7 +95,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -115,7 +103,6 @@ public final class TopLevelArmResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public TopLevelArmResourceInner withLocation(String location) {
         super.withLocation(location);
@@ -125,7 +112,6 @@ public final class TopLevelArmResourceInner extends Resource {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public TopLevelArmResourceInner withTags(Map<String, String> tags) {
         super.withTags(tags);
@@ -137,7 +123,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the configurationEndpoints value.
      */
-    @Generated
     public List<String> configurationEndpoints() {
         return this.innerProperties() == null ? null : this.innerProperties().configurationEndpoints();
     }
@@ -147,7 +132,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the userName value.
      */
-    @Generated
     public String userName() {
         return this.innerProperties() == null ? null : this.innerProperties().userName();
     }
@@ -158,7 +142,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * @param userName the userName value to set.
      * @return the TopLevelArmResourceInner object itself.
      */
-    @Generated
     public TopLevelArmResourceInner withUserName(String userName) {
         if (this.innerProperties() == null) {
             this.innerProperties = new TopLevelArmResourceProperties();
@@ -172,7 +155,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the userNames value.
      */
-    @Generated
     public String userNames() {
         return this.innerProperties() == null ? null : this.innerProperties().userNames();
     }
@@ -183,7 +165,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * @param userNames the userNames value to set.
      * @return the TopLevelArmResourceInner object itself.
      */
-    @Generated
     public TopLevelArmResourceInner withUserNames(String userNames) {
         if (this.innerProperties() == null) {
             this.innerProperties = new TopLevelArmResourceProperties();
@@ -197,7 +178,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the accuserName value.
      */
-    @Generated
     public String accuserName() {
         return this.innerProperties() == null ? null : this.innerProperties().accuserName();
     }
@@ -208,7 +188,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * @param accuserName the accuserName value to set.
      * @return the TopLevelArmResourceInner object itself.
      */
-    @Generated
     public TopLevelArmResourceInner withAccuserName(String accuserName) {
         if (this.innerProperties() == null) {
             this.innerProperties = new TopLevelArmResourceProperties();
@@ -222,7 +201,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the startTimeStamp value.
      */
-    @Generated
     public OffsetDateTime startTimeStamp() {
         return this.innerProperties() == null ? null : this.innerProperties().startTimeStamp();
     }
@@ -233,7 +211,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * @param startTimeStamp the startTimeStamp value to set.
      * @return the TopLevelArmResourceInner object itself.
      */
-    @Generated
     public TopLevelArmResourceInner withStartTimeStamp(OffsetDateTime startTimeStamp) {
         if (this.innerProperties() == null) {
             this.innerProperties = new TopLevelArmResourceProperties();
@@ -247,7 +224,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.innerProperties() == null ? null : this.innerProperties().provisioningState();
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/TopLevelArmResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/TopLevelArmResourceProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.CoreUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -26,43 +25,36 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
     /*
      * Configuration Endpoints.
      */
-    @Generated
     private List<String> configurationEndpoints;
 
     /*
      * The userName property.
      */
-    @Generated
     private String userName;
 
     /*
      * The userNames property.
      */
-    @Generated
     private String userNames;
 
     /*
      * The accuserName property.
      */
-    @Generated
     private String accuserName;
 
     /*
      * The startTimeStamp property.
      */
-    @Generated
     private OffsetDateTime startTimeStamp;
 
     /*
      * The status of the last operation.
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /**
      * Creates an instance of TopLevelArmResourceProperties class.
      */
-    @Generated
     public TopLevelArmResourceProperties() {
     }
 
@@ -71,7 +63,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * 
      * @return the configurationEndpoints value.
      */
-    @Generated
     public List<String> configurationEndpoints() {
         return this.configurationEndpoints;
     }
@@ -81,7 +72,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * 
      * @return the userName value.
      */
-    @Generated
     public String userName() {
         return this.userName;
     }
@@ -92,7 +82,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * @param userName the userName value to set.
      * @return the TopLevelArmResourceProperties object itself.
      */
-    @Generated
     public TopLevelArmResourceProperties withUserName(String userName) {
         this.userName = userName;
         return this;
@@ -103,7 +92,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * 
      * @return the userNames value.
      */
-    @Generated
     public String userNames() {
         return this.userNames;
     }
@@ -114,7 +102,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * @param userNames the userNames value to set.
      * @return the TopLevelArmResourceProperties object itself.
      */
-    @Generated
     public TopLevelArmResourceProperties withUserNames(String userNames) {
         this.userNames = userNames;
         return this;
@@ -125,7 +112,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * 
      * @return the accuserName value.
      */
-    @Generated
     public String accuserName() {
         return this.accuserName;
     }
@@ -136,7 +122,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * @param accuserName the accuserName value to set.
      * @return the TopLevelArmResourceProperties object itself.
      */
-    @Generated
     public TopLevelArmResourceProperties withAccuserName(String accuserName) {
         this.accuserName = accuserName;
         return this;
@@ -147,7 +132,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * 
      * @return the startTimeStamp value.
      */
-    @Generated
     public OffsetDateTime startTimeStamp() {
         return this.startTimeStamp;
     }
@@ -158,7 +142,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * @param startTimeStamp the startTimeStamp value to set.
      * @return the TopLevelArmResourceProperties object itself.
      */
-    @Generated
     public TopLevelArmResourceProperties withStartTimeStamp(OffsetDateTime startTimeStamp) {
         this.startTimeStamp = startTimeStamp;
         return this;
@@ -169,7 +152,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/TopLevelArmResourceUpdateProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/fluent/models/TopLevelArmResourceUpdateProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -21,25 +20,21 @@ public final class TopLevelArmResourceUpdateProperties
     /*
      * The userName property.
      */
-    @Generated
     private String userName;
 
     /*
      * The userNames property.
      */
-    @Generated
     private String userNames;
 
     /*
      * The accuserName property.
      */
-    @Generated
     private String accuserName;
 
     /**
      * Creates an instance of TopLevelArmResourceUpdateProperties class.
      */
-    @Generated
     public TopLevelArmResourceUpdateProperties() {
     }
 
@@ -48,7 +43,6 @@ public final class TopLevelArmResourceUpdateProperties
      * 
      * @return the userName value.
      */
-    @Generated
     public String userName() {
         return this.userName;
     }
@@ -59,7 +53,6 @@ public final class TopLevelArmResourceUpdateProperties
      * @param userName the userName value to set.
      * @return the TopLevelArmResourceUpdateProperties object itself.
      */
-    @Generated
     public TopLevelArmResourceUpdateProperties withUserName(String userName) {
         this.userName = userName;
         return this;
@@ -70,7 +63,6 @@ public final class TopLevelArmResourceUpdateProperties
      * 
      * @return the userNames value.
      */
-    @Generated
     public String userNames() {
         return this.userNames;
     }
@@ -81,7 +73,6 @@ public final class TopLevelArmResourceUpdateProperties
      * @param userNames the userNames value to set.
      * @return the TopLevelArmResourceUpdateProperties object itself.
      */
-    @Generated
     public TopLevelArmResourceUpdateProperties withUserNames(String userNames) {
         this.userNames = userNames;
         return this;
@@ -92,7 +83,6 @@ public final class TopLevelArmResourceUpdateProperties
      * 
      * @return the accuserName value.
      */
-    @Generated
     public String accuserName() {
         return this.accuserName;
     }
@@ -103,7 +93,6 @@ public final class TopLevelArmResourceUpdateProperties
      * @param accuserName the accuserName value to set.
      * @return the TopLevelArmResourceUpdateProperties object itself.
      */
-    @Generated
     public TopLevelArmResourceUpdateProperties withAccuserName(String accuserName) {
         this.accuserName = accuserName;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/ChildExtensionResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/ChildExtensionResourceListResult.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.implementation.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class ChildExtensionResourceListResult implements JsonSerializable<
     /*
      * The ChildExtensionResource items on this page
      */
-    @Generated
     private List<ChildExtensionResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of ChildExtensionResourceListResult class.
      */
-    @Generated
     private ChildExtensionResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class ChildExtensionResourceListResult implements JsonSerializable<
      * 
      * @return the value value.
      */
-    @Generated
     public List<ChildExtensionResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class ChildExtensionResourceListResult implements JsonSerializable<
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/ChildResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/ChildResourceListResult.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.implementation.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class ChildResourceListResult implements JsonSerializable<ChildReso
     /*
      * The ChildResource items on this page
      */
-    @Generated
     private List<ChildResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of ChildResourceListResult class.
      */
-    @Generated
     private ChildResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class ChildResourceListResult implements JsonSerializable<ChildReso
      * 
      * @return the value value.
      */
-    @Generated
     public List<ChildResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class ChildResourceListResult implements JsonSerializable<ChildReso
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/OperationListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/OperationListResult.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.implementation.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -24,19 +23,16 @@ public final class OperationListResult implements JsonSerializable<OperationList
     /*
      * The Operation items on this page
      */
-    @Generated
     private List<OperationInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of OperationListResult class.
      */
-    @Generated
     private OperationListResult() {
     }
 
@@ -45,7 +41,6 @@ public final class OperationListResult implements JsonSerializable<OperationList
      * 
      * @return the value value.
      */
-    @Generated
     public List<OperationInner> value() {
         return this.value;
     }
@@ -55,7 +50,6 @@ public final class OperationListResult implements JsonSerializable<OperationList
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/TopLevelArmResourceListResult.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/models/TopLevelArmResourceListResult.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.implementation.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,19 +22,16 @@ public final class TopLevelArmResourceListResult implements JsonSerializable<Top
     /*
      * The TopLevelArmResource items on this page
      */
-    @Generated
     private List<TopLevelArmResourceInner> value;
 
     /*
      * The link to the next page of items
      */
-    @Generated
     private String nextLink;
 
     /**
      * Creates an instance of TopLevelArmResourceListResult class.
      */
-    @Generated
     private TopLevelArmResourceListResult() {
     }
 
@@ -44,7 +40,6 @@ public final class TopLevelArmResourceListResult implements JsonSerializable<Top
      * 
      * @return the value value.
      */
-    @Generated
     public List<TopLevelArmResourceInner> value() {
         return this.value;
     }
@@ -54,7 +49,6 @@ public final class TopLevelArmResourceListResult implements JsonSerializable<Top
      * 
      * @return the nextLink value.
      */
-    @Generated
     public String nextLink() {
         return this.nextLink;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ChildExtensionResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ChildExtensionResourceProperties.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,13 +19,11 @@ public final class ChildExtensionResourceProperties implements JsonSerializable<
     /*
      * Provisioning State of the Resource
      */
-    @Generated
     private ProvisioningState provisioningState;
 
     /**
      * Creates an instance of ChildExtensionResourceProperties class.
      */
-    @Generated
     public ChildExtensionResourceProperties() {
     }
 
@@ -35,7 +32,6 @@ public final class ChildExtensionResourceProperties implements JsonSerializable<
      * 
      * @return the provisioningState value.
      */
-    @Generated
     public ProvisioningState provisioningState() {
         return this.provisioningState;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ChildExtensionResourceUpdate.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ChildExtensionResourceUpdate.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,7 +19,6 @@ public final class ChildExtensionResourceUpdate implements JsonSerializable<Chil
     /**
      * Creates an instance of ChildExtensionResourceUpdate class.
      */
-    @Generated
     public ChildExtensionResourceUpdate() {
     }
 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ChildResourceUpdate.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ChildResourceUpdate.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -21,13 +20,11 @@ public final class ChildResourceUpdate implements JsonSerializable<ChildResource
     /*
      * Resource tags.
      */
-    @Generated
     private Map<String, String> tags;
 
     /**
      * Creates an instance of ChildResourceUpdate class.
      */
-    @Generated
     public ChildResourceUpdate() {
     }
 
@@ -36,7 +33,6 @@ public final class ChildResourceUpdate implements JsonSerializable<ChildResource
      * 
      * @return the tags value.
      */
-    @Generated
     public Map<String, String> tags() {
         return this.tags;
     }
@@ -47,7 +43,6 @@ public final class ChildResourceUpdate implements JsonSerializable<ChildResource
      * @param tags the tags value to set.
      * @return the ChildResourceUpdate object itself.
      */
-    @Generated
     public ChildResourceUpdate withTags(Map<String, String> tags) {
         this.tags = tags;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/CustomTemplateResourcePatch.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/CustomTemplateResourcePatch.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,13 +19,11 @@ public final class CustomTemplateResourcePatch implements JsonSerializable<Custo
     /*
      * Managed identity.
      */
-    @Generated
     private ManagedServiceIdentity identity;
 
     /**
      * Creates an instance of CustomTemplateResourcePatch class.
      */
-    @Generated
     public CustomTemplateResourcePatch() {
     }
 
@@ -35,7 +32,6 @@ public final class CustomTemplateResourcePatch implements JsonSerializable<Custo
      * 
      * @return the identity value.
      */
-    @Generated
     public ManagedServiceIdentity identity() {
         return this.identity;
     }
@@ -46,7 +42,6 @@ public final class CustomTemplateResourcePatch implements JsonSerializable<Custo
      * @param identity the identity value to set.
      * @return the CustomTemplateResourcePatch object itself.
      */
-    @Generated
     public CustomTemplateResourcePatch withIdentity(ManagedServiceIdentity identity) {
         this.identity = identity;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/CustomTemplateResourcePropertiesAnonymousEmptyModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/CustomTemplateResourcePropertiesAnonymousEmptyModel.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,7 +20,6 @@ public final class CustomTemplateResourcePropertiesAnonymousEmptyModel
     /**
      * Creates an instance of CustomTemplateResourcePropertiesAnonymousEmptyModel class.
      */
-    @Generated
     public CustomTemplateResourcePropertiesAnonymousEmptyModel() {
     }
 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/Dog.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/Dog.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public class Dog implements JsonSerializable<Dog> {
     /*
      * discriminator property
      */
-    @Generated
     private DogKind kind = DogKind.fromString("Dog");
 
     /*
      * Weight of the dog
      */
-    @Generated
     private int weight;
 
     /**
      * Creates an instance of Dog class.
      */
-    @Generated
     public Dog() {
     }
 
@@ -41,7 +37,6 @@ public class Dog implements JsonSerializable<Dog> {
      * 
      * @return the kind value.
      */
-    @Generated
     public DogKind kind() {
         return this.kind;
     }
@@ -51,7 +46,6 @@ public class Dog implements JsonSerializable<Dog> {
      * 
      * @return the weight value.
      */
-    @Generated
     public int weight() {
         return this.weight;
     }
@@ -62,7 +56,6 @@ public class Dog implements JsonSerializable<Dog> {
      * @param weight the weight value to set.
      * @return the Dog object itself.
      */
-    @Generated
     public Dog withWeight(int weight) {
         this.weight = weight;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/EmptyModel.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/EmptyModel.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,7 +19,6 @@ public final class EmptyModel implements JsonSerializable<EmptyModel> {
     /**
      * Creates an instance of EmptyModel class.
      */
-    @Generated
     public EmptyModel() {
     }
 

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/Golden.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/Golden.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
@@ -19,13 +18,11 @@ public final class Golden extends Dog {
     /*
      * discriminator property
      */
-    @Generated
     private DogKind kind = DogKind.GOLDEN;
 
     /**
      * Creates an instance of Golden class.
      */
-    @Generated
     public Golden() {
     }
 
@@ -34,7 +31,6 @@ public final class Golden extends Dog {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public DogKind kind() {
         return this.kind;
@@ -43,7 +39,6 @@ public final class Golden extends Dog {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public Golden withWeight(int weight) {
         super.withWeight(weight);

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ManagedServiceIdentity.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/ManagedServiceIdentity.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -23,32 +22,27 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * The service principal ID of the system assigned identity. This property will only be provided for a system
      * assigned identity.
      */
-    @Generated
     private String principalId;
 
     /*
      * The tenant ID of the system assigned identity. This property will only be provided for a system assigned
      * identity.
      */
-    @Generated
     private String tenantId;
 
     /*
      * The type of managed identity assigned to this resource.
      */
-    @Generated
     private ManagedServiceIdentityType type;
 
     /*
      * The identities assigned to this resource by the user.
      */
-    @Generated
     private Map<String, UserAssignedIdentity> userAssignedIdentities;
 
     /**
      * Creates an instance of ManagedServiceIdentity class.
      */
-    @Generated
     public ManagedServiceIdentity() {
     }
 
@@ -58,7 +52,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the principalId value.
      */
-    @Generated
     public String principalId() {
         return this.principalId;
     }
@@ -69,7 +62,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the tenantId value.
      */
-    @Generated
     public String tenantId() {
         return this.tenantId;
     }
@@ -79,7 +71,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the type value.
      */
-    @Generated
     public ManagedServiceIdentityType type() {
         return this.type;
     }
@@ -90,7 +81,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * @param type the type value to set.
      * @return the ManagedServiceIdentity object itself.
      */
-    @Generated
     public ManagedServiceIdentity withType(ManagedServiceIdentityType type) {
         this.type = type;
         return this;
@@ -101,7 +91,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * 
      * @return the userAssignedIdentities value.
      */
-    @Generated
     public Map<String, UserAssignedIdentity> userAssignedIdentities() {
         return this.userAssignedIdentities;
     }
@@ -112,7 +101,6 @@ public final class ManagedServiceIdentity implements JsonSerializable<ManagedSer
      * @param userAssignedIdentities the userAssignedIdentities value to set.
      * @return the ManagedServiceIdentity object itself.
      */
-    @Generated
     public ManagedServiceIdentity withUserAssignedIdentities(Map<String, UserAssignedIdentity> userAssignedIdentities) {
         this.userAssignedIdentities = userAssignedIdentities;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/OperationDisplay.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/OperationDisplay.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,33 +20,28 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or
      * "Microsoft Compute".
      */
-    @Generated
     private String provider;
 
     /*
      * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or
      * "Job Schedule Collections".
      */
-    @Generated
     private String resource;
 
     /*
      * The concise, localized friendly name for the operation; suitable for dropdowns. E.g.
      * "Create or Update Virtual Machine", "Restart Virtual Machine".
      */
-    @Generated
     private String operation;
 
     /*
      * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
      */
-    @Generated
     private String description;
 
     /**
      * Creates an instance of OperationDisplay class.
      */
-    @Generated
     private OperationDisplay() {
     }
 
@@ -57,7 +51,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the provider value.
      */
-    @Generated
     public String provider() {
         return this.provider;
     }
@@ -68,7 +61,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the resource value.
      */
-    @Generated
     public String resource() {
         return this.resource;
     }
@@ -79,7 +71,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the operation value.
      */
-    @Generated
     public String operation() {
         return this.operation;
     }
@@ -90,7 +81,6 @@ public final class OperationDisplay implements JsonSerializable<OperationDisplay
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/TopLevelArmResourceUpdate.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/TopLevelArmResourceUpdate.java
@@ -5,7 +5,6 @@
 package tsptest.armresourceprovider.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -22,19 +21,16 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
     /*
      * Resource tags.
      */
-    @Generated
     private Map<String, String> tags;
 
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private TopLevelArmResourceUpdateProperties innerProperties;
 
     /**
      * Creates an instance of TopLevelArmResourceUpdate class.
      */
-    @Generated
     public TopLevelArmResourceUpdate() {
     }
 
@@ -43,7 +39,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * 
      * @return the tags value.
      */
-    @Generated
     public Map<String, String> tags() {
         return this.tags;
     }
@@ -54,7 +49,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * @param tags the tags value to set.
      * @return the TopLevelArmResourceUpdate object itself.
      */
-    @Generated
     public TopLevelArmResourceUpdate withTags(Map<String, String> tags) {
         this.tags = tags;
         return this;
@@ -65,7 +59,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private TopLevelArmResourceUpdateProperties innerProperties() {
         return this.innerProperties;
     }
@@ -75,7 +68,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * 
      * @return the userName value.
      */
-    @Generated
     public String userName() {
         return this.innerProperties() == null ? null : this.innerProperties().userName();
     }
@@ -86,7 +78,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * @param userName the userName value to set.
      * @return the TopLevelArmResourceUpdate object itself.
      */
-    @Generated
     public TopLevelArmResourceUpdate withUserName(String userName) {
         if (this.innerProperties() == null) {
             this.innerProperties = new TopLevelArmResourceUpdateProperties();
@@ -100,7 +91,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * 
      * @return the userNames value.
      */
-    @Generated
     public String userNames() {
         return this.innerProperties() == null ? null : this.innerProperties().userNames();
     }
@@ -111,7 +101,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * @param userNames the userNames value to set.
      * @return the TopLevelArmResourceUpdate object itself.
      */
-    @Generated
     public TopLevelArmResourceUpdate withUserNames(String userNames) {
         if (this.innerProperties() == null) {
             this.innerProperties = new TopLevelArmResourceUpdateProperties();
@@ -125,7 +114,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * 
      * @return the accuserName value.
      */
-    @Generated
     public String accuserName() {
         return this.innerProperties() == null ? null : this.innerProperties().accuserName();
     }
@@ -136,7 +124,6 @@ public final class TopLevelArmResourceUpdate implements JsonSerializable<TopLeve
      * @param accuserName the accuserName value to set.
      * @return the TopLevelArmResourceUpdate object itself.
      */
-    @Generated
     public TopLevelArmResourceUpdate withAccuserName(String accuserName) {
         if (this.innerProperties() == null) {
             this.innerProperties = new TopLevelArmResourceUpdateProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/UserAssignedIdentity.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/models/UserAssignedIdentity.java
@@ -4,7 +4,6 @@
 
 package tsptest.armresourceprovider.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,19 +19,16 @@ public final class UserAssignedIdentity implements JsonSerializable<UserAssigned
     /*
      * The principal ID of the assigned identity.
      */
-    @Generated
     private String principalId;
 
     /*
      * The client ID of the assigned identity.
      */
-    @Generated
     private String clientId;
 
     /**
      * Creates an instance of UserAssignedIdentity class.
      */
-    @Generated
     public UserAssignedIdentity() {
     }
 
@@ -41,7 +37,6 @@ public final class UserAssignedIdentity implements JsonSerializable<UserAssigned
      * 
      * @return the principalId value.
      */
-    @Generated
     public String principalId() {
         return this.principalId;
     }
@@ -51,7 +46,6 @@ public final class UserAssignedIdentity implements JsonSerializable<UserAssigned
      * 
      * @return the clientId value.
      */
-    @Generated
     public String clientId() {
         return this.clientId;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/AnotherFishProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/AnotherFishProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,13 +20,11 @@ public final class AnotherFishProperties implements JsonSerializable<AnotherFish
     /*
      * The eyeProperties property.
      */
-    @Generated
     private EyeProperties innerEyeProperties = new EyeProperties();
 
     /**
      * Creates an instance of AnotherFishProperties class.
      */
-    @Generated
     public AnotherFishProperties() {
     }
 
@@ -36,7 +33,6 @@ public final class AnotherFishProperties implements JsonSerializable<AnotherFish
      * 
      * @return the innerEyeProperties value.
      */
-    @Generated
     private EyeProperties innerEyeProperties() {
         return this.innerEyeProperties;
     }
@@ -46,7 +42,6 @@ public final class AnotherFishProperties implements JsonSerializable<AnotherFish
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.innerEyeProperties() == null ? 0.0 : this.innerEyeProperties().length();
     }
@@ -57,7 +52,6 @@ public final class AnotherFishProperties implements JsonSerializable<AnotherFish
      * @param length the length value to set.
      * @return the AnotherFishProperties object itself.
      */
-    @Generated
     public AnotherFishProperties withLength(double length) {
         if (this.innerEyeProperties() == null) {
             this.innerEyeProperties = new EyeProperties();
@@ -71,7 +65,6 @@ public final class AnotherFishProperties implements JsonSerializable<AnotherFish
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.innerEyeProperties() == null ? null : this.innerEyeProperties().patten();
     }
@@ -81,7 +74,6 @@ public final class AnotherFishProperties implements JsonSerializable<AnotherFish
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.innerEyeProperties() == null ? null : this.innerEyeProperties().requiredString();
     }
@@ -92,7 +84,6 @@ public final class AnotherFishProperties implements JsonSerializable<AnotherFish
      * @param requiredString the requiredString value to set.
      * @return the AnotherFishProperties object itself.
      */
-    @Generated
     public AnotherFishProperties withRequiredString(String requiredString) {
         if (this.innerEyeProperties() == null) {
             this.innerEyeProperties = new EyeProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/EyeProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/EyeProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,25 +20,21 @@ public final class EyeProperties implements JsonSerializable<EyeProperties> {
     /*
      * The length property.
      */
-    @Generated
     private double length;
 
     /*
      * The patten property.
      */
-    @Generated
     private String patten;
 
     /*
      * The requiredString property.
      */
-    @Generated
     private String requiredString;
 
     /**
      * Creates an instance of EyeProperties class.
      */
-    @Generated
     public EyeProperties() {
     }
 
@@ -48,7 +43,6 @@ public final class EyeProperties implements JsonSerializable<EyeProperties> {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.length;
     }
@@ -59,7 +53,6 @@ public final class EyeProperties implements JsonSerializable<EyeProperties> {
      * @param length the length value to set.
      * @return the EyeProperties object itself.
      */
-    @Generated
     public EyeProperties withLength(double length) {
         this.length = length;
         return this;
@@ -70,7 +63,6 @@ public final class EyeProperties implements JsonSerializable<EyeProperties> {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.patten;
     }
@@ -80,7 +72,6 @@ public final class EyeProperties implements JsonSerializable<EyeProperties> {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.requiredString;
     }
@@ -91,7 +82,6 @@ public final class EyeProperties implements JsonSerializable<EyeProperties> {
      * @param requiredString the requiredString value to set.
      * @return the EyeProperties object itself.
      */
-    @Generated
     public EyeProperties withRequiredString(String requiredString) {
         this.requiredString = requiredString;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FishInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FishInner.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -22,37 +21,31 @@ public class FishInner implements JsonSerializable<FishInner> {
     /*
      * Discriminator property for Fish.
      */
-    @Generated
     private String kind = "Fish";
 
     /*
      * The age property.
      */
-    @Generated
     private int age;
 
     /*
      * The dna property.
      */
-    @Generated
     private String dna;
 
     /*
      * The properties property.
      */
-    @Generated
     private FishProperties innerProperties = new FishProperties();
 
     /*
      * The anotherProperties property.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /**
      * Creates an instance of FishInner class.
      */
-    @Generated
     public FishInner() {
     }
 
@@ -61,7 +54,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the kind value.
      */
-    @Generated
     public String kind() {
         return this.kind;
     }
@@ -71,7 +63,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the age value.
      */
-    @Generated
     public int age() {
         return this.age;
     }
@@ -82,7 +73,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param age the age value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     public FishInner withAge(int age) {
         this.age = age;
         return this;
@@ -93,7 +83,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the dna value.
      */
-    @Generated
     public String dna() {
         return this.dna;
     }
@@ -104,7 +93,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param dna the dna value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     FishInner withDna(String dna) {
         this.dna = dna;
         return this;
@@ -115,7 +103,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private FishProperties innerProperties() {
         return this.innerProperties;
     }
@@ -126,7 +113,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param innerProperties the innerProperties value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     FishInner withInnerProperties(FishProperties innerProperties) {
         this.innerProperties = innerProperties;
         return this;
@@ -137,7 +123,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the innerAnotherProperties value.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties() {
         return this.innerAnotherProperties;
     }
@@ -148,7 +133,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param innerAnotherProperties the innerAnotherProperties value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     FishInner withInnerAnotherProperties(AnotherFishProperties innerAnotherProperties) {
         this.innerAnotherProperties = innerAnotherProperties;
         return this;
@@ -159,7 +143,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.innerProperties() == null ? 0.0 : this.innerProperties().length();
     }
@@ -170,7 +153,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param length the length value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     public FishInner withLength(double length) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -184,7 +166,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.innerProperties() == null ? null : this.innerProperties().patten();
     }
@@ -194,7 +175,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.innerProperties() == null ? null : this.innerProperties().requiredString();
     }
@@ -205,7 +185,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param requiredString the requiredString value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     public FishInner withRequiredString(String requiredString) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -219,7 +198,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the length value.
      */
-    @Generated
     public double lengthAnotherPropertiesLength() {
         return this.innerAnotherProperties() == null ? 0.0 : this.innerAnotherProperties().length();
     }
@@ -230,7 +208,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param length the length value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     public FishInner withLengthAnotherPropertiesLength(double length) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();
@@ -244,7 +221,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the patten value.
      */
-    @Generated
     public String pattenAnotherPropertiesPatten() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().patten();
     }
@@ -254,7 +230,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredStringAnotherPropertiesRequiredString() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().requiredString();
     }
@@ -265,7 +240,6 @@ public class FishInner implements JsonSerializable<FishInner> {
      * @param requiredString the requiredString value to set.
      * @return the FishInner object itself.
      */
-    @Generated
     public FishInner withRequiredStringAnotherPropertiesRequiredString(String requiredString) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FishProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FishProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,13 +20,11 @@ public final class FishProperties implements JsonSerializable<FishProperties> {
     /*
      * The tailProperties property.
      */
-    @Generated
     private TailProperties innerTailProperties = new TailProperties();
 
     /**
      * Creates an instance of FishProperties class.
      */
-    @Generated
     public FishProperties() {
     }
 
@@ -36,7 +33,6 @@ public final class FishProperties implements JsonSerializable<FishProperties> {
      * 
      * @return the innerTailProperties value.
      */
-    @Generated
     private TailProperties innerTailProperties() {
         return this.innerTailProperties;
     }
@@ -46,7 +42,6 @@ public final class FishProperties implements JsonSerializable<FishProperties> {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.innerTailProperties() == null ? 0.0 : this.innerTailProperties().length();
     }
@@ -57,7 +52,6 @@ public final class FishProperties implements JsonSerializable<FishProperties> {
      * @param length the length value to set.
      * @return the FishProperties object itself.
      */
-    @Generated
     public FishProperties withLength(double length) {
         if (this.innerTailProperties() == null) {
             this.innerTailProperties = new TailProperties();
@@ -71,7 +65,6 @@ public final class FishProperties implements JsonSerializable<FishProperties> {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.innerTailProperties() == null ? null : this.innerTailProperties().patten();
     }
@@ -81,7 +74,6 @@ public final class FishProperties implements JsonSerializable<FishProperties> {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.innerTailProperties() == null ? null : this.innerTailProperties().requiredString();
     }
@@ -92,7 +84,6 @@ public final class FishProperties implements JsonSerializable<FishProperties> {
      * @param requiredString the requiredString value to set.
      * @return the FishProperties object itself.
      */
-    @Generated
     public FishProperties withRequiredString(String requiredString) {
         if (this.innerTailProperties() == null) {
             this.innerTailProperties = new TailProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FunctionConfiguration.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FunctionConfiguration.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -20,19 +19,16 @@ public final class FunctionConfiguration implements JsonSerializable<FunctionCon
     /*
      * The input property.
      */
-    @Generated
     private String input;
 
     /*
      * The output property.
      */
-    @Generated
     private String output;
 
     /**
      * Creates an instance of FunctionConfiguration class.
      */
-    @Generated
     public FunctionConfiguration() {
     }
 
@@ -41,7 +37,6 @@ public final class FunctionConfiguration implements JsonSerializable<FunctionCon
      * 
      * @return the input value.
      */
-    @Generated
     public String input() {
         return this.input;
     }
@@ -52,7 +47,6 @@ public final class FunctionConfiguration implements JsonSerializable<FunctionCon
      * @param input the input value to set.
      * @return the FunctionConfiguration object itself.
      */
-    @Generated
     public FunctionConfiguration withInput(String input) {
         this.input = input;
         return this;
@@ -63,7 +57,6 @@ public final class FunctionConfiguration implements JsonSerializable<FunctionCon
      * 
      * @return the output value.
      */
-    @Generated
     public String output() {
         return this.output;
     }
@@ -74,7 +67,6 @@ public final class FunctionConfiguration implements JsonSerializable<FunctionCon
      * @param output the output value to set.
      * @return the FunctionConfiguration object itself.
      */
-    @Generated
     public FunctionConfiguration withOutput(String output) {
         this.output = output;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FunctionInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/FunctionInner.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -22,13 +21,11 @@ public final class FunctionInner implements JsonSerializable<FunctionInner> {
     /*
      * The properties property.
      */
-    @Generated
     private FunctionProperties properties;
 
     /**
      * Creates an instance of FunctionInner class.
      */
-    @Generated
     public FunctionInner() {
     }
 
@@ -37,7 +34,6 @@ public final class FunctionInner implements JsonSerializable<FunctionInner> {
      * 
      * @return the properties value.
      */
-    @Generated
     public FunctionProperties properties() {
         return this.properties;
     }
@@ -48,7 +44,6 @@ public final class FunctionInner implements JsonSerializable<FunctionInner> {
      * @param properties the properties value to set.
      * @return the FunctionInner object itself.
      */
-    @Generated
     public FunctionInner withProperties(FunctionProperties properties) {
         this.properties = properties;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/OutputOnlyModelInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/OutputOnlyModelInner.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -23,31 +22,26 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
     /*
      * Discriminator property for OutputOnlyModel.
      */
-    @Generated
     private String kind = "OutputOnlyModel";
 
     /*
      * The name property.
      */
-    @Generated
     private String name;
 
     /*
      * The id property.
      */
-    @Generated
     private String id;
 
     /*
      * The properties property.
      */
-    @Generated
     private OutputOnlyModelProperties innerProperties;
 
     /**
      * Creates an instance of OutputOnlyModelInner class.
      */
-    @Generated
     protected OutputOnlyModelInner() {
     }
 
@@ -56,7 +50,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * 
      * @return the kind value.
      */
-    @Generated
     public String kind() {
         return this.kind;
     }
@@ -66,7 +59,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * 
      * @return the name value.
      */
-    @Generated
     public String name() {
         return this.name;
     }
@@ -77,7 +69,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * @param name the name value to set.
      * @return the OutputOnlyModelInner object itself.
      */
-    @Generated
     OutputOnlyModelInner withName(String name) {
         this.name = name;
         return this;
@@ -88,7 +79,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * 
      * @return the id value.
      */
-    @Generated
     public String id() {
         return this.id;
     }
@@ -99,7 +89,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * @param id the id value to set.
      * @return the OutputOnlyModelInner object itself.
      */
-    @Generated
     OutputOnlyModelInner withId(String id) {
         this.id = id;
         return this;
@@ -110,7 +99,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private OutputOnlyModelProperties innerProperties() {
         return this.innerProperties;
     }
@@ -121,7 +109,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * @param innerProperties the innerProperties value to set.
      * @return the OutputOnlyModelInner object itself.
      */
-    @Generated
     OutputOnlyModelInner withInnerProperties(OutputOnlyModelProperties innerProperties) {
         this.innerProperties = innerProperties;
         return this;
@@ -132,7 +119,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * 
      * @return the title value.
      */
-    @Generated
     public String title() {
         return this.innerProperties() == null ? null : this.innerProperties().title();
     }
@@ -142,7 +128,6 @@ public class OutputOnlyModelInner implements JsonSerializable<OutputOnlyModelInn
      * 
      * @return the dog value.
      */
-    @Generated
     public Dog dog() {
         return this.innerProperties() == null ? null : this.innerProperties().dog();
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/OutputOnlyModelProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/OutputOnlyModelProperties.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -22,19 +21,16 @@ public final class OutputOnlyModelProperties implements JsonSerializable<OutputO
     /*
      * The title property.
      */
-    @Generated
     private String title;
 
     /*
      * The dog property.
      */
-    @Generated
     private Dog dog;
 
     /**
      * Creates an instance of OutputOnlyModelProperties class.
      */
-    @Generated
     private OutputOnlyModelProperties() {
     }
 
@@ -43,7 +39,6 @@ public final class OutputOnlyModelProperties implements JsonSerializable<OutputO
      * 
      * @return the title value.
      */
-    @Generated
     public String title() {
         return this.title;
     }
@@ -53,7 +48,6 @@ public final class OutputOnlyModelProperties implements JsonSerializable<OutputO
      * 
      * @return the dog value.
      */
-    @Generated
     public Dog dog() {
         return this.dog;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/SalmonInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/SalmonInner.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -23,49 +22,41 @@ public final class SalmonInner extends FishInner {
     /*
      * Discriminator property for Fish.
      */
-    @Generated
     private String kind = "salmon";
 
     /*
      * The friends property.
      */
-    @Generated
     private List<FishInner> friends;
 
     /*
      * The hate property.
      */
-    @Generated
     private Map<String, FishInner> hate;
 
     /*
      * The partner property.
      */
-    @Generated
     private FishInner partner;
 
     /*
      * The anotherProperties property.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /*
      * The properties property.
      */
-    @Generated
     private FishProperties innerProperties = new FishProperties();
 
     /*
      * The dna property.
      */
-    @Generated
     private String dna;
 
     /**
      * Creates an instance of SalmonInner class.
      */
-    @Generated
     public SalmonInner() {
     }
 
@@ -74,7 +65,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public String kind() {
         return this.kind;
@@ -85,7 +75,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the friends value.
      */
-    @Generated
     public List<FishInner> friends() {
         return this.friends;
     }
@@ -96,7 +85,6 @@ public final class SalmonInner extends FishInner {
      * @param friends the friends value to set.
      * @return the SalmonInner object itself.
      */
-    @Generated
     public SalmonInner withFriends(List<FishInner> friends) {
         this.friends = friends;
         return this;
@@ -107,7 +95,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the hate value.
      */
-    @Generated
     public Map<String, FishInner> hate() {
         return this.hate;
     }
@@ -118,7 +105,6 @@ public final class SalmonInner extends FishInner {
      * @param hate the hate value to set.
      * @return the SalmonInner object itself.
      */
-    @Generated
     public SalmonInner withHate(Map<String, FishInner> hate) {
         this.hate = hate;
         return this;
@@ -129,7 +115,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the partner value.
      */
-    @Generated
     public FishInner partner() {
         return this.partner;
     }
@@ -140,7 +125,6 @@ public final class SalmonInner extends FishInner {
      * @param partner the partner value to set.
      * @return the SalmonInner object itself.
      */
-    @Generated
     public SalmonInner withPartner(FishInner partner) {
         this.partner = partner;
         return this;
@@ -151,7 +135,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the innerAnotherProperties value.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties() {
         return this.innerAnotherProperties;
     }
@@ -161,7 +144,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private FishProperties innerProperties() {
         return this.innerProperties;
     }
@@ -171,7 +153,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the dna value.
      */
-    @Generated
     @Override
     public String dna() {
         return this.dna;
@@ -180,7 +161,6 @@ public final class SalmonInner extends FishInner {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public SalmonInner withAge(int age) {
         super.withAge(age);
@@ -192,7 +172,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.innerProperties() == null ? 0.0 : this.innerProperties().length();
     }
@@ -203,7 +182,6 @@ public final class SalmonInner extends FishInner {
      * @param length the length value to set.
      * @return the SalmonInner object itself.
      */
-    @Generated
     public SalmonInner withLength(double length) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -217,7 +195,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.innerProperties() == null ? null : this.innerProperties().patten();
     }
@@ -227,7 +204,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.innerProperties() == null ? null : this.innerProperties().requiredString();
     }
@@ -238,7 +214,6 @@ public final class SalmonInner extends FishInner {
      * @param requiredString the requiredString value to set.
      * @return the SalmonInner object itself.
      */
-    @Generated
     public SalmonInner withRequiredString(String requiredString) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -252,7 +227,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the length value.
      */
-    @Generated
     public double lengthAnotherPropertiesLength() {
         return this.innerAnotherProperties() == null ? 0.0 : this.innerAnotherProperties().length();
     }
@@ -263,7 +237,6 @@ public final class SalmonInner extends FishInner {
      * @param length the length value to set.
      * @return the SalmonInner object itself.
      */
-    @Generated
     public SalmonInner withLengthAnotherPropertiesLength(double length) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();
@@ -277,7 +250,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the patten value.
      */
-    @Generated
     public String pattenAnotherPropertiesPatten() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().patten();
     }
@@ -287,7 +259,6 @@ public final class SalmonInner extends FishInner {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredStringAnotherPropertiesRequiredString() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().requiredString();
     }
@@ -298,7 +269,6 @@ public final class SalmonInner extends FishInner {
      * @param requiredString the requiredString value to set.
      * @return the SalmonInner object itself.
      */
-    @Generated
     public SalmonInner withRequiredStringAnotherPropertiesRequiredString(String requiredString) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/TailProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/TailProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.fluent.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -21,25 +20,21 @@ public final class TailProperties implements JsonSerializable<TailProperties> {
     /*
      * The length property.
      */
-    @Generated
     private double length;
 
     /*
      * The patten property.
      */
-    @Generated
     private String patten;
 
     /*
      * The requiredString property.
      */
-    @Generated
     private String requiredString;
 
     /**
      * Creates an instance of TailProperties class.
      */
-    @Generated
     public TailProperties() {
     }
 
@@ -48,7 +43,6 @@ public final class TailProperties implements JsonSerializable<TailProperties> {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.length;
     }
@@ -59,7 +53,6 @@ public final class TailProperties implements JsonSerializable<TailProperties> {
      * @param length the length value to set.
      * @return the TailProperties object itself.
      */
-    @Generated
     public TailProperties withLength(double length) {
         this.length = length;
         return this;
@@ -70,7 +63,6 @@ public final class TailProperties implements JsonSerializable<TailProperties> {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.patten;
     }
@@ -80,7 +72,6 @@ public final class TailProperties implements JsonSerializable<TailProperties> {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.requiredString;
     }
@@ -91,7 +82,6 @@ public final class TailProperties implements JsonSerializable<TailProperties> {
      * @param requiredString the requiredString value to set.
      * @return the TailProperties object itself.
      */
-    @Generated
     public TailProperties withRequiredString(String requiredString) {
         this.requiredString = requiredString;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/TopLevelArmResourceInner.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/fluent/models/TopLevelArmResourceInner.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.fluent.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.management.Resource;
 import com.azure.core.management.SystemData;
@@ -23,37 +22,31 @@ public final class TopLevelArmResourceInner extends Resource {
     /*
      * The resource-specific properties for this resource.
      */
-    @Generated
     private TopLevelArmResourceProperties properties;
 
     /*
      * Azure Resource Manager metadata containing createdBy and modifiedBy information.
      */
-    @Generated
     private SystemData systemData;
 
     /*
      * The type of the resource.
      */
-    @Generated
     private String type;
 
     /*
      * The name of the resource.
      */
-    @Generated
     private String name;
 
     /*
      * Fully qualified resource Id for the resource.
      */
-    @Generated
     private String id;
 
     /**
      * Creates an instance of TopLevelArmResourceInner class.
      */
-    @Generated
     private TopLevelArmResourceInner() {
     }
 
@@ -62,7 +55,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the properties value.
      */
-    @Generated
     public TopLevelArmResourceProperties properties() {
         return this.properties;
     }
@@ -72,7 +64,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the systemData value.
      */
-    @Generated
     public SystemData systemData() {
         return this.systemData;
     }
@@ -82,7 +73,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the type value.
      */
-    @Generated
     @Override
     public String type() {
         return this.type;
@@ -93,7 +83,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -104,7 +93,6 @@ public final class TopLevelArmResourceInner extends Resource {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/AggregateFunctionProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/AggregateFunctionProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -21,13 +20,11 @@ public final class AggregateFunctionProperties extends FunctionProperties {
     /*
      * Discriminator property for FunctionProperties.
      */
-    @Generated
     private String kind = "aggregate";
 
     /**
      * Creates an instance of AggregateFunctionProperties class.
      */
-    @Generated
     public AggregateFunctionProperties() {
     }
 
@@ -36,7 +33,6 @@ public final class AggregateFunctionProperties extends FunctionProperties {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public String kind() {
         return this.kind;
@@ -47,7 +43,6 @@ public final class AggregateFunctionProperties extends FunctionProperties {
      * 
      * @return the input value.
      */
-    @Generated
     public String input() {
         return this.innerProperties() == null ? null : this.innerProperties().input();
     }
@@ -58,7 +53,6 @@ public final class AggregateFunctionProperties extends FunctionProperties {
      * @param input the input value to set.
      * @return the AggregateFunctionProperties object itself.
      */
-    @Generated
     public AggregateFunctionProperties withInput(String input) {
         if (this.innerProperties() == null) {
             this.withInnerProperties(new FunctionConfiguration());
@@ -72,7 +66,6 @@ public final class AggregateFunctionProperties extends FunctionProperties {
      * 
      * @return the output value.
      */
-    @Generated
     public String output() {
         return this.innerProperties() == null ? null : this.innerProperties().output();
     }
@@ -83,7 +76,6 @@ public final class AggregateFunctionProperties extends FunctionProperties {
      * @param output the output value to set.
      * @return the AggregateFunctionProperties object itself.
      */
-    @Generated
     public AggregateFunctionProperties withOutput(String output) {
         if (this.innerProperties() == null) {
             this.withInnerProperties(new FunctionConfiguration());

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Dog.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Dog.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,25 +19,21 @@ public class Dog implements JsonSerializable<Dog> {
     /*
      * discriminator property
      */
-    @Generated
     private DogKind kind = DogKind.fromString("Dog");
 
     /*
      * Weight of the dog
      */
-    @Generated
     private int weight;
 
     /*
      * dna of the dog
      */
-    @Generated
     private String dna;
 
     /**
      * Creates an instance of Dog class.
      */
-    @Generated
     protected Dog() {
     }
 
@@ -47,7 +42,6 @@ public class Dog implements JsonSerializable<Dog> {
      * 
      * @return the kind value.
      */
-    @Generated
     public DogKind kind() {
         return this.kind;
     }
@@ -57,7 +51,6 @@ public class Dog implements JsonSerializable<Dog> {
      * 
      * @return the weight value.
      */
-    @Generated
     public int weight() {
         return this.weight;
     }
@@ -68,7 +61,6 @@ public class Dog implements JsonSerializable<Dog> {
      * @param weight the weight value to set.
      * @return the Dog object itself.
      */
-    @Generated
     Dog withWeight(int weight) {
         this.weight = weight;
         return this;
@@ -79,7 +71,6 @@ public class Dog implements JsonSerializable<Dog> {
      * 
      * @return the dna value.
      */
-    @Generated
     public String dna() {
         return this.dna;
     }
@@ -90,7 +81,6 @@ public class Dog implements JsonSerializable<Dog> {
      * @param dna the dna value to set.
      * @return the Dog object itself.
      */
-    @Generated
     Dog withDna(String dna) {
         this.dna = dna;
         return this;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Error.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Error.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.management.exception.AdditionalInfo;
 import com.azure.core.management.exception.ManagementError;
@@ -22,43 +21,36 @@ public final class Error extends ManagementError {
     /*
      * The details property.
      */
-    @Generated
     private List<Error> details;
 
     /*
      * The additionalProperty property.
      */
-    @Generated
     private String additionalProperty;
 
     /*
      * Additional info for the error.
      */
-    @Generated
     private List<AdditionalInfo> additionalInfo;
 
     /*
      * The target of the error.
      */
-    @Generated
     private String target;
 
     /*
      * The error message parsed from the body of the http error response.
      */
-    @Generated
     private String message;
 
     /*
      * The error code parsed from the body of the http error response.
      */
-    @Generated
     private String code;
 
     /**
      * Creates an instance of Error class.
      */
-    @Generated
     private Error() {
     }
 
@@ -67,7 +59,6 @@ public final class Error extends ManagementError {
      * 
      * @return the details value.
      */
-    @Generated
     @Override
     public List<Error> getDetails() {
         return this.details;
@@ -78,7 +69,6 @@ public final class Error extends ManagementError {
      * 
      * @return the additionalProperty value.
      */
-    @Generated
     public String getAdditionalProperty() {
         return this.additionalProperty;
     }
@@ -88,7 +78,6 @@ public final class Error extends ManagementError {
      * 
      * @return the additionalInfo value.
      */
-    @Generated
     @Override
     public List<AdditionalInfo> getAdditionalInfo() {
         return this.additionalInfo;
@@ -99,7 +88,6 @@ public final class Error extends ManagementError {
      * 
      * @return the target value.
      */
-    @Generated
     @Override
     public String getTarget() {
         return this.target;
@@ -110,7 +98,6 @@ public final class Error extends ManagementError {
      * 
      * @return the message value.
      */
-    @Generated
     @Override
     public String getMessage() {
         return this.message;
@@ -121,7 +108,6 @@ public final class Error extends ManagementError {
      * 
      * @return the code value.
      */
-    @Generated
     @Override
     public String getCode() {
         return this.code;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/ErrorMin.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/ErrorMin.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.management.exception.AdditionalInfo;
 import com.azure.core.management.exception.ManagementError;
@@ -22,43 +21,36 @@ public final class ErrorMin extends ManagementError {
     /*
      * The additionalProperty property.
      */
-    @Generated
     private String additionalProperty;
 
     /*
      * Additional info for the error.
      */
-    @Generated
     private List<AdditionalInfo> additionalInfo;
 
     /*
      * Details for the error.
      */
-    @Generated
     private List<ManagementError> details;
 
     /*
      * The target of the error.
      */
-    @Generated
     private String target;
 
     /*
      * The error message parsed from the body of the http error response.
      */
-    @Generated
     private String message;
 
     /*
      * The error code parsed from the body of the http error response.
      */
-    @Generated
     private String code;
 
     /**
      * Creates an instance of ErrorMin class.
      */
-    @Generated
     private ErrorMin() {
     }
 
@@ -67,7 +59,6 @@ public final class ErrorMin extends ManagementError {
      * 
      * @return the additionalProperty value.
      */
-    @Generated
     public String getAdditionalProperty() {
         return this.additionalProperty;
     }
@@ -77,7 +68,6 @@ public final class ErrorMin extends ManagementError {
      * 
      * @return the additionalInfo value.
      */
-    @Generated
     @Override
     public List<AdditionalInfo> getAdditionalInfo() {
         return this.additionalInfo;
@@ -88,7 +78,6 @@ public final class ErrorMin extends ManagementError {
      * 
      * @return the details value.
      */
-    @Generated
     @Override
     public List<ManagementError> getDetails() {
         return this.details;
@@ -99,7 +88,6 @@ public final class ErrorMin extends ManagementError {
      * 
      * @return the target value.
      */
-    @Generated
     @Override
     public String getTarget() {
         return this.target;
@@ -110,7 +98,6 @@ public final class ErrorMin extends ManagementError {
      * 
      * @return the message value.
      */
-    @Generated
     @Override
     public String getMessage() {
         return this.message;
@@ -121,7 +108,6 @@ public final class ErrorMin extends ManagementError {
      * 
      * @return the code value.
      */
-    @Generated
     @Override
     public String getCode() {
         return this.code;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/FunctionProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/FunctionProperties.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -22,19 +21,16 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
     /*
      * Discriminator property for FunctionProperties.
      */
-    @Generated
     private String kind = "FunctionProperties";
 
     /*
      * The properties property.
      */
-    @Generated
     private FunctionConfiguration innerProperties = new FunctionConfiguration();
 
     /**
      * Creates an instance of FunctionProperties class.
      */
-    @Generated
     public FunctionProperties() {
     }
 
@@ -43,7 +39,6 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
      * 
      * @return the kind value.
      */
-    @Generated
     public String kind() {
         return this.kind;
     }
@@ -53,7 +48,6 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
      * 
      * @return the innerProperties value.
      */
-    @Generated
     FunctionConfiguration innerProperties() {
         return this.innerProperties;
     }
@@ -64,7 +58,6 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
      * @param innerProperties the innerProperties value to set.
      * @return the FunctionProperties object itself.
      */
-    @Generated
     FunctionProperties withInnerProperties(FunctionConfiguration innerProperties) {
         this.innerProperties = innerProperties;
         return this;
@@ -75,7 +68,6 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
      * 
      * @return the input value.
      */
-    @Generated
     public String input() {
         return this.innerProperties() == null ? null : this.innerProperties().input();
     }
@@ -86,7 +78,6 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
      * @param input the input value to set.
      * @return the FunctionProperties object itself.
      */
-    @Generated
     public FunctionProperties withInput(String input) {
         if (this.innerProperties() == null) {
             this.withInnerProperties(new FunctionConfiguration());
@@ -100,7 +91,6 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
      * 
      * @return the output value.
      */
-    @Generated
     public String output() {
         return this.innerProperties() == null ? null : this.innerProperties().output();
     }
@@ -111,7 +101,6 @@ public class FunctionProperties implements JsonSerializable<FunctionProperties> 
      * @param output the output value to set.
      * @return the FunctionProperties object itself.
      */
-    @Generated
     public FunctionProperties withOutput(String output) {
         if (this.innerProperties() == null) {
             this.withInnerProperties(new FunctionConfiguration());

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/GoblinShark.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/GoblinShark.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -22,37 +21,31 @@ public final class GoblinShark extends Shark {
     /*
      * Discriminator property for Fish.
      */
-    @Generated
     private String kind = "shark";
 
     /*
      * The sharktype property.
      */
-    @Generated
     private String sharktype = "goblin";
 
     /*
      * The anotherProperties property.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /*
      * The properties property.
      */
-    @Generated
     private FishProperties innerProperties = new FishProperties();
 
     /*
      * The dna property.
      */
-    @Generated
     private String dna;
 
     /**
      * Creates an instance of GoblinShark class.
      */
-    @Generated
     public GoblinShark() {
     }
 
@@ -61,7 +54,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public String kind() {
         return this.kind;
@@ -72,7 +64,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the sharktype value.
      */
-    @Generated
     @Override
     public String sharktype() {
         return this.sharktype;
@@ -83,7 +74,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the innerAnotherProperties value.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties() {
         return this.innerAnotherProperties;
     }
@@ -93,7 +83,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private FishProperties innerProperties() {
         return this.innerProperties;
     }
@@ -103,7 +92,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the dna value.
      */
-    @Generated
     @Override
     public String dna() {
         return this.dna;
@@ -112,7 +100,6 @@ public final class GoblinShark extends Shark {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public GoblinShark withAge(int age) {
         super.withAge(age);
@@ -124,7 +111,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.innerProperties() == null ? 0.0 : this.innerProperties().length();
     }
@@ -135,7 +121,6 @@ public final class GoblinShark extends Shark {
      * @param length the length value to set.
      * @return the GoblinShark object itself.
      */
-    @Generated
     public GoblinShark withLength(double length) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -149,7 +134,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.innerProperties() == null ? null : this.innerProperties().patten();
     }
@@ -159,7 +143,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.innerProperties() == null ? null : this.innerProperties().requiredString();
     }
@@ -170,7 +153,6 @@ public final class GoblinShark extends Shark {
      * @param requiredString the requiredString value to set.
      * @return the GoblinShark object itself.
      */
-    @Generated
     public GoblinShark withRequiredString(String requiredString) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -184,7 +166,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the length value.
      */
-    @Generated
     public double lengthAnotherPropertiesLength() {
         return this.innerAnotherProperties() == null ? 0.0 : this.innerAnotherProperties().length();
     }
@@ -195,7 +176,6 @@ public final class GoblinShark extends Shark {
      * @param length the length value to set.
      * @return the GoblinShark object itself.
      */
-    @Generated
     public GoblinShark withLengthAnotherPropertiesLength(double length) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();
@@ -209,7 +189,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the patten value.
      */
-    @Generated
     public String pattenAnotherPropertiesPatten() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().patten();
     }
@@ -219,7 +198,6 @@ public final class GoblinShark extends Shark {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredStringAnotherPropertiesRequiredString() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().requiredString();
     }
@@ -230,7 +208,6 @@ public final class GoblinShark extends Shark {
      * @param requiredString the requiredString value to set.
      * @return the GoblinShark object itself.
      */
-    @Generated
     public GoblinShark withRequiredStringAnotherPropertiesRequiredString(String requiredString) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Golden.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Golden.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -19,13 +18,11 @@ public final class Golden extends Dog {
     /*
      * discriminator property
      */
-    @Generated
     private DogKind kind = DogKind.GOLDEN;
 
     /**
      * Creates an instance of Golden class.
      */
-    @Generated
     private Golden() {
     }
 
@@ -34,7 +31,6 @@ public final class Golden extends Dog {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public DogKind kind() {
         return this.kind;

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/OutputOnlyModelChild.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/OutputOnlyModelChild.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
@@ -22,37 +21,31 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
     /*
      * Discriminator property for OutputOnlyModel.
      */
-    @Generated
     private String kind = "child";
 
     /*
      * The childName property.
      */
-    @Generated
     private String childName;
 
     /*
      * The properties property.
      */
-    @Generated
     private OutputOnlyModelProperties innerProperties;
 
     /*
      * The id property.
      */
-    @Generated
     private String id;
 
     /*
      * The name property.
      */
-    @Generated
     private String name;
 
     /**
      * Creates an instance of OutputOnlyModelChild class.
      */
-    @Generated
     private OutputOnlyModelChild() {
     }
 
@@ -61,7 +54,6 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public String kind() {
         return this.kind;
@@ -72,7 +64,6 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
      * 
      * @return the childName value.
      */
-    @Generated
     public String childName() {
         return this.childName;
     }
@@ -82,7 +73,6 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private OutputOnlyModelProperties innerProperties() {
         return this.innerProperties;
     }
@@ -92,7 +82,6 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
      * 
      * @return the id value.
      */
-    @Generated
     @Override
     public String id() {
         return this.id;
@@ -103,7 +92,6 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
      * 
      * @return the name value.
      */
-    @Generated
     @Override
     public String name() {
         return this.name;
@@ -114,7 +102,6 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
      * 
      * @return the title value.
      */
-    @Generated
     public String title() {
         return this.innerProperties() == null ? null : this.innerProperties().title();
     }
@@ -124,7 +111,6 @@ public final class OutputOnlyModelChild extends OutputOnlyModelInner {
      * 
      * @return the dog value.
      */
-    @Generated
     public Dog dog() {
         return this.innerProperties() == null ? null : this.innerProperties().dog();
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/SawShark.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/SawShark.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -22,43 +21,36 @@ public final class SawShark extends Shark {
     /*
      * Discriminator property for Fish.
      */
-    @Generated
     private String kind = "shark";
 
     /*
      * The sharktype property.
      */
-    @Generated
     private String sharktype = "saw";
 
     /*
      * The dna property.
      */
-    @Generated
     private String dna;
 
     /*
      * The age property.
      */
-    @Generated
     private int age;
 
     /*
      * The anotherProperties property.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /*
      * The properties property.
      */
-    @Generated
     private FishProperties innerProperties = new FishProperties();
 
     /**
      * Creates an instance of SawShark class.
      */
-    @Generated
     public SawShark() {
     }
 
@@ -67,7 +59,6 @@ public final class SawShark extends Shark {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public String kind() {
         return this.kind;
@@ -78,7 +69,6 @@ public final class SawShark extends Shark {
      * 
      * @return the sharktype value.
      */
-    @Generated
     @Override
     public String sharktype() {
         return this.sharktype;
@@ -89,7 +79,6 @@ public final class SawShark extends Shark {
      * 
      * @return the dna value.
      */
-    @Generated
     public String dna() {
         return this.dna;
     }
@@ -100,7 +89,6 @@ public final class SawShark extends Shark {
      * @param dna the dna value to set.
      * @return the SawShark object itself.
      */
-    @Generated
     public SawShark withDna(String dna) {
         this.dna = dna;
         return this;
@@ -111,7 +99,6 @@ public final class SawShark extends Shark {
      * 
      * @return the age value.
      */
-    @Generated
     public int age() {
         return this.age;
     }
@@ -122,7 +109,6 @@ public final class SawShark extends Shark {
      * @param age the age value to set.
      * @return the SawShark object itself.
      */
-    @Generated
     public SawShark withAge(int age) {
         this.age = age;
         return this;
@@ -133,7 +119,6 @@ public final class SawShark extends Shark {
      * 
      * @return the innerAnotherProperties value.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties() {
         return this.innerAnotherProperties;
     }
@@ -143,7 +128,6 @@ public final class SawShark extends Shark {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private FishProperties innerProperties() {
         return this.innerProperties;
     }
@@ -153,7 +137,6 @@ public final class SawShark extends Shark {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.innerProperties() == null ? 0.0 : this.innerProperties().length();
     }
@@ -164,7 +147,6 @@ public final class SawShark extends Shark {
      * @param length the length value to set.
      * @return the SawShark object itself.
      */
-    @Generated
     public SawShark withLength(double length) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -178,7 +160,6 @@ public final class SawShark extends Shark {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.innerProperties() == null ? null : this.innerProperties().patten();
     }
@@ -188,7 +169,6 @@ public final class SawShark extends Shark {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.innerProperties() == null ? null : this.innerProperties().requiredString();
     }
@@ -199,7 +179,6 @@ public final class SawShark extends Shark {
      * @param requiredString the requiredString value to set.
      * @return the SawShark object itself.
      */
-    @Generated
     public SawShark withRequiredString(String requiredString) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -213,7 +192,6 @@ public final class SawShark extends Shark {
      * 
      * @return the length value.
      */
-    @Generated
     public double lengthAnotherPropertiesLength() {
         return this.innerAnotherProperties() == null ? 0.0 : this.innerAnotherProperties().length();
     }
@@ -224,7 +202,6 @@ public final class SawShark extends Shark {
      * @param length the length value to set.
      * @return the SawShark object itself.
      */
-    @Generated
     public SawShark withLengthAnotherPropertiesLength(double length) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();
@@ -238,7 +215,6 @@ public final class SawShark extends Shark {
      * 
      * @return the patten value.
      */
-    @Generated
     public String pattenAnotherPropertiesPatten() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().patten();
     }
@@ -248,7 +224,6 @@ public final class SawShark extends Shark {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredStringAnotherPropertiesRequiredString() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().requiredString();
     }
@@ -259,7 +234,6 @@ public final class SawShark extends Shark {
      * @param requiredString the requiredString value to set.
      * @return the SawShark object itself.
      */
-    @Generated
     public SawShark withRequiredStringAnotherPropertiesRequiredString(String requiredString) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Shark.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/Shark.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonToken;
@@ -23,37 +22,31 @@ public class Shark extends FishInner {
     /*
      * Discriminator property for Fish.
      */
-    @Generated
     private String kind = "shark";
 
     /*
      * The sharktype property.
      */
-    @Generated
     private String sharktype = "shark";
 
     /*
      * The anotherProperties property.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties = new AnotherFishProperties();
 
     /*
      * The properties property.
      */
-    @Generated
     private FishProperties innerProperties = new FishProperties();
 
     /*
      * The dna property.
      */
-    @Generated
     private String dna;
 
     /**
      * Creates an instance of Shark class.
      */
-    @Generated
     public Shark() {
     }
 
@@ -62,7 +55,6 @@ public class Shark extends FishInner {
      * 
      * @return the kind value.
      */
-    @Generated
     @Override
     public String kind() {
         return this.kind;
@@ -73,7 +65,6 @@ public class Shark extends FishInner {
      * 
      * @return the sharktype value.
      */
-    @Generated
     public String sharktype() {
         return this.sharktype;
     }
@@ -83,7 +74,6 @@ public class Shark extends FishInner {
      * 
      * @return the innerAnotherProperties value.
      */
-    @Generated
     private AnotherFishProperties innerAnotherProperties() {
         return this.innerAnotherProperties;
     }
@@ -93,7 +83,6 @@ public class Shark extends FishInner {
      * 
      * @return the innerProperties value.
      */
-    @Generated
     private FishProperties innerProperties() {
         return this.innerProperties;
     }
@@ -103,7 +92,6 @@ public class Shark extends FishInner {
      * 
      * @return the dna value.
      */
-    @Generated
     @Override
     public String dna() {
         return this.dna;
@@ -112,7 +100,6 @@ public class Shark extends FishInner {
     /**
      * {@inheritDoc}
      */
-    @Generated
     @Override
     public Shark withAge(int age) {
         super.withAge(age);
@@ -124,7 +111,6 @@ public class Shark extends FishInner {
      * 
      * @return the length value.
      */
-    @Generated
     public double length() {
         return this.innerProperties() == null ? 0.0 : this.innerProperties().length();
     }
@@ -135,7 +121,6 @@ public class Shark extends FishInner {
      * @param length the length value to set.
      * @return the Shark object itself.
      */
-    @Generated
     public Shark withLength(double length) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -149,7 +134,6 @@ public class Shark extends FishInner {
      * 
      * @return the patten value.
      */
-    @Generated
     public String patten() {
         return this.innerProperties() == null ? null : this.innerProperties().patten();
     }
@@ -159,7 +143,6 @@ public class Shark extends FishInner {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredString() {
         return this.innerProperties() == null ? null : this.innerProperties().requiredString();
     }
@@ -170,7 +153,6 @@ public class Shark extends FishInner {
      * @param requiredString the requiredString value to set.
      * @return the Shark object itself.
      */
-    @Generated
     public Shark withRequiredString(String requiredString) {
         if (this.innerProperties() == null) {
             this.innerProperties = new FishProperties();
@@ -184,7 +166,6 @@ public class Shark extends FishInner {
      * 
      * @return the length value.
      */
-    @Generated
     public double lengthAnotherPropertiesLength() {
         return this.innerAnotherProperties() == null ? 0.0 : this.innerAnotherProperties().length();
     }
@@ -195,7 +176,6 @@ public class Shark extends FishInner {
      * @param length the length value to set.
      * @return the Shark object itself.
      */
-    @Generated
     public Shark withLengthAnotherPropertiesLength(double length) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();
@@ -209,7 +189,6 @@ public class Shark extends FishInner {
      * 
      * @return the patten value.
      */
-    @Generated
     public String pattenAnotherPropertiesPatten() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().patten();
     }
@@ -219,7 +198,6 @@ public class Shark extends FishInner {
      * 
      * @return the requiredString value.
      */
-    @Generated
     public String requiredStringAnotherPropertiesRequiredString() {
         return this.innerAnotherProperties() == null ? null : this.innerAnotherProperties().requiredString();
     }
@@ -230,7 +208,6 @@ public class Shark extends FishInner {
      * @param requiredString the requiredString value to set.
      * @return the Shark object itself.
      */
-    @Generated
     public Shark withRequiredStringAnotherPropertiesRequiredString(String requiredString) {
         if (this.innerAnotherProperties() == null) {
             this.innerAnotherProperties = new AnotherFishProperties();

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/TopLevelArmResourceProperties.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/TopLevelArmResourceProperties.java
@@ -4,7 +4,6 @@
 
 package tsptest.armstreamstyleserialization.models;
 
-import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.Immutable;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
@@ -20,13 +19,11 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
     /*
      * The description property.
      */
-    @Generated
     private String description;
 
     /**
      * Creates an instance of TopLevelArmResourceProperties class.
      */
-    @Generated
     private TopLevelArmResourceProperties() {
     }
 
@@ -35,7 +32,6 @@ public final class TopLevelArmResourceProperties implements JsonSerializable<Top
      * 
      * @return the description value.
      */
-    @Generated
     public String description() {
         return this.description;
     }

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/TopLevelArmResourceTagsUpdate.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/models/TopLevelArmResourceTagsUpdate.java
@@ -5,7 +5,6 @@
 package tsptest.armstreamstyleserialization.models;
 
 import com.azure.core.annotation.Fluent;
-import com.azure.core.annotation.Generated;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -21,13 +20,11 @@ public final class TopLevelArmResourceTagsUpdate implements JsonSerializable<Top
     /*
      * Resource tags.
      */
-    @Generated
     private Map<String, String> tags;
 
     /**
      * Creates an instance of TopLevelArmResourceTagsUpdate class.
      */
-    @Generated
     public TopLevelArmResourceTagsUpdate() {
     }
 
@@ -36,7 +33,6 @@ public final class TopLevelArmResourceTagsUpdate implements JsonSerializable<Top
      * 
      * @return the tags value.
      */
-    @Generated
     public Map<String, String> tags() {
         return this.tags;
     }
@@ -47,7 +43,6 @@ public final class TopLevelArmResourceTagsUpdate implements JsonSerializable<Top
      * @param tags the tags value to set.
      * @return the TopLevelArmResourceTagsUpdate object itself.
      */
-    @Generated
     public TopLevelArmResourceTagsUpdate withTags(Map<String, String> tags) {
         this.tags = tags;
         return this;


### PR DESCRIPTION
This is a bug exposed by [VNext PR](https://github.com/microsoft/typespec/pull/7115). Previously, the bug is hidden behind isDataPlane check in `addGeneratedAnnotation` that's been removed in VNext PR. 