### PR TITLE
[hsjs] Don't consider node built-in modules external dependencies

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-scaffold-fix-node-deps-2025-4-7-16-30-38.md
+++ b/.chronus/changes/witemple-msft-hsjs-scaffold-fix-node-deps-2025-4-7-16-30-38.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Fixed an error in which the scaffolding script incorrectly considered built-in Node.js modules external dependencies.

--- a/packages/http-server-js/src/scripts/scaffold/bin.mts
+++ b/packages/http-server-js/src/scripts/scaffold/bin.mts
@@ -610,8 +610,9 @@ function getAllExternalDependencies(ctx: JsContext): Set<string> {
     for (const _import of module.imports) {
       if (
         typeof _import.from === "string" &&
-        !_import.from.startsWith(".") &&
-        !_import.from.startsWith("/")
+        !_import.from.startsWith(".") && // is a relative path
+        !_import.from.startsWith("/") && // is an absolute path
+        !_import.from.startsWith("node:") // is node builtin
       ) {
         externalDependencies.add(_import.from);
       } else if (typeof _import.from !== "string") {


### PR DESCRIPTION
The scaffolding script incorrectly considers node built-in modules to be external dependencies. This can cause the scaffolding script to fail in some cases because it cannot find a dependency version to use for those builtins. The fix is to simply exclude node builtins like `node:http` from the external dependencies in the same way we currently exclude absolute and relative paths.