### PR TITLE
[core] Even more aggressively deduplicate the results of visibility transforms.

### DIFF
--- a/.chronus/changes/witemple-msft-visibility-mutator-replace-2025-4-8-15-28-29.md
+++ b/.chronus/changes/witemple-msft-visibility-mutator-replace-2025-4-8-15-28-29.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Corrected visibility filtering logic to even more aggressively deduplicate the models it visits when the applied visibility transform does not actually remove any properties from a model.

--- a/packages/compiler/test/visibility.test.ts
+++ b/packages/compiler/test/visibility.test.ts
@@ -1109,6 +1109,34 @@ describe("compiler: visibility core", () => {
     ok(C.properties.has("c"));
   });
 
+  it("correctly caches and deduplicates instances that are not transformed", async () => {
+    const { example, B } = (await runner.compile(`
+      @test op example(): Read<A>;
+
+      model A {
+        b: B;
+      }
+      
+      @test
+      model B {
+        c: string;
+      }
+    `)) as { example: Operation; B: Model };
+
+    ok(example);
+    strictEqual(example.kind, "Operation");
+
+    const ReadA = example.returnType as Model;
+
+    strictEqual(ReadA.kind, "Model");
+
+    const aB = ReadA.properties.get("b")!.type as Model;
+
+    strictEqual(aB.kind, "Model");
+
+    ok(aB === B);
+  });
+
   it("correctly transforms arrays and records", async () => {
     const { Result } = (await runner.compile(`
       model A {


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/7294
This changes the visibility mutators to use replacement functions instead of mutations, making it so that if the visibility transform does not actually modify a model, it will return the same input model instance. Integrated with the caching system, this should produce a minimally-copied tree. The only node that is guaranteed to be duplicated is the root node, since we cannot deduplicate the template instance.