### PR TITLE
[asset-emitter] improve intern performance

### DIFF
--- a/.chronus/changes/improved-intern-2025-4-9-10-26-22.md
+++ b/.chronus/changes/improved-intern-2025-4-9-10-26-22.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/asset-emitter"
+---
+
+Added performance improvements for larger specs


### PR DESCRIPTION
Fixes the performance issue mentioned in https://github.com/microsoft/typespec/issues/7287

This PR optimized the `intern` function used by the asset emitter. It now uses a trie-like structure to optimize lookups.

Some performance testing based on a customer-provided spec repo showing time spent in the `intern` function:

__before__ - approximately 7 seconds:
![image](https://github.com/user-attachments/assets/594ec2dd-27c8-4f61-8816-52a46c1ed3e0)

__after__ - approximately 65ms:
![image](https://github.com/user-attachments/assets/fb4af260-a59c-44c4-9d11-88ee83cf7bcc)
