### PR TITLE
enable emitting code from tspconfig.yaml

### DIFF
--- a/.chronus/changes/emitFromConfigFile-2025-4-12-11-47-13.md
+++ b/.chronus/changes/emitFromConfigFile-2025-4-12-11-47-13.md
@@ -4,4 +4,4 @@ packages:
   - typespec-vscode
 ---
 
-Enable code emission from tspconfig.yaml.
+Enable emit code command on tspconfig.yaml.

--- a/.chronus/changes/emitFromConfigFile-2025-4-12-11-47-13.md
+++ b/.chronus/changes/emitFromConfigFile-2025-4-12-11-47-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - typespec-vscode
+---
+
+Enable code emission from tspconfig.yaml.

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -121,7 +121,7 @@
         },
         {
           "command": "typespec.emitCode",
-          "when": "explorerResourceIsFolder || resourceLangId == typespec",
+          "when": "explorerResourceIsFolder || resourceLangId == typespec || resourceFilename == 'tspconfig.yaml'",
           "group": "typespec@1"
         },
         {
@@ -133,7 +133,7 @@
       "editor/context": [
         {
           "command": "typespec.emitCode",
-          "when": "resourceLangId == typespec",
+          "when": "resourceLangId == typespec || resourceFilename == 'tspconfig.yaml'",
           "group": "typespec@1"
         },
         {


### PR DESCRIPTION
Fix https://github.com/microsoft/typespec/issues/6630

- enable emitting code when select `tspconfig.yaml` in folder explorer or in the texter editor