### PR TITLE
Target node id for diagnostic in playground

### DIFF
--- a/.chronus/changes/playground-target-id-2025-4-12-15-22-16.md
+++ b/.chronus/changes/playground-target-id-2025-4-12-15-22-16.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/playground"
+---
+
+Reduce visual noise in diagnostics by targeting the specific node id rather than the entire node.

--- a/packages/playground/src/services.ts
+++ b/packages/playground/src/services.ts
@@ -370,7 +370,7 @@ export function getMonacoRange(
   typespecCompiler: typeof import("@typespec/compiler"),
   target: DiagnosticTarget | typeof NoTarget,
 ): monaco.IRange {
-  const loc = typespecCompiler.getSourceLocation(target);
+  const loc = typespecCompiler.getSourceLocation(target, { locateId: true });
   if (loc === undefined || loc.file.path !== "/test/main.tsp") {
     return {
       startLineNumber: 1,


### PR DESCRIPTION
fix #7318 This was already done for the cli and LSP but missed in the playground


try with the following code

```tsp
model A {}
model A {}
```

[Before](https://typespec.io/playground/?c=bW9kZWwgQSB7fQrKCw%3D%3D&e=%40typespec%2Fopenapi3&options=%7B%7D)
