### PR TITLE
[emitter-framework] Render discriminated unions correctly

### DIFF
--- a/.chronus/changes/discriminated-union-ef-2025-4-15-22-11-29.md
+++ b/.chronus/changes/discriminated-union-ef-2025-4-15-22-11-29.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/emitter-framework"
+---
+
+Render discriminated unions correctly

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -154,7 +154,7 @@ function InterfaceBody(props: TypedInterfaceDeclarationProps): Children {
 
   return (
     <>
-      <ay.For each={validTypeMembers} line {...enderProp}>
+      <ay.For each={validTypeMembers} semicolon line {...enderProp}>
         {(typeMember) => {
           return <InterfaceMember type={typeMember} />;
         }}

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -43,14 +43,12 @@ export function UnionExpression({ type, children }: UnionExpressionProps) {
               />
             );
           default:
-            // not a discriminated union
             return <TypeExpression type={type.type} />;
         }
       }}
     </ay.For>
   );
 
-  // Handle additional children if present
   if (children || (Array.isArray(children) && children.length)) {
     return (
       <>
@@ -121,5 +119,5 @@ function NoneEnvelope(props: NoneEnvelopeProps) {
     return <TypeExpression type={model} />;
   }
 
-  return ay.code`{kind: "${String(props.type.name)}"} & ${efRefkey(props.type.type)}`;
+  return ay.code`{${props.discriminatorPropertyName}: "${String(props.type.name)}"} & ${efRefkey(props.type.type)}`;
 }

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -29,9 +29,10 @@ export function UnionExpression({ type, children }: UnionExpressionProps) {
           return <ts.ValueExpression jsValue={value.value ?? value.name} />;
         }
 
-        if (discriminatedUnion?.options.envelope) {
+        if (discriminatedUnion?.options.envelope === "object") {
           const discriminatorPropertyName = discriminatedUnion.options.discriminatorPropertyName;
           const envelopePropertyName = discriminatedUnion.options.envelopePropertyName;
+
           const envelope = $.model.create({
             properties: {
               [discriminatorPropertyName]: $.modelProperty.create({
@@ -46,6 +47,10 @@ export function UnionExpression({ type, children }: UnionExpressionProps) {
           });
 
           return <TypeExpression type={envelope} />;
+        } else if (discriminatedUnion?.options.envelope === "none") {
+          // this is a discriminated union with no envelope
+          // we need a model where the discriminator and the rest of the values are side-by-side
+          return <TypeExpression type={value.type} />;
         } else {
           return <TypeExpression type={value.type} />;
         }

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -106,7 +106,7 @@ function NoneEnvelope(props: NoneEnvelopeProps) {
     "Expected all union variants to be models when using a discriminated union with no envelope",
   );
 
-  // This is an anonymous type, so we render its properties along the discriminator property
+  // Render anonymous models as a set of properties + the discriminator
   if ($.model.isExpresion(props.type.type)) {
     const model = $.model.create({
       properties: {
@@ -120,6 +120,7 @@ function NoneEnvelope(props: NoneEnvelopeProps) {
     return <TypeExpression type={model} />;
   }
 
+  // Render named models as an intersection of the model + the discriminator
   const children = [
     <ts.ObjectExpression>
       <ts.ObjectProperty

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -17,11 +17,35 @@ export function UnionExpression({ type, children }: UnionExpressionProps) {
     UnionVariant | EnumMember
   >;
 
+  let discriminatedUnion = undefined;
+  if ($.union.is(type)) {
+    discriminatedUnion = $.union.getDiscriminatedUnion(type);
+  }
+
   const variants = (
     <ay.For joiner={" | "} each={items}>
       {(_, value) => {
         if ($.enumMember.is(value)) {
           return <ts.ValueExpression jsValue={value.value ?? value.name} />;
+        }
+
+        if (discriminatedUnion?.options.envelope) {
+          const discriminatorPropertyName = discriminatedUnion.options.discriminatorPropertyName;
+          const envelopePropertyName = discriminatedUnion.options.envelopePropertyName;
+          const envelope = $.model.create({
+            properties: {
+              [discriminatorPropertyName]: $.modelProperty.create({
+                name: discriminatedUnion.options.discriminatorPropertyName,
+                type: $.literal.createString(value.name as string),
+              }),
+              [envelopePropertyName]: $.modelProperty.create({
+                name: discriminatedUnion.options.envelopePropertyName,
+                type: value.type,
+              }),
+            },
+          });
+
+          return <TypeExpression type={envelope} />;
         } else {
           return <TypeExpression type={value.type} />;
         }

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -32,7 +32,7 @@ export function UnionExpression({ type, children }: UnionExpressionProps) {
   if (children || (Array.isArray(children) && children.length)) {
     return (
       <>
-        {variants} {` | ${children}`}
+        {variants} {`| ${children}`}
       </>
     );
   }

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -120,5 +120,18 @@ function NoneEnvelope(props: NoneEnvelopeProps) {
     return <TypeExpression type={model} />;
   }
 
-  return ay.code`{${props.discriminatorPropertyName}: "${String(props.type.name)}"} & ${efRefkey(props.type.type)}`;
+  const children = [
+    <ts.ObjectExpression>
+      <ts.ObjectProperty
+        name={props.discriminatorPropertyName}
+        value={<ts.ValueExpression jsValue={props.type.name} />}
+      />
+    </ts.ObjectExpression>,
+    efRefkey(props.type.type),
+  ];
+  return (
+    <ay.For joiner={" & "} each={children}>
+      {(c) => c}
+    </ay.For>
+  );
 }

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -106,6 +106,7 @@ function NoneEnvelope(props: NoneEnvelopeProps) {
     "Expected all union variants to be models when using a discriminated union with no envelope",
   );
 
+  // This is an anonymous type, so we render its properties along the discriminator property
   if ($.model.isExpresion(props.type.type)) {
     const model = $.model.create({
       properties: {

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -3,6 +3,7 @@ import { Children } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { compilerAssert, Enum, EnumMember, Union, UnionVariant } from "@typespec/compiler";
 import { useTsp } from "../../core/context/tsp-context.js";
+import { efRefkey } from "../utils/refkey.js";
 import { TypeExpression } from "./type-expression.jsx";
 
 export interface UnionExpressionProps {
@@ -107,15 +108,18 @@ function NoneEnvelope(props: NoneEnvelopeProps) {
     "Expected all union variants to be models when using a discriminated union with no envelope",
   );
 
-  const model = $.model.create({
-    properties: {
-      [props.discriminatorPropertyName]: $.modelProperty.create({
-        name: props.discriminatorPropertyName,
-        type: $.literal.createString(props.type.name as string),
-      }),
-      ...Object.fromEntries(props.type.type.properties),
-    },
-  });
+  if ($.model.isExpresion(props.type.type)) {
+    const model = $.model.create({
+      properties: {
+        [props.discriminatorPropertyName]: $.modelProperty.create({
+          name: props.discriminatorPropertyName,
+          type: $.literal.createString(props.type.name as string),
+        }),
+        ...Object.fromEntries(props.type.type.properties),
+      },
+    });
+    return <TypeExpression type={model} />;
+  }
 
-  return <TypeExpression type={model} />;
+  return ay.code`{kind: "${String(props.type.name)}"} & ${efRefkey(props.type.type)}`;
 }

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -1,7 +1,8 @@
 import * as ay from "@alloy-js/core";
 import { Children } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
-import { Enum, EnumMember, Union, UnionVariant } from "@typespec/compiler";
+import { compilerAssert, Enum, EnumMember, Union, UnionVariant } from "@typespec/compiler";
+import { Typekit } from "@typespec/compiler/typekit";
 import { useTsp } from "../../core/context/tsp-context.js";
 import { TypeExpression } from "./type-expression.jsx";
 
@@ -17,47 +18,13 @@ export function UnionExpression({ type, children }: UnionExpressionProps) {
     UnionVariant | EnumMember
   >;
 
-  let discriminatedUnion = undefined;
-  if ($.union.is(type)) {
-    discriminatedUnion = $.union.getDiscriminatedUnion(type);
-  }
-
   const variants = (
     <ay.For joiner={" | "} each={items}>
-      {(_, value) => {
-        if ($.enumMember.is(value)) {
-          return <ts.ValueExpression jsValue={value.value ?? value.name} />;
-        }
-
-        if (discriminatedUnion?.options.envelope === "object") {
-          const discriminatorPropertyName = discriminatedUnion.options.discriminatorPropertyName;
-          const envelopePropertyName = discriminatedUnion.options.envelopePropertyName;
-
-          const envelope = $.model.create({
-            properties: {
-              [discriminatorPropertyName]: $.modelProperty.create({
-                name: discriminatedUnion.options.discriminatorPropertyName,
-                type: $.literal.createString(value.name as string),
-              }),
-              [envelopePropertyName]: $.modelProperty.create({
-                name: discriminatedUnion.options.envelopePropertyName,
-                type: value.type,
-              }),
-            },
-          });
-
-          return <TypeExpression type={envelope} />;
-        } else if (discriminatedUnion?.options.envelope === "none") {
-          // this is a discriminated union with no envelope
-          // we need a model where the discriminator and the rest of the values are side-by-side
-          return <TypeExpression type={value.type} />;
-        } else {
-          return <TypeExpression type={value.type} />;
-        }
-      }}
+      {(_, value) => renderVariant($, value)}
     </ay.For>
   );
 
+  // Handle additional children if present
   if (children || (Array.isArray(children) && children.length)) {
     return (
       <>
@@ -67,4 +34,94 @@ export function UnionExpression({ type, children }: UnionExpressionProps) {
   }
 
   return variants;
+}
+
+/**
+ * Renders a union variant or enum member based on its type
+ */
+function renderVariant($: Typekit, value: UnionVariant | EnumMember) {
+  if ($.enumMember.is(value)) {
+    return <ts.ValueExpression jsValue={value.value ?? value.name} />;
+  }
+
+  const discriminatedUnion = $.union.getDiscriminatedUnion(value.union);
+  switch (discriminatedUnion?.options.envelope) {
+    case "object":
+      return (
+        <ObjectEnvelope
+          discriminatorPropertyName={discriminatedUnion.options.discriminatorPropertyName}
+          envelopePropertyName={discriminatedUnion.options.envelopePropertyName}
+          type={value}
+        />
+      );
+    case "none":
+      return (
+        <NoneEnvelope
+          discriminatorPropertyName={discriminatedUnion.options.discriminatorPropertyName}
+          type={value}
+        />
+      );
+    default:
+      // not a discriminated union
+      return <TypeExpression type={value.type} />;
+  }
+}
+
+interface ObjectEnvelopeProps {
+  type: UnionVariant;
+  discriminatorPropertyName: string;
+  envelopePropertyName: string;
+}
+
+/**
+ * Renders a discriminated union with "object" envelope style
+ * where model properties are nested inside an envelope
+ */
+function ObjectEnvelope(props: ObjectEnvelopeProps) {
+  const { $ } = useTsp();
+
+  const envelope = $.model.create({
+    properties: {
+      [props.discriminatorPropertyName]: $.modelProperty.create({
+        name: props.discriminatorPropertyName,
+        type: $.literal.createString(props.type.name as string),
+      }),
+      [props.envelopePropertyName]: $.modelProperty.create({
+        name: props.envelopePropertyName,
+        type: props.type.type,
+      }),
+    },
+  });
+
+  return <TypeExpression type={envelope} />;
+}
+
+interface NoneEnvelopeProps {
+  type: UnionVariant;
+  discriminatorPropertyName: string;
+}
+
+/**
+ * Renders a discriminated union with "none" envelope style
+ * where discriminator property sits alongside model properties
+ */
+function NoneEnvelope(props: NoneEnvelopeProps) {
+  const { $ } = useTsp();
+
+  compilerAssert(
+    $.model.is(props.type.type),
+    "Expected all union variants to be models when using a discriminated union with no envelope",
+  );
+
+  const model = $.model.create({
+    properties: {
+      [props.discriminatorPropertyName]: $.modelProperty.create({
+        name: props.discriminatorPropertyName,
+        type: $.literal.createString(props.type.name as string),
+      }),
+      ...Object.fromEntries(props.type.type.properties),
+    },
+  });
+
+  return <TypeExpression type={model} />;
 }

--- a/packages/emitter-framework/src/typescript/components/union-expression.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-expression.tsx
@@ -120,19 +120,15 @@ function NoneEnvelope(props: NoneEnvelopeProps) {
     return <TypeExpression type={model} />;
   }
 
-  // Render named models as an intersection of the model + the discriminator
-  const children = [
-    <ts.ObjectExpression>
-      <ts.ObjectProperty
-        name={props.discriminatorPropertyName}
-        value={<ts.ValueExpression jsValue={props.type.name} />}
-      />
-    </ts.ObjectExpression>,
-    efRefkey(props.type.type),
-  ];
   return (
-    <ay.For joiner={" & "} each={children}>
-      {(c) => c}
-    </ay.For>
+    <ay.List joiner={" & "}>
+      <ts.ObjectExpression>
+        <ts.ObjectProperty
+          name={props.discriminatorPropertyName}
+          value={<ts.ValueExpression jsValue={props.type.name} />}
+        />
+      </ts.ObjectExpression>
+      <>{efRefkey(props.type.type)}</>
+    </ay.List>
   );
 }

--- a/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
@@ -141,7 +141,7 @@ describe("Typescript Union Declaration", () => {
       });
 
       describe("Discriminated Union", () => {
-        it("renders a discriminated union declaration", async () => {
+        it("renders a discriminated union", async () => {
           const { TestUnion } = (await runner.compile(`
             namespace DemoService;
             @discriminated
@@ -176,7 +176,7 @@ describe("Typescript Union Declaration", () => {
         });
       });
 
-      it("renders a discriminated union declaration with custom properties", async () => {
+      it("renders a discriminated union with custom properties", async () => {
         const { TestUnion } = (await runner.compile(`
           namespace DemoService;
             @discriminated(#{ discriminatorPropertyName: "dataKind", envelopePropertyName: "data" })
@@ -263,7 +263,7 @@ describe("Typescript Union Declaration", () => {
       });
 
       describe("Discriminated Union with no envelope", () => {
-        it("renders named discriminated union declarations", async () => {
+        it("renders named discriminated union", async () => {
           const { Pet, Cat, Dog } = (await runner.compile(`
             namespace DemoService;
 
@@ -295,6 +295,7 @@ describe("Typescript Union Declaration", () => {
               </SourceFile>
             </Output>,
           );
+
           assertFileContents(
             res,
             d`
@@ -306,15 +307,19 @@ describe("Typescript Union Declaration", () => {
                 name: string;
                 bark: boolean;
               }
-              type Pet = {dataKind: "cat"} & Cat | {dataKind: "dog"} & Dog;
+              type Pet = {
+                dataKind: "cat"
+              } & Cat | {
+                dataKind: "dog"
+              } & Dog;
             `,
           );
         });
 
-        it("renders a discriminated union declaration with no envelope", async () => {
+        it("renders anonymous discriminated union", async () => {
           const { TestUnion } = (await runner.compile(`
             namespace DemoService;
-            @discriminated(#{ envelope: "none" })
+            @discriminated(#{ envelope: "none", discriminatorPropertyName: "dataKind" })
             @test union TestUnion {
               one: { oneItem: true },
               two: { secondItem: false }
@@ -333,10 +338,10 @@ describe("Typescript Union Declaration", () => {
             res,
             d`
               type TestUnion = {
-                kind: "one";
+                dataKind: "one";
                 oneItem: true;
               } | {
-                kind: "two";
+                dataKind: "two";
                 secondItem: false;
               };
             `,

--- a/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
@@ -243,22 +243,22 @@ describe("Typescript Union Declaration", () => {
         assertFileContents(
           res,
           d`
-              interface Cat {
-                name: string;
-                meow: boolean;
-              }
-              interface Dog {
-                name: string;
-                bark: boolean;
-              }
-              type Pet = {
-                kind: "cat";
-                value: Cat;
-              } | {
-                kind: "dog";
-                value: Dog;
-              };
-            `,
+            interface Cat {
+              name: string;
+              meow: boolean;
+            }
+            interface Dog {
+              name: string;
+              bark: boolean;
+            }
+            type Pet = {
+              kind: "cat";
+              value: Cat;
+            } | {
+              kind: "dog";
+              value: Dog;
+            };
+          `,
         );
       });
 

--- a/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
@@ -277,7 +277,7 @@ describe("Typescript Union Declaration", () => {
               bark: boolean;
             }
 
-            @discriminated(#{ envelope: "none" })
+            @discriminated(#{ envelope: "none", discriminatorPropertyName: "dataKind" })
             @test union Pet {
               cat: Cat,
               dog: Dog,
@@ -306,7 +306,7 @@ describe("Typescript Union Declaration", () => {
                 name: string;
                 bark: boolean;
               }
-              type Pet = {kind: "cat"} & Cat | {kind: "dog"} & Dog;
+              type Pet = {dataKind: "cat"} & Cat | {dataKind: "dog"} & Dog;
             `,
           );
         });

--- a/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
@@ -1,182 +1,170 @@
 import { render } from "@alloy-js/core";
+import { d } from "@alloy-js/core/testing";
 import { SourceFile } from "@alloy-js/typescript";
-import { Namespace } from "@typespec/compiler";
-import { format } from "prettier";
-import { assert, describe, expect, it } from "vitest";
+import { Enum, Union } from "@typespec/compiler";
+import { BasicTestRunner } from "@typespec/compiler/testing";
+import { beforeEach, describe, it } from "vitest";
 import { Output } from "../../../src/core/components/output.jsx";
 import { UnionDeclaration } from "../../../src/typescript/components/union-declaration.js";
 import { UnionExpression } from "../../../src/typescript/components/union-expression.js";
-import { getProgram } from "../test-host.js";
+import { assertFileContents } from "../../utils.js";
+import { createEmitterFrameworkTestRunner } from "../test-host.js";
 
 describe("Typescript Union Declaration", () => {
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    runner = await createEmitterFrameworkTestRunner();
+  });
+
   describe("Union not bound to Typespec Types", () => {
+    // TODO: clean up this test
     it("creates a union declaration", async () => {
-      const program = await getProgram("");
+      await runner.compile(``);
       const res = render(
-        <Output program={program}>
+        <Output program={runner.program}>
           <SourceFile path="test.ts">
             <UnionDeclaration name="MyUnion">"red" | "blue"</UnionDeclaration>
           </SourceFile>
         </Output>,
       );
 
-      const testFile = res.contents.find((file) => file.path === "test.ts");
-      assert(testFile, "test.ts file not rendered");
-      const actualContent = await format(testFile.contents as string, { parser: "typescript" });
-      const expectedContent = await format(`type MyUnion = "red" | "blue"`, {
-        parser: "typescript",
-      });
-      expect(actualContent).toBe(expectedContent);
+      assertFileContents(
+        res,
+        d`
+          type MyUnion = "red" | "blue";
+        `,
+      );
     });
   });
 
   describe("Union bound to Typespec Types", () => {
     describe("Bound to Union", () => {
       it("creates a union declaration", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        union TestUnion {
-          one: "one",
-          two: "two"
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const union = Array.from((namespace as Namespace).unions.values())[0];
-
-        const res = render(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <UnionDeclaration type={union} />
-            </SourceFile>
-          </Output>,
-        );
-
-        const testFile = res.contents.find((file) => file.path === "test.ts");
-        assert(testFile, "test.ts file not rendered");
-        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
-        const expectedContent = await format(`type TestUnion = "one" | "two"`, {
-          parser: "typescript",
-        });
-        expect(actualContent).toBe(expectedContent);
-      });
-
-      it("creates a union declaration with name override", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        union TestUnion {
-          one: "one",
-          two: "two"
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const union = Array.from((namespace as Namespace).unions.values())[0];
-
-        const res = render(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <UnionDeclaration export type={union} name="MyUnion" />
-            </SourceFile>
-          </Output>,
-        );
-
-        const testFile = res.contents.find((file) => file.path === "test.ts");
-        assert(testFile, "test.ts file not rendered");
-        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
-        const expectedContent = await format(`export type MyUnion = "one" | "two"`, {
-          parser: "typescript",
-        });
-        expect(actualContent).toBe(expectedContent);
-      });
-
-      it("creates a union declaration with extra children", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        union TestUnion {
-          one: "one",
-          two: "two"
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const union = Array.from((namespace as Namespace).unions.values())[0];
-
-        const res = render(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <UnionDeclaration type={union}>"three"</UnionDeclaration>
-            </SourceFile>
-          </Output>,
-        );
-
-        const testFile = res.contents.find((file) => file.path === "test.ts");
-        assert(testFile, "test.ts file not rendered");
-        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
-        const expectedContent = await format(`type TestUnion = "one" | "two" | "three"`, {
-          parser: "typescript",
-        });
-        expect(actualContent).toBe(expectedContent);
-      });
-
-      it("renders an union expression", async () => {
-        const program = await getProgram(`
+        const { TestUnion } = (await runner.compile(`
           namespace DemoService;
-          union TestUnion {
+          @test union TestUnion {
             one: "one",
             two: "two"
           }
-          `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const union = Array.from((namespace as Namespace).unions.values())[0];
+        `)) as { TestUnion: Union };
 
         const res = render(
-          <Output program={program}>
+          <Output program={runner.program}>
             <SourceFile path="test.ts">
-              let x: <UnionExpression type={union} /> = "one";
+              <UnionDeclaration type={TestUnion} />
             </SourceFile>
           </Output>,
         );
 
-        const testFile = res.contents.find((file) => file.path === "test.ts");
-        assert(testFile, "test.ts file not rendered");
-        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
-        const expectedContent = await format(`let x:"one" | "two" = "one"`, {
-          parser: "typescript",
-        });
-        expect(actualContent).toBe(expectedContent);
+        assertFileContents(
+          res,
+          d`
+            type TestUnion = "one" | "two";
+          `,
+        );
+      });
+
+      it("creates a union declaration with name override", async () => {
+        const { TestUnion } = (await runner.compile(`
+          namespace DemoService;
+          @test union TestUnion {
+            one: "one",
+            two: "two"
+          }
+        `)) as { TestUnion: Union };
+
+        const res = render(
+          <Output program={runner.program}>
+            <SourceFile path="test.ts">
+              <UnionDeclaration export type={TestUnion} name="MyUnion" />
+            </SourceFile>
+          </Output>,
+        );
+
+        assertFileContents(
+          res,
+          d`
+            export type MyUnion = "one" | "two";
+          `,
+        );
+      });
+
+      it("creates a union declaration with extra children", async () => {
+        const { TestUnion } = (await runner.compile(`
+          namespace DemoService;
+          @test union TestUnion {
+            one: "one",
+            two: "two"
+          }
+        `)) as { TestUnion: Union };
+
+        const res = render(
+          <Output program={runner.program}>
+            <SourceFile path="test.ts">
+              <UnionDeclaration type={TestUnion}>"three"</UnionDeclaration>
+            </SourceFile>
+          </Output>,
+        );
+
+        assertFileContents(
+          res,
+          d`
+            type TestUnion = "one" | "two" | "three";
+          `,
+        );
+      });
+
+      it("renders a union expression", async () => {
+        const { TestUnion } = (await runner.compile(`
+          namespace DemoService;
+          @test union TestUnion {
+            one: "one",
+            two: "two"
+          }
+        `)) as { TestUnion: Union };
+
+        const res = render(
+          <Output program={runner.program}>
+            <SourceFile path="test.ts">
+              let x: <UnionExpression type={TestUnion} /> = "one";
+            </SourceFile>
+          </Output>,
+        );
+
+        assertFileContents(
+          res,
+          d`
+            let x: "one" | "two" = "one";
+          `,
+        );
       });
     });
 
     describe("Bound to Enum", () => {
       it("creates a union declaration", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        enum TestEnum {
-          one: "one",
-          two: "two"
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const union = Array.from((namespace as Namespace).enums.values())[0];
+        const { TestEnum } = (await runner.compile(`
+          namespace DemoService;
+          @test enum TestEnum {
+            one: "one",
+            two: "two"
+          }
+        `)) as { TestEnum: Enum };
 
         const res = render(
-          <Output program={program}>
+          <Output program={runner.program}>
             <SourceFile path="test.ts">
-              <UnionDeclaration type={union} />
+              <UnionDeclaration type={TestEnum} />
             </SourceFile>
           </Output>,
         );
 
-        const testFile = res.contents.find((file) => file.path === "test.ts");
-        assert(testFile, "test.ts file not rendered");
-        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
-        const expectedContent = await format(`type TestEnum = "one" | "two"`, {
-          parser: "typescript",
-        });
-        expect(actualContent).toBe(expectedContent);
+        assertFileContents(
+          res,
+          d`
+            type TestEnum = "one" | "two";
+          `,
+        );
       });
     });
   });

--- a/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
@@ -18,7 +18,6 @@ describe("Typescript Union Declaration", () => {
   });
 
   describe("Union not bound to Typespec Types", () => {
-    // TODO: clean up this test
     it("creates a union declaration", async () => {
       await runner.compile(``);
       const res = render(


### PR DESCRIPTION
This pull request enhances the handling of discriminated unions in the `@typespec/emitter-framework` package. It introduces new rendering logic for discriminated unions, updates existing components to support these changes, and improves test coverage to validate the new functionality.

### Enhancements to discriminated union rendering:

* Added new rendering logic for discriminated unions, including support for "object" and "none" envelope styles, through the  `ObjectEnvelope` and `NoneEnvelope` functions in `union-expression.tsx`. These handle different discriminator configurations and ensure proper rendering of union variants. [[1]](diffhunk://#diff-400029c681b8e2281a1bde7777af749a18d635dcf9ddaa4a6c9cb1bd86301fe7L22-R27) [[2]](diffhunk://#diff-400029c681b8e2281a1bde7777af749a18d635dcf9ddaa4a6c9cb1bd86301fe7R38-R127)

### Updates to existing components:

* Modified the `InterfaceBody` component in `interface-declaration.tsx` to include a semicolon when rendering type members, ensuring consistency with TypeScript syntax. Found in passing and validated via the new tests


### Improvements to test coverage:

* Refactored and expanded tests in `union-declaration.test.tsx` using the new testing patterns

Fixes #7174
