### PR TITLE
Compiler statistics

### DIFF
--- a/.chronus/changes/compiler-statistics-2025-4-16-17-5-19.md
+++ b/.chronus/changes/compiler-statistics-2025-4-16-17-5-19.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Add a `--stats` flag to `tsp compile` to log some performance and complexity statistics

--- a/packages/compiler/src/core/cli/actions/compile/args.ts
+++ b/packages/compiler/src/core/cli/actions/compile/args.ts
@@ -9,6 +9,8 @@ import { CompilerHost, Diagnostic, NoTarget } from "../../../types.js";
 export interface CompileCliArgs {
   path?: string;
   pretty?: boolean;
+  /** Print statistics about the compilation(Task duration, types created, etc.) */
+  stats?: boolean;
   "output-dir"?: string;
   "output-path"?: string;
   nostdlib?: boolean;

--- a/packages/compiler/src/core/cli/actions/compile/compile.ts
+++ b/packages/compiler/src/core/cli/actions/compile/compile.ts
@@ -200,6 +200,7 @@ function logProgramResult(
 
 function printStats(stats: Stats) {
   print("Compiler statistics:");
+  printRuntime(stats, "loader");
   printRuntime(stats, "resolver");
   printRuntime(stats, "checker");
   printGroup(stats, "validation", "validators");

--- a/packages/compiler/src/core/cli/cli.ts
+++ b/packages/compiler/src/core/cli/cli.ts
@@ -91,6 +91,11 @@ async function main() {
             default: false,
             describe: "Watch project files for changes and recompile.",
           })
+          .option("stats", {
+            type: "boolean",
+            default: false,
+            describe: "Print statistics about the compilation.",
+          })
           .option("emit", {
             type: "array",
             string: true,

--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -7,6 +7,7 @@ import { createDiagnostic } from "./messages.js";
 import { NameResolver } from "./name-resolver.js";
 import type { Program } from "./program.js";
 import { EventEmitter, mapEventEmitterToNodeListener, navigateProgram } from "./semantic-walker.js";
+import { startTimer, time } from "./stats.js";
 import {
   Diagnostic,
   DiagnosticMessages,
@@ -26,7 +27,18 @@ type LinterLibraryInstance = { linter: LinterResolvedDefinition };
 export interface Linter {
   extendRuleSet(ruleSet: LinterRuleSet): Promise<readonly Diagnostic[]>;
   registerLinterLibrary(name: string, lib?: LinterLibraryInstance): void;
-  lint(): readonly Diagnostic[];
+  lint(): LinterResult;
+}
+
+export interface LinterStats {
+  runtime: {
+    total: number;
+    rules: Record<string, number>;
+  };
+}
+export interface LinterResult {
+  readonly diagnostics: readonly Diagnostic[];
+  readonly stats: LinterStats;
 }
 
 /**
@@ -146,23 +158,35 @@ export function createLinter(
     return diagnostics.diagnostics;
   }
 
-  function lint(): readonly Diagnostic[] {
+  function lint(): LinterResult {
     const diagnostics = createDiagnosticCollector();
     const eventEmitter = new EventEmitter<SemanticNodeListener>();
+    const stats: LinterStats = {
+      runtime: {
+        total: 0,
+        rules: {},
+      },
+    };
     tracer.trace(
       "lint",
       `Running linter with following rules:\n` +
         [...enabledRules.keys()].map((x) => ` - ${x}`).join("\n"),
     );
 
+    const timer = startTimer();
     for (const rule of enabledRules.values()) {
       const listener = rule.create(createLinterRuleContext(program, rule, diagnostics));
       for (const [name, cb] of Object.entries(listener)) {
-        eventEmitter.on(name as any, cb as any);
+        const timedCb = (...args: any[]) => {
+          const duration = time(() => (cb as any)(...args));
+          stats.runtime.rules[rule.id] = (stats.runtime.rules[rule.id] ?? 0) + duration;
+        };
+        eventEmitter.on(name as any, timedCb);
       }
     }
     navigateProgram(program, mapEventEmitterToNodeListener(eventEmitter));
-    return diagnostics.diagnostics;
+    stats.runtime.total = timer.end();
+    return { diagnostics: diagnostics.diagnostics, stats };
   }
 
   async function resolveLibrary(name: string): Promise<LinterLibraryInstance | undefined> {

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -42,7 +42,7 @@ import {
   moduleResolutionErrorToDiagnostic,
 } from "./source-loader.js";
 import { createStateAccessors } from "./state-accessors.js";
-import { Stats, startTimer, time } from "./stats.js";
+import { Stats, startTimer, time, timeAsync } from "./stats.js";
 import {
   CompilerHost,
   Diagnostic,
@@ -267,7 +267,7 @@ async function createProgram(
   const basedir = getDirectoryPath(resolvedMain) || "/";
   await checkForCompilerVersionMismatch(basedir);
 
-  await loadSources(resolvedMain);
+  stats.loader = await timeAsync(() => loadSources(resolvedMain));
 
   const emit = options.noEmit ? [] : (options.emit ?? []);
   const emitterOptions = options.options;

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -42,6 +42,7 @@ import {
   moduleResolutionErrorToDiagnostic,
 } from "./source-loader.js";
 import { createStateAccessors } from "./state-accessors.js";
+import { Stats, startTimer, time } from "./stats.js";
 import {
   CompilerHost,
   Diagnostic,
@@ -105,6 +106,8 @@ export interface Program {
   /** @internal */
   stateSets: Map<symbol, Set<Type>>;
   stateMap(key: symbol): Map<Type, any>;
+  /**@internal */
+  stats: Stats;
   /** @internal */
   stateMaps: Map<symbol, Map<Type, unknown>>;
   hasError(): boolean;
@@ -174,18 +177,25 @@ export async function compile(
     return program;
   }
 
+  const emitStats: Stats["emit"] = {
+    total: 0,
+    emitters: {},
+  };
+  const timer = startTimer();
   // Emitter stage
   for (const emitter of program.emitters) {
     // If in dry mode run and an emitter doesn't support it we have to skip it.
     if (program.compilerOptions.dryRun && !emitter.library.definition?.capabilities?.dryRun) {
       continue;
     }
-    await emit(emitter, program);
-
+    const { duration } = await emit(emitter, program);
+    emitStats.emitters[emitter.metadata.name ?? "<unnamed>"] = duration;
     if (options.listFiles) {
       logEmittedFilesPath(host.logSink);
     }
   }
+  emitStats.total = timer.end();
+  program.stats.emit = emitStats;
   return program;
 }
 
@@ -195,6 +205,7 @@ async function createProgram(
   options: CompilerOptions = {},
   oldProgram?: Program,
 ): Promise<{ program: Program; shouldAbort: boolean }> {
+  const stats: Partial<Stats> = {};
   const validateCbs: Validator[] = [];
   const stateMaps = new Map<symbol, Map<Type, unknown>>();
   const stateSets = new Map<symbol, Set<Type>>();
@@ -222,6 +233,7 @@ async function createProgram(
     getOption,
     stateMaps,
     stateSets,
+    stats: stats as any,
     tracer,
     trace,
     ...createStateAccessors(stateMaps, stateSets),
@@ -274,7 +286,7 @@ async function createProgram(
   oldProgram = undefined;
 
   const resolver = createResolver(program);
-  resolver.resolveProgram();
+  stats.resolver = time(() => resolver.resolveProgram());
 
   const linter = createLinter(program, (name) => loadLibrary(basedir, name));
   linter.registerLinterLibrary(builtInLinterLibraryName, createBuiltInLinterLibrary(resolver));
@@ -283,7 +295,7 @@ async function createProgram(
   }
 
   program.checker = createChecker(program, resolver);
-  program.checker.checkProgram();
+  stats.checker = time(() => program.checker.checkProgram());
 
   if (!continueToNextStage) {
     return { program, shouldAbort: true };
@@ -301,7 +313,9 @@ async function createProgram(
   }
 
   // Linter stage
-  program.reportDiagnostics(linter.lint());
+  const lintResult = linter.lint();
+  stats.linter = lintResult.stats.runtime;
+  program.reportDiagnostics(lintResult.diagnostics);
 
   return { program, shouldAbort: false };
 
@@ -606,10 +620,16 @@ async function createProgram(
   }
 
   async function runValidators() {
+    const start = startTimer();
+    stats.validation = { total: 0, validators: {} };
     runCompilerValidators();
+    stats.validation.validators.compiler = start.end();
     for (const validator of validateCbs) {
+      const start = startTimer();
       await runValidator(validator);
+      stats.validation.validators[validator.metadata.name ?? "<unnamed>"] = start.end();
     }
+    stats.validation.total = start.end();
   }
 
   async function runValidator(validator: Validator) {
@@ -935,7 +955,7 @@ function resolveOptions(options: CompilerOptions): CompilerOptions {
   return { ...options };
 }
 
-async function emit(emitter: EmitterRef, program: Program) {
+async function emit(emitter: EmitterRef, program: Program): Promise<{ duration: number }> {
   const emitterName = emitter.metadata.name ?? "";
   const relativePathForEmittedFiles =
     transformPathForSink(program.host.logSink, emitter.emitterOutputDir) + "/";
@@ -943,21 +963,22 @@ async function emit(emitter: EmitterRef, program: Program) {
   const errorCount = program.diagnostics.filter((x) => x.severity === "error").length;
   const warnCount = program.diagnostics.filter((x) => x.severity === "warning").length;
   const logger = createLogger({ sink: program.host.logSink });
-  await logger.trackAction(
-    `Running ${emitterName}...`,
-    `${emitterName}    ${pc.dim(relativePathForEmittedFiles)}`,
-    async (task) => {
-      await runEmitter(emitter, program);
-
-      const newErrorCount = program.diagnostics.filter((x) => x.severity === "error").length;
-      const newWarnCount = program.diagnostics.filter((x) => x.severity === "warning").length;
-      if (newErrorCount > errorCount) {
-        task.fail();
-      } else if (newWarnCount > warnCount) {
-        task.warn();
-      }
-    },
-  );
+  return await logger.trackAction(`Running ${emitterName}...`, "", async (task) => {
+    const start = startTimer();
+    await runEmitter(emitter, program);
+    const duration = start.end();
+    const message = `${emitterName} ${pc.green(`${Math.round(duration)}ms`)} ${pc.dim(relativePathForEmittedFiles)}`;
+    const newErrorCount = program.diagnostics.filter((x) => x.severity === "error").length;
+    const newWarnCount = program.diagnostics.filter((x) => x.severity === "warning").length;
+    if (newErrorCount > errorCount) {
+      task.fail(message);
+    } else if (newWarnCount > warnCount) {
+      task.warn(message);
+    } else {
+      task.succeed(message);
+    }
+    return { duration };
+  });
 }
 
 /**

--- a/packages/compiler/src/core/stats.ts
+++ b/packages/compiler/src/core/stats.ts
@@ -1,0 +1,43 @@
+export interface Stats {
+  total: number;
+  parser: number;
+  resolver: number;
+  checker: number;
+  validation: {
+    total: number;
+    validators: {
+      [validator: string]: number;
+    };
+  };
+  linter: {
+    total: number;
+    rules: {
+      [rule: string]: number;
+    };
+  };
+  emit: {
+    total: number;
+    emitters: {
+      [rule: string]: number;
+    };
+  };
+}
+
+export interface Timer {
+  end: () => number;
+}
+
+export function startTimer(): Timer {
+  const start = performance.now();
+  return {
+    end: () => {
+      return performance.now() - start;
+    },
+  };
+}
+
+export function time(fn: () => void): number {
+  const timer = startTimer();
+  fn();
+  return timer.end();
+}

--- a/packages/compiler/src/core/stats.ts
+++ b/packages/compiler/src/core/stats.ts
@@ -1,6 +1,6 @@
 export interface Stats {
   total: number;
-  parser: number;
+  loader: number;
   resolver: number;
   checker: number;
   validation: {
@@ -39,5 +39,11 @@ export function startTimer(): Timer {
 export function time(fn: () => void): number {
   const timer = startTimer();
   fn();
+  return timer.end();
+}
+
+export async function timeAsync(fn: () => Promise<void>): Promise<number> {
+  const timer = startTimer();
+  await fn();
   return timer.end();
 }

--- a/packages/compiler/src/core/stats.ts
+++ b/packages/compiler/src/core/stats.ts
@@ -1,4 +1,14 @@
 export interface Stats {
+  complexity: ComplexityStats;
+  runtime: RuntimeStats;
+}
+
+export interface ComplexityStats {
+  createdTypes: number;
+  finishedTypes: number;
+}
+
+export interface RuntimeStats {
   total: number;
   loader: number;
   resolver: number;

--- a/packages/compiler/test/core/linter.test.ts
+++ b/packages/compiler/test/core/linter.test.ts
@@ -82,7 +82,7 @@ describe("compiler: linter", () => {
     const linter = await createTestLinter(`model Foo {}`, {
       rules: [noModelFoo],
     });
-    expectDiagnosticEmpty(linter.lint());
+    expectDiagnosticEmpty(linter.lint().diagnostics);
   });
 
   it("enabling a rule that doesn't exists emit a diagnostic", async () => {
@@ -159,7 +159,7 @@ describe("compiler: linter", () => {
       const linter = await createTestLinterAndEnableRules(files, {
         rules: [noModelFoo],
       });
-      expectDiagnosticEmpty(linter.lint());
+      expectDiagnosticEmpty(linter.lint().diagnostics);
     });
 
     it("emit diagnostic when in the user code", async () => {
@@ -174,7 +174,7 @@ describe("compiler: linter", () => {
       const linter = await createTestLinterAndEnableRules(files, {
         rules: [noModelFoo],
       });
-      expectDiagnostics(linter.lint(), {
+      expectDiagnostics(linter.lint().diagnostics, {
         severity: "warning",
         code: "@typespec/test-linter/no-model-foo",
         message: `Cannot call model 'Foo'`,
@@ -192,7 +192,7 @@ describe("compiler: linter", () => {
           enable: { "@typespec/test-linter/no-model-foo": true },
         }),
       );
-      expectDiagnostics(linter.lint(), {
+      expectDiagnostics(linter.lint().diagnostics, {
         severity: "warning",
         code: "@typespec/test-linter/no-model-foo",
         message: `Cannot call model 'Foo'`,
@@ -208,7 +208,7 @@ describe("compiler: linter", () => {
           enable: { "@typespec/test-linter/no-model-foo": true },
         }),
       );
-      expectDiagnosticEmpty(linter.lint());
+      expectDiagnosticEmpty(linter.lint().diagnostics);
     });
   });
 
@@ -222,7 +222,7 @@ describe("compiler: linter", () => {
           extends: ["@typespec/test-linter/all"],
         }),
       );
-      expectDiagnostics(linter.lint(), {
+      expectDiagnostics(linter.lint().diagnostics, {
         severity: "warning",
         code: "@typespec/test-linter/no-model-foo",
         message: `Cannot call model 'Foo'`,
@@ -242,7 +242,7 @@ describe("compiler: linter", () => {
           extends: ["@typespec/test-linter/custom"],
         }),
       );
-      expectDiagnostics(linter.lint(), {
+      expectDiagnostics(linter.lint().diagnostics, {
         severity: "warning",
         code: "@typespec/test-linter/no-model-foo",
         message: `Cannot call model 'Foo'`,


### PR DESCRIPTION
Add a `--stats` flag to tsp compile that logs performance and complexity statistics

<img width="878" alt="image" src="https://github.com/user-attachments/assets/e76c1ead-c9d7-4b80-924b-c72f95a0e97c" />

The `stats` property on the program contains the progrmmatic value of this but is not exposed right now as we'll probably be iterating on how this is structured as we need more info