### PR TITLE
Fix reference typo in docs/language-basics/models.md

### DIFF
--- a/website/src/content/docs/docs/language-basics/models.md
+++ b/website/src/content/docs/docs/language-basics/models.md
@@ -100,7 +100,7 @@ model Person {
 
 When using `is Record<T>`, it indicates that all properties of this model are of type T. This means that each property explicitly defined in the model must also be of type T.
 
-The example above would be invalid
+The example below would be invalid
 
 ```tsp
 model Person is Record<string> {


### PR DESCRIPTION
Change example reference to `below` from `above` to reflect the example's position in the document relative to the statement.