### PR TITLE
Allow for construction of an enumTypeValue without its parent being constructed yet

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumType.cs
@@ -7,7 +7,10 @@ namespace Microsoft.TypeSpec.Generator.Input
 {
     public class InputEnumType : InputType
     {
+        // We always call the Values setter so we know the field will not be null.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         public InputEnumType(string name, string @namespace, string crossLanguageDefinitionId, string? access, string? deprecation, string? summary, string? doc, InputModelTypeUsage usage, InputPrimitiveType valueType, IReadOnlyList<InputEnumTypeValue> values, bool isExtensible)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
             : base(name)
         {
             Namespace = @namespace;
@@ -30,7 +33,19 @@ namespace Microsoft.TypeSpec.Generator.Input
         public string? Doc { get; internal set; }
         public InputModelTypeUsage Usage { get; internal set; }
         public InputPrimitiveType ValueType { get; internal set; }
-        public IReadOnlyList<InputEnumTypeValue> Values { get; internal set; }
+        private IReadOnlyList<InputEnumTypeValue> _values;
+        public IReadOnlyList<InputEnumTypeValue> Values
+        {
+            get => _values;
+            internal set
+            {
+                foreach (var enumValue in value)
+                {
+                    enumValue.EnumType = this;
+                }
+                _values = value;
+            }
+        }
         public bool IsExtensible { get; internal set; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeFloatValue.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeFloatValue.cs
@@ -5,7 +5,8 @@ namespace Microsoft.TypeSpec.Generator.Input
 {
     internal class InputEnumTypeFloatValue : InputEnumTypeValue
     {
-        public InputEnumTypeFloatValue(string name, float floatValue, InputPrimitiveType valueType, InputEnumType enumType, string? summary, string? doc) : base(name, floatValue, valueType, enumType, summary, doc)
+        public InputEnumTypeFloatValue(string name, float floatValue, InputPrimitiveType valueType, string? summary, string? doc, InputEnumType? enumType = default)
+            : base(name, floatValue, valueType, summary, doc, enumType)
         {
             FloatValue = floatValue;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeIntegerValue.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeIntegerValue.cs
@@ -5,7 +5,8 @@ namespace Microsoft.TypeSpec.Generator.Input
 {
     internal class InputEnumTypeIntegerValue : InputEnumTypeValue
     {
-        public InputEnumTypeIntegerValue(string name, int integerValue, InputPrimitiveType valueType, InputEnumType enumType, string? summary, string? doc) : base(name, integerValue, valueType, enumType, summary, doc)
+        public InputEnumTypeIntegerValue(string name, int integerValue, InputPrimitiveType valueType, string? summary, string? doc, InputEnumType? enumType = default)
+            : base(name, integerValue, valueType, summary, doc, enumType)
         {
             IntegerValue = integerValue;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeStringValue.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeStringValue.cs
@@ -5,7 +5,8 @@ namespace Microsoft.TypeSpec.Generator.Input
 {
     internal class InputEnumTypeStringValue : InputEnumTypeValue
     {
-        public InputEnumTypeStringValue(string name, string stringValue, InputPrimitiveType valueType, InputEnumType enumType, string? summary, string? doc) : base(name, stringValue, valueType, enumType, summary, doc)
+        public InputEnumTypeStringValue(string name, string stringValue, InputPrimitiveType valueType, string? summary, string? doc, InputEnumType? enumType = default)
+            : base(name, stringValue, valueType, summary, doc, enumType)
         {
             StringValue = stringValue;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeValue.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeValue.cs
@@ -5,19 +5,26 @@ namespace Microsoft.TypeSpec.Generator.Input
 {
     public class InputEnumTypeValue : InputType
     {
-        public InputEnumTypeValue(string name, object value, InputPrimitiveType valueType, InputEnumType enumType, string? summary, string? doc) : base(name)
+        // We only access these types from an InputEnumType and in the Values setter the owner is always set so we can safely assume they are not null.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+        public InputEnumTypeValue(string name, object value, InputPrimitiveType valueType, string? summary, string? doc, InputEnumType? enumType = default) : base(name)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         {
             Name = name;
             Value = value;
             ValueType = valueType;
-            EnumType = enumType;
+            // EnumType will be set when the value is applied to an enum type if this parameter is null
+            if (enumType is not null)
+            {
+                EnumType = enumType;
+            }
             Summary = summary;
             Doc = doc;
         }
 
         public object Value { get; }
         public InputPrimitiveType ValueType { get; }
-        public InputEnumType EnumType { get; }
+        public InputEnumType EnumType { get; internal set; }
         public string? Summary { get; }
         public string? Doc { get; }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecInputEnumTypeValueConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecInputEnumTypeValueConverter.cs
@@ -59,9 +59,9 @@ namespace Microsoft.TypeSpec.Generator.Input
 
             InputEnumTypeValue enumValue = valueType.Kind switch
             {
-                InputPrimitiveTypeKind.String => new InputEnumTypeStringValue(name, rawValue.Value.GetString() ?? throw new JsonException(), valueType, enumType, summary, doc) { Decorators = decorators ?? [] },
-                InputPrimitiveTypeKind.Int32 => new InputEnumTypeIntegerValue(name, rawValue.Value.GetInt32(), valueType, enumType, summary, doc) { Decorators = decorators ?? [] },
-                InputPrimitiveTypeKind.Float32 => new InputEnumTypeFloatValue(name, rawValue.Value.GetSingle(), valueType, enumType, summary, doc) { Decorators = decorators ?? [] },
+                InputPrimitiveTypeKind.String => new InputEnumTypeStringValue(name, rawValue.Value.GetString() ?? throw new JsonException(), valueType, summary, doc, enumType) { Decorators = decorators ?? [] },
+                InputPrimitiveTypeKind.Int32 => new InputEnumTypeIntegerValue(name, rawValue.Value.GetInt32(), valueType, summary, doc, enumType) { Decorators = decorators ?? [] },
+                InputPrimitiveTypeKind.Float32 => new InputEnumTypeFloatValue(name, rawValue.Value.GetSingle(), valueType, summary, doc, enumType) { Decorators = decorators ?? [] },
                 _ => throw new JsonException()
             };
             if (id != null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -63,7 +63,7 @@ namespace Microsoft.TypeSpec.Generator
             {
                 var values = new List<InputEnumTypeValue>();
                 var enumType = new InputEnumType(literal.Name, literal.Namespace, $"{literal.Namespace}.{literal.Name}", null, null, null, $"The {literal.Name}", InputModelTypeUsage.Input | InputModelTypeUsage.Output, literal.ValueType, values, true);
-                values.Add(new InputEnumTypeValue(literal.Value.ToString() ?? "Null", literal.Value, literal.ValueType, enumType, null, literal.Value.ToString()));
+                values.Add(new InputEnumTypeValue(literal.Value.ToString() ?? "Null", literal.Value, literal.ValueType, null, literal.Value.ToString(), enumType));
                 valueType = enumType;
             }
             LiteralValueTypeCache.Add(literal, valueType);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
@@ -14,17 +14,17 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
         {
             public static InputEnumTypeValue Int32(string name, int value, InputEnumType enumType)
             {
-                return new InputEnumTypeValue(name, value, InputPrimitiveType.Int32, enumType, "", $"{name} description");
+                return new InputEnumTypeValue(name, value, InputPrimitiveType.Int32, "", $"{name} description", enumType);
             }
 
             public static InputEnumTypeValue Float32(string name, float value, InputEnumType enumType)
             {
-                return new InputEnumTypeValue(name, value, InputPrimitiveType.Float32, enumType, "", $"{name} description");
+                return new InputEnumTypeValue(name, value, InputPrimitiveType.Float32, "", $"{name} description", enumType);
             }
 
             public static InputEnumTypeValue String(string name, string value, InputEnumType enumType)
             {
-                return new InputEnumTypeValue(name, value, InputPrimitiveType.String, enumType, "", $"{name} description");
+                return new InputEnumTypeValue(name, value, InputPrimitiveType.String, "", $"{name} description", enumType);
             }
         }
 


### PR DESCRIPTION
If a plugin wants to create a new InputEnumType they will need to pass a set of values in.  Those InputEnumValueTypes won't know their parent yet since its being constructed inline and therefore the InputEnumType should apply this for them.