### PR TITLE
[Typekit] - Add `builtin.is(type: Type): boolean`

### DIFF
--- a/packages/compiler/src/typekit/kits/builtin.ts
+++ b/packages/compiler/src/typekit/kits/builtin.ts
@@ -1,4 +1,4 @@
-import type { Scalar } from "../../core/types.js";
+import type { Scalar, Type } from "../../core/types.js";
 import { defineKit } from "../define-kit.js";
 
 /**
@@ -6,6 +6,13 @@ import { defineKit } from "../define-kit.js";
  * @typekit builtin
  */
 export interface BuiltinKit {
+  /**
+   * Checks if the given type is a built-in type.
+   * @param type The type to check.
+   * @returns True if the type is a built-in type, false otherwise.
+   */
+  is(type: Type): boolean;
+
   /**
    * Accessor for the string builtin type.
    */
@@ -142,6 +149,9 @@ declare module "../define-kit.js" {
 
 defineKit<TypekitExtension>({
   builtin: {
+    is(type: Type): boolean {
+      return this.program.checker.isStdType(type);
+    },
     get string(): Scalar {
       return this.program.checker.getStdType("string");
     },

--- a/packages/compiler/test/typekit/builtin.test.ts
+++ b/packages/compiler/test/typekit/builtin.test.ts
@@ -159,3 +159,13 @@ it("can get the builtin utcDateTime type", async () => {
   expect(utcDateTimeType).toBeDefined();
   expect(utcDateTimeType.name).toBe("utcDateTime");
 });
+
+it("returns true for a built-in type", async () => {
+  const utcDateTimeType = $(program).builtin.utcDateTime;
+  expect($(program).builtin.is(utcDateTimeType)).toBe(true);
+});
+
+it("returns false for a non-built-in type", async () => {
+  const stringType = $(program).model.create({ name: "MyModel", properties: {} });
+  expect($(program).builtin.is(stringType)).toBe(false);
+});


### PR DESCRIPTION
Introduce `builtin.is(type: Type): boolean`, which returns true for any type defined in the global `TypeSpec` namespace (i.e. built-in/standard library types).