### PR TITLE
[Emitter Framework] Emit TypeSpec docs as JSDoc in TypeScript components

### DIFF
--- a/.chronus/changes/joheredi-ef-plumb-docs-2025-4-21-1-15-10.md
+++ b/.chronus/changes/joheredi-ef-plumb-docs-2025-4-21-1-15-10.md
@@ -1,0 +1,8 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/emitter-framework"
+  - "@typespec/http-client-js"
+---
+
+Emit TypeSpec comments as JSDoc in TypeScript components

--- a/packages/emitter-framework/src/typescript/components/enum-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/enum-declaration.tsx
@@ -28,13 +28,22 @@ export function EnumDeclaration(props: EnumDeclarationProps) {
   const refkeys = declarationRefkeys(props.refkey, props.type);
   const name = props.name ?? ts.useTSNamePolicy().getName(props.type.name!, "enum");
   const members = Array.from(type.members.entries());
+  const doc = props.doc ?? $.type.getDoc(type);
 
   return (
-    <ts.EnumDeclaration name={name} refkey={refkeys} default={props.default} export={props.export}>
+    <ts.EnumDeclaration
+      doc={doc}
+      name={name}
+      refkey={refkeys}
+      default={props.default}
+      export={props.export}
+    >
       <ay.For each={members} joiner={",\n"}>
         {([key, value]) => {
+          const memberDoc = $.type.getDoc(value);
           return (
             <EnumMember
+              doc={memberDoc}
               type={value}
               refkey={
                 $.union.is(props.type) ? efRefkey(props.type.variants.get(key)) : efRefkey(value)
@@ -49,12 +58,14 @@ export function EnumDeclaration(props: EnumDeclarationProps) {
 
 export interface EnumMemberProps {
   type: TspEnumMember;
+  doc?: ay.Children;
   refkey?: ay.Refkey;
 }
 
 export function EnumMember(props: EnumMemberProps) {
   return (
     <ts.EnumMember
+      doc={props.doc}
       name={props.type.name}
       jsValue={props.type.value ?? props.type.name}
       refkey={props.refkey}

--- a/packages/emitter-framework/src/typescript/components/function-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/function-declaration.tsx
@@ -1,5 +1,6 @@
 import * as ts from "@alloy-js/typescript";
 import { Model, Operation } from "@typespec/compiler";
+import { useTsp } from "../../core/index.js";
 import { buildParameterDescriptors, getReturnType } from "../utils/operation.js";
 import { declarationRefkeys } from "../utils/refkey.js";
 import { TypeExpression } from "./type-expression.js";
@@ -21,6 +22,8 @@ export type FunctionDeclarationProps =
  * provided will take precedence.
  */
 export function FunctionDeclaration(props: FunctionDeclarationProps) {
+  const { $ } = useTsp();
+
   if (!isTypedFunctionDeclarationProps(props)) {
     return <ts.FunctionDeclaration {...props} />;
   }
@@ -40,8 +43,10 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
     params: props.parameters,
     mode: props.parametersMode,
   });
+  const doc = props.doc ?? $.type.getDoc(props.type);
   return (
     <ts.FunctionDeclaration
+      doc={doc}
       refkey={refkeys}
       name={name}
       async={props.async}
@@ -49,8 +54,8 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
       export={props.export}
       kind={props.kind}
       returnType={returnType}
+      parameters={allParameters}
     >
-      <ts.FunctionDeclaration.Parameters parameters={allParameters} />
       {props.children}
     </ts.FunctionDeclaration>
   );

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -45,9 +45,11 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
   const refkeys = declarationRefkeys(props.refkey, props.type);
 
   const extendsType = props.extends ?? getExtendsType($, props.type);
+  const doc = props.doc ?? $.type.getDoc(props.type);
 
   return (
     <ts.InterfaceDeclaration
+      doc={doc}
       default={props.default}
       export={props.export}
       kind={props.kind}

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -1,3 +1,4 @@
+import { Children } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { isNeverType, ModelProperty, Operation } from "@typespec/compiler";
 import { getHttpPart } from "@typespec/http";
@@ -7,6 +8,7 @@ import { TypeExpression } from "./type-expression.js";
 
 export interface InterfaceMemberProps {
   type: ModelProperty | Operation;
+  doc?: Children;
   optional?: boolean;
 }
 
@@ -14,6 +16,7 @@ export function InterfaceMember(props: InterfaceMemberProps) {
   const { $ } = useTsp();
   const namer = ts.useTSNamePolicy();
   const name = namer.getName(props.type.name, "object-member-getter");
+  const doc = props.doc ?? $.type.getDoc(props.type);
 
   if ($.modelProperty.is(props.type)) {
     if (isNeverType(props.type.type)) {
@@ -28,6 +31,7 @@ export function InterfaceMember(props: InterfaceMemberProps) {
 
     return (
       <ts.InterfaceMember
+        doc={doc}
         name={name}
         optional={props.optional ?? props.type.optional}
         type={<TypeExpression type={unpackedType} />}

--- a/packages/emitter-framework/src/typescript/components/interface-method.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-method.tsx
@@ -1,12 +1,14 @@
-import { splitProps } from "@alloy-js/core/jsx-runtime";
+import { Children, splitProps } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { Operation } from "@typespec/compiler";
+import { useTsp } from "../../core/index.js";
 import { buildParameterDescriptors, getReturnType } from "../utils/operation.js";
 import { TypeExpression } from "./type-expression.jsx";
 
 export interface InterfaceMethodPropsWithType extends Omit<ts.InterfaceMethodProps, "name"> {
   type: Operation;
   name?: string;
+  doc?: Children;
   parametersMode?: "prepend" | "append" | "replace";
 }
 
@@ -18,6 +20,7 @@ export type InterfaceMethodProps = InterfaceMethodPropsWithType | ts.InterfaceMe
  * provided will take precedence.
  */
 export function InterfaceMethod(props: Readonly<InterfaceMethodProps>) {
+  const { $ } = useTsp();
   const isTypeSpecTyped = "type" in props;
   if (!isTypeSpecTyped) {
     return <ts.InterfaceMethod {...props} />;
@@ -36,6 +39,8 @@ export function InterfaceMethod(props: Readonly<InterfaceMethodProps>) {
     mode: props.parametersMode,
   });
 
+  const doc = props.doc ?? $.type.getDoc(props.type);
+
   return (
     <ts.InterfaceMethod
       {...forwardProps}
@@ -43,6 +48,7 @@ export function InterfaceMethod(props: Readonly<InterfaceMethodProps>) {
       name={name}
       returnType={returnType}
       parameters={allParameters}
+      doc={doc}
     />
   );
 }

--- a/packages/emitter-framework/src/typescript/components/type-alias-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/type-alias-declaration.tsx
@@ -30,11 +30,12 @@ export function TypeAliasDeclaration(props: TypeAliasDeclarationProps) {
     reportDiagnostic($.program, { code: "type-declaration-missing-name", target: props.type });
   }
 
+  const doc = props.doc ?? $.type.getDoc(props.type);
   const refkeys = declarationRefkeys(props.refkey, props.name);
 
   const name = ts.useTSNamePolicy().getName(originalName, "type");
   return (
-    <ts.TypeDeclaration {...props} name={name} refkey={refkeys}>
+    <ts.TypeDeclaration doc={doc} {...props} name={name} refkey={refkeys}>
       <TypeExpression type={props.type} noReference />
       {props.children}
     </ts.TypeDeclaration>

--- a/packages/emitter-framework/src/typescript/components/type-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/type-declaration.tsx
@@ -1,5 +1,6 @@
 import * as ts from "@alloy-js/typescript";
 import { Type } from "@typespec/compiler";
+import { useTsp } from "../../core/index.js";
 import { declarationRefkeys } from "../utils/refkey.js";
 import { EnumDeclaration } from "./enum-declaration.js";
 import { InterfaceDeclaration } from "./interface-declaration.jsx";
@@ -14,9 +15,9 @@ export interface TypeDeclarationProps extends Omit<ts.TypeDeclarationProps, "nam
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 export function TypeDeclaration(props: TypeDeclarationProps) {
+  const { $ } = useTsp();
   if (!props.type) {
     const refkeys = declarationRefkeys(props.refkey, props.name);
-
     return (
       <ts.TypeDeclaration
         {...(props as WithRequired<ts.TypeDeclarationProps, "name">)}
@@ -26,16 +27,17 @@ export function TypeDeclaration(props: TypeDeclarationProps) {
   }
 
   const { type, ...restProps } = props;
+  const doc = props.doc ?? $.type.getDoc(type);
   switch (type.kind) {
     case "Model":
-      return <InterfaceDeclaration type={type} {...restProps} />;
+      return <InterfaceDeclaration doc={doc} type={type} {...restProps} />;
     case "Union":
-      return <UnionDeclaration type={type} {...restProps} />;
+      return <UnionDeclaration doc={doc} type={type} {...restProps} />;
     case "Enum":
-      return <EnumDeclaration type={type} {...restProps} />;
+      return <EnumDeclaration doc={doc} type={type} {...restProps} />;
     case "Scalar":
-      return <TypeAliasDeclaration type={type} {...restProps} />;
+      return <TypeAliasDeclaration doc={doc} type={type} {...restProps} />;
     case "Operation":
-      return <TypeAliasDeclaration type={type} {...restProps} />;
+      return <TypeAliasDeclaration doc={doc} type={type} {...restProps} />;
   }
 }

--- a/packages/emitter-framework/src/typescript/components/union-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/union-declaration.tsx
@@ -1,3 +1,4 @@
+import { Children } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { Enum, Union } from "@typespec/compiler";
 import { useTsp } from "../../core/context/tsp-context.js";
@@ -7,6 +8,7 @@ import { UnionExpression } from "./union-expression.js";
 
 export interface TypedUnionDeclarationProps extends Omit<ts.TypeDeclarationProps, "name"> {
   type: Union | Enum;
+  doc?: Children;
   name?: string;
 }
 
@@ -29,8 +31,9 @@ export function UnionDeclaration(props: UnionDeclarationProps) {
 
   const name = ts.useTSNamePolicy().getName(originalName!, "type");
 
+  const doc = props.doc ?? $.type.getDoc(type);
   return (
-    <ts.TypeDeclaration {...props} name={name} refkey={refkeys}>
+    <ts.TypeDeclaration doc={doc} {...props} name={name} refkey={refkeys}>
       <UnionExpression type={type}>{coreProps.children}</UnionExpression>
     </ts.TypeDeclaration>
   );

--- a/packages/emitter-framework/src/typescript/utils/operation.ts
+++ b/packages/emitter-framework/src/typescript/utils/operation.ts
@@ -47,10 +47,13 @@ export function buildParameterDescriptors(
 }
 
 export function buildParameterDescriptor(modelProperty: ModelProperty): ts.ParameterDescriptor {
+  const { $ } = useTsp();
   const namePolicy = ts.useTSNamePolicy();
   const paramName = namePolicy.getName(modelProperty.name, "parameter");
   const isOptional = modelProperty.optional || modelProperty.defaultValue !== undefined;
+  const doc = $.type.getDoc(modelProperty);
   return {
+    doc,
     name: paramName,
     refkey: efRefkey(modelProperty),
     optional: isOptional,

--- a/packages/emitter-framework/test/typescript/components/enum-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/enum-declaration.test.tsx
@@ -34,6 +34,78 @@ describe("Typescript Enum Declaration", () => {
     `);
   });
 
+  it("adds JSDoc from TypeSpec", async () => {
+    const code = `
+      /**
+       * This is a test enum
+       */
+      enum Foo {
+        @doc("This is one")
+        one: 1,
+        two: 2,
+        three: 3
+      }
+    `;
+    const output = await getEmitOutput(code, (program) => {
+      const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
+      return (
+        <TspContext.Provider value={{ program }}>
+          <EnumDeclaration type={Foo} />
+        </TspContext.Provider>
+      );
+    });
+
+    expect(output).toBe(d`
+      /**
+       * This is a test enum
+       */
+      enum Foo {
+        /**
+         * This is one
+         */
+        one = 1,
+        two = 2,
+        three = 3
+      }
+    `);
+  });
+
+  it("explicit doc take precedence", async () => {
+    const code = `
+      /**
+       * This is a test enum
+       */
+      enum Foo {
+        @doc("This is one")
+        one: 1,
+        two: 2,
+        three: 3
+      }
+    `;
+    const output = await getEmitOutput(code, (program) => {
+      const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
+      return (
+        <TspContext.Provider value={{ program }}>
+          <EnumDeclaration type={Foo} doc={["This is an explicit doc"]} />
+        </TspContext.Provider>
+      );
+    });
+
+    expect(output).toBe(d`
+      /**
+       * This is an explicit doc
+       */
+      enum Foo {
+        /**
+         * This is one
+         */
+        one = 1,
+        two = 2,
+        three = 3
+      }
+    `);
+  });
+
   it("takes a union type parameter", async () => {
     const code = `
       union Foo {

--- a/packages/emitter-framework/test/typescript/components/function-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/function-declaration.test.tsx
@@ -36,6 +36,84 @@ describe("Typescript Function Declaration", () => {
         expect(actualContent).toBe(expectedContent);
       });
 
+      it("creates a function with JSDoc", async () => {
+        const program = await getProgram(`
+        namespace DemoService;
+        /**
+         * This is a test function
+         */
+        op getName(
+        @doc("This is the id")
+        id: string, name: string): string;
+        `);
+
+        const [namespace] = program.resolveTypeReference("DemoService");
+        const operation = Array.from((namespace as Namespace).operations.values())[0];
+
+        const res = render(
+          <Output program={program}>
+            <SourceFile path="test.ts">
+              <FunctionDeclaration type={operation} />
+            </SourceFile>
+          </Output>,
+        );
+
+        const testFile = res.contents.find((file) => file.path === "test.ts");
+        assert(testFile, "test.ts file not rendered");
+        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
+        const expectedContent = await format(
+          `
+          /**
+           * This is a test function
+           * 
+           * @param {string} id - This is the id
+           * @param {string} name
+           */
+          function getName(id: string, name: string): string{}`,
+          {
+            parser: "typescript",
+          },
+        );
+        expect(actualContent).toBe(expectedContent);
+      });
+
+      it("creates a function with overriden JSDoc", async () => {
+        const program = await getProgram(`
+        namespace DemoService;
+        /**
+         * This is a test function
+         */
+        op getName(id: string): string;`);
+
+        const [namespace] = program.resolveTypeReference("DemoService");
+        const operation = Array.from((namespace as Namespace).operations.values())[0];
+
+        const res = render(
+          <Output program={program}>
+            <SourceFile path="test.ts">
+              <FunctionDeclaration doc={["This is a custom description"]} type={operation} />
+            </SourceFile>
+          </Output>,
+        );
+
+        const testFile = res.contents.find((file) => file.path === "test.ts");
+        assert(testFile, "test.ts file not rendered");
+        const actualContent = await format(testFile.contents as string, { parser: "typescript" });
+        const expectedContent = await format(
+          `
+          /**
+           * This is a custom description
+           *
+           * @param {string} id
+           */
+          function getName(id: string): string{}`,
+          {
+            parser: "typescript",
+          },
+        );
+        expect(actualContent).toBe(expectedContent);
+      });
+
       it("creates an async function", async () => {
         const program = await getProgram(`
         namespace DemoService;

--- a/packages/emitter-framework/test/typescript/components/function-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/function-declaration.test.tsx
@@ -77,7 +77,7 @@ describe("Typescript Function Declaration", () => {
         expect(actualContent).toBe(expectedContent);
       });
 
-      it("creates a function with overriden JSDoc", async () => {
+      it("creates a function with overridden JSDoc", async () => {
         const program = await getProgram(`
         namespace DemoService;
         /**

--- a/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/union-declaration.test.tsx
@@ -65,6 +65,37 @@ describe("Typescript Union Declaration", () => {
         );
       });
 
+      it("creates a union declaration with JSDoc", async () => {
+        const { TestUnion } = (await runner.compile(`
+          namespace DemoService;
+          /**
+           * Test Union
+           */
+          @test union TestUnion {
+            one: "one",
+            two: "two"
+          }
+        `)) as { TestUnion: Union };
+
+        const res = render(
+          <Output program={runner.program}>
+            <SourceFile path="test.ts">
+              <UnionDeclaration type={TestUnion} />
+            </SourceFile>
+          </Output>,
+        );
+
+        assertFileContents(
+          res,
+          d`
+            /**
+             * Test Union
+             */
+            type TestUnion = "one" | "two";
+          `,
+        );
+      });
+
       it("creates a union declaration with name override", async () => {
         const { TestUnion } = (await runner.compile(`
           namespace DemoService;

--- a/packages/http-client-js/test/scenarios/serializers/scalars.md
+++ b/packages/http-client-js/test/scenarios/serializers/scalars.md
@@ -19,8 +19,14 @@ op foo(a: MyDate, b: MyUtcDate, c: MyIsoDate, d: MyUnixDate): void;
 ## TypeScript
 
 ```ts src/models/models.ts
+/**
+ * A sequence of textual characters.
+ */
 export type String = string;
 export type MyDate = Date;
+/**
+ * An instant in coordinated universal time (UTC)"
+ */
 export type UtcDateTime = Date;
 export type MyUtcDate = Date;
 export type MyIsoDate = Date;


### PR DESCRIPTION
Plumbing TypeSpec docs all the way through alloy to emit JSDocs based on TypeSpec docs