### PR TITLE
Expose StringExtensions as public

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientOptionsProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientOptionsProvider.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Utilities;
@@ -139,7 +140,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                             description,
                             MethodSignatureModifiers.Public,
                             type,
-                            p.Name.ToCleanName(),
+                            p.Name.ToCleanIdentifierName(),
                             new AutoPropertyBody(true),
                             this));
                     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientOptionsProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientOptionsProvider.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Utilities;
@@ -140,7 +140,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                             description,
                             MethodSignatureModifiers.Public,
                             type,
-                            p.Name.ToCleanIdentifierName(),
+                            p.Name.ToIdentifierName(),
                             new AutoPropertyBody(true),
                             this));
                     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.TypeSpec.Generator.ClientModel.Primitives;
 using Microsoft.TypeSpec.Generator.ClientModel.Utilities;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -171,7 +171,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var ns = ScmCodeModelGenerator.Instance.TypeFactory.GetCleanNameSpace(_inputClient.Namespace);
 
             // figure out if this namespace has been changed for this client
-            if (!StringHelpers.IsLastNamespaceSegmentTheSame(ns, _inputClient.Namespace))
+            if (!StringExtensions.IsLastNamespaceSegmentTheSame(ns, _inputClient.Namespace))
             {
                 ScmCodeModelGenerator.Instance.Emitter.ReportDiagnostic(DiagnosticCodes.ClientNamespaceConflict, $"namespace {_inputClient.Namespace} conflicts with client {_inputClient.Name}, please use `@clientName` to specify a different name for the client.", _inputClient.CrossLanguageDefinitionId);
             }
@@ -240,7 +240,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", $"{Name}.cs");
 
-        protected override string BuildName() => _inputClient.Name.ToCleanIdentifierName();
+        protected override string BuildName() => _inputClient.Name.ToIdentifierName();
 
         protected override FieldProvider[] BuildFields()
         {
@@ -464,16 +464,16 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             body.Add(PipelineProperty.Assign(This.ToApi<ClientPipelineApi>().Create(ClientOptionsParameter.Value, perRetryPolicies)).Terminate());
 
-            var clientOptionsPropertyDict = ClientOptions.Value.Properties.ToDictionary(p => p.Name.ToCleanIdentifierName());
+            var clientOptionsPropertyDict = ClientOptions.Value.Properties.ToDictionary(p => p.Name.ToIdentifierName());
             foreach (var f in Fields)
             {
                 if (f == _apiVersionField && ClientOptions.Value.VersionProperty != null)
                 {
                     body.Add(f.Assign(ClientOptionsParameter.Value.Property(ClientOptions.Value.VersionProperty.Name)).Terminate());
                 }
-                else if (clientOptionsPropertyDict.TryGetValue(f.Name.ToCleanIdentifierName(), out var optionsProperty))
+                else if (clientOptionsPropertyDict.TryGetValue(f.Name.ToIdentifierName(), out var optionsProperty))
                 {
-                    clientOptionsPropertyDict.TryGetValue(f.Name.ToCleanIdentifierName(), out optionsProperty);
+                    clientOptionsPropertyDict.TryGetValue(f.Name.ToIdentifierName(), out optionsProperty);
                 }
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -171,11 +171,56 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var ns = ScmCodeModelGenerator.Instance.TypeFactory.GetCleanNameSpace(_inputClient.Namespace);
 
             // figure out if this namespace has been changed for this client
-            if (!StringExtensions.IsLastNamespaceSegmentTheSame(ns, _inputClient.Namespace))
+            if (!IsLastNamespaceSegmentTheSame(ns, _inputClient.Namespace))
             {
                 ScmCodeModelGenerator.Instance.Emitter.ReportDiagnostic(DiagnosticCodes.ClientNamespaceConflict, $"namespace {_inputClient.Namespace} conflicts with client {_inputClient.Name}, please use `@clientName` to specify a different name for the client.", _inputClient.CrossLanguageDefinitionId);
             }
             return ns;
+        }
+
+        /// <summary>
+        /// Checks if two namespaces share the same last segment
+        /// </summary>
+        /// <param name="left">the first namespace</param>
+        /// <param name="right">the second namespace</param>
+        /// <returns></returns>
+        internal static bool IsLastNamespaceSegmentTheSame(string left, string right)
+        {
+            // finish this via Span API
+            var leftSpan = left.AsSpan();
+            var rightSpan = right.AsSpan();
+            // swap if left is longer, we ensure left is the shorter one
+            if (leftSpan.Length > rightSpan.Length)
+            {
+                var temp = leftSpan;
+                leftSpan = rightSpan;
+                rightSpan = temp;
+            }
+            for (int i = 1; i <= leftSpan.Length; i++)
+            {
+                var lc = leftSpan[^i];
+                var rc = rightSpan[^i];
+                // check if each char is the same from the right-most side
+                // if both of them are dot, we finished scanning the last segment - and if we could be here, meaning all of them are the same, return true.
+                if (lc == '.' && rc == '.')
+                {
+                    return true;
+                }
+                // if these are different - there is one different character, return false.
+                if (lc != rc)
+                {
+                    return false;
+                }
+            }
+
+            // we come here because we run out of characters in left - which means left does not have a dot.
+            // if they have the same length, they are identical, return true
+            if (leftSpan.Length == rightSpan.Length)
+            {
+                return true;
+            }
+            // otherwise, right is longer, we check its next character, if it is the dot, return true, otherwise return false.
+            return rightSpan[^(leftSpan.Length + 1)] == '.';
         }
 
         private IReadOnlyList<ParameterProvider> GetSubClientInternalConstructorParameters()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.TypeSpec.Generator.ClientModel.Primitives;
 using Microsoft.TypeSpec.Generator.ClientModel.Utilities;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -170,7 +171,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var ns = ScmCodeModelGenerator.Instance.TypeFactory.GetCleanNameSpace(_inputClient.Namespace);
 
             // figure out if this namespace has been changed for this client
-            if (!StringExtensions.IsLastNamespaceSegmentTheSame(ns, _inputClient.Namespace))
+            if (!StringHelpers.IsLastNamespaceSegmentTheSame(ns, _inputClient.Namespace))
             {
                 ScmCodeModelGenerator.Instance.Emitter.ReportDiagnostic(DiagnosticCodes.ClientNamespaceConflict, $"namespace {_inputClient.Namespace} conflicts with client {_inputClient.Name}, please use `@clientName` to specify a different name for the client.", _inputClient.CrossLanguageDefinitionId);
             }
@@ -239,7 +240,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", $"{Name}.cs");
 
-        protected override string BuildName() => _inputClient.Name.ToCleanName();
+        protected override string BuildName() => _inputClient.Name.ToCleanIdentifierName();
 
         protected override FieldProvider[] BuildFields()
         {
@@ -463,16 +464,16 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             body.Add(PipelineProperty.Assign(This.ToApi<ClientPipelineApi>().Create(ClientOptionsParameter.Value, perRetryPolicies)).Terminate());
 
-            var clientOptionsPropertyDict = ClientOptions.Value.Properties.ToDictionary(p => p.Name.ToCleanName());
+            var clientOptionsPropertyDict = ClientOptions.Value.Properties.ToDictionary(p => p.Name.ToCleanIdentifierName());
             foreach (var f in Fields)
             {
                 if (f == _apiVersionField && ClientOptions.Value.VersionProperty != null)
                 {
                     body.Add(f.Assign(ClientOptionsParameter.Value.Property(ClientOptions.Value.VersionProperty.Name)).Terminate());
                 }
-                else if (clientOptionsPropertyDict.TryGetValue(f.Name.ToCleanName(), out var optionsProperty))
+                else if (clientOptionsPropertyDict.TryGetValue(f.Name.ToCleanIdentifierName(), out var optionsProperty))
                 {
-                    clientOptionsPropertyDict.TryGetValue(f.Name.ToCleanName(), out optionsProperty);
+                    clientOptionsPropertyDict.TryGetValue(f.Name.ToCleanIdentifierName(), out optionsProperty);
                 }
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/CollectionResultDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/CollectionResultDefinition.cs
@@ -12,7 +12,7 @@ using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
 using Microsoft.TypeSpec.Generator.ClientModel.Utilities;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -126,7 +126,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         protected override string BuildNamespace() => _client.Type.Namespace;
 
         protected override string BuildName()
-            => $"{_client.Type.Name}{_operation.Name.ToCleanIdentifierName()}{(_isAsync ? "Async" : "")}CollectionResult{(_itemModelType == null ? "" : "OfT")}";
+            => $"{_client.Type.Name}{_operation.Name.ToIdentifierName()}{(_isAsync ? "Async" : "")}CollectionResult{(_itemModelType == null ? "" : "OfT")}";
 
         protected override TypeSignatureModifiers BuildDeclarationModifiers()
             => TypeSignatureModifiers.Internal | TypeSignatureModifiers.Partial | TypeSignatureModifiers.Class;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -3,7 +3,7 @@
 
 using System.ClientModel.Primitives;
 using System.IO;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -3,6 +3,7 @@
 
 using System.ClientModel.Primitives;
 using System.IO;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ClientModel.Primitives;
 using System.IO;
-using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 
@@ -11,7 +11,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 {
     internal class ModelReaderWriterContextDefinition : TypeProvider
     {
-        internal static string s_name = $"{ScmCodeModelGenerator.Instance.TypeFactory.PrimaryNamespace.RemovePeriods()}Context";
+        internal static string s_name = $"{RemovePeriods(ScmCodeModelGenerator.Instance.TypeFactory.PrimaryNamespace)}Context";
 
         protected override string BuildName() => s_name;
 
@@ -31,6 +31,23 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             ]);
             var xmlDocs = new XmlDocProvider(summary: summary);
             return xmlDocs;
+        }
+
+        private static string RemovePeriods(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            Span<char> buffer = stackalloc char[input.Length];
+            int index = 0;
+
+            foreach (char c in input)
+            {
+                if (c != '.')
+                    buffer[index++] = c;
+            }
+
+            return buffer.Slice(0, index).ToString();
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -12,7 +12,7 @@ using System.Text.Json;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -87,7 +87,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.Serialization.cs");
 
-        protected override string BuildName() => _inputModel.Name.ToCleanIdentifierName();
+        protected override string BuildName() => _inputModel.Name.ToIdentifierName();
 
         protected override IReadOnlyList<AttributeStatement> BuildAttributes()
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -86,7 +87,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.Serialization.cs");
 
-        protected override string BuildName() => _inputModel.Name.ToCleanName();
+        protected override string BuildName() => _inputModel.Name.ToCleanIdentifierName();
 
         protected override IReadOnlyList<AttributeStatement> BuildAttributes()
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.TypeSpec.Generator.ClientModel.Primitives;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -44,7 +45,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", $"{Name}.RestClient.cs");
 
-        protected override string BuildName() => _inputClient.Name.ToCleanName();
+        protected override string BuildName() => _inputClient.Name.ToCleanIdentifierName();
 
         protected override string BuildNamespace() => ClientProvider.Type.Namespace;
 
@@ -92,7 +93,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var parameters = GetMethodParameters(serviceMethod, MethodType.CreateRequest);
             var operation = serviceMethod.Operation;
             var signature = new MethodSignature(
-                $"Create{operation.Name.ToCleanName()}Request",
+                $"Create{operation.Name.ToCleanIdentifierName()}Request",
                 null,
                 MethodSignatureModifiers.Internal,
                 ScmCodeModelGenerator.Instance.TypeFactory.HttpMessageApi.HttpMessageType,
@@ -182,7 +183,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         null,
                         MethodSignatureModifiers.Private | MethodSignatureModifiers.Static,
                         ScmCodeModelGenerator.Instance.TypeFactory.StatusCodeClassifierApi.ResponseClassifierType,
-                        classifierBackingField.Name.Substring(1).ToCleanName(),
+                        classifierBackingField.Name.Substring(1).ToCleanIdentifierName(),
                         new ExpressionPropertyBody(
                             classifierBackingField.Assign(This.ToApi<StatusCodeClassifierApi>().Create(GetSuccessStatusCodes(inputOperation)))),
                         this)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -10,7 +10,7 @@ using Microsoft.TypeSpec.Generator.ClientModel.Primitives;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -45,7 +45,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", $"{Name}.RestClient.cs");
 
-        protected override string BuildName() => _inputClient.Name.ToCleanIdentifierName();
+        protected override string BuildName() => _inputClient.Name.ToIdentifierName();
 
         protected override string BuildNamespace() => ClientProvider.Type.Namespace;
 
@@ -93,7 +93,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var parameters = GetMethodParameters(serviceMethod, MethodType.CreateRequest);
             var operation = serviceMethod.Operation;
             var signature = new MethodSignature(
-                $"Create{operation.Name.ToCleanIdentifierName()}Request",
+                $"Create{operation.Name.ToIdentifierName()}Request",
                 null,
                 MethodSignatureModifiers.Internal,
                 ScmCodeModelGenerator.Instance.TypeFactory.HttpMessageApi.HttpMessageType,
@@ -183,7 +183,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         null,
                         MethodSignatureModifiers.Private | MethodSignatureModifiers.Static,
                         ScmCodeModelGenerator.Instance.TypeFactory.StatusCodeClassifierApi.ResponseClassifierType,
-                        classifierBackingField.Name.Substring(1).ToCleanIdentifierName(),
+                        classifierBackingField.Name.Substring(1).ToIdentifierName(),
                         new ExpressionPropertyBody(
                             classifierBackingField.Assign(This.ToApi<StatusCodeClassifierApi>().Create(GetSuccessStatusCodes(inputOperation)))),
                         this)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -11,7 +11,7 @@ using Microsoft.TypeSpec.Generator.ClientModel.Primitives;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -63,7 +63,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         {
             ServiceMethod = serviceMethod;
             EnclosingType = enclosingType;
-            _cleanOperationName = serviceMethod.Operation.Name.ToCleanIdentifierName();
+            _cleanOperationName = serviceMethod.Operation.Name.ToIdentifierName();
             Client = enclosingType as ClientProvider ?? throw new InvalidOperationException("Scm methods can only be built for client types.");
             _createRequestMethod = Client.RestClient.GetCreateRequestMethod(ServiceMethod.Operation);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -11,6 +11,7 @@ using Microsoft.TypeSpec.Generator.ClientModel.Primitives;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -62,7 +63,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         {
             ServiceMethod = serviceMethod;
             EnclosingType = enclosingType;
-            _cleanOperationName = serviceMethod.Operation.Name.ToCleanName();
+            _cleanOperationName = serviceMethod.Operation.Name.ToCleanIdentifierName();
             Client = enclosingType as ClientProvider ?? throw new InvalidOperationException("Scm methods can only be built for client types.");
             _createRequestMethod = Client.RestClient.GetCreateRequestMethod(ServiceMethod.Operation);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Tests.Common;
@@ -32,7 +33,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         [Test]
         public void ServiceClientWithSubClient()
         {
-            string[] expectedSubClientFactoryMethodNames = [$"Get{_animalClient.Name.ToCleanName()}Client"];
+            string[] expectedSubClientFactoryMethodNames = [$"Get{_animalClient.Name.ToCleanIdentifierName()}Client"];
             var clientProvider = new MockClientProvider(_testClient, expectedSubClientFactoryMethodNames);
             var writer = new TypeProviderWriter(clientProvider);
             var file = writer.Write();
@@ -43,7 +44,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         [Test]
         public void SubClientWithSingleSubClient()
         {
-            string[] expectedSubClientFactoryMethodNames = [$"Get{_huskyClient.Name.ToCleanName()}Client"];
+            string[] expectedSubClientFactoryMethodNames = [$"Get{_huskyClient.Name.ToCleanIdentifierName()}Client"];
             var clientProvider = new MockClientProvider(_dogClient, expectedSubClientFactoryMethodNames);
             var writer = new TypeProviderWriter(clientProvider);
             var file = writer.Write();
@@ -56,9 +57,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         {
             string[] expectedSubClientFactoryMethodNames =
             [
-                $"Get{_dogClient.Name.ToCleanName()}Client",
-                $"Get{_catClient.Name.ToCleanName()}Client",
-                $"Get{_hawkClient.Name.ToCleanName()}"
+                $"Get{_dogClient.Name.ToCleanIdentifierName()}Client",
+                $"Get{_catClient.Name.ToCleanIdentifierName()}Client",
+                $"Get{_hawkClient.Name.ToCleanIdentifierName()}"
             ];
             var clientProvider = new MockClientProvider(_animalClient, expectedSubClientFactoryMethodNames);
             var writer = new TypeProviderWriter(clientProvider);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderSubClientTests.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Tests.Common;
@@ -33,7 +33,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         [Test]
         public void ServiceClientWithSubClient()
         {
-            string[] expectedSubClientFactoryMethodNames = [$"Get{_animalClient.Name.ToCleanIdentifierName()}Client"];
+            string[] expectedSubClientFactoryMethodNames = [$"Get{_animalClient.Name.ToIdentifierName()}Client"];
             var clientProvider = new MockClientProvider(_testClient, expectedSubClientFactoryMethodNames);
             var writer = new TypeProviderWriter(clientProvider);
             var file = writer.Write();
@@ -44,7 +44,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         [Test]
         public void SubClientWithSingleSubClient()
         {
-            string[] expectedSubClientFactoryMethodNames = [$"Get{_huskyClient.Name.ToCleanIdentifierName()}Client"];
+            string[] expectedSubClientFactoryMethodNames = [$"Get{_huskyClient.Name.ToIdentifierName()}Client"];
             var clientProvider = new MockClientProvider(_dogClient, expectedSubClientFactoryMethodNames);
             var writer = new TypeProviderWriter(clientProvider);
             var file = writer.Write();
@@ -57,9 +57,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         {
             string[] expectedSubClientFactoryMethodNames =
             [
-                $"Get{_dogClient.Name.ToCleanIdentifierName()}Client",
-                $"Get{_catClient.Name.ToCleanIdentifierName()}Client",
-                $"Get{_hawkClient.Name.ToCleanIdentifierName()}"
+                $"Get{_dogClient.Name.ToIdentifierName()}Client",
+                $"Get{_catClient.Name.ToIdentifierName()}Client",
+                $"Get{_hawkClient.Name.ToIdentifierName()}"
             ];
             var clientProvider = new MockClientProvider(_animalClient, expectedSubClientFactoryMethodNames);
             var writer = new TypeProviderWriter(clientProvider);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
@@ -22,6 +22,24 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
 {
     public class ClientProviderTests
     {
+        [TestCase("Foo", "Foo", ExpectedResult = true)]
+        [TestCase("Foo", "Bar", ExpectedResult = false)]
+        [TestCase("Foo", "_Foo", ExpectedResult = false)]
+        [TestCase("_Foo", "Foo", ExpectedResult = false)]
+        [TestCase("Foo", "Bar.Foo", ExpectedResult = true)]
+        [TestCase("Bar.Foo", "Foo", ExpectedResult = true)]
+        [TestCase("Foo", "Bar._Foo", ExpectedResult = false)]
+        [TestCase("Bar._Foo", "Foo", ExpectedResult = false)]
+        [TestCase("Foo", "/Foo", ExpectedResult = false)]
+        [TestCase("/Foo", "Foo", ExpectedResult = false)]
+        [TestCase(".Foo", ".Foo", ExpectedResult = true)]
+        [TestCase("Foo", ".Foo", ExpectedResult = true)]
+        [TestCase(".Foo", "Foo", ExpectedResult = true)]
+        public bool ValidateIsLastNamespaceSegmentTheSame(string left, string right)
+        {
+            return ClientProvider.IsLastNamespaceSegmentTheSame(left, right);
+        }
+
         private const string SubClientsCategory = "WithSubClients";
         private const string KeyAuthCategory = "WithKeyAuth";
         private const string OAuth2Category = "WithOAuth2";

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/AdditionalPropertiesTest.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/AdditionalPropertiesTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 
@@ -44,7 +45,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             // validate the additional properties variable declarations
             for (var i = 0; i < expectedValueTypeNames.Length; i++)
             {
-                var expectedVariableName = i == 0 ? "additionalProperties" : $"additional{expectedValueTypeNames[i].ToCleanName()}Properties";
+                var expectedVariableName = i == 0 ? "additionalProperties" : $"additional{expectedValueTypeNames[i].ToCleanIdentifierName()}Properties";
                 var expectedDeclaration = $"global::System.Collections.Generic.IDictionary<string, {expectedValueTypeNames[i].ToVariableName()}> {expectedVariableName}";
                 Assert.IsTrue(methodBodyString.Contains(expectedDeclaration, StringComparison.InvariantCultureIgnoreCase));
             }
@@ -59,7 +60,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             if (expectedValueTypeNames.Length > 1)
             {
                 // skip the first value type name as it is already included in the return statement
-                var additionalPropertiesVariables = "additionalProperties, " + string.Join(", ", expectedValueTypeNames.Skip(1).Select(v => $"additional{v.ToCleanName()}Properties,"));
+                var additionalPropertiesVariables = "additionalProperties, " + string.Join(", ", expectedValueTypeNames.Skip(1).Select(v => $"additional{v.ToCleanIdentifierName()}Properties,"));
                 var expectedReturnStatement = $"return new global::Sample.Models.Cat(color, {additionalPropertiesVariables} additionalBinaryDataProperties);";
                 Assert.IsTrue(methodBodyString.Contains(expectedReturnStatement));
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/AdditionalPropertiesTest.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/AdditionalPropertiesTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 
@@ -45,7 +45,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             // validate the additional properties variable declarations
             for (var i = 0; i < expectedValueTypeNames.Length; i++)
             {
-                var expectedVariableName = i == 0 ? "additionalProperties" : $"additional{expectedValueTypeNames[i].ToCleanIdentifierName()}Properties";
+                var expectedVariableName = i == 0 ? "additionalProperties" : $"additional{expectedValueTypeNames[i].ToIdentifierName()}Properties";
                 var expectedDeclaration = $"global::System.Collections.Generic.IDictionary<string, {expectedValueTypeNames[i].ToVariableName()}> {expectedVariableName}";
                 Assert.IsTrue(methodBodyString.Contains(expectedDeclaration, StringComparison.InvariantCultureIgnoreCase));
             }
@@ -60,7 +60,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             if (expectedValueTypeNames.Length > 1)
             {
                 // skip the first value type name as it is already included in the return statement
-                var additionalPropertiesVariables = "additionalProperties, " + string.Join(", ", expectedValueTypeNames.Skip(1).Select(v => $"additional{v.ToCleanIdentifierName()}Properties,"));
+                var additionalPropertiesVariables = "additionalProperties, " + string.Join(", ", expectedValueTypeNames.Skip(1).Select(v => $"additional{v.ToIdentifierName()}Properties,"));
                 var expectedReturnStatement = $"return new global::Sample.Models.Cat(color, {additionalPropertiesVariables} additionalBinaryDataProperties);";
                 Assert.IsTrue(methodBodyString.Contains(expectedReturnStatement));
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -671,7 +672,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             Assert.IsNotNull(methodSignature);
 
             var expectedModifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static | MethodSignatureModifiers.Explicit | MethodSignatureModifiers.Operator;
-            Assert.AreEqual(inputModel.Name.ToCleanName(), methodSignature?.Name);
+            Assert.AreEqual(inputModel.Name.ToCleanIdentifierName(), methodSignature?.Name);
             Assert.AreEqual(expectedModifiers, methodSignature?.Modifiers);
 
             var methodParameters = methodSignature?.Parameters;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -672,7 +672,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             Assert.IsNotNull(methodSignature);
 
             var expectedModifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static | MethodSignatureModifiers.Explicit | MethodSignatureModifiers.Operator;
-            Assert.AreEqual(inputModel.Name.ToCleanIdentifierName(), methodSignature?.Name);
+            Assert.AreEqual(inputModel.Name.ToIdentifierName(), methodSignature?.Name);
             Assert.AreEqual(expectedModifiers, methodSignature?.Modifiers);
 
             var methodParameters = methodSignature?.Parameters;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
@@ -13,6 +13,7 @@ using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientProviders
 {
@@ -46,7 +47,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientPro
             var method = restClientProvider.Methods![0];
             var signature = method.Signature;
             Assert.IsNotNull(signature);
-            Assert.AreEqual($"Create{inputOperation.Name.ToCleanName()}Request", signature.Name);
+            Assert.AreEqual($"Create{inputOperation.Name.ToCleanIdentifierName()}Request", signature.Name);
 
             var parameters = signature.Parameters;
             Assert.IsNotNull(parameters);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
@@ -13,7 +13,7 @@ using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientProviders
 {
@@ -47,7 +47,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientPro
             var method = restClientProvider.Methods![0];
             var signature = method.Signature;
             Assert.IsNotNull(signature);
-            Assert.AreEqual($"Create{inputOperation.Name.ToCleanIdentifierName()}Request", signature.Name);
+            Assert.AreEqual($"Create{inputOperation.Name.ToIdentifierName()}Request", signature.Name);
 
             var parameters = signature.Parameters;
             Assert.IsNotNull(parameters);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Tests.Common;
@@ -45,7 +45,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             var signature = method.Signature;
             Assert.IsNotNull(signature);
             var operation = serviceMethod.Operation;
-            Assert.AreEqual(operation.Name.ToCleanIdentifierName(), signature.Name);
+            Assert.AreEqual(operation.Name.ToIdentifierName(), signature.Name);
 
             var parameters = signature.Parameters;
             Assert.IsNotNull(parameters);
@@ -53,7 +53,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
 
             var convenienceMethod = methodCollection.FirstOrDefault(m
                 => !m.Signature.Parameters.Any(p => p.Name == "content")
-                    && m.Signature.Name == $"{operation.Name.ToCleanIdentifierName()}");
+                    && m.Signature.Name == $"{operation.Name.ToIdentifierName()}");
             Assert.IsNotNull(convenienceMethod);
             Assert.AreEqual(serviceMethod, convenienceMethod!.ServiceMethod);
 
@@ -88,7 +88,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             var operation = serviceMethod.Operation;
             var asyncConvenienceMethod = methodCollection.FirstOrDefault(m
                 => !m.Signature.Parameters.Any(p => p.Name == "content")
-                    && m.Signature.Name == $"{operation.Name.ToCleanIdentifierName()}Async");
+                    && m.Signature.Name == $"{operation.Name.ToIdentifierName()}Async");
             Assert.IsNotNull(asyncConvenienceMethod);
 
             var asyncConvenienceMethodParameters = asyncConvenienceMethod!.Signature.Parameters;
@@ -101,7 +101,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
 
             var syncConvenienceMethod = methodCollection.FirstOrDefault(m
                 => !m.Signature.Parameters.Any(p => p.Name == "content")
-                   && m.Signature.Name == operation.Name.ToCleanIdentifierName());
+                   && m.Signature.Name == operation.Name.ToIdentifierName());
             Assert.IsNotNull(syncConvenienceMethod);
 
             var syncConvenienceMethodParameters = syncConvenienceMethod!.Signature.Parameters;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Tests.Common;
@@ -44,7 +45,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             var signature = method.Signature;
             Assert.IsNotNull(signature);
             var operation = serviceMethod.Operation;
-            Assert.AreEqual(operation.Name.ToCleanName(), signature.Name);
+            Assert.AreEqual(operation.Name.ToCleanIdentifierName(), signature.Name);
 
             var parameters = signature.Parameters;
             Assert.IsNotNull(parameters);
@@ -52,7 +53,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
 
             var convenienceMethod = methodCollection.FirstOrDefault(m
                 => !m.Signature.Parameters.Any(p => p.Name == "content")
-                    && m.Signature.Name == $"{operation.Name.ToCleanName()}");
+                    && m.Signature.Name == $"{operation.Name.ToCleanIdentifierName()}");
             Assert.IsNotNull(convenienceMethod);
             Assert.AreEqual(serviceMethod, convenienceMethod!.ServiceMethod);
 
@@ -87,7 +88,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             var operation = serviceMethod.Operation;
             var asyncConvenienceMethod = methodCollection.FirstOrDefault(m
                 => !m.Signature.Parameters.Any(p => p.Name == "content")
-                    && m.Signature.Name == $"{operation.Name.ToCleanName()}Async");
+                    && m.Signature.Name == $"{operation.Name.ToCleanIdentifierName()}Async");
             Assert.IsNotNull(asyncConvenienceMethod);
 
             var asyncConvenienceMethodParameters = asyncConvenienceMethod!.Signature.Parameters;
@@ -100,7 +101,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
 
             var syncConvenienceMethod = methodCollection.FirstOrDefault(m
                 => !m.Signature.Parameters.Any(p => p.Name == "content")
-                   && m.Signature.Name == operation.Name.ToCleanName());
+                   && m.Signature.Name == operation.Name.ToCleanIdentifierName());
             Assert.IsNotNull(syncConvenienceMethod);
 
             var syncConvenienceMethodParameters = syncConvenienceMethod!.Signature.Parameters;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
@@ -79,50 +78,5 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
 
         [return: NotNullIfNotNull(nameof(name))]
         public static string ToVariableName(this string name) => name.ToIdentifierName(isCamelCase: false);
-
-        /// <summary>
-        /// Checks if two namespaces share the same last segment
-        /// </summary>
-        /// <param name="left">the first namespace</param>
-        /// <param name="right">the second namespace</param>
-        /// <returns></returns>
-        public static bool IsLastNamespaceSegmentTheSame(string left, string right)
-        {
-            // finish this via Span API
-            var leftSpan = left.AsSpan();
-            var rightSpan = right.AsSpan();
-            // swap if left is longer, we ensure left is the shorter one
-            if (leftSpan.Length > rightSpan.Length)
-            {
-                var temp = leftSpan;
-                leftSpan = rightSpan;
-                rightSpan = temp;
-            }
-            for (int i = 1; i <= leftSpan.Length; i++)
-            {
-                var lc = leftSpan[^i];
-                var rc = rightSpan[^i];
-                // check if each char is the same from the right-most side
-                // if both of them are dot, we finished scanning the last segment - and if we could be here, meaning all of them are the same, return true.
-                if (lc == '.' && rc == '.')
-                {
-                    return true;
-                }
-                // if these are different - there is one different character, return false.
-                if (lc != rc)
-                {
-                    return false;
-                }
-            }
-
-            // we come here because we run out of characters in left - which means left does not have a dot.
-            // if they have the same length, they are identical, return true
-            if (leftSpan.Length == rightSpan.Length)
-            {
-                return true;
-            }
-            // otherwise, right is longer, we check its next character, if it is the dot, return true, otherwise return false.
-            return rightSpan[^(leftSpan.Length + 1)] == '.';
-        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -80,23 +80,6 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
         [return: NotNullIfNotNull(nameof(name))]
         public static string ToVariableName(this string name) => name.ToIdentifierName(isCamelCase: false);
 
-        public static string RemovePeriods(this string input)
-        {
-            if (string.IsNullOrEmpty(input))
-                return input;
-
-            Span<char> buffer = stackalloc char[input.Length];
-            int index = 0;
-
-            foreach (char c in input)
-            {
-                if (c != '.')
-                    buffer[index++] = c;
-            }
-
-            return buffer.Slice(0, index).ToString();
-        }
-
         /// <summary>
         /// Checks if two namespaces share the same last segment
         /// </summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.TypeSpec.Generator.Input.Extensions
+{
+    public static class StringExtensions
+    {
+        private static bool IsWordSeparator(char c) => !SyntaxFacts.IsIdentifierPartCharacter(c) || c == '_';
+
+        [return: NotNullIfNotNull("name")]
+        public static string ToIdentifierName(this string name, bool isCamelCase = true)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+            StringBuilder nameBuilder = new StringBuilder();
+
+            int i = 0;
+
+            if (char.IsDigit(name[0]))
+            {
+                nameBuilder.Append("_");
+            }
+            else
+            {
+                while (!SyntaxFacts.IsIdentifierStartCharacter(name[i]))
+                {
+                    i++;
+                }
+            }
+
+            bool upperCase = false;
+            int firstWordLength = 1;
+            for (; i < name.Length; i++)
+            {
+                var c = name[i];
+                if (IsWordSeparator(c))
+                {
+                    upperCase = true;
+                    continue;
+                }
+
+                if (nameBuilder.Length == 0 && isCamelCase)
+                {
+                    c = char.ToUpper(c);
+                    upperCase = false;
+                }
+                else if (nameBuilder.Length < firstWordLength && !isCamelCase)
+                {
+                    c = char.ToLower(c);
+                    upperCase = false;
+                    // grow the first word length when this letter follows by two other upper case letters
+                    // this happens in OSProfile, where OS is the first word
+                    if (i + 2 < name.Length && char.IsUpper(name[i + 1]) && (char.IsUpper(name[i + 2]) || IsWordSeparator(name[i + 2])))
+                        firstWordLength++;
+                    // grow the first word length when this letter follows by another upper case letter and an end of the string
+                    // this happens when the string only has one word, like OS, DNS
+                    if (i + 2 == name.Length && char.IsUpper(name[i + 1]))
+                        firstWordLength++;
+                }
+
+                if (upperCase)
+                {
+                    c = char.ToUpper(c);
+                    upperCase = false;
+                }
+
+                nameBuilder.Append(c);
+            }
+
+            return nameBuilder.ToString();
+        }
+
+        [return: NotNullIfNotNull(nameof(name))]
+        public static string ToVariableName(this string name) => name.ToIdentifierName(isCamelCase: false);
+
+        public static string RemovePeriods(this string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            Span<char> buffer = stackalloc char[input.Length];
+            int index = 0;
+
+            foreach (char c in input)
+            {
+                if (c != '.')
+                    buffer[index++] = c;
+            }
+
+            return buffer.Slice(0, index).ToString();
+        }
+
+        /// <summary>
+        /// Checks if two namespaces share the same last segment
+        /// </summary>
+        /// <param name="left">the first namespace</param>
+        /// <param name="right">the second namespace</param>
+        /// <returns></returns>
+        public static bool IsLastNamespaceSegmentTheSame(string left, string right)
+        {
+            // finish this via Span API
+            var leftSpan = left.AsSpan();
+            var rightSpan = right.AsSpan();
+            // swap if left is longer, we ensure left is the shorter one
+            if (leftSpan.Length > rightSpan.Length)
+            {
+                var temp = leftSpan;
+                leftSpan = rightSpan;
+                rightSpan = temp;
+            }
+            for (int i = 1; i <= leftSpan.Length; i++)
+            {
+                var lc = leftSpan[^i];
+                var rc = rightSpan[^i];
+                // check if each char is the same from the right-most side
+                // if both of them are dot, we finished scanning the last segment - and if we could be here, meaning all of them are the same, return true.
+                if (lc == '.' && rc == '.')
+                {
+                    return true;
+                }
+                // if these are different - there is one different character, return false.
+                if (lc != rc)
+                {
+                    return false;
+                }
+            }
+
+            // we come here because we run out of characters in left - which means left does not have a dot.
+            // if they have the same length, they are identical, return true
+            if (leftSpan.Length == rightSpan.Length)
+            {
+                return true;
+            }
+            // otherwise, right is longer, we check its next character, if it is the dot, return true, otherwise return false.
+            return rightSpan[^(leftSpan.Length + 1)] == '.';
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 
 namespace Microsoft.TypeSpec.Generator.Input
 {
@@ -92,7 +92,7 @@ namespace Microsoft.TypeSpec.Generator.Input
 
                 _discriminatedSubtypes = new Dictionary<string, InputModelType>(value);
 
-                var cleanBaseName = Name.ToCleanIdentifierName();
+                var cleanBaseName = Name.ToIdentifierName();
                 _discriminatedSubtypes.Add(UnknownDiscriminatorValue,
                 new InputModelType(
                     $"Unknown{cleanBaseName}",

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.Input
 {
@@ -91,7 +92,7 @@ namespace Microsoft.TypeSpec.Generator.Input
 
                 _discriminatedSubtypes = new Dictionary<string, InputModelType>(value);
 
-                var cleanBaseName = Name.ToCleanName();
+                var cleanBaseName = Name.ToCleanIdentifierName();
                 _discriminatedSubtypes.Add(UnknownDiscriminatorValue,
                 new InputModelType(
                     $"Unknown{cleanBaseName}",

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecSerialization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecSerialization.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AutoRest.CSharp.Common.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.Input
 {
@@ -77,7 +78,7 @@ namespace Microsoft.TypeSpec.Generator.Input
         {
             foreach (var client in clients)
             {
-                var cleanName = client.Name.ToCleanName();
+                var cleanName = client.Name.ToCleanIdentifierName();
                 client.Name = BuildClientName(cleanName, parentNames);
 
                 var lastSegment = GetLastSegment(client.Namespace);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecSerialization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecSerialization.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AutoRest.CSharp.Common.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 
 namespace Microsoft.TypeSpec.Generator.Input
 {
@@ -78,7 +78,7 @@ namespace Microsoft.TypeSpec.Generator.Input
         {
             foreach (var client in clients)
             {
-                var cleanName = client.Name.ToCleanIdentifierName();
+                var cleanName = client.Name.ToIdentifierName();
                 client.Name = BuildClientName(cleanName, parentNames);
 
                 var lastSegment = GetLastSegment(client.Namespace);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Microsoft.TypeSpec.Generator.Input.csproj
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Microsoft.TypeSpec.Generator.Input.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Microsoft.TypeSpec.Generator.Input</PackageId>
@@ -8,10 +8,6 @@
   <ItemGroup>
     <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\Microsoft.TypeSpec.Generator\src\Shared\StringExtensions.cs" LinkBase="Shared" />
   </ItemGroup>
 
 </Project>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Utilities/StringHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Utilities/StringHelpers.cs
@@ -8,15 +8,15 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace Microsoft.TypeSpec.Generator
+namespace Microsoft.TypeSpec.Generator.Input.Utilities
 {
-    internal static class StringExtensions
+    public static class StringHelpers
     {
         private static bool IsWordSeparator(char c) => !SyntaxFacts.IsIdentifierPartCharacter(c) || c == '_';
         private static readonly Regex HumanizedCamelCaseRegex = new Regex(@"([A-Z])", RegexOptions.Compiled);
 
         [return: NotNullIfNotNull("name")]
-        public static string ToCleanName(this string name, bool isCamelCase = true)
+        public static string ToCleanIdentifierName(this string name, bool isCamelCase = true)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -81,7 +81,7 @@ namespace Microsoft.TypeSpec.Generator
         }
 
         [return: NotNullIfNotNull(nameof(name))]
-        public static string ToVariableName(this string name) => ToCleanName(name, isCamelCase: false);
+        public static string ToVariableName(this string name) => name.ToCleanIdentifierName(isCamelCase: false);
 
         public static GetPathPartsEnumerator GetFormattableStringFormatParts(string? format) => new GetPathPartsEnumerator(format);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.Expressions
@@ -32,7 +31,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         {
             writer.AppendRaw("$\"");
             var argumentCount = 0;
-            foreach ((var span, bool isLiteral) in InternalStringExtensions.GetFormattableStringFormatParts(Format))
+            foreach ((var span, bool isLiteral) in StringExtensions.GetFormattableStringFormatParts(Format))
             {
                 if (isLiteral)
                 {
@@ -53,7 +52,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         private static void Validate(string format, IReadOnlyList<ValueExpression> args)
         {
             var count = 0;
-            foreach (var (_, isLiteral) in InternalStringExtensions.GetFormattableStringFormatParts(format))
+            foreach (var (_, isLiteral) in StringExtensions.GetFormattableStringFormatParts(format))
             {
                 if (!isLiteral)
                     count++;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
+using Microsoft.TypeSpec.Generator.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.Expressions
 {
@@ -31,7 +32,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         {
             writer.AppendRaw("$\"");
             var argumentCount = 0;
-            foreach ((var span, bool isLiteral) in StringHelpers.GetFormattableStringFormatParts(Format))
+            foreach ((var span, bool isLiteral) in InternalStringExtensions.GetFormattableStringFormatParts(Format))
             {
                 if (isLiteral)
                 {
@@ -52,7 +53,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         private static void Validate(string format, IReadOnlyList<ValueExpression> args)
         {
             var count = 0;
-            foreach (var (_, isLiteral) in StringHelpers.GetFormattableStringFormatParts(format))
+            foreach (var (_, isLiteral) in InternalStringExtensions.GetFormattableStringFormatParts(format))
             {
                 if (!isLiteral)
                     count++;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.Expressions
 {
@@ -30,7 +31,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         {
             writer.AppendRaw("$\"");
             var argumentCount = 0;
-            foreach ((var span, bool isLiteral) in StringExtensions.GetFormattableStringFormatParts(Format))
+            foreach ((var span, bool isLiteral) in StringHelpers.GetFormattableStringFormatParts(Format))
             {
                 if (isLiteral)
                 {
@@ -51,7 +52,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         private static void Validate(string format, IReadOnlyList<ValueExpression> args)
         {
             var count = 0;
-            foreach (var (_, isLiteral) in StringExtensions.GetFormattableStringFormatParts(format))
+            foreach (var (_, isLiteral) in StringHelpers.GetFormattableStringFormatParts(format))
             {
                 if (!isLiteral)
                     count++;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.SourceInput;
 
@@ -25,7 +25,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _generatedTypeProvider = generatedTypeProvider;
             var inputModel = inputType as InputModelType;
             var specProperties = inputModel?.Properties ?? [];
-            _specPropertiesMap = specProperties.ToDictionary(p => p.Name.ToCleanIdentifierName(), p => p);
+            _specPropertiesMap = specProperties.ToDictionary(p => p.Name.ToIdentifierName(), p => p);
             _serializedNameMap = BuildSerializationNameMap();
             _renamedProperties = (_generatedTypeProvider.CustomCodeView?.Properties ?? [])
                 .Where(p => p.OriginalName != null).Select(p => p.OriginalName!).ToHashSet();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.SourceInput;
 
@@ -24,7 +25,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _generatedTypeProvider = generatedTypeProvider;
             var inputModel = inputType as InputModelType;
             var specProperties = inputModel?.Properties ?? [];
-            _specPropertiesMap = specProperties.ToDictionary(p => p.Name.ToCleanName(), p => p);
+            _specPropertiesMap = specProperties.ToDictionary(p => p.Name.ToCleanIdentifierName(), p => p);
             _serializedNameMap = BuildSerializationNameMap();
             _renamedProperties = (_generatedTypeProvider.CustomCodeView?.Properties ?? [])
                 .Where(p => p.OriginalName != null).Select(p => p.OriginalName!).ToHashSet();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Utilities;
 
@@ -48,7 +49,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.cs");
 
-        protected override string BuildName() => _inputType.Name.ToCleanName();
+        protected override string BuildName() => _inputType.Name.ToCleanIdentifierName();
         protected override FormattableString Description { get; }
 
         protected override TypeProvider[] BuildSerializationProviders()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Utilities;
 
@@ -49,7 +49,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.cs");
 
-        protected override string BuildName() => _inputType.Name.ToCleanIdentifierName();
+        protected override string BuildName() => _inputType.Name.ToIdentifierName();
         protected override FormattableString Description { get; }
 
         protected override TypeProvider[] BuildSerializationProviders()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ExtensibleEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ExtensibleEnumProvider.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -51,7 +52,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // build the field
                 var modifiers = FieldModifiers.Private | FieldModifiers.Const;
                 // the fields for extensible enums are private and const, storing the underlying values, therefore we need to append the word `Value` to the name
-                var valueName = inputValue.Name.ToCleanName();
+                var valueName = inputValue.Name.ToCleanIdentifierName();
                 var name = $"{valueName}Value";
                 // for initializationValue, if the enum is extensible, we always need it
                 var initializationValue = Literal(inputValue.Value);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ExtensibleEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ExtensibleEnumProvider.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -52,7 +52,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // build the field
                 var modifiers = FieldModifiers.Private | FieldModifiers.Const;
                 // the fields for extensible enums are private and const, storing the underlying values, therefore we need to append the word `Value` to the name
-                var valueName = inputValue.Name.ToCleanIdentifierName();
+                var valueName = inputValue.Name.ToIdentifierName();
                 var name = $"{valueName}Value";
                 // for initializationValue, if the enum is extensible, we always need it
                 var initializationValue = Literal(inputValue.Value);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Statements;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Statements;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FixedEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FixedEnumProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Utilities;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
@@ -63,7 +63,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // the fields for fixed enums are just its members (we use fields to represent the values in a system `enum` type), we just use the name for this field
                 var name = _isApiVersionEnum
                     ? inputValue.Name.ToApiVersionMemberName()
-                    : inputValue.Name.ToCleanIdentifierName();
+                    : inputValue.Name.ToIdentifierName();
 
                 // check if the enum member was renamed in custom code
                 string? customMemberName = null;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FixedEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FixedEnumProvider.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
-using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Utilities;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
@@ -63,7 +63,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // the fields for fixed enums are just its members (we use fields to represent the values in a system `enum` type), we just use the name for this field
                 var name = _isApiVersionEnum
                     ? inputValue.Name.ToApiVersionMemberName()
-                    : inputValue.Name.ToCleanName();
+                    : inputValue.Name.ToCleanIdentifierName();
 
                 // check if the enum member was renamed in custom code
                 string? customMemberName = null;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -139,7 +139,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.cs");
 
-        protected override string BuildName() => _inputModel.Name.ToCleanIdentifierName();
+        protected override string BuildName() => _inputModel.Name.ToIdentifierName();
 
         protected override TypeSignatureModifiers BuildDeclarationModifiers()
         {
@@ -290,7 +290,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     null,
                     MethodSignatureModifiers.Public,
                     propertyType,
-                    i == 0 ? AdditionalPropertiesHelper.DefaultAdditionalPropertiesPropertyName : field.Name.ToCleanIdentifierName(),
+                    i == 0 ? AdditionalPropertiesHelper.DefaultAdditionalPropertiesPropertyName : field.Name.ToIdentifierName(),
                     assignment,
                     this)
                 {
@@ -321,7 +321,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 var name = !containsAdditionalTypeProperties
                     ? AdditionalPropertiesHelper.DefaultAdditionalPropertiesPropertyName
-                    : RawDataField.Name.ToCleanIdentifierName();
+                    : RawDataField.Name.ToIdentifierName();
                 var type = !_inputModel.Usage.HasFlag(InputModelTypeUsage.Input)
                     ? additionalPropsType.OutputType
                     : additionalPropsType;
@@ -938,7 +938,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 name += additionalPropertiesValueType.Name;
             }
 
-            return $"_additional{name.ToCleanIdentifierName()}Properties";
+            return $"_additional{name.ToIdentifierName()}Properties";
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -138,7 +139,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.cs");
 
-        protected override string BuildName() => _inputModel.Name.ToCleanName();
+        protected override string BuildName() => _inputModel.Name.ToCleanIdentifierName();
 
         protected override TypeSignatureModifiers BuildDeclarationModifiers()
         {
@@ -289,7 +290,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     null,
                     MethodSignatureModifiers.Public,
                     propertyType,
-                    i == 0 ? AdditionalPropertiesHelper.DefaultAdditionalPropertiesPropertyName : field.Name.ToCleanName(),
+                    i == 0 ? AdditionalPropertiesHelper.DefaultAdditionalPropertiesPropertyName : field.Name.ToCleanIdentifierName(),
                     assignment,
                     this)
                 {
@@ -320,7 +321,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 var name = !containsAdditionalTypeProperties
                     ? AdditionalPropertiesHelper.DefaultAdditionalPropertiesPropertyName
-                    : RawDataField.Name.ToCleanName();
+                    : RawDataField.Name.ToCleanIdentifierName();
                 var type = !_inputModel.Usage.HasFlag(InputModelTypeUsage.Input)
                     ? additionalPropsType.OutputType
                     : additionalPropsType;
@@ -937,7 +938,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 name += additionalPropertiesValueType.Name;
             }
 
-            return $"_additional{name.ToCleanName()}Properties";
+            return $"_additional{name.ToCleanIdentifierName()}Properties";
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -90,8 +90,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             Type = inputProperty.IsReadOnly ? propertyType.OutputType : propertyType;
             Modifiers = inputProperty.IsDiscriminator ? MethodSignatureModifiers.Internal : MethodSignatureModifiers.Public;
             Name = inputProperty.Name == enclosingType.Name
-                ? $"{inputProperty.Name.ToCleanIdentifierName()}Property"
-                : inputProperty.Name.ToCleanIdentifierName();
+                ? $"{inputProperty.Name.ToIdentifierName()}Property"
+                : inputProperty.Name.ToIdentifierName();
             Body = new AutoPropertyBody(propHasSetter, setterModifier, GetPropertyInitializationValue(propertyType, inputProperty));
 
             WireInfo = new PropertyWireInformation(inputProperty);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -89,8 +90,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             Type = inputProperty.IsReadOnly ? propertyType.OutputType : propertyType;
             Modifiers = inputProperty.IsDiscriminator ? MethodSignatureModifiers.Internal : MethodSignatureModifiers.Public;
             Name = inputProperty.Name == enclosingType.Name
-                ? $"{inputProperty.Name.ToCleanName()}Property"
-                : inputProperty.Name.ToCleanName();
+                ? $"{inputProperty.Name.ToCleanIdentifierName()}Property"
+                : inputProperty.Name.ToCleanIdentifierName();
             Body = new AutoPropertyBody(propHasSetter, setterModifier, GetPropertyInitializationValue(propertyType, inputProperty));
 
             WireInfo = new PropertyWireInformation(inputProperty);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/FormattableStringHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/FormattableStringHelpers.cs
@@ -8,8 +8,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Utilities;
 
 namespace Microsoft.TypeSpec.Generator
 {
@@ -131,7 +132,7 @@ namespace Microsoft.TypeSpec.Generator
             // For instance, when the format string is all \n, it will produce n+1 segments (because we did not omit empty entries).
             Span<Range> splitIndices = stackalloc Range[input.Format.Length + 1];
             ReadOnlySpan<char> formatSpan = input.Format.AsSpan();
-            foreach ((ReadOnlySpan<char> span, bool isLiteral, int index) in StringHelpers.GetFormattableStringFormatParts(formatSpan))
+            foreach ((ReadOnlySpan<char> span, bool isLiteral, int index) in InternalStringExtensions.GetFormattableStringFormatParts(formatSpan))
             {
                 // if isLiteral - put in formatBuilder
                 if (isLiteral)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/FormattableStringHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/FormattableStringHelpers.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Utilities;
 
@@ -132,7 +131,7 @@ namespace Microsoft.TypeSpec.Generator
             // For instance, when the format string is all \n, it will produce n+1 segments (because we did not omit empty entries).
             Span<Range> splitIndices = stackalloc Range[input.Format.Length + 1];
             ReadOnlySpan<char> formatSpan = input.Format.AsSpan();
-            foreach ((ReadOnlySpan<char> span, bool isLiteral, int index) in InternalStringExtensions.GetFormattableStringFormatParts(formatSpan))
+            foreach ((ReadOnlySpan<char> span, bool isLiteral, int index) in StringExtensions.GetFormattableStringFormatParts(formatSpan))
             {
                 // if isLiteral - put in formatBuilder
                 if (isLiteral)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/FormattableStringHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/FormattableStringHelpers.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Providers;
 
 namespace Microsoft.TypeSpec.Generator
@@ -130,7 +131,7 @@ namespace Microsoft.TypeSpec.Generator
             // For instance, when the format string is all \n, it will produce n+1 segments (because we did not omit empty entries).
             Span<Range> splitIndices = stackalloc Range[input.Format.Length + 1];
             ReadOnlySpan<char> formatSpan = input.Format.AsSpan();
-            foreach ((ReadOnlySpan<char> span, bool isLiteral, int index) in StringExtensions.GetFormattableStringFormatParts(formatSpan))
+            foreach ((ReadOnlySpan<char> span, bool isLiteral, int index) in StringHelpers.GetFormattableStringFormatParts(formatSpan))
             {
                 // if isLiteral - put in formatBuilder
                 if (isLiteral)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/InternalStringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/InternalStringExtensions.cs
@@ -5,84 +5,12 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace Microsoft.TypeSpec.Generator.Input.Utilities
+namespace Microsoft.TypeSpec.Generator.Utilities
 {
-    public static class StringHelpers
+    internal static class InternalStringExtensions
     {
-        private static bool IsWordSeparator(char c) => !SyntaxFacts.IsIdentifierPartCharacter(c) || c == '_';
-        private static readonly Regex HumanizedCamelCaseRegex = new Regex(@"([A-Z])", RegexOptions.Compiled);
-
-        [return: NotNullIfNotNull("name")]
-        public static string ToCleanIdentifierName(this string name, bool isCamelCase = true)
-        {
-            if (string.IsNullOrEmpty(name))
-            {
-                return name;
-            }
-            StringBuilder nameBuilder = new StringBuilder();
-
-            int i = 0;
-
-            if (char.IsDigit(name[0]))
-            {
-                nameBuilder.Append("_");
-            }
-            else
-            {
-                while (!SyntaxFacts.IsIdentifierStartCharacter(name[i]))
-                {
-                    i++;
-                }
-            }
-
-            bool upperCase = false;
-            int firstWordLength = 1;
-            for (; i < name.Length; i++)
-            {
-                var c = name[i];
-                if (IsWordSeparator(c))
-                {
-                    upperCase = true;
-                    continue;
-                }
-
-                if (nameBuilder.Length == 0 && isCamelCase)
-                {
-                    c = char.ToUpper(c);
-                    upperCase = false;
-                }
-                else if (nameBuilder.Length < firstWordLength && !isCamelCase)
-                {
-                    c = char.ToLower(c);
-                    upperCase = false;
-                    // grow the first word length when this letter follows by two other upper case letters
-                    // this happens in OSProfile, where OS is the first word
-                    if (i + 2 < name.Length && char.IsUpper(name[i + 1]) && (char.IsUpper(name[i + 2]) || IsWordSeparator(name[i + 2])))
-                        firstWordLength++;
-                    // grow the first word length when this letter follows by another upper case letter and an end of the string
-                    // this happens when the string only has one word, like OS, DNS
-                    if (i + 2 == name.Length && char.IsUpper(name[i + 1]))
-                        firstWordLength++;
-                }
-
-                if (upperCase)
-                {
-                    c = char.ToUpper(c);
-                    upperCase = false;
-                }
-
-                nameBuilder.Append(c);
-            }
-
-            return nameBuilder.ToString();
-        }
-
-        [return: NotNullIfNotNull(nameof(name))]
-        public static string ToVariableName(this string name) => name.ToCleanIdentifierName(isCamelCase: false);
-
         public static GetPathPartsEnumerator GetFormattableStringFormatParts(string? format) => new GetPathPartsEnumerator(format);
 
         public static GetPathPartsEnumerator GetFormattableStringFormatParts(ReadOnlySpan<char> format) => new GetPathPartsEnumerator(format);
@@ -150,7 +78,7 @@ namespace Microsoft.TypeSpec.Generator.Input.Utilities
                 return true;
             }
 
-            public readonly ref struct Part
+            internal readonly ref struct Part
             {
                 public Part(ReadOnlySpan<char> span, bool isLiteral)
                 {
@@ -243,68 +171,6 @@ namespace Microsoft.TypeSpec.Generator.Input.Utilities
             }
 
             return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(sb.ToString());
-        }
-
-        /// <summary>
-        /// Checks if two namespaces share the same last segment
-        /// </summary>
-        /// <param name="left">the first namespace</param>
-        /// <param name="right">the second namespace</param>
-        /// <returns></returns>
-        public static bool IsLastNamespaceSegmentTheSame(string left, string right)
-        {
-            // finish this via Span API
-            var leftSpan = left.AsSpan();
-            var rightSpan = right.AsSpan();
-            // swap if left is longer, we ensure left is the shorter one
-            if (leftSpan.Length > rightSpan.Length)
-            {
-                var temp = leftSpan;
-                leftSpan = rightSpan;
-                rightSpan = temp;
-            }
-            for (int i = 1; i <= leftSpan.Length; i++)
-            {
-                var lc = leftSpan[^i];
-                var rc = rightSpan[^i];
-                // check if each char is the same from the right-most side
-                // if both of them are dot, we finished scanning the last segment - and if we could be here, meaning all of them are the same, return true.
-                if (lc == '.' && rc == '.')
-                {
-                    return true;
-                }
-                // if these are different - there is one different character, return false.
-                if (lc != rc)
-                {
-                    return false;
-                }
-            }
-
-            // we come here because we run out of characters in left - which means left does not have a dot.
-            // if they have the same length, they are identical, return true
-            if (leftSpan.Length == rightSpan.Length)
-            {
-                return true;
-            }
-            // otherwise, right is longer, we check its next character, if it is the dot, return true, otherwise return false.
-            return rightSpan[^(leftSpan.Length + 1)] == '.';
-        }
-
-        public static string RemovePeriods(this string input)
-        {
-            if (string.IsNullOrEmpty(input))
-                return input;
-
-            Span<char> buffer = stackalloc char[input.Length];
-            int index = 0;
-
-            foreach (char c in input)
-            {
-                if (c != '.')
-                    buffer[index++] = c;
-            }
-
-            return buffer.Slice(0, index).ToString();
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/StringExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.TypeSpec.Generator.Utilities
 {
-    internal static class InternalStringExtensions
+    internal static class StringExtensions
     {
         public static GetPathPartsEnumerator GetFormattableStringFormatParts(string? format) => new GetPathPartsEnumerator(format);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -79,7 +80,7 @@ namespace Microsoft.TypeSpec.Generator
             const string declarationFormatString = ":D"; // :D :)
             const string identifierFormatString = ":I";
             const string crefFormatString = ":C"; // wraps content into "see cref" tag, available only in xmlDoc
-            foreach ((var span, bool isLiteral, int index) in StringExtensions.GetFormattableStringFormatParts(formattableString.Format))
+            foreach ((var span, bool isLiteral, int index) in StringHelpers.GetFormattableStringFormatParts(formattableString.Format))
             {
                 if (isLiteral)
                 {
@@ -683,7 +684,7 @@ namespace Microsoft.TypeSpec.Generator
             {
                 return AppendRaw(identifier.ToXmlDocIdentifierName());
             }
-            if (StringExtensions.IsCSharpKeyword(identifier))
+            if (StringHelpers.IsCSharpKeyword(identifier))
             {
                 AppendRaw("@");
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -8,11 +8,12 @@ using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
+using Microsoft.TypeSpec.Generator.Utilities;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Microsoft.TypeSpec.Generator
@@ -80,7 +81,7 @@ namespace Microsoft.TypeSpec.Generator
             const string declarationFormatString = ":D"; // :D :)
             const string identifierFormatString = ":I";
             const string crefFormatString = ":C"; // wraps content into "see cref" tag, available only in xmlDoc
-            foreach ((var span, bool isLiteral, int index) in StringHelpers.GetFormattableStringFormatParts(formattableString.Format))
+            foreach ((var span, bool isLiteral, int index) in InternalStringExtensions.GetFormattableStringFormatParts(formattableString.Format))
             {
                 if (isLiteral)
                 {
@@ -684,7 +685,7 @@ namespace Microsoft.TypeSpec.Generator
             {
                 return AppendRaw(identifier.ToXmlDocIdentifierName());
             }
-            if (StringHelpers.IsCSharpKeyword(identifier))
+            if (InternalStringExtensions.IsCSharpKeyword(identifier))
             {
                 AppendRaw("@");
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
-using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -81,7 +80,7 @@ namespace Microsoft.TypeSpec.Generator
             const string declarationFormatString = ":D"; // :D :)
             const string identifierFormatString = ":I";
             const string crefFormatString = ":C"; // wraps content into "see cref" tag, available only in xmlDoc
-            foreach ((var span, bool isLiteral, int index) in InternalStringExtensions.GetFormattableStringFormatParts(formattableString.Format))
+            foreach ((var span, bool isLiteral, int index) in StringExtensions.GetFormattableStringFormatParts(formattableString.Format))
             {
                 if (isLiteral)
                 {
@@ -685,7 +684,7 @@ namespace Microsoft.TypeSpec.Generator
             {
                 return AppendRaw(identifier.ToXmlDocIdentifierName());
             }
-            if (InternalStringExtensions.IsCSharpKeyword(identifier))
+            if (StringExtensions.IsCSharpKeyword(identifier))
             {
                 AppendRaw("@");
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviderTests.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviderTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Linq;
-using System.Text;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
-using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Tests.Common;
@@ -81,7 +81,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             InputFactory.Model("TestModel", properties: [collectionProperty]);
             var property = new PropertyProvider(collectionProperty, new TestTypeProvider());
 
-            Assert.AreEqual(collectionProperty.Name.ToCleanIdentifierName(), property.Name);
+            Assert.AreEqual(collectionProperty.Name.ToIdentifierName(), property.Name);
             Assert.AreEqual(expectedType, property.Type);
 
             // validate the parameter conversion
@@ -122,7 +122,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             InputFactory.Model("TestModel", properties: [inputModelProperty]);
 
             var property = new PropertyProvider(inputModelProperty, testTypeProvider);
-            Assert.AreEqual(inputPropertyName.ToCleanIdentifierName() + "Property", property.Name);
+            Assert.AreEqual(inputPropertyName.ToIdentifierName() + "Property", property.Name);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Tests.Common;
@@ -80,7 +81,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             InputFactory.Model("TestModel", properties: [collectionProperty]);
             var property = new PropertyProvider(collectionProperty, new TestTypeProvider());
 
-            Assert.AreEqual(collectionProperty.Name.ToCleanName(), property.Name);
+            Assert.AreEqual(collectionProperty.Name.ToCleanIdentifierName(), property.Name);
             Assert.AreEqual(expectedType, property.Type);
 
             // validate the parameter conversion
@@ -121,7 +122,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             InputFactory.Model("TestModel", properties: [inputModelProperty]);
 
             var property = new PropertyProvider(inputModelProperty, testTypeProvider);
-            Assert.AreEqual(inputPropertyName.ToCleanName() + "Property", property.Name);
+            Assert.AreEqual(inputPropertyName.ToCleanIdentifierName() + "Property", property.Name);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Utilities
@@ -113,7 +114,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         [TestCase("yield", true)]
         public void TestIsCSharpKeyword(string name, bool isKeyword)
         {
-            var result = StringExtensions.IsCSharpKeyword(name);
+            var result = StringHelpers.IsCSharpKeyword(name);
             Assert.AreEqual(isKeyword, result);
         }
 
@@ -133,7 +134,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         public void ValidateGetFormattableStringFormatParts(string format, IReadOnlyList<Part> parts)
         {
             var i = 0;
-            foreach (var (span, isLiteral, index) in StringExtensions.GetFormattableStringFormatParts(format))
+            foreach (var (span, isLiteral, index) in StringHelpers.GetFormattableStringFormatParts(format))
             {
                 Assert.AreEqual(parts[i].Value, span.ToString());
                 Assert.AreEqual(parts[i].IsLiteral, isLiteral);
@@ -157,7 +158,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         [TestCase(".Foo", "Foo", ExpectedResult = true)]
         public bool ValidateIsLastNamespaceSegmentTheSame(string left, string right)
         {
-            return StringExtensions.IsLastNamespaceSegmentTheSame(left, right);
+            return StringHelpers.IsLastNamespaceSegmentTheSame(left, right);
         }
 
         public record Part(string Value, bool IsLiteral, int ArgumentIndex);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
+using Microsoft.TypeSpec.Generator.Utilities;
 using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Utilities
@@ -114,7 +115,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         [TestCase("yield", true)]
         public void TestIsCSharpKeyword(string name, bool isKeyword)
         {
-            var result = StringHelpers.IsCSharpKeyword(name);
+            var result = InternalStringExtensions.IsCSharpKeyword(name);
             Assert.AreEqual(isKeyword, result);
         }
 
@@ -134,7 +135,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         public void ValidateGetFormattableStringFormatParts(string format, IReadOnlyList<Part> parts)
         {
             var i = 0;
-            foreach (var (span, isLiteral, index) in StringHelpers.GetFormattableStringFormatParts(format))
+            foreach (var (span, isLiteral, index) in InternalStringExtensions.GetFormattableStringFormatParts(format))
             {
                 Assert.AreEqual(parts[i].Value, span.ToString());
                 Assert.AreEqual(parts[i].IsLiteral, isLiteral);
@@ -158,7 +159,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         [TestCase(".Foo", "Foo", ExpectedResult = true)]
         public bool ValidateIsLastNamespaceSegmentTheSame(string left, string right)
         {
-            return StringHelpers.IsLastNamespaceSegmentTheSame(left, right);
+            return StringExtensions.IsLastNamespaceSegmentTheSame(left, right);
         }
 
         public record Part(string Value, bool IsLiteral, int ArgumentIndex);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using PublicStringExtensions = Microsoft.TypeSpec.Generator.Input.Extensions.StringExtensions;
 using Microsoft.TypeSpec.Generator.Utilities;
-using InternalStringExtensions = Microsoft.TypeSpec.Generator.Utilities.StringExtensions;
 using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Utilities
@@ -116,7 +114,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         [TestCase("yield", true)]
         public void TestIsCSharpKeyword(string name, bool isKeyword)
         {
-            var result = InternalStringExtensions.IsCSharpKeyword(name);
+            var result = StringExtensions.IsCSharpKeyword(name);
             Assert.AreEqual(isKeyword, result);
         }
 
@@ -136,31 +134,13 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         public void ValidateGetFormattableStringFormatParts(string format, IReadOnlyList<Part> parts)
         {
             var i = 0;
-            foreach (var (span, isLiteral, index) in InternalStringExtensions.GetFormattableStringFormatParts(format))
+            foreach (var (span, isLiteral, index) in StringExtensions.GetFormattableStringFormatParts(format))
             {
                 Assert.AreEqual(parts[i].Value, span.ToString());
                 Assert.AreEqual(parts[i].IsLiteral, isLiteral);
                 Assert.AreEqual(parts[i].ArgumentIndex, index);
                 i++;
             }
-        }
-
-        [TestCase("Foo", "Foo", ExpectedResult = true)]
-        [TestCase("Foo", "Bar", ExpectedResult = false)]
-        [TestCase("Foo", "_Foo", ExpectedResult = false)]
-        [TestCase("_Foo", "Foo", ExpectedResult = false)]
-        [TestCase("Foo", "Bar.Foo", ExpectedResult = true)]
-        [TestCase("Bar.Foo", "Foo", ExpectedResult = true)]
-        [TestCase("Foo", "Bar._Foo", ExpectedResult = false)]
-        [TestCase("Bar._Foo", "Foo", ExpectedResult = false)]
-        [TestCase("Foo", "/Foo", ExpectedResult = false)]
-        [TestCase("/Foo", "Foo", ExpectedResult = false)]
-        [TestCase(".Foo", ".Foo", ExpectedResult = true)]
-        [TestCase("Foo", ".Foo", ExpectedResult = true)]
-        [TestCase(".Foo", "Foo", ExpectedResult = true)]
-        public bool ValidateIsLastNamespaceSegmentTheSame(string left, string right)
-        {
-            return PublicStringExtensions.IsLastNamespaceSegmentTheSame(left, right);
         }
 
         public record Part(string Value, bool IsLiteral, int ArgumentIndex);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.TypeSpec.Generator.Input.Extensions;
+using PublicStringExtensions = Microsoft.TypeSpec.Generator.Input.Extensions.StringExtensions;
 using Microsoft.TypeSpec.Generator.Utilities;
+using InternalStringExtensions = Microsoft.TypeSpec.Generator.Utilities.StringExtensions;
 using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Utilities
@@ -159,7 +160,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         [TestCase(".Foo", "Foo", ExpectedResult = true)]
         public bool ValidateIsLastNamespaceSegmentTheSame(string left, string right)
         {
-            return StringExtensions.IsLastNamespaceSegmentTheSame(left, right);
+            return PublicStringExtensions.IsLastNamespaceSegmentTheSame(left, right);
         }
 
         public record Part(string Value, bool IsLiteral, int ArgumentIndex);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Input.Utilities;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Common
 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Common
 {


### PR DESCRIPTION
Resolves https://github.com/microsoft/typespec/issues/7386
Split StringExtensions.cs into 2 parts:
- Add a new public StringExtensions.cs in Microsoft.TypeSpec.Generator.Input since it is needed there and Input is the base dependency for all others
- Keep Internal StringExtensions.cs in Microsoft.TypeSpec.Generator with internal methods