### PR TITLE
http-client-java, use kebab case for code snippet id

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ProxyMethodExampleMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ProxyMethodExampleMapper.java
@@ -63,14 +63,14 @@ public class ProxyMethodExampleMapper implements IMapper<XmsExampleWrapper, Prox
         return builder.build();
     }
 
-    private String buildCodeSnippetIdentifier(String operationId, String exampleName) {
-        return String
-            .format("%s.generated.%s.%s", JavaSettings.getInstance().getPackage(), getValidName(operationId),
-                getValidName(exampleName))
-            .toLowerCase(Locale.ROOT);
+    static String buildCodeSnippetIdentifier(String operationId, String exampleName) {
+        return String.format("%s.generated.%s.%s", JavaSettings.getInstance().getPackage(),
+            getValidNameInKebabCase(operationId), getValidNameInKebabCase(exampleName));
     }
 
-    private String getValidName(String exampleName) {
-        return CodeNamer.getValidName(exampleName).replace("_", "");
+    private static String getValidNameInKebabCase(String exampleName) {
+        String removeInvalidChar = CodeNamer.getValidName(exampleName).replace("_", "-");
+        // convert camelCase to kebab-case
+        return removeInvalidChar.replaceAll("([a-z])([A-Z]+)", "$1-$2").toLowerCase(Locale.ROOT);
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/mapper/ProxyMethodExampleMapperTests.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/mapper/ProxyMethodExampleMapperTests.java
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.typespec.http.client.generator.core.mapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public final class ProxyMethodExampleMapperTests {
+
+    @Test
+    public void testBuildCodeSnippetIdentifier() {
+        String operationId = "OnlineExperimentation_CreateOrUpdateMetric";
+        String exampleName = "CreateOrUpdateMetric_Average";
+
+        String codeSnippetIdentifier = ProxyMethodExampleMapper.buildCodeSnippetIdentifier(operationId, exampleName);
+        Assertions.assertEquals(
+            "com.azure.mock.generated.online-experimentation-create-or-update-metric.create-or-update-metric-average",
+            codeSnippetIdentifier);
+    }
+}


### PR DESCRIPTION
Mostly to get this code snippet id be cspell friendly.

Context https://github.com/Azure/azure-sdk-for-java/pull/44980#discussion_r2094742197