### PR TITLE
Remove templateArguments property

### DIFF
--- a/.chronus/changes/fix-remove-template-args-2025-4-23-15-39-59.md
+++ b/.chronus/changes/fix-remove-template-args-2025-4-23-15-39-59.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Remove non documented `templateArguments` property on types

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -140,6 +140,7 @@ import {
   TemplateParameterDeclarationNode,
   TemplateableNode,
   TemplatedType,
+  TemplatedTypeBase,
   Tuple,
   TupleExpressionNode,
   Type,
@@ -6395,14 +6396,10 @@ export function finishTypeForProgram<T extends Type>(program: Program, typeDef: 
   return finishTypeForProgramAndChecker(program, program.checker.typePrototype, typeDef);
 }
 
-function linkMapper<T extends Type>(typeDef: T, mapper?: TypeMapper) {
+function linkMapper<T extends Type & TemplatedTypeBase>(typeDef: T, mapper?: TypeMapper) {
   if (mapper) {
-    compilerAssert(
-      !(typeDef as any).templateArguments,
-      "Mapper provided but template arguments already set.",
-    );
-    (typeDef as any).templateMapper = mapper;
-    (typeDef as any).templateArguments = mapper.args;
+    compilerAssert(!typeDef.templateMapper, "Mapper provided but template arguments already set.");
+    typeDef.templateMapper = mapper;
   }
 }
 


### PR DESCRIPTION
fix #7456

That property was deprecated and removed for 1.0 but seems like due to the cast to `as any` we missed the actual assignment part