### PR TITLE
[http-client-csharp]: Generate model factory method from LastContractView if the only thing that changed was the parameter ordering

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -333,7 +333,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 bool boolValue => boolValue ? True : False,
                 int intValue => Int(intValue),
                 double doubleValue => Double(doubleValue),
-                _ => null
+                float floatValue => Float(floatValue),
+                long longValue => Long(longValue),
+                _ => Default
             };
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -16,9 +16,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
     public class ModelFactoryProviderTests
     {
         private static readonly InputModelType[] ModelList = GetTestModels();
-        private CodeModelGenerator _instance;
+        private CodeModelGenerator? _instance;
 
-        public ModelFactoryProviderTests()
+        [SetUp]
+        public void Setup()
         {
             _instance = MockHelpers.LoadMockGenerator(inputModelTypes: ModelList).Object;
         }
@@ -26,14 +27,14 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         [Test]
         public void SkipInternalModels()
         {
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             Assert.AreEqual(ModelList.Length - ModelList.Where(m => m.Access == "internal").Count(), modelFactory.Methods.Count);
         }
 
         [Test]
         public void ListParamShape()
         {
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             var models = ModelList.Select(CodeModelGenerator.Instance.TypeFactory.CreateModel);
             foreach (var model in models)
             {
@@ -56,7 +57,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         [Test]
         public void DictionaryParamShape()
         {
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             var models = ModelList.Select(CodeModelGenerator.Instance.TypeFactory.CreateModel);
             foreach (var model in models)
             {
@@ -79,7 +80,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         [Test]
         public void DiscriminatorEnumParamShape()
         {
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             var models = ModelList.Select(CodeModelGenerator.Instance.TypeFactory.CreateModel);
             foreach (var model in models)
             {
@@ -101,7 +102,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         [Test]
         public void AdditionalPropertiesParamShape()
         {
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             var models = ModelList.Select(CodeModelGenerator.Instance.TypeFactory.CreateModel);
             foreach (var model in models)
             {
@@ -125,19 +126,18 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         [Test]
         public void ModelFactoryName()
         {
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             Assert.AreEqual("SampleNamespaceModelFactory", modelFactory.Name);
         }
 
         [Test]
         public async Task BackCompatibility_NewModelPropertyAdded()
         {
-            var currentInstance = _instance;
             _instance = (await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: ModelList,
                 lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
 
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             Assert.AreEqual("SampleNamespaceModelFactory", modelFactory.Name);
 
             var methods = modelFactory.Methods;
@@ -183,19 +183,83 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             Assert.AreEqual(
                 "return PublicModel1(stringProp, modelProp, listProp, dictProp: default);\n",
                 result);
+        }
 
-            _instance = currentInstance;
+        // This test validates that only the previous model factory methods are generated when only the parameter ordering is changed
+        // in the current library version.
+        [Test]
+        public async Task BackCompatibility_OnlyParamOrderingChanged()
+        {
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputModelTypes: ModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            Assert.AreEqual("SampleNamespaceModelFactory", modelFactory.Name);
+
+            var methods = modelFactory.Methods;
+            Assert.AreEqual(ModelList.Length - ModelList.Where(m => m.Access == "internal").Count(), methods.Count);
+
+            var factoryMethods = methods.Where(m => m.Signature.Name == "PublicModel1" || m.Signature.Name == "PublicModel2");
+            Assert.AreEqual(2, factoryMethods.Count());
+
+            var model1BackCompatMethod = factoryMethods
+                .First(m => m.Signature.Name == "PublicModel1");
+            Assert.IsNotNull(model1BackCompatMethod);
+
+            var attributes = model1BackCompatMethod!.Signature.Attributes;
+            Assert.AreEqual(0, attributes.Count);
+
+            var parameters = model1BackCompatMethod!.Signature.Parameters;
+            Assert.AreEqual(4, parameters.Count);
+            Assert.AreEqual("modelProp", parameters[0].Name);
+            Assert.AreEqual("stringProp", parameters[1].Name);
+            Assert.AreEqual("listProp", parameters[2].Name);
+            Assert.AreEqual("dictProp", parameters[3].Name);
+
+            var model2BackCompatMethod = factoryMethods
+               .First(m => m.Signature.Name == "PublicModel2");
+            Assert.IsNotNull(model2BackCompatMethod);
+
+            attributes = model2BackCompatMethod!.Signature.Attributes;
+            Assert.AreEqual(0, attributes.Count);
+
+            parameters = model2BackCompatMethod!.Signature.Parameters;
+            Assert.AreEqual(4, parameters.Count);
+            Assert.AreEqual("listProp", parameters[0].Name);
+            Assert.AreEqual("modelProp", parameters[1].Name);
+            Assert.AreEqual("stringProp", parameters[2].Name);
+            Assert.AreEqual("dictProp", parameters[3].Name);
+
+
+            // validate the previous method bodies
+            var body = model1BackCompatMethod!.BodyStatements;
+            Assert.IsNotNull(body);
+            var result = body!.ToDisplayString();
+            Assert.AreEqual(
+                "listProp ??= new global::Sample.ChangeTrackingList<string>();\n" +
+                "dictProp ??= new global::Sample.ChangeTrackingDictionary<string, string>();\n\n" +
+                "return new global::Sample.Models.PublicModel1(stringProp, modelProp, listProp?.ToList(), dictProp, additionalBinaryDataProperties: null);\n",
+                result);
+
+            body = model2BackCompatMethod!.BodyStatements;
+            Assert.IsNotNull(body);
+            result = body!.ToDisplayString();
+            Assert.AreEqual(
+                "listProp ??= new global::Sample.ChangeTrackingList<string>();\n" +
+                "dictProp ??= new global::Sample.ChangeTrackingDictionary<string, string>();\n\n" +
+                "return new global::Sample.Models.PublicModel2(stringProp, modelProp, listProp?.ToList(), dictProp, additionalBinaryDataProperties: null);\n",
+                result);
         }
 
         [Test]
         public async Task BackCompatibility_NoCurrentOverloadFound()
         {
-            var currentInstance = _instance;
             _instance = (await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: ModelList,
                 lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
 
-            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
             Assert.AreEqual("SampleNamespaceModelFactory", modelFactory.Name);
 
             var methods = modelFactory.Methods;
@@ -230,8 +294,6 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             Assert.AreEqual(
                 "return new global::Sample.Models.PublicModel1(stringProp, default, default, default, additionalBinaryDataProperties: null);\n",
                 result);
-
-            _instance = currentInstance;
         }
 
         private static InputModelType[] GetTestModels()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_OnlyParamOrderingChanged/SampleNamespaceModelFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_OnlyParamOrderingChanged/SampleNamespaceModelFactory.cs
@@ -26,12 +26,6 @@ namespace Sample
 
 namespace Sample.Models
 {
-    public partial class PublicModel1
-    { }
-
-    public partial class PublicModel2
-    { }
-
     public partial class Thing
     { }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_OnlyParamOrderingChanged/SampleNamespaceModelFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_OnlyParamOrderingChanged/SampleNamespaceModelFactory.cs
@@ -1,0 +1,37 @@
+using SampleTypeSpec;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Sample.Models;
+
+namespace Sample
+{
+    public static partial class SampleNamespaceModelFactory
+    {
+        public static PublicModel1 PublicModel1(
+            Thing modelProp = default,
+            string stringProp = default,
+            IEnumerable<string> listProp = default,
+            IDictionary<string, string> dictProp = default)
+        { }
+
+        public static PublicModel2 PublicModel2(
+            IEnumerable<string> listProp = default,
+            Thing modelProp = default,
+            string stringProp = default,
+            IDictionary<string, string> dictProp = default)
+        { }
+    }
+}
+
+namespace Sample.Models
+{
+    public partial class PublicModel1
+    { }
+
+    public partial class PublicModel2
+    { }
+
+    public partial class Thing
+    { }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
@@ -279,8 +279,13 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
                 yield return new TestCaseData(typeof(int), Literal(2));
                 yield return new TestCaseData(typeof(string), Literal("Foo"));
                 yield return new TestCaseData(typeof(double), Literal(2.2));
+                yield return new TestCaseData(typeof(double?), Literal(2.2));
+                yield return new TestCaseData(typeof(float), Literal(2.2f));
+                yield return new TestCaseData(typeof(float?), Literal(2.2f));
+                yield return new TestCaseData(typeof(long), Long(2));
                 yield return new TestCaseData(typeof(bool), False);
                 yield return new TestCaseData(typeof(object), Default);
+                yield return new TestCaseData(typeof(BinaryData), Default);
             }
         }
     }


### PR DESCRIPTION
This PR extends the back-compat support for model factory methods by skipping generation of model factory methods that were present in the previous version of the generated code if only the parameter ordering changed in the current version. In this case, the factory method from the previous version is used.

fixes: https://github.com/microsoft/typespec/issues/7406