### PR TITLE
Make RelativeFilePath property public

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         /// Gets the relative file path where the generated file will be stored.
         /// This path is relative to the project's root directory.
         /// </summary>
-        internal string RelativeFilePath => _relativeFilePath ??= BuildRelativeFilePath();
+        public string RelativeFilePath => _relativeFilePath ??= BuildRelativeFilePath();
 
         private string? _relativeFilePath;
 


### PR DESCRIPTION
This should be public to match the pattern of public properties and protected Build methods.