### PR TITLE
ClientMethodTemplate: Remove method parameters that can be obtained from other parameters and Improve ClientType to WireType function

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/MethodPageDetails.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/MethodPageDetails.java
@@ -68,7 +68,8 @@ public final class MethodPageDetails {
     }
 
     public boolean nonNullNextLink() {
-        return getNextLinkName() != null && !getNextLinkName().isEmpty();
+        final String nextLinkName = getNextLinkName();
+        return nextLinkName != null && !nextLinkName.isEmpty();
     }
 
     public boolean shouldHideParameter(ClientMethodParameter parameter) {

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentClientMethodTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentClientMethodTemplate.java
@@ -25,8 +25,8 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
     }
 
     @Override
-    protected void generatePagedAsyncSinglePage(ClientMethod clientMethod, JavaType typeBlock,
-        ProxyMethod restAPIMethod, JavaSettings settings) {
+    protected void generatePagedAsyncSinglePage(ClientMethod clientMethod, JavaType typeBlock, JavaSettings settings) {
+        final ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
         boolean addContextParameter = !contextInParameters(clientMethod);
         boolean mergeContextParameter = contextInParameters(clientMethod);
         boolean isLroPagination = GenericType.Mono(GenericType.Response(GenericType.FLUX_BYTE_BUFFER))
@@ -40,11 +40,10 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
         String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
         if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
             writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
-                addValidations(function, clientMethod.getRequiredNullableParameterExpressions(),
-                    clientMethod.getValidateExpressions(), clientMethod.getType(), settings);
-                addOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
+                addValidations(function, clientMethod, settings);
+                addOptionalAndConstantVariables(function, clientMethod, settings);
                 applyParameterTransformations(function, clientMethod, settings);
-                convertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters());
+                convertClientTypesToWireTypes(function, clientMethod);
                 if (mergeContextParameter) {
                     function
                         .line(String.format("context = %s.mergeContext(context);", clientMethod.getClientReference()));
@@ -125,11 +124,10 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
             });
         } else {
             writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
-                addValidations(function, clientMethod.getRequiredNullableParameterExpressions(),
-                    clientMethod.getValidateExpressions(), clientMethod.getType(), settings);
-                addOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
+                addValidations(function, clientMethod, settings);
+                addOptionalAndConstantVariables(function, clientMethod, settings);
                 applyParameterTransformations(function, clientMethod, settings);
-                convertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters());
+                convertClientTypesToWireTypes(function, clientMethod);
                 if (mergeContextParameter) {
                     function
                         .line(String.format("context = %s.mergeContext(context);", clientMethod.getClientReference()));
@@ -241,17 +239,17 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
 
     @Override
     protected void generateSimpleAsyncRestResponse(ClientMethod clientMethod, JavaType typeBlock,
-        ProxyMethod restAPIMethod, JavaSettings settings) {
+        JavaSettings settings) {
+        final ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
         boolean addContextParameter = !contextInParameters(clientMethod);
         boolean mergeContextParameter = !addContextParameter;
 
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
         writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
-            addValidations(function, clientMethod.getRequiredNullableParameterExpressions(),
-                clientMethod.getValidateExpressions(), clientMethod.getType(), settings);
-            addOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
+            addValidations(function, clientMethod, settings);
+            addOptionalAndConstantVariables(function, clientMethod, settings);
             applyParameterTransformations(function, clientMethod, settings);
-            convertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters());
+            convertClientTypesToWireTypes(function, clientMethod);
 
             String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
             String serviceMethodCall
@@ -273,8 +271,9 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
     }
 
     @Override
-    protected void generateLongRunningAsync(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod,
-        JavaSettings settings) {
+    protected void generateLongRunningAsync(ClientMethod clientMethod, JavaType typeBlock, JavaSettings settings) {
+        final ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
+
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
         String beginAsyncMethodName = MethodNamer.getLroBeginAsyncMethodName(restAPIMethod.getName());
         writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
@@ -289,8 +288,9 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
     }
 
     @Override
-    protected void generateLongRunningPlainSync(ClientMethod clientMethod, JavaType typeBlock,
-        ProxyMethod restAPIMethod, JavaSettings settings) {
+    protected void generateLongRunningPlainSync(ClientMethod clientMethod, JavaType typeBlock, JavaSettings settings) {
+        final ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
+
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
         writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
             addOptionalVariables(function, clientMethod);
@@ -305,8 +305,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
     }
 
     @Override
-    protected void generateLongRunningBeginAsync(ClientMethod clientMethod, JavaType typeBlock,
-        ProxyMethod restAPIMethod, JavaSettings settings) {
+    protected void generateLongRunningBeginAsync(ClientMethod clientMethod, JavaType typeBlock, JavaSettings settings) {
         boolean mergeContextParameter = contextInParameters(clientMethod);
         String contextParam
             = mergeContextParameter ? "context" : String.format("%s.getContext()", clientMethod.getClientReference());;
@@ -342,9 +341,10 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
     }
 
     @Override
-    protected void generateLongRunningBeginSync(ClientMethod clientMethod, JavaType typeBlock,
-        ProxyMethod restAPIMethod, JavaSettings settings) {
+    protected void generateLongRunningBeginSync(ClientMethod clientMethod, JavaType typeBlock, JavaSettings settings) {
+        final ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
         boolean contextInParameters = contextInParameters(clientMethod);
+
         typeBlock.annotation("ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)");
         typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
             addOptionalVariables(function, clientMethod);


### PR DESCRIPTION
1.	In `ClientMethodTemplate` (and its extended types) methods, there is no need to pass `ProxyMethod` as an explicit argument, since it can be obtained from `ClientMethod` argument.
2.	Similarly, no need to provide ` List<ProxyMethodParameter>` explicitly when it can be obtained from `ClientMethod ::ProxyMethod::parameters`
3. The function `convertClientTypesToWireTypes` has been simplified and updated to be extensible for future prs that aim to simplify inherited templates such as client core.
4.	Few other minor cleanup for readability. 

AutoRest validation [pr](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4920004&view=results).