### PR TITLE
Fix: Invalid example for `@header` decorator

### DIFF
--- a/.chronus/changes/fix-header-example-2025-4-29-19-16-10.md
+++ b/.chronus/changes/fix-header-example-2025-4-29-19-16-10.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/http"
+---
+
+Fix: Invalid example for `@header` decorator

--- a/.chronus/changes/fix-header-example-2025-4-29-19-16-10.md
+++ b/.chronus/changes/fix-header-example-2025-4-29-19-16-10.md
@@ -1,6 +1,6 @@
 ---
 # Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
+changeKind: internal
 packages:
   - "@typespec/http"
 ---

--- a/packages/http/lib/decorators.tsp
+++ b/packages/http/lib/decorators.tsp
@@ -33,7 +33,7 @@ model HeaderOptions {
  *
  * ```typespec
  * op read(@header accept: string): {@header("ETag") eTag: string};
- * op create(@header({name: "X-Color", format: "csv"}) colors: string[]): void;
+ * op create(@header(#{name: "X-Color"}) colors: string[]): void;
  * ```
  *
  * @example Implicit header name

--- a/website/src/content/docs/docs/libraries/http/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/http/reference/decorators.md
@@ -229,9 +229,8 @@ op read(@header accept: string): {
   @header("ETag") eTag: string;
 };
 op create(
-  @header({
+  @header(#{
     name: "X-Color",
-    format: "csv",
   })
   colors: string[],
 ): void;


### PR DESCRIPTION
The current documentation for the `@header` HTTP decorator contains an example which has been valid in `v0.6.x`, but is not valid in `v1.0.0` of TypeSpec.

The current, live example yields the following error:

```
[{
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "invalid-argument",
	"severity": 8,
	"message": "Argument of type '{ name: \"header-name\", format: \"csv\" }' is not assignable to parameter of type 'string | TypeSpec.Http.HeaderOptions'",
	"source": "TypeSpec",
	"startLineNumber": 31,
	"startColumn": 21,
	"endLineNumber": 31,
	"endColumn": 72
}]
```

This PR removes the deprecated "format" key from the example, fixing the issue.