### PR TITLE
[WIP]: Updating ClientCoreClientMethodTemplate to reuse functionalities from  base ClientMethodTemplate

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodParameterProcessor.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodParameterProcessor.java
@@ -14,7 +14,7 @@ import com.microsoft.typespec.http.client.generator.core.model.clientmodel.Param
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ProxyMethodParameter;
 import com.microsoft.typespec.http.client.generator.core.util.MethodUtil;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -28,7 +28,7 @@ final class ClientMethodParameterProcessor {
         final List<Parameter> codeModelParameters = getCodeModelParameters(request, isProtocolMethod);
         final List<ParametersTuple> parametersTuples = new ArrayList<>();
         final List<String> requiredNullableParameterExpressions = new ArrayList<>();
-        final Map<String, String> validateParameterExpressions = new HashMap<>();
+        final Map<String, String> validateParameterExpressions = new LinkedHashMap<>();
         final boolean isJsonPatch = MethodUtil.isContentTypeInRequest(request, "application/json-patch+json");
 
         final ParametersTransformationProcessor transformationProcessor

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplate.java
@@ -39,7 +39,7 @@ import com.microsoft.typespec.http.client.generator.core.util.CodeNamer;
 import com.microsoft.typespec.http.client.generator.core.util.MethodNamer;
 import com.microsoft.typespec.http.client.generator.core.util.MethodUtil;
 import com.microsoft.typespec.http.client.generator.core.util.TemplateUtil;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -77,7 +77,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
         // Parameter expressions to validate for non-null value.
         final List<String> paramReferenceExpressions = clientMethod.getRequiredNullableParameterExpressions();
         // Parameter expressions for custom validation (key is the expression, value is the validation).
-        final Map<String, String> validateParamExpressions = new HashMap<>(clientMethod.getValidateExpressions());
+        final Map<String, String> validateParamExpressions = new LinkedHashMap<>(clientMethod.getValidateExpressions());
 
         for (String paramReferenceExpression : paramReferenceExpressions) {
             final JavaIfBlock nullCheck = function.ifBlock(paramReferenceExpression + " == null", ifBlock -> {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplate.java
@@ -114,16 +114,22 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
      * @param function The client method code block.
      * @param clientMethod The client method.
      */
-    protected static void addOptionalVariables(JavaBlock function, ClientMethod clientMethod) {
+    protected void addOptionalVariables(JavaBlock function, ClientMethod clientMethod) {
         if (!clientMethod.getOnlyRequiredParameters()) {
             return;
         }
 
+        final MethodPageDetails pageDetails
+            = clientMethod.isPageStreamingType() ? clientMethod.getMethodPageDetails() : null;
         for (ClientMethodParameter parameter : clientMethod.getMethodParameters()) {
             if (parameter.isRequired()) {
                 // Parameter is required and will be part of the method signature.
                 continue;
             }
+            if (pageDetails != null && pageDetails.shouldHideParameter(parameter)) {
+                continue;
+            }
+
             final String defaultValue = parameterDefaultValueExpression(parameter);
             function.line("final %s %s = %s;", parameter.getClientType(), parameter.getName(),
                 defaultValue == null ? "null" : defaultValue);

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ClientMethodTemplate.java
@@ -69,7 +69,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
      * @param clientMethod the client method to add parameter validations for.
      * @param settings AutoRest generation settings, used to determine if validations should be added.
      */
-    protected static void addValidations(JavaBlock function, ClientMethod clientMethod, JavaSettings settings) {
+    protected void addValidations(JavaBlock function, ClientMethod clientMethod, JavaSettings settings) {
         if (!settings.isClientSideValidations()) {
             return;
         }
@@ -137,7 +137,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
      * @param clientMethod The client method.
      * @param settings AutoRest generation settings.
      */
-    protected static void addOptionalAndConstantVariables(JavaBlock function, ClientMethod clientMethod,
+    protected void addOptionalAndConstantVariables(JavaBlock function, ClientMethod clientMethod,
         JavaSettings settings) {
         final List<ProxyMethodParameter> proxyMethodParameters = clientMethod.getProxyMethod().getParameters();
         for (ProxyMethodParameter parameter : proxyMethodParameters) {
@@ -203,8 +203,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
      * @param clientMethod The client method.
      * @param settings AutoRest generation settings.
      */
-    protected static void applyParameterTransformations(JavaBlock function, ClientMethod clientMethod,
-        JavaSettings settings) {
+    protected void applyParameterTransformations(JavaBlock function, ClientMethod clientMethod, JavaSettings settings) {
         for (ParameterTransformation transformation : clientMethod.getParameterTransformations().asList()) {
             if (!transformation.hasMappings()) {
                 // the case that this flattened parameter is not original parameter from any other parameters
@@ -316,7 +315,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
      * @param function The client method code block.
      * @param clientMethod The client method.
      */
-    protected static void convertClientTypesToWireTypes(JavaBlock function, ClientMethod clientMethod) {
+    protected void convertClientTypesToWireTypes(JavaBlock function, ClientMethod clientMethod) {
         final List<ProxyMethodParameter> proxyMethodParameters = clientMethod.getProxyMethod().getParameters();
         for (ProxyMethodParameter parameter : proxyMethodParameters) {
             final RequestParameterLocation location = parameter.getRequestParameterLocation();
@@ -568,7 +567,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
      * @param wireType the wire type of the parameter, used to determine whether to encode as a string or url.
      * @return Java code that converts a byte[] parameter to Base64 encoded form.
      */
-    private static String byteArrayToBase64Encoded(String parameterName, IType wireType) {
+    protected String byteArrayToBase64Encoded(String parameterName, IType wireType) {
         if ((wireType == ClassType.STRING)) {
             // byte[] to Base64-encoded String.
             return "Base64Util.encodeToString" + "(" + parameterName + ")";

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/azurevnext/AzureVNextClientMethodTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/azurevnext/AzureVNextClientMethodTemplate.java
@@ -9,7 +9,6 @@ import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSe
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethod;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ParameterSynthesizedOrigin;
-import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ProxyMethod;
 import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaType;
 import com.microsoft.typespec.http.client.generator.core.template.clientcore.ClientCoreClientMethodTemplate;
 import com.microsoft.typespec.http.client.generator.core.util.TemplateUtil;
@@ -27,8 +26,7 @@ public class AzureVNextClientMethodTemplate extends ClientCoreClientMethodTempla
     }
 
     @Override
-    protected void generateLongRunningBeginSync(ClientMethod clientMethod, JavaType typeBlock,
-        ProxyMethod restAPIMethod, JavaSettings settings) {
+    protected void generateLongRunningBeginSync(ClientMethod clientMethod, JavaType typeBlock, JavaSettings settings) {
         typeBlock.annotation("ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)");
         String contextParam;
         if (clientMethod.getParameters().stream().anyMatch(p -> p.getClientType().equals(ClassType.REQUEST_CONTEXT))) {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/clientcore/ClientCoreClientMethodTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/clientcore/ClientCoreClientMethodTemplate.java
@@ -8,7 +8,6 @@ import com.azure.core.http.HttpHeaderName;
 import com.azure.core.util.CoreUtils;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.RequestParameterLocation;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
-import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ArrayType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethod;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethodParameter;
@@ -51,48 +50,6 @@ public class ClientCoreClientMethodTemplate extends ClientMethodTemplate {
 
     public static ClientCoreClientMethodTemplate getInstance() {
         return INSTANCE;
-    }
-
-    /**
-     * Adds optional variable instantiations into the client method.
-     *
-     * @param function The client method code block.
-     * @param clientMethod The client method.
-     */
-    protected static void addOptionalVariables(JavaBlock function, ClientMethod clientMethod) {
-        if (!clientMethod.getOnlyRequiredParameters()) {
-            return;
-        }
-
-        final MethodPageDetails pageDetails
-            = clientMethod.isPageStreamingType() ? clientMethod.getMethodPageDetails() : null;
-        for (ClientMethodParameter parameter : clientMethod.getMethodParameters()) {
-            if (parameter.isRequired()) {
-                // Parameter is required and will be part of the method signature.
-                continue;
-            }
-            if (pageDetails != null && pageDetails.shouldHideParameter(parameter)) {
-                continue;
-            }
-
-            IType parameterClientType = parameter.getClientType();
-            String defaultValue = parameterDefaultValueExpression(parameterClientType, parameter.getDefaultValue(),
-                JavaSettings.getInstance());
-            function.line("final %s %s = %s;", parameterClientType, parameter.getName(),
-                defaultValue == null ? "null" : defaultValue);
-        }
-    }
-
-    private static String parameterDefaultValueExpression(IType parameterClientType, String parameterDefaultValue,
-        JavaSettings settings) {
-        String defaultValue;
-        if (settings.isNullByteArrayMapsToEmptyArray() && parameterClientType == ArrayType.BYTE_ARRAY) {
-            // there's no EMPTY_BYTE_ARRAY in clients, unlike that in models
-            defaultValue = "new byte[0]";
-        } else {
-            defaultValue = parameterClientType.defaultValueExpression(parameterDefaultValue);
-        }
-        return defaultValue;
     }
 
     /**


### PR DESCRIPTION
The pr update "ClientCoreClientMethodTemplate" to reuse `addValidation`, ` addOptionalAndConstantVariables`, ` addOptionalAndConstantVariables`and ` convertClientTypesToWireTypes` methods from "ClientMethodTemplate".