### PR TITLE
Fix empty string emitting error when used in string interpolation in a template

### DIFF
--- a/.chronus/changes/fix-empty-string-template-2025-4-29-22-20-26.md
+++ b/.chronus/changes/fix-empty-string-template-2025-4-29-22-20-26.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix empty string emitting error when used in string interpolation in a template

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3280,7 +3280,7 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
         const spanValue = createTemplateSpanValue(span.expression, type);
         spans.push(spanValue);
         const spanValueAsString = stringifyTypeForTemplate(type);
-        if (spanValueAsString) {
+        if (spanValueAsString !== undefined) {
           stringValue += spanValueAsString;
         } else {
           hasNonStringElement = true;

--- a/packages/compiler/test/checker/string-template.test.ts
+++ b/packages/compiler/test/checker/string-template.test.ts
@@ -4,6 +4,7 @@ import { Model, StringTemplate } from "../../src/index.js";
 import {
   BasicTestRunner,
   createTestRunner,
+  expectDiagnosticEmpty,
   expectDiagnostics,
   extractSquiggles,
 } from "../../src/testing/index.js";
@@ -74,6 +75,18 @@ it("can interpolate a model", async () => {
 
   strictEqual(template.spans[2].isInterpolated, false);
   strictEqual(template.spans[2].type.value, " end");
+});
+
+// Regression test for https://github.com/microsoft/typespec/issues/7401
+it("can use empty string to interpolate in tempalates", async () => {
+  const diagnostics = await runner.diagnose(
+    `
+    @doc("\${T} strange")
+    model Test<T extends valueof string> {}
+    model B is Test<"">;
+    `,
+  );
+  expectDiagnosticEmpty(diagnostics);
 });
 
 it("emit error if interpolating value and types", async () => {


### PR DESCRIPTION
fix  #7401
