### PR TITLE
Use absolute url for customization guide link

### DIFF
--- a/packages/http-client-csharp/.tspd/docs/usage.md
+++ b/packages/http-client-csharp/.tspd/docs/usage.md
@@ -5,4 +5,4 @@
 
 ### Customizing Generated Code
 
-For detailed instructions on how to customize the generated C# code, see the [Customization Guide](./customization.md).
+For detailed instructions on how to customize the generated C# code, see the [Customization Guide](https://github.com/microsoft/typespec/blob/main/packages/http-client-csharp/.tspd/docs/customization.md).

--- a/packages/http-client-csharp/readme.md
+++ b/packages/http-client-csharp/readme.md
@@ -17,7 +17,7 @@ npm install @typespec/http-client-csharp
 
 ### Customizing Generated Code
 
-For detailed instructions on how to customize the generated C# code, see the [Customization Guide](./customization.md).
+For detailed instructions on how to customize the generated C# code, see the [Customization Guide](https://github.com/microsoft/typespec/blob/main/packages/http-client-csharp/.tspd/docs/customization.md).
 
 ## Usage
 


### PR DESCRIPTION
The usage.md gets injected into the readme, so the relative link would be different there than when looking at the usage.md file.