### PR TITLE
[http-client-csharp] chore: cleanup doc regeneration

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Generation.psm1
+++ b/packages/http-client-csharp/eng/scripts/Generation.psm1
@@ -61,9 +61,8 @@ function Get-TspCommand {
 }
 
 function Refresh-Build {
-    Write-Host "Regenerating docs and building emitter and generator" -ForegroundColor Cyan
-    # regen docs will also build the emitter
-    Invoke "npm run regen-docs"
+    Write-Host "Building emitter" -ForegroundColor Cyan
+    Invoke "npm run build:emitter"
     # exit if the generation failed
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE

--- a/packages/http-client-csharp/eng/scripts/Test-Packages.ps1
+++ b/packages/http-client-csharp/eng/scripts/Test-Packages.ps1
@@ -39,7 +39,7 @@ try {
         Write-Host "Setting up workspace" -ForegroundColor Cyan
         Invoke-LoggedCommand "pnpm setup:min" $packageRoot/../..
 
-        Invoke-LoggedCommand "npm run build" -GroupOutput
+        Invoke-LoggedCommand "npm run build && npm run regen-docs" -GroupOutput
         # run E2E Test for TypeSpec emitter
         Write-Host "Generating test projects ..."
         & "$packageRoot/eng/scripts/Generate.ps1"


### PR DESCRIPTION
This PR adjusts the doc regen step to not run as part of the `Get-Spector-Coverage` script.