### PR TITLE
Java generator bug fixes

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/Editor.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/customization/Editor.java
@@ -80,7 +80,7 @@ public final class Editor {
         return contents.keySet()
             .stream()
             .filter(fileName -> fileName.startsWith(packagePath))
-            .map(fileName -> fileName.substring(packagePath.length() + 1, fileName.length() - 5))
+            .map(fileName -> fileName.substring(packagePath.length(), fileName.length() - 5))
             .collect(Collectors.toList());
     }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClassType.java
@@ -723,6 +723,13 @@ public class ClassType implements IType {
             imports.add(DateTimeFormatter.class.getName());
         }
 
+        if (this == ClassType.DATE_TIME_RFC_1123) {
+            // May need OffsetDateTime when consuming DateTimeRfc1123 APIs as DateTimeRfc1123 APIs consume and return
+            // OffsetDateTime.
+            // If OffsetDateTime isn't needed, when running Spotless the unused import will be removed.
+            imports.add(OffsetDateTime.class.getName());
+        }
+
         if (this == ClassType.URL) {
             imports.add(java.net.URL.class.getName());
             imports.add(java.net.MalformedURLException.class.getName());

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/util/ModelTemplateHeaderHelper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/util/ModelTemplateHeaderHelper.java
@@ -292,7 +292,7 @@ public final class ModelTemplateHeaderHelper {
 
         block.block("rawHeaders.stream().forEach(header -> ", body -> {
             if (JavaSettings.getInstance().isAzureV1()) {
-                body.line("String headerName = header.getName().getValue();");
+                body.line("String headerName = header.getName();");
             } else {
                 body.line("String headerName = header.getName().getValue();");
             }


### PR DESCRIPTION
Few small fixes to Java generator.

- `Editor.classesInPackage` was errantly removing the first character of the class name (`Class` -> `lass`)
- Getting the name of the header was using non-existent APIs when generating using Core V1
- `DateTimeRfc1123` should defensively include a dependency on `OffsetDateTime` as many `DateTimeRfc1123` generations use the type internally but expose it as Java's standard `OffsetDateTime`.