### PR TITLE
[http-client-csharp] Add Back-Compat Support for Service Versions

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientOptionsProviderTests/BackCompat_GAApiVersionsAdded/SampleNamespaceClientOptions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientOptionsProviderTests/BackCompat_GAApiVersionsAdded/SampleNamespaceClientOptions.cs
@@ -1,0 +1,30 @@
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+
+namespace SampleNamespace
+{
+    public partial class TestClientOptions : ClientPipelineOptions
+    {
+        private const ServiceVersion LatestVersion = ServiceVersion.V1;
+
+        public TestClientOptions(ServiceVersion version = LatestVersion)
+        {
+            Version = version switch
+            {
+                ServiceVersion.V1 => "1.0.0",
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        /// <summary> Gets the Version. </summary>
+        internal string Version { get; }
+
+        /// <summary> The version of the service to use. </summary>
+        public enum ServiceVersion
+        {
+            V1_0_0 = 1,
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientOptionsProviderTests/BackCompat_PrereleaseApiVersionsAdded/SampleNamespaceClientOptions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientOptionsProviderTests/BackCompat_PrereleaseApiVersionsAdded/SampleNamespaceClientOptions.cs
@@ -1,0 +1,32 @@
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+
+namespace SampleNamespace
+{
+    public partial class TestClientOptions : ClientPipelineOptions
+    {
+        private const ServiceVersion LatestVersion = ServiceVersion.V2023_11_01_Beta;
+
+        public TestClientOptions(ServiceVersion version = LatestVersion)
+        {
+            Version = version switch
+            {
+                ServiceVersion.V2023_10_01_beta_1 => "2023-10-01-beta",
+                ServiceVersion.V2023_11_01_beta_2 => "2023-11-01-beta",
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        /// <summary> Gets the Version. </summary>
+        internal string Version { get; }
+
+        /// <summary> The version of the service to use. </summary>
+        public enum ServiceVersion
+        {
+            V2023_10_01_Beta = 1,
+            V2023_11_01_Beta = 2
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestHelpers/MockHelpers.cs
@@ -28,6 +28,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
             Func<IReadOnlyList<InputClient>>? clients = null,
             Func<IReadOnlyList<InputLiteralType>>? inputLiterals = null,
             Func<Task<Compilation>>? compilation = null,
+            Func<Task<Compilation>>? lastContractCompilation = null,
+            Func<IReadOnlyList<string>>? apiVersions = null,
             string? configuration = null)
         {
             var mockGenerator = LoadMockGenerator(
@@ -35,11 +37,13 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
                 inputEnums: inputEnums,
                 inputModels: inputModels,
                 clients: clients,
+                apiVersions: apiVersions,
                 configuration: configuration);
 
             var compilationResult = compilation == null ? null : await compilation();
+            var lastContractCompilationResult = lastContractCompilation == null ? null : await lastContractCompilation();
 
-            var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(compilationResult, null)) { CallBase = true };
+            var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(compilationResult, lastContractCompilationResult)) { CallBase = true };
             mockGenerator.Setup(p => p.SourceInputModel).Returns(sourceInputModel.Object);
 
             return mockGenerator;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
@@ -24,7 +26,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         protected override IReadOnlyList<EnumTypeMember> BuildEnumValues()
         {
             var customMembers = new HashSet<FieldProvider>(CustomCodeView?.Fields ?? []);
-            var values = new EnumTypeMember[AllowedValues.Count];
+            List<EnumTypeMember> values = new(AllowedValues.Count);
 
             for (int i = 0; i < AllowedValues.Count; i++)
             {
@@ -56,9 +58,140 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     DocHelpers.GetFormattableDescription(inputValue.Summary, inputValue.Doc) ?? $"{name}",
                     initializationValue);
 
-                values[i] = new EnumTypeMember(name, field, inputValue.Value);
+                values.Add(new EnumTypeMember(name, field, inputValue.Value));
             }
-            return values;
+
+            return BuildApiVersionEnumValuesForBackwardCompatibility(values);
+        }
+
+        private List<EnumTypeMember> BuildApiVersionEnumValuesForBackwardCompatibility(List<EnumTypeMember> currentApiVersions)
+        {
+            var lastContractFields = LastContractView?.Fields;
+            if (lastContractFields == null || lastContractFields.Count == 0)
+            {
+                return currentApiVersions;
+            }
+
+            var currentVersionNames = new HashSet<string>(currentApiVersions.Select(v => v.Name), StringComparer.OrdinalIgnoreCase);
+            var allMembers = new List<EnumTypeMember>(currentApiVersions.Count + lastContractFields.Count);
+            allMembers.AddRange(currentApiVersions);
+
+            bool addedPreviousApiVersion = false;
+            foreach (var field in lastContractFields)
+            {
+                if (!currentVersionNames.Contains(field.Name))
+                {
+                    var (versionPrefix, versionSeparator) = ExtractVersionFormatInfo(field.Name, currentApiVersions);
+                    string enumValue = field.Name.ToApiVersionValue(versionPrefix, versionSeparator);
+                    allMembers.Add(new EnumTypeMember(field.Name, field, enumValue));
+                    addedPreviousApiVersion = true;
+                }
+            }
+
+            if (!addedPreviousApiVersion)
+            {
+                return currentApiVersions;
+            }
+
+            allMembers.Sort(static (x, y) => string.Compare(x.Name, y.Name, StringComparison.OrdinalIgnoreCase));
+            for (int i = 0; i < allMembers.Count; i++)
+            {
+                var member = allMembers[i];
+                var updatedField = new FieldProvider(
+                    member.Field.Modifiers,
+                    member.Field.Type,
+                    member.Name,
+                    member.Field.EnclosingType,
+                    member.Field.Description,
+                    Literal(i + 1));
+                allMembers[i] = new EnumTypeMember(member.Name, updatedField, member.Value);
+            }
+
+            return allMembers;
+        }
+
+        private static (string? Prefix, char? Separator) ExtractVersionFormatInfo(string previousVersion, List<EnumTypeMember> currentApiVersions)
+        {
+            if (currentApiVersions.Count == 0)
+            {
+                return (null, null);
+            }
+
+            bool previousVersionIsDateFormat = IsDateFormat(previousVersion);
+
+            // validate if any current version is also a date format, if so follow the same format
+            if (previousVersionIsDateFormat)
+            {
+                EnumTypeMember? dateFormatVersion = currentApiVersions.FirstOrDefault(v => v.Value is string apiValue && IsDateFormat(apiValue));
+                if (dateFormatVersion?.Value is string apiValue)
+                {
+                    string? versionPrefix = apiValue.StartsWith("v", StringComparison.InvariantCultureIgnoreCase)
+                        ? apiValue[0].ToString()
+                        : null;
+                    char? separator = ExtractApiVersionSeparator(apiValue);
+                    return (versionPrefix, separator);
+                }
+            }
+            else
+            {
+                // If the previous version is not a date format, try to extract the prefix and separator from the first non-date format version
+                EnumTypeMember? nonDateVersion = currentApiVersions.FirstOrDefault(v => v.Value is string apiValue && !IsDateFormat(apiValue));
+                if (nonDateVersion?.Value is string currentVersionValue)
+                {
+                    string? versionPrefix = currentVersionValue.StartsWith("v", StringComparison.InvariantCultureIgnoreCase)
+                        ? currentVersionValue[0].ToString()
+                        : null;
+                    char? separator = ExtractApiVersionSeparator(currentVersionValue);
+                    return (versionPrefix, separator);
+                }
+            }
+
+            return (null, null);
+        }
+
+        private static bool IsDateFormat(string version)
+        {
+            if (string.IsNullOrEmpty(version) || version.Length < 10)
+            {
+                return false;
+            }
+
+            // Common date formats found in API versions
+            string[] formats =
+            [
+                "yyyy_MM_dd",
+                "yyyy-MM-dd",
+                "yyyy.MM.dd",
+                "MM/dd/yyyy",
+                "MM_dd_yyyy",
+                "yyyy/MM/dd",
+                "dd-MM-yyyy",
+                "dd.MM.yyyy",
+            ];
+
+            int startIndex = version.StartsWith("v", StringComparison.InvariantCultureIgnoreCase) ? 1 : 0;
+            // extract the date string
+            version = version.Substring(startIndex, 10);
+            foreach (var format in formats)
+            {
+                if (DateTime.TryParseExact(version, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static char? ExtractApiVersionSeparator(string version)
+        {
+            if (string.IsNullOrEmpty(version))
+                return null;
+
+            char[] versionSeparators = ['-', '.', '_', '/'];
+            int separatorIndex = version.IndexOfAny(versionSeparators);
+
+            return separatorIndex >= 0 ? version[separatorIndex] : null;
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -37,10 +37,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
         }
 
         private protected virtual TypeProvider? GetCustomCodeView()
-            => CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(BuildNamespace(), BuildName());
+            => CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(BuildNamespace(), BuildName(), DeclaringTypeProvider?.BuildName());
 
         private protected virtual TypeProvider? GetLastContractView()
-            => CodeModelGenerator.Instance.SourceInputModel.FindForTypeInLastContract(BuildNamespace(), BuildName());
+            => CodeModelGenerator.Instance.SourceInputModel.FindForTypeInLastContract(BuildNamespace(), BuildName(), DeclaringTypeProvider?.BuildName());
 
         public TypeProvider? CustomCodeView => _customCodeView.Value;
         public TypeProvider? LastContractView => _lastContractView.Value;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
@@ -52,23 +52,31 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
             return nameMap;
         }
 
-        public TypeProvider? FindForTypeInCustomization(string ns, string name)
+        public TypeProvider? FindForTypeInCustomization(string ns, string name, string? declaringTypeName = null)
         {
-            return FindTypeInCompilation(Customization, ns, name, false);
+            return FindTypeInCompilation(Customization, ns, name, false, declaringTypeName);
         }
 
-        public TypeProvider? FindForTypeInLastContract(string ns, string name)
+        public TypeProvider? FindForTypeInLastContract(string ns, string name, string? declaringTypeName = null)
         {
-            return FindTypeInCompilation(LastContract, ns, name, true);
+            return FindTypeInCompilation(LastContract, ns, name, true, declaringTypeName);
         }
 
-        private TypeProvider? FindTypeInCompilation(Compilation? compilation, string ns, string name, bool includeReferencedAssemblies)
+        private TypeProvider? FindTypeInCompilation(
+            Compilation? compilation,
+            string ns,
+            string name,
+            bool includeReferencedAssemblies,
+            string? declaringTypeName = null)
         {
             if (compilation == null)
             {
                 return null;
             }
-            var fullyQualifiedMetadataName = $"{ns}.{name}";
+
+            var fullyQualifiedMetadataName = declaringTypeName != null
+                ? $"{ns}.{declaringTypeName}+{name}"
+                : $"{ns}.{name}";
             if (!_nameMap.Value.TryGetValue(name, out var type) &&
                 !_nameMap.Value.TryGetValue(fullyQualifiedMetadataName, out type))
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/StringExtensions.cs
@@ -172,5 +172,29 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
             return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(sb.ToString());
         }
+
+        public static string ToApiVersionValue(this string version, string? versionPrefix = null, char? separator = null)
+        {
+            StringBuilder sb = versionPrefix == null
+                ? new StringBuilder()
+                : new StringBuilder(versionPrefix);
+            separator ??= '-';
+            int startIndex = 1;
+
+            for (int i = startIndex; i < version.Length; i++)
+            {
+                char c = version[i];
+                if (c == '_')
+                {
+                    sb.Append(separator);
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+
+            return CultureInfo.InvariantCulture.TextInfo.ToLower(sb.ToString());
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ApiVersionEnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ApiVersionEnumProviderTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Snippets;
+using Microsoft.TypeSpec.Generator.Tests.Common;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Providers
+{
+    public class ApiVersionEnumProviderTests
+    {
+        [Test]
+        public async Task BackCompat_PrereleaseApiVersionsAdded()
+        {
+            string[] apiVersions = ["1.0.0"];
+            var input = InputFactory.Int32Enum(
+                "mockInputEnum",
+                apiVersions.Select((a, index) => (a, index)),
+                usage: InputModelTypeUsage.ApiVersionEnum,
+                clientNamespace: "SampleNamespace");
+            await MockHelpers.LoadMockGeneratorAsync(lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var mockDeclaringType = new Mock<TypeProvider>();
+            mockDeclaringType.Protected().Setup<string>("BuildName").Returns("SampleNamespaceClientOptions");
+            mockDeclaringType.Protected().Setup<string>("BuildNamespace").Returns("SampleNamespace");
+            var enumType = EnumProvider.Create(input, mockDeclaringType.Object);
+            Assert.IsTrue(enumType is ApiVersionEnumProvider);
+
+            var provider = (ApiVersionEnumProvider)enumType;
+            Assert.IsNotNull(provider);
+            Assert.That(provider.Name, Is.EqualTo("ServiceVersion"));
+            Assert.That(provider.EnumValues.Count, Is.EqualTo(3));
+            Assert.That(provider.EnumValues.Select(v => v.Name), Is.EquivalentTo(new[] { "V1_0_0", "V2023_10_01_Beta", "V2023_11_01_Beta" }));
+        }
+
+        [Test]
+        public async Task BackCompat_GAApiVersionsAdded()
+        {
+            string[] apiVersions = ["2.0.0", "3.0.0"];
+            var input = InputFactory.Int32Enum(
+                "mockInputEnum",
+                apiVersions.Select((a, index) => (a, index)),
+                usage: InputModelTypeUsage.ApiVersionEnum,
+                clientNamespace: "SampleNamespace");
+            await MockHelpers.LoadMockGeneratorAsync(lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var mockDeclaringType = new Mock<TypeProvider>();
+            mockDeclaringType.Protected().Setup<string>("BuildName").Returns("SampleNamespaceClientOptions");
+            mockDeclaringType.Protected().Setup<string>("BuildNamespace").Returns("SampleNamespace");
+            var enumType = EnumProvider.Create(input, mockDeclaringType.Object);
+            Assert.IsTrue(enumType is ApiVersionEnumProvider);
+
+            var provider = (ApiVersionEnumProvider)enumType;
+            Assert.IsNotNull(provider);
+            Assert.That(provider.Name, Is.EqualTo("ServiceVersion"));
+            Assert.That(provider.EnumValues.Count, Is.EqualTo(3));
+            Assert.That(provider.EnumValues.Select(v => v.Name), Is.EquivalentTo(new[] { "V1_0_0", "V2_0_0", "V3_0_0" }));
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/ApiVersionEnumProviderTests/BackCompat_GAApiVersionsAdded/SampleNamespaceClientOptions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/ApiVersionEnumProviderTests/BackCompat_GAApiVersionsAdded/SampleNamespaceClientOptions.cs
@@ -1,0 +1,30 @@
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+
+namespace SampleNamespace
+{
+    public partial class SampleNamespaceClientOptions : ClientPipelineOptions
+    {
+        private const ServiceVersion LatestVersion = ServiceVersion.V1;
+
+        public SampleNamespaceClientOptions(ServiceVersion version = LatestVersion)
+        {
+            Version = version switch
+            {
+                ServiceVersion.V1 => "1.0.0",
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        /// <summary> Gets the Version. </summary>
+        internal string Version { get; }
+
+        /// <summary> The version of the service to use. </summary>
+        public enum ServiceVersion
+        {
+            V1_0_0 = 1,
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/ApiVersionEnumProviderTests/BackCompat_PrereleaseApiVersionsAdded/SampleNamespaceClientOptions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/ApiVersionEnumProviderTests/BackCompat_PrereleaseApiVersionsAdded/SampleNamespaceClientOptions.cs
@@ -1,0 +1,32 @@
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+
+namespace SampleNamespace
+{
+    public partial class SampleNamespaceClientOptions : ClientPipelineOptions
+    {
+        private const ServiceVersion LatestVersion = ServiceVersion.V2023_11_01_Beta;
+
+        public SampleNamespaceClientOptions(ServiceVersion version = LatestVersion)
+        {
+            Version = version switch
+            {
+                ServiceVersion.V2023_10_01_beta_1 => "2023-10-01-beta",
+                ServiceVersion.V2023_11_01_beta_2 => "2023-11-01-beta",
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        /// <summary> Gets the Version. </summary>
+        internal string Version { get; }
+
+        /// <summary> The version of the service to use. </summary>
+        public enum ServiceVersion
+        {
+            V2023_10_01_Beta = 1,
+            V2023_11_01_Beta = 2
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/StringExtensionsTests.cs
@@ -143,6 +143,51 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
             }
         }
 
+        [TestCase("V1_0_0", "1-0-0")]
+        [TestCase("V2022_05_15_Preview", "2022-05-15-preview")]
+        [TestCase("V1_2_3_Beta", "1-2-3-beta")]
+        [TestCase("V3_0", "3-0")]
+        [TestCase("V3", "3")]
+        [TestCase("V2024_01_01_RC", "2024-01-01-rc")]
+        [TestCase("V1_0_0_Alpha", "1-0-0-alpha")]
+        [TestCase("V10_5_2", "10-5-2")]
+        [TestCase("V2023_12_31", "2023-12-31")]
+        [TestCase("V2023-12-31", "2023-12-31")]
+        public void TestToApiVersionValue(string apiVersion, string expectedValue)
+        {
+            var result = apiVersion.ToApiVersionValue();
+            Assert.AreEqual(expectedValue, result);
+        }
+
+        [TestCase("V1_0_0", ".", "1.0.0")]
+        [TestCase("V2022_05_15_Preview", ".", "2022.05.15.preview")]
+        [TestCase("V1_2_3", "/", "1/2/3")]
+        [TestCase("V2024_01_01", "_", "2024_01_01")]
+        [TestCase("V1_0", ":", "1:0")]
+        public void TestToApiVersionValueWithCustomSeparator(string apiVersion, string separator, string expectedValue)
+        {
+            var result = apiVersion.ToApiVersionValue(separator: separator[0]);
+            Assert.AreEqual(expectedValue, result);
+        }
+
+        [TestCase("V1_0_0", "api-version-", "api-version-1-0-0")]
+        [TestCase("V2022_05_15", "v", "v2022-05-15")]
+        [TestCase("V1_2_3_Beta", "release-", "release-1-2-3-beta")]
+        public void TestToApiVersionValueWithVersionPrefix(string apiVersion, string versionPrefix, string expectedValue)
+        {
+            var result = apiVersion.ToApiVersionValue(versionPrefix: versionPrefix);
+            Assert.AreEqual(expectedValue, result);
+        }
+
+        [TestCase("V1_0_0", "v", ".", "v1.0.0")]
+        [TestCase("V2022_05_15_Preview", "v", "/", "v2022/05/15/preview")]
+        [TestCase("V1_2_3", "v", "_", "v1_2_3")]
+        public void TestToApiVersionValueWithPrefixAndSeparator(string apiVersion, string versionPrefix, string separator, string expectedValue)
+        {
+            var result = apiVersion.ToApiVersionValue(versionPrefix: versionPrefix, separator: separator[0]);
+            Assert.AreEqual(expectedValue, result);
+        }
+
         public record Part(string Value, bool IsLiteral, int ArgumentIndex);
 
         public static IEnumerable<TestCaseData> BuildFormattableStringFormatParts


### PR DESCRIPTION
This PR adds back-compatibility support for client service versions.

fixes: https://github.com/microsoft/typespec/issues/6087