### PR TITLE
Show full definition of model/interface when it's 'extends' or 'is' other model/interfaces.

### DIFF
--- a/.chronus/changes/full-def-hover-2025-5-3-14-54-27.md
+++ b/.chronus/changes/full-def-hover-2025-5-3-14-54-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Show the full definition of model and interface when it has 'extends' and 'is' relationship in the hover text

--- a/packages/compiler/src/core/helpers/type-name-utils.ts
+++ b/packages/compiler/src/core/helpers/type-name-utils.ts
@@ -20,9 +20,7 @@ import { printIdentifier } from "./syntax-utils.js";
 export interface TypeNameOptions {
   namespaceFilter?: (ns: Namespace) => boolean;
   printable?: boolean;
-  // Whether to include the interface prefix for operations defined in interfaces.
-  // Default is true
-  includeInterfacePrefix?: boolean;
+  nameOnly?: boolean;
 }
 
 export function getTypeName(type: Type, options?: TypeNameOptions): string {
@@ -138,7 +136,7 @@ export function getNamespaceFullName(type: Namespace, options?: TypeNameOptions)
 }
 
 function getNamespacePrefix(type: Namespace | undefined, options?: TypeNameOptions) {
-  if (type === undefined || isStdNamespace(type)) {
+  if (type === undefined || isStdNamespace(type) || options?.nameOnly === true) {
     return "";
   }
   const namespaceFullName = getNamespaceFullName(type, options);
@@ -215,6 +213,9 @@ function isInTypeSpecNamespace(type: Type & { namespace?: Namespace }): boolean 
 }
 
 function getModelPropertyName(prop: ModelProperty, options: TypeNameOptions | undefined) {
+  if (options?.nameOnly === true) {
+    return prop.name;
+  }
   const modelName = prop.model ? getModelName(prop.model, options) : undefined;
 
   return `${modelName ?? "(anonymous model)"}.${prop.name}`;
@@ -237,12 +238,12 @@ function getOperationName(op: Operation, options: TypeNameOptions | undefined) {
     const params = op.node.templateParameters.map((t) => getIdentifierName(t.id.sv, options));
     opName += `<${params.join(", ")}>`;
   }
-  if (op.interface) {
-    return options?.includeInterfacePrefix === false
-      ? opName
-      : `${getInterfaceName(op.interface, options)}.${opName}`;
+  if (options?.nameOnly === true) {
+    return opName;
   } else {
-    const prefix = getNamespacePrefix(op.namespace, options);
+    const prefix = op.interface
+      ? getInterfaceName(op.interface, options) + "."
+      : getNamespacePrefix(op.namespace, options);
     return `${prefix}${opName}`;
   }
 }

--- a/packages/compiler/src/core/helpers/type-name-utils.ts
+++ b/packages/compiler/src/core/helpers/type-name-utils.ts
@@ -20,9 +20,6 @@ import { printIdentifier } from "./syntax-utils.js";
 export interface TypeNameOptions {
   namespaceFilter?: (ns: Namespace) => boolean;
   printable?: boolean;
-  // Whether to include the interface prefix for operations defined in interfaces.
-  // Default is true
-  includeInterfacePrefix?: boolean;
 }
 
 export function getTypeName(type: Type, options?: TypeNameOptions): string {
@@ -237,14 +234,10 @@ function getOperationName(op: Operation, options: TypeNameOptions | undefined) {
     const params = op.node.templateParameters.map((t) => getIdentifierName(t.id.sv, options));
     opName += `<${params.join(", ")}>`;
   }
-  if (op.interface) {
-    return options?.includeInterfacePrefix === false
-      ? opName
-      : `${getInterfaceName(op.interface, options)}.${opName}`;
-  } else {
-    const prefix = getNamespacePrefix(op.namespace, options);
-    return `${prefix}${opName}`;
-  }
+  const prefix = op.interface
+    ? getInterfaceName(op.interface, options) + "."
+    : getNamespacePrefix(op.namespace, options);
+  return `${prefix}${opName}`;
 }
 
 function getIdentifierName(name: string, options: TypeNameOptions | undefined) {

--- a/packages/compiler/src/core/helpers/type-name-utils.ts
+++ b/packages/compiler/src/core/helpers/type-name-utils.ts
@@ -20,6 +20,9 @@ import { printIdentifier } from "./syntax-utils.js";
 export interface TypeNameOptions {
   namespaceFilter?: (ns: Namespace) => boolean;
   printable?: boolean;
+  // Whether to include the interface prefix for operations defined in interfaces.
+  // Default is true
+  includeInterfacePrefix?: boolean;
 }
 
 export function getTypeName(type: Type, options?: TypeNameOptions): string {
@@ -234,10 +237,14 @@ function getOperationName(op: Operation, options: TypeNameOptions | undefined) {
     const params = op.node.templateParameters.map((t) => getIdentifierName(t.id.sv, options));
     opName += `<${params.join(", ")}>`;
   }
-  const prefix = op.interface
-    ? getInterfaceName(op.interface, options) + "."
-    : getNamespacePrefix(op.namespace, options);
-  return `${prefix}${opName}`;
+  if (op.interface) {
+    return options?.includeInterfacePrefix === false
+      ? opName
+      : `${getInterfaceName(op.interface, options)}.${opName}`;
+  } else {
+    const prefix = getNamespacePrefix(op.namespace, options);
+    return `${prefix}${opName}`;
+  }
 }
 
 function getIdentifierName(name: string, options: TypeNameOptions | undefined) {

--- a/packages/compiler/src/server/type-details.ts
+++ b/packages/compiler/src/server/type-details.ts
@@ -17,6 +17,7 @@ export function getSymbolDetails(
   options = {
     includeSignature: true,
     includeParameterTags: true,
+    includeFullDefinition: false,
   },
 ): string {
   const lines = [];
@@ -42,6 +43,14 @@ export function getSymbolDetails(
         );
       }
     }
+  }
+  if (options.includeFullDefinition) {
+    lines.push(`\n\n*Full Definition:*\n`);
+    lines.push(
+      getSymbolSignature(program, symbol, {
+        includeBody: true,
+      }),
+    );
   }
   return lines.join("\n\n");
 }

--- a/packages/compiler/src/server/type-details.ts
+++ b/packages/compiler/src/server/type-details.ts
@@ -6,6 +6,17 @@ import { isType } from "../core/type-utils.js";
 import { DocContent, Node, Sym, SyntaxKind, TemplateDeclarationNode, Type } from "../core/types.js";
 import { getSymbolSignature } from "./type-signature.js";
 
+interface GetSymbolDetailsOptions {
+  includeSignature: boolean;
+  includeParameterTags: boolean;
+  /**
+   * Whether to include the final expended definition of the symbol
+   * For Model and Interface, it's body with expended members will be included. Otherwise, it will be the same as signature. (Support for other type may be added in the future as needed)
+   * This is useful for models and interfaces with complex 'extends' and 'is' relationship when user wants to know the final expended definition.
+   */
+  includeExpandedDefinition?: boolean;
+}
+
 /**
  * Get the detailed documentation for a symbol.
  * @param program The program
@@ -14,10 +25,10 @@ import { getSymbolSignature } from "./type-signature.js";
 export function getSymbolDetails(
   program: Program,
   symbol: Sym,
-  options = {
+  options: GetSymbolDetailsOptions = {
     includeSignature: true,
     includeParameterTags: true,
-    includeFullDefinition: false,
+    includeExpandedDefinition: false,
   },
 ): string {
   const lines = [];
@@ -44,14 +55,15 @@ export function getSymbolDetails(
       }
     }
   }
-  if (options.includeFullDefinition) {
-    lines.push(`\n\n*Full Definition:*\n`);
+  if (options.includeExpandedDefinition) {
+    lines.push(`*Full Definition:*`);
     lines.push(
       getSymbolSignature(program, symbol, {
         includeBody: true,
       }),
     );
   }
+
   return lines.join("\n\n");
 }
 

--- a/packages/compiler/src/server/type-signature.ts
+++ b/packages/compiler/src/server/type-signature.ts
@@ -9,6 +9,8 @@ import {
   Decorator,
   EnumMember,
   FunctionParameter,
+  Interface,
+  Model,
   ModelProperty,
   Operation,
   StringTemplate,
@@ -18,19 +20,37 @@ import {
   UnionVariant,
   Value,
 } from "../core/types.js";
+import { walkPropertiesInherited } from "../index.js";
+
+interface GetSymbolSignatureOptions {
+  /**
+   * Whether to include the body in the signature. Only support Model and Interface type now
+   */
+  includeBody: boolean;
+}
 
 /** @internal */
-export function getSymbolSignature(program: Program, sym: Sym): string {
+export function getSymbolSignature(
+  program: Program,
+  sym: Sym,
+  options: GetSymbolSignatureOptions = {
+    includeBody: false,
+  },
+): string {
   const decl = getSymNode(sym);
   switch (decl?.kind) {
     case SyntaxKind.AliasStatement:
       return fence(`alias ${getAliasSignature(decl)}`);
   }
   const entity = sym.type ?? program.checker.getTypeOrValueForNode(decl);
-  return getEntitySignature(sym, entity);
+  return getEntitySignature(sym, entity, options);
 }
 
-function getEntitySignature(sym: Sym, entity: Type | Value | null): string {
+function getEntitySignature(
+  sym: Sym,
+  entity: Type | Value | null,
+  options: GetSymbolSignatureOptions,
+): string {
   if (entity === null) {
     return "(error)";
   }
@@ -38,20 +58,22 @@ function getEntitySignature(sym: Sym, entity: Type | Value | null): string {
     return fence(`const ${sym.name}: ${getTypeName(entity.type)}`);
   }
 
-  return getTypeSignature(entity);
+  return getTypeSignature(entity, options);
 }
 
-function getTypeSignature(type: Type): string {
+function getTypeSignature(type: Type, options: GetSymbolSignatureOptions): string {
   switch (type.kind) {
     case "Scalar":
     case "Enum":
     case "Union":
-    case "Interface":
-    case "Model":
     case "Namespace":
       return fence(`${type.kind.toLowerCase()} ${getPrintableTypeName(type)}`);
+    case "Interface":
+      return fence(getInterfaceSignature(type, options.includeBody));
+    case "Model":
+      return fence(getModelSignature(type, options.includeBody));
     case "ScalarConstructor":
-      return fence(`init ${getTypeSignature(type.scalar)}.${type.name}`);
+      return fence(`init ${getTypeSignature(type.scalar, options)}.${type.name}`);
     case "Decorator":
       return fence(getDecoratorSignature(type));
     case "Operation":
@@ -80,7 +102,7 @@ function getTypeSignature(type: Type): string {
     case "UnionVariant":
       return `(union variant)\n${fence(getUnionVariantSignature(type))}`;
     case "Tuple":
-      return `(tuple)\n[${fence(type.values.map(getTypeSignature).join(", "))}]`;
+      return `(tuple)\n[${fence(type.values.map((v) => getTypeSignature(v, options)).join(", "))}]`;
     default:
       const _assertNever: never = type;
       compilerAssert(false, "Unexpected type kind");
@@ -94,9 +116,51 @@ function getDecoratorSignature(type: Decorator) {
   return `dec ${ns}${name}(${parameters.join(", ")})`;
 }
 
-function getOperationSignature(type: Operation) {
-  const parameters = [...type.parameters.properties.values()].map(getModelPropertySignature);
-  return `op ${getTypeName(type)}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
+function getOperationSignature(type: Operation, includeQualifier: boolean = true) {
+  const parameters = [...type.parameters.properties.values()].map((p) =>
+    getModelPropertySignature(p, false /* includeQualifier */),
+  );
+  if (includeQualifier) {
+    return `op ${getTypeName(type)}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
+  } else {
+    let opName = printIdentifier(type.name, "allow-reserved");
+    if (type.node && type.node.templateParameters.length > 0) {
+      // template
+      const params = type.node.templateParameters.map((t) =>
+        printIdentifier(t.id.sv, "allow-reserved"),
+      );
+      opName += `<${params.join(", ")}>`;
+    }
+    return `op ${opName}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
+  }
+}
+
+function getInterfaceSignature(type: Interface, includeBody: boolean) {
+  if (includeBody) {
+    const INDENT = "  ";
+    const opDescs = Array.from(type.operations).map(
+      ([name, op]) => INDENT + getOperationSignature(op),
+    );
+    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)} {\n${opDescs.join("\n")}\n}`;
+  } else {
+    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)}`;
+  }
+}
+
+/**
+ * All properties from 'extends' and 'is' will be included if includeBody is true.
+ */
+function getModelSignature(type: Model, includeBody: boolean) {
+  if (includeBody) {
+    const propDescs = [];
+    const INDENT = "  ";
+    for (const prop of walkPropertiesInherited(type)) {
+      propDescs.push(INDENT + getModelPropertySignature(prop, false /*includeQualifier*/));
+    }
+    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)}{\n${propDescs.map((d) => `${d};`).join("\n")}\n}`;
+  } else {
+    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)}`;
+  }
 }
 
 function getFunctionParameterSignature(parameter: FunctionParameter) {
@@ -117,8 +181,8 @@ function getStringTemplateSignature(stringTemplate: StringTemplate) {
   );
 }
 
-function getModelPropertySignature(property: ModelProperty) {
-  const ns = getQualifier(property.model);
+function getModelPropertySignature(property: ModelProperty, includeQualifier: boolean = true) {
+  const ns = includeQualifier ? getQualifier(property.model) : "";
   return `${ns}${printIdentifier(property.name, "allow-reserved")}: ${getPrintableTypeName(property.type)}`;
 }
 

--- a/packages/compiler/src/server/type-signature.ts
+++ b/packages/compiler/src/server/type-signature.ts
@@ -120,26 +120,16 @@ function getOperationSignature(type: Operation, includeQualifier: boolean = true
   const parameters = [...type.parameters.properties.values()].map((p) =>
     getModelPropertySignature(p, false /* includeQualifier */),
   );
-  if (includeQualifier) {
-    return `op ${getTypeName(type)}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
-  } else {
-    let opName = printIdentifier(type.name, "allow-reserved");
-    if (type.node && type.node.templateParameters.length > 0) {
-      // template
-      const params = type.node.templateParameters.map((t) =>
-        printIdentifier(t.id.sv, "allow-reserved"),
-      );
-      opName += `<${params.join(", ")}>`;
-    }
-    return `op ${opName}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
-  }
+  return `op ${getTypeName(type, {
+    includeInterfacePrefix: includeQualifier,
+  })}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
 }
 
 function getInterfaceSignature(type: Interface, includeBody: boolean) {
   if (includeBody) {
     const INDENT = "  ";
     const opDescs = Array.from(type.operations).map(
-      ([name, op]) => INDENT + getOperationSignature(op),
+      ([name, op]) => INDENT + getOperationSignature(op, false /* includeQualifier */) + ";",
     );
     return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)} {\n${opDescs.join("\n")}\n}`;
   } else {

--- a/packages/compiler/src/server/type-signature.ts
+++ b/packages/compiler/src/server/type-signature.ts
@@ -121,7 +121,7 @@ function getOperationSignature(type: Operation, includeQualifier: boolean = true
     getModelPropertySignature(p, false /* includeQualifier */),
   );
   return `op ${getTypeName(type, {
-    includeInterfacePrefix: includeQualifier,
+    nameOnly: !includeQualifier,
   })}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
 }
 

--- a/packages/compiler/src/server/type-signature.ts
+++ b/packages/compiler/src/server/type-signature.ts
@@ -120,9 +120,17 @@ function getOperationSignature(type: Operation, includeQualifier: boolean = true
   const parameters = [...type.parameters.properties.values()].map((p) =>
     getModelPropertySignature(p, false /* includeQualifier */),
   );
-  return `op ${getTypeName(type, {
-    includeInterfacePrefix: includeQualifier,
-  })}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
+  if (includeQualifier) {
+    return `op ${getTypeName(type)}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
+  } else {
+    let opName = type.name;
+    if (type.node && type.node.templateParameters.length > 0) {
+      // template
+      const params = type.node.templateParameters.map((t) => printIdentifier(t.id.sv));
+      opName += `<${params.join(", ")}>`;
+    }
+    return `op ${opName}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
+  }
 }
 
 function getInterfaceSignature(type: Interface, includeBody: boolean) {

--- a/packages/compiler/src/server/type-signature.ts
+++ b/packages/compiler/src/server/type-signature.ts
@@ -128,10 +128,10 @@ function getOperationSignature(type: Operation, includeQualifier: boolean = true
 function getInterfaceSignature(type: Interface, includeBody: boolean) {
   if (includeBody) {
     const INDENT = "  ";
-    const opDescs = Array.from(type.operations).map(
+    const opDesc = Array.from(type.operations).map(
       ([name, op]) => INDENT + getOperationSignature(op, false /* includeQualifier */) + ";",
     );
-    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)} {\n${opDescs.join("\n")}\n}`;
+    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)} {\n${opDesc.join("\n")}\n}`;
   } else {
     return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)}`;
   }
@@ -142,12 +142,12 @@ function getInterfaceSignature(type: Interface, includeBody: boolean) {
  */
 function getModelSignature(type: Model, includeBody: boolean) {
   if (includeBody) {
-    const propDescs = [];
+    const propDesc = [];
     const INDENT = "  ";
     for (const prop of walkPropertiesInherited(type)) {
-      propDescs.push(INDENT + getModelPropertySignature(prop, false /*includeQualifier*/));
+      propDesc.push(INDENT + getModelPropertySignature(prop, false /*includeQualifier*/));
     }
-    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)}{\n${propDescs.map((d) => `${d};`).join("\n")}\n}`;
+    return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)}{\n${propDesc.map((d) => `${d};`).join("\n")}\n}`;
   } else {
     return `${type.kind.toLowerCase()} ${getPrintableTypeName(type)}`;
   }

--- a/packages/compiler/src/server/type-signature.ts
+++ b/packages/compiler/src/server/type-signature.ts
@@ -120,17 +120,9 @@ function getOperationSignature(type: Operation, includeQualifier: boolean = true
   const parameters = [...type.parameters.properties.values()].map((p) =>
     getModelPropertySignature(p, false /* includeQualifier */),
   );
-  if (includeQualifier) {
-    return `op ${getTypeName(type)}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
-  } else {
-    let opName = type.name;
-    if (type.node && type.node.templateParameters.length > 0) {
-      // template
-      const params = type.node.templateParameters.map((t) => printIdentifier(t.id.sv));
-      opName += `<${params.join(", ")}>`;
-    }
-    return `op ${opName}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
-  }
+  return `op ${getTypeName(type, {
+    includeInterfacePrefix: includeQualifier,
+  })}(${parameters.join(", ")}): ${getPrintableTypeName(type.returnType)}`;
 }
 
 function getInterfaceSignature(type: Interface, includeBody: boolean) {

--- a/packages/compiler/test/server/get-hover.test.ts
+++ b/packages/compiler/test/server/get-hover.test.ts
@@ -398,7 +398,6 @@ describe("compiler: server: on hover", () => {
     it("model with extends and is (full definition expected)", async () => {
       const hover = await getHoverAtCursor(
         `
-          @service(#{title: "RT"})
           namespace TestNs;
           
           model Do┆g is Animal<string, DogProperties> {

--- a/packages/compiler/test/server/get-hover.test.ts
+++ b/packages/compiler/test/server/get-hover.test.ts
@@ -504,7 +504,6 @@ model TestNs.Dog {
     it("interface with extends", async () => {
       const hover = await getHoverAtCursor(
         `
-          @service(#{title: "RT"})
           namespace TestNs;
           
           interface IActions{

--- a/packages/compiler/test/server/get-hover.test.ts
+++ b/packages/compiler/test/server/get-hover.test.ts
@@ -433,7 +433,7 @@ model TestNs.Dog
 *Full Definition:*
 
 \`\`\`typespec
-model TestNs.Dog{
+model TestNs.Dog {
   name: string;
   age: int16;
   tTag: string;

--- a/packages/compiler/test/server/get-hover.test.ts
+++ b/packages/compiler/test/server/get-hover.test.ts
@@ -432,7 +432,7 @@ model TestNs.Dog
 *Full Definition:*
 
 \`\`\`typespec
-model TestNs.Dog{
+model TestNs.Dog {
   name: string;
   age: int16;
   tTag: string;

--- a/packages/compiler/test/server/get-hover.test.ts
+++ b/packages/compiler/test/server/get-hover.test.ts
@@ -394,6 +394,57 @@ describe("compiler: server: on hover", () => {
         },
       });
     });
+
+    it("model with extends and is (full definition expected)", async () => {
+      const hover = await getHoverAtCursor(
+        `
+          @service(#{title: "RT"})
+          namespace TestNs;
+          
+          model Do┆g is Animal<string, DogProperties> {
+              barkVolume: int32;
+          }
+
+          model Animal<T, P> extends AnimalBase<P>{
+              name: string;
+              age: int16;
+              tTag: T;
+          }
+
+          model AnimalBase<P> {
+              id: string;
+              properties: P;
+          }
+
+
+          model DogProperties {
+              breed: string;
+              color: string;
+          }
+        `,
+      );
+      deepStrictEqual(hover, {
+        contents: {
+          kind: MarkupKind.Markdown,
+          value: `\`\`\`typespec
+model TestNs.Dog
+\`\`\`
+
+*Full Definition:*
+
+\`\`\`typespec
+model TestNs.Dog{
+  name: string;
+  age: int16;
+  tTag: string;
+  barkVolume: int32;
+  id: string;
+  properties: TestNs.DogProperties;
+}
+\`\`\``,
+        },
+      });
+    });
   });
 
   describe("interface", () => {
@@ -446,6 +497,40 @@ describe("compiler: server: on hover", () => {
         contents: {
           kind: MarkupKind.Markdown,
           value: "```typespec\n" + "interface TestNs.IActions\n" + "```",
+        },
+      });
+    });
+
+    it("interface with extends", async () => {
+      const hover = await getHoverAtCursor(
+        `
+          @service(#{title: "RT"})
+          namespace TestNs;
+          
+          interface IActions{
+            fly(): void;
+          }
+
+          interface Bi┆rd extends IActions {
+            eat(): void;
+          }
+        `,
+      );
+      deepStrictEqual(hover, {
+        contents: {
+          kind: MarkupKind.Markdown,
+          value: `\`\`\`typespec
+interface TestNs.Bird
+\`\`\`
+
+*Full Definition:*
+
+\`\`\`typespec
+interface TestNs.Bird {
+  op fly(): void;
+  op eat(): void;
+}
+\`\`\``,
         },
       });
     });

--- a/packages/compiler/test/server/get-hover.test.ts
+++ b/packages/compiler/test/server/get-hover.test.ts
@@ -432,7 +432,7 @@ model TestNs.Dog
 *Full Definition:*
 
 \`\`\`typespec
-model TestNs.Dog {
+model TestNs.Dog{
   name: string;
   age: int16;
   tTag: string;


### PR DESCRIPTION
Show full definition of model and interface when it's 'extends' or 'is' other model/interfaces for the pain point when people working with project with complex model/interface relationship like in our specs repo.

fixes #6991 