### PR TITLE
Revert "Don't remove usings needed for crefs"

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/PostProcessorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/PostProcessorTests.cs
@@ -100,7 +100,6 @@ namespace Microsoft.TypeSpec.Generator.Tests.PostProcessing
             var usings = compilation.Usings.Select(u => u.Name!.ToString()).ToList();
             CollectionAssert.Contains(usings, "Sample.Models");
             CollectionAssert.Contains(usings, "System");
-            CollectionAssert.Contains(usings, "Microsoft.TypeSpec.Generator.Tests.Writers");
         }
 
         private class TestPostProcessor : PostProcessor

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/DoesNotRemoveValidUsings/DoesNotRemoveValidUsings.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/DoesNotRemoveValidUsings/DoesNotRemoveValidUsings.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using Sample.Models;
-using Microsoft.TypeSpec.Generator.Tests.Writers
 
 namespace Sample
 {
     public class KeepMe
     {
-        /// <summary> Reference to a type in a different namespace like <see cref="global::Microsoft.TypeSpec.Generator.Tests.Writers.CodeScopeTests"/> </summary>
         public Model Foo() => new Model();
     }
 }


### PR DESCRIPTION
Reverts microsoft/typespec#7533

This is not actually necessary - the bug was in the Azure generator not specifying the cref type correctly.