### PR TITLE
Expose API for other vscode extension to be able to register more Init Template

### DIFF
--- a/.chronus/changes/scaffolding-api-2025-5-4-17-46-14.md
+++ b/.chronus/changes/scaffolding-api-2025-5-4-17-46-14.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - typespec-vscode
+---
+
+Add extension API for other vscode extension to be able to register more TypeSpec InitTemplate to choose when scaffolding TypeSpec project.

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -28,6 +28,11 @@
   "engines": {
     "vscode": "^1.100.0"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/declaration/src/index.d.ts"
+    }
+  },
   "activationEvents": [
     "onLanguage:typespec",
     "onCommand:typespec.restartServer",
@@ -240,8 +245,9 @@
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",
-    "build": "pnpm compile && pnpm check && pnpm copy-templates && pnpm copy-tmlanguage && pnpm generate-language-configuration && pnpm generate-third-party-notices && pnpm package-vsix",
+    "build": "pnpm compile && pnpm check && pnpm declaration-only && pnpm copy-templates && pnpm copy-tmlanguage && pnpm generate-language-configuration && pnpm generate-third-party-notices && pnpm package-vsix",
     "check": "tsc --noEmit",
+    "declaration-only": "tsc --project tsconfig.declaration.json",
     "compile": "tsx ./scripts/build.ts",
     "watch": "tsx ./scripts/build.ts --watch",
     "dogfood": "node scripts/dogfood.js",

--- a/packages/typespec-vscode/src/extension.ts
+++ b/packages/typespec-vscode/src/extension.ts
@@ -27,7 +27,11 @@ import {
 } from "./types.js";
 import { installCompilerWithUi } from "./typespec-utils.js";
 import { isWhitespaceStringOrUndefined, spawnExecutionAndLogToOutput } from "./utils.js";
-import { createTypeSpecProject } from "./vscode-cmd/create-tsp-project.js";
+import {
+  createTypeSpecProject,
+  InitTemplatesUrlSetting,
+  registerInitTemplateUrls as registerInitTemplateUrlsInternal,
+} from "./vscode-cmd/create-tsp-project.js";
 import { emitCode } from "./vscode-cmd/emit-code/emit-code.js";
 import { importFromOpenApi3 } from "./vscode-cmd/import-from-openapi3.js";
 import { installCompilerGlobally } from "./vscode-cmd/install-tsp-compiler.js";
@@ -321,6 +325,15 @@ export async function activate(context: ExtensionContext) {
       telemetryClient.sendDelayedTelemetryEvents();
     },
   );
+
+  // Expose API for other extensions to consume
+  const api = {
+    /** Register more InitTemplateUrls which will be included in the Create TypeSpec Project scenario */
+    registerInitTemplateUrls(items: InitTemplatesUrlSetting[]) {
+      registerInitTemplateUrlsInternal(items);
+    },
+  };
+  return api;
 }
 
 export async function deactivate() {

--- a/packages/typespec-vscode/src/extension.ts
+++ b/packages/typespec-vscode/src/extension.ts
@@ -24,6 +24,7 @@ import {
   Result,
   ResultCode,
   SettingName,
+  TypeSpecExtensionApi,
 } from "./types.js";
 import { installCompilerWithUi } from "./typespec-utils.js";
 import { isWhitespaceStringOrUndefined, spawnExecutionAndLogToOutput } from "./utils.js";
@@ -327,7 +328,7 @@ export async function activate(context: ExtensionContext) {
   );
 
   // Expose API for other extensions to consume
-  const api = {
+  const api: TypeSpecExtensionApi = {
     /** Register more InitTemplateUrls which will be included in the Create TypeSpec Project scenario */
     registerInitTemplateUrls(items: InitTemplatesUrlSetting[]) {
       registerInitTemplateUrlsInternal(items);

--- a/packages/typespec-vscode/src/index.ts
+++ b/packages/typespec-vscode/src/index.ts
@@ -1,0 +1,3 @@
+// Types we want to export by default for other lib to reference should be defined in this file.
+
+export { TypeSpecExtensionApi } from "./types.js";

--- a/packages/typespec-vscode/src/types.ts
+++ b/packages/typespec-vscode/src/types.ts
@@ -1,4 +1,5 @@
 import { TspLanguageClient } from "./tsp-language-client.js";
+import { InitTemplatesUrlSetting } from "./vscode-cmd/create-tsp-project.js";
 
 export const enum SettingName {
   TspServerPath = "typespec.tsp-server.path",
@@ -67,3 +68,8 @@ interface UnsuccessResult {
 }
 
 export type Result<T = void> = SuccessResult<T> | UnsuccessResult;
+
+export interface TypeSpecExtensionApi {
+  /** Register more InitTemplateUrls which will be included in the Create TypeSpec Project scenario */
+  registerInitTemplateUrls(items: InitTemplatesUrlSetting[]): void;
+}

--- a/packages/typespec-vscode/src/utils.ts
+++ b/packages/typespec-vscode/src/utils.ts
@@ -477,3 +477,13 @@ export function getVscodeUriFromPath(path: string): string {
   const uri = vscode.Uri.file(path);
   return uri.toString();
 }
+
+export function distinctArray<T>(arr: T[], compare: (a: T, b: T) => boolean): T[] {
+  const result: T[] = [];
+  for (const item of arr) {
+    if (!result.some((r) => compare(r, item))) {
+      result.push(item);
+    }
+  }
+  return result;
+}

--- a/packages/typespec-vscode/tsconfig.declaration.json
+++ b/packages/typespec-vscode/tsconfig.declaration.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/declaration",
+  },
+  "include": ["./src/index.ts"]
+}

--- a/packages/typespec-vscode/tsconfig.declaration.json
+++ b/packages/typespec-vscode/tsconfig.declaration.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./dist/declaration",
+    "outDir": "./dist/declaration"
   },
   "include": ["./src/index.ts"]
 }


### PR DESCRIPTION
Expose API for other vscode extension to be able to register more Init Template. i.e. when user installs azure typespec extension, it will be able to call the api to register Azure related init template automatically.