### PR TITLE
fix the range of float32

### DIFF
--- a/website/src/content/docs/docs/language-basics/built-in-types.md
+++ b/website/src/content/docs/docs/language-basics/built-in-types.md
@@ -23,7 +23,7 @@ Built in types are related to each other according to the rules described in [ty
 | `uint32`     | `0` to `4,294,967,295`                                                                                       | Unsigned 32-bit integer                   |
 | `uint16`     | `0` to `65,535`                                                                                              | Unsigned 16-bit integer                   |
 | `uint8`      | `0` to `255 `                                                                                                | Unsigned 8-bit integer                    |
-| `float32`    | <code> ±1.5 x 10<sup>45</sup></code> to <code>±3.4 x 10<sup>38</sup></code>                                  | A 32 bit floating point number            |
+| `float32`    | <code>±1.5 x 10<sup>−45</sup></code> to <code>±3.4 x 10<sup>38</sup></code>                                  | A 32 bit floating point number            |
 | `float64`    | <code>±5.0 × 10<sup>−324</sup></code> to <code>±1.7 × 10<sup>308</sup></code>                                | A 64 bit floating point number            |
 | `decimal`    | [\*](#numeric-supertypes)                                                                                    | A decimal number                          |
 | `decimal128` | 34 decimal digits with an exponent range from `-6143` to `6144`                                              | A 128 bit decimal number                  |


### PR DESCRIPTION
the range of float32 should be `±1.5 x 10^−45` to `±3.4 x 10^38`.

- https://typespec.io/docs/standard-library/built-in-data-types/#float32