### PR TITLE
[http-client-csharp] handle nested types in custom code

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
@@ -165,7 +165,9 @@ namespace Microsoft.TypeSpec.Generator.Primitives
         /// Gets or sets the name of the type.
         /// </summary>
         public string Name { get; private set; }
-        internal string FullyQualifiedName => $"{Namespace}.{Name}";
+        internal string FullyQualifiedName => DeclaringType is null
+            ? $"{Namespace}.{Name}"
+            : $"{Namespace}.{DeclaringType.Name}.{Name}";
         public CSharpType? DeclaringType { get; private init; }
         public bool IsValueType { get; private init; }
         public bool IsEnum => _underlyingType is not null;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/TypeSymbolExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/TypeSymbolExtensions.cs
@@ -201,12 +201,21 @@ namespace Microsoft.TypeSpec.Generator
                 pieces = GetFullyQualifiedName(typeArg).Split('.');
             }
 
+            string ns = string.Join('.', pieces.Take(pieces.Length - 1));
+            CSharpType? containingType = null;
+
+            if (typeSymbol.ContainingType != null)
+            {
+                containingType = GetCSharpType(typeSymbol.ContainingType);
+                ns = string.Join('.', pieces.Take(pieces.Length - 2));
+            }
+
             return new CSharpType(
                 name,
-                string.Join('.', pieces.Take(pieces.Length - 1)),
+                ns,
                 isValueType,
                 isNullable,
-                typeSymbol.ContainingType is not null ? GetCSharpType(typeSymbol.ContainingType) : null,
+                containingType,
                 arguments,
                 typeSymbol.DeclaredAccessibility == Accessibility.Public,
                 isValueType && !isEnum,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Primitives/CSharpTypeTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Primitives/CSharpTypeTests.cs
@@ -143,6 +143,83 @@ namespace Microsoft.TypeSpec.Generator.Tests.Primitives
             Assert.IsFalse(nested1.Equals(nested2));
         }
 
+        [Test]
+        public void FullyQualifiedName()
+        {
+            var declaringType1 = new CSharpType(
+                "type1",
+                "namespace1",
+                false,
+                false,
+                null,
+                [],
+                true,
+                false);
+            var declaringType2 = new CSharpType(
+                "type2",
+                "namespace2",
+                false,
+                false,
+                null,
+                [],
+                true,
+                false);
+
+            var nested1Name = declaringType1.FullyQualifiedName;
+            Assert.AreEqual($"namespace1.{declaringType1.Name}", nested1Name);
+
+            var nested2Name = declaringType2.FullyQualifiedName;
+            Assert.AreEqual($"namespace2.{declaringType2.Name}", nested2Name);
+        }
+
+        [Test]
+        public void FullyQualifiedName_NestedTypes()
+        {
+            var declaringType1 = new CSharpType(
+                "type1",
+                "namespace1",
+                false,
+                false,
+                null,
+                [],
+                true,
+                false);
+            var declaringType2 = new CSharpType(
+                "type2",
+                "namespace2",
+                false,
+                false,
+                null,
+                [],
+                true,
+                false);
+
+            var nested1 = new CSharpType(
+                "nested",
+                declaringType1.Namespace,
+                false,
+                false,
+                declaringType1,
+                [],
+                true,
+                false);
+            var nested2 = new CSharpType(
+                "nested",
+                declaringType2.Namespace,
+                false,
+                false,
+                declaringType2,
+                [],
+                true,
+                false);
+
+            var nested1Name = nested1.FullyQualifiedName;
+            Assert.AreEqual($"{nested1.Namespace}.{declaringType1.Name}.{nested1.Name}", nested1Name);
+
+            var nested2Name = nested2.FullyQualifiedName;
+            Assert.AreEqual($"{nested2.Namespace}.{declaringType2.Name}.{nested2.Name}", nested2Name);
+        }
+
         [TestCase(typeof(IList<>), new[] { typeof(int) })]
         [TestCase(typeof(IReadOnlyList<>), new[] { typeof(string) })]
         [TestCase(typeof(IDictionary<,>), new[] { typeof(string), typeof(string) })]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
@@ -57,6 +57,31 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
         }
 
         [Test]
+        public void ValidateNamespaceNestedType()
+        {
+            // Get all members, including nested types
+            var allMembers = _iNamedSymbol.GetMembers().OfType<INamedTypeSymbol>();
+            INamedTypeSymbol? nestedType = null;
+
+            // Iterate over the members and find the nested types
+            foreach (var member in allMembers)
+            {
+                if (member.Kind == SymbolKind.NamedType && SymbolEqualityComparer.Default.Equals(member.ContainingSymbol, _iNamedSymbol))
+                {
+                    nestedType = member;
+                    break;
+                }
+            }
+
+            Assert.IsNotNull(nestedType, "Nested type not found in the named symbol.");
+            var type = nestedType!.GetCSharpType();
+            Assert.AreEqual("Sample.Models", type.Namespace);
+
+            var fullName = type.FullyQualifiedName;
+            Assert.AreEqual("Sample.Models.NamedSymbol.Foo", fullName);
+        }
+
+        [Test]
         public void ValidateProperties()
         {
             Dictionary<string, PropertyProvider> properties = _namedTypeSymbolProvider.Properties.ToDictionary(p => p.Name);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/TypeProviderTests/TestCustomizeNestedTypes/TestCustomizeNestedTypes(false).cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/TypeProviderTests/TestCustomizeNestedTypes/TestCustomizeNestedTypes(false).cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test
+{
+    /// <summary>
+    /// This is a simple test type.
+    /// </summary>
+    public class TestCustomizeNestedTypes
+    {
+        public class NestedType
+        {
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/TypeProviderTests/TestCustomizeNestedTypes/TestCustomizeNestedTypes(true).cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TestData/TypeProviderTests/TestCustomizeNestedTypes/TestCustomizeNestedTypes(true).cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test
+{
+    /// <summary>
+    /// This is a simple test type.
+    /// </summary>
+    public class TestCustomizeNestedTypes
+    {
+        public enum TestEnum
+        {
+            Value1,
+            Value2,
+            Value3
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
@@ -49,6 +52,32 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             var signature = methods[0].Signature;
             Assert.AreEqual("Foo", signature.Name);
             Assert.AreEqual("p1", signature.Parameters[0].Name);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task TestCustomizeNestedTypes(bool isNestedTypeAnEnum)
+        {
+            await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            TypeProvider nestedType;
+            if (isNestedTypeAnEnum)
+            {
+                var inputEnum = InputFactory.Int32Enum("TestEnum", [("Value1", 0), ("Value2", 1), ("Value3", 2)], clientNamespace: "Test");
+                nestedType = EnumProvider.Create(inputEnum, new TestTypeProvider(name: "TestCustomizeNestedTypes"));
+            }
+            else
+            {
+                nestedType = new TestTypeProvider(name: "NestedType");
+            }
+
+            var typeProvider = new TestTypeProvider(name: "TestCustomizeNestedTypes");
+            typeProvider.NestedTypesInternal = [nestedType];
+            Assert.IsNotNull(typeProvider.CustomCodeView);
+
+            var nestedTypes = typeProvider.NestedTypes;
+            var expectedCount = isNestedTypeAnEnum ? 0 : 1;
+            Assert.AreEqual(expectedCount, nestedTypes.Count);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestNamedSymbol.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestNamedSymbol.cs
@@ -124,5 +124,10 @@ namespace Microsoft.TypeSpec.Generator.Tests
                     this)
             ];
         }
+
+        protected override TypeProvider[] BuildNestedTypes()
+        {
+            return [new TestTypeProvider("Foo")];
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestTypeProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
         protected override string BuildNamespace() => "Test";
 
         protected override MethodProvider[] BuildMethods() => _methods;
+        protected override TypeProvider[] BuildNestedTypes() => NestedTypesInternal ?? base.BuildNestedTypes();
 
         public static readonly TypeProvider Empty = new TestTypeProvider();
 
@@ -32,6 +33,8 @@ namespace Microsoft.TypeSpec.Generator.Tests
             _methods = methods?.ToArray() ?? [];
             _name = name ?? "TestName";
         }
+
+        internal TypeProvider[]? NestedTypesInternal { get; set; }
 
         protected override TypeSignatureModifiers BuildDeclarationModifiers() => _declarationModifiers ?? base.BuildDeclarationModifiers();
     }


### PR DESCRIPTION
This PR fixes issues related to customization for nested types. It also applies the existing logic for not generating FixedEnums if a custom fixed enum exists as a nested type.

contributes to: https://github.com/Azure/azure-sdk-for-net/issues/50288