### PR TITLE
http-server-js - support leading underscores in names

### DIFF
--- a/.chronus/changes/hsjs-underscore-body-2025-5-4-15-12-34.md
+++ b/.chronus/changes/hsjs-underscore-body-2025-5-4-15-12-34.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Fixes emitter crash when operation return types included metadata or `@body` properties that only contained underscores

--- a/packages/http-server-js/test/case.test.ts
+++ b/packages/http-server-js/test/case.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isUnspeakable, parseCase } from "../src/util/case.js";
+
+describe("parseCase", () => {
+  it.each([
+    {
+      input: "HTTPResponse",
+      snakeCase: "http_response",
+      camelCase: "httpResponse",
+      pascalCase: "HttpResponse",
+    },
+    {
+      input: "OpenAIContext",
+      snakeCase: "open_ai_context",
+      camelCase: "openAiContext",
+      pascalCase: "OpenAiContext",
+    },
+    { input: "_", snakeCase: "_", camelCase: "_", pascalCase: "_" },
+    { input: "__type", snakeCase: "__type", camelCase: "__type", pascalCase: "__Type" },
+    { input: "_Foo", snakeCase: "_foo", camelCase: "_foo", pascalCase: "_Foo" },
+  ])("$input", (testCase) => {
+    const result = parseCase(testCase.input);
+    expect(result.snakeCase).toBe(testCase.snakeCase);
+    expect(result.camelCase).toBe(testCase.camelCase);
+    expect(result.pascalCase).toBe(testCase.pascalCase);
+  });
+});
+
+describe("isUnspeakable", () => {
+  it.each([
+    { name: "", expected: true },
+    { name: "_", expected: false },
+    { name: "123abc", expected: true },
+    { name: "abc123", expected: false },
+  ])("$name unspeakable: $expected", ({ name, expected }) => {
+    expect(isUnspeakable(name)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Fixes #6819 

Using metadata/`@body` response property names that contained only underscores.

For example - the following crashed for both the statusCode and body properties:

```tsp
import "@typespec/http";
using Http;

@service
namespace Service;

@route("/body")
op body(): {
  @statusCode _: 200;
  @body __: string;
} | {
  @statusCode _: 400;
  code: int32;
};
```