### PR TITLE
apply underline text-decoration to inlined links and improve contrast of links in codeboxes

### DIFF
--- a/website/src/css/tsp.css
+++ b/website/src/css/tsp.css
@@ -2,12 +2,6 @@
 :root[data-theme="light"],
 :root[data-theme="dark"] {
   --header-height: 50px;
-  --sl-color-text-accent: var(--colorBrandForeground1);
-  --sl-color-gray-5: var(--colorNeutralStroke1);
-}
-
-:root[data-theme="dark"] {
-  --sl-color-bg-inline-code: var(--ec-frm-edBg);
 }
 
 .DocSearch-Button {
@@ -29,4 +23,14 @@
 header.header {
   padding: 0;
   padding-inline-end: unset !important;
+}
+
+/* Apply link decorations for inline links, not navigation/tab links */
+p a,
+li > a {
+  text-decoration: underline;
+}
+nav a,
+li:is([role="presentation"]) a {
+  text-decoration: none;
 }


### PR DESCRIPTION
Addresses a18y issues reported here:
https://webcompliance.trafficmanager.net/ScanResultsApi/GetAccessibilityScanConsolidatedReport?siteId=2fae20ee-d671-4a89-c500-08dc261f6c8b

The trend I've been noticing after doing a couple of these fixes is that if we want to deviate from the starlight/astro styles, we really need to develop our own theme and use it wholesale. If we only use bits and pieces (like we were doing for link coloring), we will inevitably run into these contrast issues again the next time starlight changes any of their css color styles. That's largely because we are so close to the contrast limits that even an almost imperceptible change triggers the accessibility warnings.