### PR TITLE
Reference current type name in custom code view

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
@@ -663,7 +663,7 @@ namespace Microsoft.TypeSpec.Generator.Primitives
         /// </summary>
         /// <param name="name">Name of the <see cref="CSharpType"/></param>
         /// <param name="namespace">Namespace of the <see cref="CSharpType"/></param>
-        public void Update(string? name = null, string? @namespace = null)
+        internal void Update(string? name = null, string? @namespace = null)
         {
             if (name != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -816,5 +816,19 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
 
             Assert.AreEqual(1, modelProvider.CanonicalView!.Properties.Count);
         }
+
+        [Test]
+        public async Task CanCustomizeTypeRenamedInVisitor()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var inputModel = InputFactory.Model("mockInputModel", properties: []);
+            var modelTypeProvider = new ModelProvider(inputModel);
+
+            // Simulate a visitor that renames the type
+            modelTypeProvider.Update(name: "RenamedModel");
+
+            Assert.IsNotNull(modelTypeProvider.CustomCodeView);
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.CustomCodeView!.Name);
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeTypeRenamedInVisitor/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeTypeRenamedInVisitor/MockInputModel.cs
@@ -1,0 +1,12 @@
+#nullable disable
+
+using Sample;
+using SampleTypeSpec;
+
+namespace NewNamespace.Models
+{
+    [CodeGenType("RenamedModel")]
+    public class CustomizedTypeName
+    {
+    }
+}


### PR DESCRIPTION
If a visitor renames a type and a customer tries to rename the same type with custom code, the custom code view won't work if they are referencing the renamed type. They would have to know what the original type name was. This PR fixes that behavior so the generated type is what they can reference via custom code.