### PR TITLE
Don't run spotless on every file in case of error

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/postprocessor/Postprocessor.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/postprocessor/Postprocessor.java
@@ -45,7 +45,7 @@ public class Postprocessor {
         if (className == null) {
             try {
                 writeToFiles(fileContents, plugin, logger);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("Failed to complete postprocessing.", e);
                 throw new RuntimeException("Failed to complete postprocessing.", e);
             }
@@ -120,11 +120,7 @@ public class Postprocessor {
             handlePartialUpdate(javaFiles, plugin, logger);
         }
 
-        try {
-            CodeFormatterUtil.formatCode(javaFiles, plugin, logger);
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
+        CodeFormatterUtil.formatCode(javaFiles, plugin, logger);
     }
 
     private static String getReadme(NewPlugin plugin) {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/postprocessor/implementation/CodeFormatterUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/postprocessor/implementation/CodeFormatterUtil.java
@@ -139,13 +139,13 @@ public final class CodeFormatterUtil {
                 String fileName = fileNameMatcher.group(1);
                 Path filePath = sources.resolve(fileName);
                 if (!Files.exists(filePath)) {
-                    return String.format("file name: '%s', content is not available", fileName);
+                    return String.format("file='%s', content is not available", fileName);
                 }
 
                 String fileContent = Files.readString(filePath);
                 Matcher lineNumberMatcher = SPOTLESS_ERROR_LINE_NUMBER_PATTERN.matcher(allLines.get(i + 1));
                 if (!lineNumberMatcher.find()) {
-                    return String.format("file name: '%s', Full content:\n---\n%s\n---", fileName, fileContent);
+                    return String.format("file='%s', Full content:\n---\n%s\n---", fileName, fileContent);
                 }
 
                 int lineNumber = Integer.parseInt(lineNumberMatcher.group(1));
@@ -155,7 +155,8 @@ public final class CodeFormatterUtil {
                     .limit(SPOTLESS_FILE_CONTENT_RANGE * 2 + 1)
                     .collect(Collectors.joining("\n"));
 
-                return String.format("file name: '%s', Content around error:\n---\n%s\n---", fileName, errorContent);
+                return String.format("file='%s:%s', Content around error:\n---\n%s\n---", fileName, lineNumber,
+                    errorContent);
             }
         }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/postprocessor/implementation/CodeFormatterUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/postprocessor/implementation/CodeFormatterUtil.java
@@ -139,13 +139,14 @@ public final class CodeFormatterUtil {
                 String fileName = fileNameMatcher.group(1);
                 Path filePath = sources.resolve(fileName);
                 if (!Files.exists(filePath)) {
-                    return String.format("file='%s', content is not available", fileName);
+                    return String.format("file='%s', content is not available", filePath);
                 }
 
                 String fileContent = Files.readString(filePath);
                 Matcher lineNumberMatcher = SPOTLESS_ERROR_LINE_NUMBER_PATTERN.matcher(allLines.get(i + 1));
                 if (!lineNumberMatcher.find()) {
-                    return String.format("file='%s', Full content:\n---\n%s\n---", fileName, fileContent);
+                    return String.format("file='%s', Full content:\n---\n%s\n---", filePath,
+                        fileContent);
                 }
 
                 int lineNumber = Integer.parseInt(lineNumberMatcher.group(1));
@@ -155,8 +156,8 @@ public final class CodeFormatterUtil {
                     .limit(SPOTLESS_FILE_CONTENT_RANGE * 2 + 1)
                     .collect(Collectors.joining("\n"));
 
-                return String.format("file='%s:%s', Content around error:\n---\n%s\n---", fileName, lineNumber,
-                    errorContent);
+                return String.format("file='%s:%s', Content around error:\n---\n%s\n---", filePath,
+                    lineNumber, errorContent);
             }
         }
 


### PR DESCRIPTION
If generated code is not correct, we re-run spotless on every file 

https://github.com/microsoft/typespec/blob/94a9b9ea8a2981be406486388789c990aa153346/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/postprocessor/implementation/CodeFormatterUtil.java#L48

It results in VERY long time to learn that your code is broken. E.g. 2.5 mins to generate todo code.

This change 
- preserves the whole tmp dir in case of failure for future inspection. We should probably archive and publish it as build artifact in CI
- preserves the whole spotless log in the file 
- returns error info in output based on info already available in spotless log

What I see in the output from this PR (completes in ~6 sec instead of 2.5 min):

```
error @typespec/http-client-java/generator-error: com.microsoft.typespec.http.client.generator.Main - Unhandled error.
java.lang.RuntimeException: Failed to complete postprocessing.
        at com.microsoft.typespec.http.client.generator.core.postprocessor.Postprocessor.postProcess(Postprocessor.java:50)
        at com.microsoft.typespec.http.client.generator.Main.handleDPG(Main.java:164)
        at com.microsoft.typespec.http.client.generator.Main.main(Main.java:89)
Caused by: com.microsoft.typespec.http.client.generator.core.postprocessor.implementation.CodeFormatterUtil$SpotlessException: Spotless failed to format code. Log file: 'C:\Users\LIMOLK~1\AppData\Local\Temp\spotless92c5cd1c-9f38-4bdb-832f-e2ad9deb97be14842959181628922875\spotless5894393859582272638.log', Error info: file name: 'src\main\java\todo\TodoItemsAttachmentsClient.java', Content around error:
---
    @ServiceMethod(returns = ReturnType.COLLECTION)
    public PagedIterable<TodoAttachment> list(long itemId) {
        return
    }

    /**
     * The list operation.
---
        at com.microsoft.typespec.http.client.generator.core.postprocessor.implementation.CodeFormatterUtil.attemptMavenSpotless(CodeFormatterUtil.java:126)
        at com.microsoft.typespec.http.client.generator.core.postprocessor.implementation.CodeFormatterUtil.formatCodeInternal(CodeFormatterUtil.java:82)
        at com.microsoft.typespec.http.client.generator.core.postprocessor.implementation.CodeFormatterUtil.formatCode(CodeFormatterUtil.java:44)
        at com.microsoft.typespec.http.client.generator.core.postprocessor.Postprocessor.writeToFiles(Postprocessor.java:123)
        at com.microsoft.typespec.http.client.generator.core.postprocessor.Postprocessor.postProcess(Postprocessor.java:47)
        ... 2 more

error @typespec/http-client-java/unknown-error: An unknown error occurred. Error occurred while running Java generator. The emitter was unable to generate client code from this TypeSpec, please open an issue on https://github.com/microsoft/typespec, include TypeSpec source and all the diagnostic information in your submission. Error: java ended with code '1'.
    at ChildProcess.<anonymous> (file:///D:/repo/typespec/packages/http-client-java/generator/http-client-generator-clientcore-test/node_modules/@typespec/http-client-java/emitter/src/utils.ts:106:19)
    at ChildProcess.emit (node:events:518:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)
Error: Error: java ended with code '1'.

Found 4 errors, 9 warnings.

```
