### PR TITLE
Revert change to make CSharpProjectWriter internal

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpProjectWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpProjectWriter.cs
@@ -9,7 +9,7 @@ using Microsoft.TypeSpec.Generator.Primitives;
 
 namespace Microsoft.TypeSpec.Generator;
 
-internal class CSharpProjectWriter
+public class CSharpProjectWriter
 {
     private const char NewLine = '\n';
 


### PR DESCRIPTION
Reverts change to make this type internal from https://github.com/microsoft/typespec/pull/7526
We aren't quite ready to make this internal yet as we don't have all the necessary hooks in NewProjectScaffolding.