### PR TITLE
Fix to changing namespace

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -110,17 +110,16 @@ namespace Microsoft.TypeSpec.Generator.Providers
             private set => _deprecated = value;
         }
 
-        private string? _name;
         private CSharpType? _type;
         private CSharpType[]? _arguments;
         public CSharpType Type => _type ??=
             BuildType();
 
-        private CSharpType BuildType()
+        private CSharpType BuildType(string? name = default, string? ns = default)
         {
             return new(
-                _name ??= CustomCodeView?.Name ?? BuildName(),
-                CustomCodeView?.Type.Namespace ?? BuildNamespace(),
+                name ?? CustomCodeView?.Name ?? BuildName(),
+                ns ?? CustomCodeView?.Type.Namespace ?? BuildNamespace(),
                 this is EnumProvider ||
                 DeclarationModifiers.HasFlag(TypeSignatureModifiers.Struct) ||
                 DeclarationModifiers.HasFlag(TypeSignatureModifiers.Enum),
@@ -406,8 +405,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 // Reset the custom code view to reflect the new name
                 _customCodeView = new(GetCustomCodeView(name));
-                _name = _customCodeView.Value?.Name ?? name;
-                _type = BuildType();
+                // Give precedence to the custom code view name/namespace if they exist
+                _type = BuildType(_customCodeView.Value?.Name ?? name, _customCodeView.Value?.Type.Namespace ?? _type?.Namespace);
             }
 
             if (@namespace != null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -115,11 +115,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public CSharpType Type => _type ??=
             BuildType();
 
-        private CSharpType BuildType(string? name = default, string? ns = default)
+        private CSharpType BuildType()
         {
             return new(
-                name ?? CustomCodeView?.Name ?? BuildName(),
-                ns ?? CustomCodeView?.Type.Namespace ?? BuildNamespace(),
+                CustomCodeView?.Name ?? BuildName(),
+                CustomCodeView?.Type.Namespace ?? BuildNamespace(),
                 this is EnumProvider ||
                 DeclarationModifiers.HasFlag(TypeSignatureModifiers.Struct) ||
                 DeclarationModifiers.HasFlag(TypeSignatureModifiers.Enum),
@@ -405,8 +405,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 // Reset the custom code view to reflect the new name
                 _customCodeView = new(GetCustomCodeView(name));
-                // Give precedence to the custom code view name/namespace if they exist
-                _type = BuildType(_customCodeView.Value?.Name ?? name, _customCodeView.Value?.Type.Namespace ?? _type?.Namespace);
+                // Give precedence to the custom code view name if it exists
+                Type.Update(_customCodeView.Value?.Name ?? name);
             }
 
             if (@namespace != null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -113,11 +113,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private CSharpType? _type;
         private CSharpType[]? _arguments;
         public CSharpType Type => _type ??=
-            BuildType();
-
-        private CSharpType BuildType()
-        {
-            return new(
+            new(
                 CustomCodeView?.Name ?? BuildName(),
                 CustomCodeView?.Type.Namespace ?? BuildNamespace(),
                 this is EnumProvider ||
@@ -130,7 +126,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 DeclarationModifiers.HasFlag(TypeSignatureModifiers.Struct),
                 GetBaseType(),
                 IsEnum ? EnumUnderlyingType.FrameworkType : null);
-        }
 
         protected virtual bool GetIsEnum() => false;
         public bool IsEnum => GetIsEnum();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -856,7 +856,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         }
 
         [Test]
-        public async Task CanChangeTypeNameAndTypeNamespace()
+        public async Task CanChangeTypeNameAfterTypeNamespace()
         {
             await MockHelpers.LoadMockGeneratorAsync();
             var inputModel = InputFactory.Model("mockInputModel", properties: []);
@@ -869,6 +869,26 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
 
             // Simulate a visitor that changes the name of the type
             modelTypeProvider.Update(name: "CustomizedTypeName");
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.Type.Name);
+            Assert.AreEqual("NewNamespace", modelTypeProvider.Type.Namespace);
+
+            Assert.IsNull(modelTypeProvider.CustomCodeView);
+        }
+
+        [Test]
+        public async Task CanChangeTypeNamespaceAfterTypeName()
+        {
+            await MockHelpers.LoadMockGeneratorAsync();
+            var inputModel = InputFactory.Model("mockInputModel", properties: []);
+            var modelTypeProvider = new ModelProvider(inputModel);
+
+            // Simulate a visitor that changes the name of the type
+            modelTypeProvider.Update(name: "CustomizedTypeName");
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.Type.Name);
+            Assert.AreEqual("Sample.Models", modelTypeProvider.Type.Namespace);
+
+            // Simulate a visitor that changes the namespace of the type
+            modelTypeProvider.Update(@namespace: "NewNamespace");
             Assert.AreEqual("CustomizedTypeName", modelTypeProvider.Type.Name);
             Assert.AreEqual("NewNamespace", modelTypeProvider.Type.Namespace);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -836,6 +836,46 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         }
 
         [Test]
+        public async Task CanCustomizeTypeWithChangedNamespaceInVisitor()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var inputModel = InputFactory.Model("mockInputModel", properties: []);
+            var modelTypeProvider = new ModelProvider(inputModel);
+
+            // Simulate a visitor that changes the namespace of the type
+            modelTypeProvider.Update(@namespace: "NewNamespace");
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.Type.Name);
+            Assert.AreEqual("NewNamespace", modelTypeProvider.Type.Namespace);
+
+            Assert.IsNotNull(modelTypeProvider.CustomCodeView);
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.CustomCodeView!.Name);
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.Type.Name);
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.CanonicalView.Type.Name);
+            Assert.AreEqual("NewNamespace", modelTypeProvider.Type.Namespace);
+            Assert.AreEqual("NewNamespace", modelTypeProvider.CanonicalView.Type.Namespace);
+        }
+
+        [Test]
+        public async Task CanChangeTypeNameAndTypeNamespace()
+        {
+            await MockHelpers.LoadMockGeneratorAsync();
+            var inputModel = InputFactory.Model("mockInputModel", properties: []);
+            var modelTypeProvider = new ModelProvider(inputModel);
+
+            // Simulate a visitor that changes the namespace of the type
+            modelTypeProvider.Update(@namespace: "NewNamespace");
+            Assert.AreEqual("MockInputModel", modelTypeProvider.Type.Name);
+            Assert.AreEqual("NewNamespace", modelTypeProvider.Type.Namespace);
+
+            // Simulate a visitor that changes the name of the type
+            modelTypeProvider.Update(name: "CustomizedTypeName");
+            Assert.AreEqual("CustomizedTypeName", modelTypeProvider.Type.Name);
+            Assert.AreEqual("NewNamespace", modelTypeProvider.Type.Namespace);
+
+            Assert.IsNull(modelTypeProvider.CustomCodeView);
+        }
+
+        [Test]
         public void CanCustomizeWithVisitor()
         {
             MockHelpers.LoadMockGenerator();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeTypeWithChangedNamespaceInVisitor/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeTypeWithChangedNamespaceInVisitor/MockInputModel.cs
@@ -1,0 +1,12 @@
+#nullable disable
+
+using Sample;
+using SampleTypeSpec;
+
+namespace NewNamespace
+{
+    [CodeGenType("MockInputModel")]
+    public class CustomizedTypeName
+    {
+    }
+}


### PR DESCRIPTION
If a name was changed in a visitor after the namespace was changed in a previous visitor, the ns change would be wiped out.