### PR TITLE
Fix arg validation for required strings

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/XmlDocsAreWritten.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/XmlDocsAreWritten.cs
@@ -25,6 +25,7 @@ namespace Sample
         /// <param name="endpoint"> Service endpoint. </param>
         /// <param name="queryParam"> queryParam description. </param>
         /// <exception cref="global::System.ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="queryParam"/> is null. </exception>
+        /// <exception cref="global::System.ArgumentException"> <paramref name="queryParam"/> is an empty string, and was expected to be non-empty. </exception>
         public TestClient(global::System.Uri endpoint, string queryParam) : this(endpoint, queryParam, new global::Sample.TestClientOptions())
         {
         }
@@ -34,10 +35,11 @@ namespace Sample
         /// <param name="queryParam"> queryParam description. </param>
         /// <param name="options"> The options for configuring the client. </param>
         /// <exception cref="global::System.ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="queryParam"/> is null. </exception>
+        /// <exception cref="global::System.ArgumentException"> <paramref name="queryParam"/> is an empty string, and was expected to be non-empty. </exception>
         public TestClient(global::System.Uri endpoint, string queryParam, global::Sample.TestClientOptions options)
         {
             global::Sample.Argument.AssertNotNull(endpoint, nameof(endpoint));
-            global::Sample.Argument.AssertNotNull(queryParam, nameof(queryParam));
+            global::Sample.Argument.AssertNotNullOrEmpty(queryParam, nameof(queryParam));
 
             options ??= new global::Sample.TestClientOptions();
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBody.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBody.cs
@@ -18,7 +18,7 @@ namespace Sample
 
         public CatClientGetCatsCollectionResult(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyAsync.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyAsync.cs
@@ -18,7 +18,7 @@ namespace Sample
 
         public CatClientGetCatsAsyncCollectionResult(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfT.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfT.cs
@@ -18,7 +18,7 @@ namespace Sample
 
         public CatClientGetCatsCollectionResultOfT(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfTAsync.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInBodyOfTAsync.cs
@@ -19,7 +19,7 @@ namespace Sample
 
         public CatClientGetCatsAsyncCollectionResultOfT(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeader.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeader.cs
@@ -17,7 +17,7 @@ namespace Sample
 
         public CatClientGetCatsCollectionResult(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderAsync.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderAsync.cs
@@ -17,7 +17,7 @@ namespace Sample
 
         public CatClientGetCatsAsyncCollectionResult(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfT.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfT.cs
@@ -18,7 +18,7 @@ namespace Sample
 
         public CatClientGetCatsCollectionResultOfT(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfTAsync.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ContinuationTokenTests/ContinuationTokenInHeaderOfTAsync.cs
@@ -19,7 +19,7 @@ namespace Sample
 
         public CatClientGetCatsAsyncCollectionResultOfT(global::Sample.CatClient client, string myToken, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(myToken, nameof(myToken));
+            global::Sample.Argument.AssertNotNullOrEmpty(myToken, nameof(myToken));
 
             _client = client;
             _myToken = myToken;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationToken.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationToken.cs
@@ -16,7 +16,7 @@ namespace Sample
 
         public CatClientGetCatsCollectionResult(global::Sample.CatClient client, string animalKind, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(animalKind, nameof(animalKind));
+            global::Sample.Argument.AssertNotNullOrEmpty(animalKind, nameof(animalKind));
 
             _client = client;
             _animalKind = animalKind;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenAsync.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenAsync.cs
@@ -16,7 +16,7 @@ namespace Sample
 
         public CatClientGetCatsAsyncCollectionResult(global::Sample.CatClient client, string animalKind, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(animalKind, nameof(animalKind));
+            global::Sample.Argument.AssertNotNullOrEmpty(animalKind, nameof(animalKind));
 
             _client = client;
             _animalKind = animalKind;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenOfT.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenOfT.cs
@@ -17,7 +17,7 @@ namespace Sample
 
         public CatClientGetCatsCollectionResultOfT(global::Sample.CatClient client, string animalKind, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(animalKind, nameof(animalKind));
+            global::Sample.Argument.AssertNotNullOrEmpty(animalKind, nameof(animalKind));
 
             _client = client;
             _animalKind = animalKind;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenOfTAsync.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/TestData/ListPageableTests/NoNextLinkOrContinuationTokenOfTAsync.cs
@@ -18,7 +18,7 @@ namespace Sample
 
         public CatClientGetCatsAsyncCollectionResultOfT(global::Sample.CatClient client, string animalKind, global::System.ClientModel.Primitives.RequestOptions options)
         {
-            global::Sample.Argument.AssertNotNull(animalKind, nameof(animalKind));
+            global::Sample.Argument.AssertNotNullOrEmpty(animalKind, nameof(animalKind));
 
             _client = client;
             _animalKind = animalKind;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ArgumentDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ArgumentDefinition.cs
@@ -20,7 +20,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private const string AssertNotNullMethodName = "AssertNotNull";
         private const string AssertNotNullOrEmptyMethodName = "AssertNotNullOrEmpty";
-        private const string AssertNotNullOrWhiteSpaceMethodName = "AssertNotNullOrWhiteSpace";
 
         private readonly CSharpType _t = typeof(Template<>).GetGenericArguments()[0];
         private readonly ParameterProvider _nameParam = new ParameterProvider("name", $"The name.", typeof(string));
@@ -64,127 +63,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             [
                 BuildAssertNotNull(),
                 BuildAssertNotNullStruct(),
-                BuildAssertNotNullOrEmptyCollection(),
                 BuildAssertNotNullOrEmptyString(),
-                BuildAssertNotNullOrWhiteSpace(),
-                BuildAssertNotDefault(),
-                BuildAssertInRange(),
-                BuildAssertEnumDefined(),
-                BuildCheckNotNull(),
-                BuildCheckNotNullOrEmptyString(),
-                BuildAssertNull(),
             ];
-        }
-
-        private MethodProvider BuildAssertNull()
-        {
-            var value = new ParameterProvider("value", $"The value.", _t);
-            var message = new ParameterProvider("message", $"The message.", typeof(string), DefaultOf(new CSharpType(typeof(string), true)));
-            var signature = GetSignature("AssertNull", [value, _nameParam, message], [_t]);
-            return new MethodProvider(signature, new MethodBodyStatement[]
-            {
-                new IfStatement(value.NotEqual(Null))
-                {
-                    ThrowArgumentException(message.NullCoalesce(Literal("Value must be null.")))
-                }
-            },
-            this);
-        }
-
-        private MethodProvider BuildCheckNotNullOrEmptyString()
-        {
-            var value = new ParameterProvider("value", $"The value.", typeof(string));
-            var signature = GetSignature("CheckNotNullOrEmpty", [value, _nameParam], returnType: typeof(string));
-            return new MethodProvider(signature, new MethodBodyStatement[]
-            {
-                AssertNotNullOrEmpty(value, _nameParam),
-                Return(value)
-            },
-            this);
-        }
-
-        private MethodProvider BuildCheckNotNull()
-        {
-            var value = new ParameterProvider("value", $"The value.", _t);
-            var signature = GetSignature("CheckNotNull", [value, _nameParam], new[] { _t }, new[] { Where.Class(_t) }, _t);
-            return new MethodProvider(signature, new MethodBodyStatement[]
-            {
-                AssertNotNull(value, _nameParam),
-                Return(value)
-            },
-            this);
-        }
-
-        private MethodProvider BuildAssertEnumDefined()
-        {
-            var value = new ParameterProvider("value", $"The value.", typeof(object), null);
-            var enumType = new ParameterProvider("enumType", $"The enum value.", typeof(Type));
-            var signature = GetSignature("AssertEnumDefined", [enumType, value, _nameParam]);
-            return new MethodProvider(signature, new MethodBodyStatement[]
-            {
-                new IfStatement(Not(Static<Enum>().Invoke("IsDefined", [enumType, value])))
-                {
-                    ThrowArgumentException(new FormattableStringExpression("Value not defined for {0}.", [new MemberExpression(enumType, "FullName")]))
-                }
-            },
-            this);
-        }
-
-        private MethodProvider BuildAssertInRange()
-        {
-            var value = new ParameterProvider("value", $"The value.", _t);
-            var min = new ParameterProvider("minimum", $"The minimum value.", _t);
-            var max = new ParameterProvider("maximum", $"The maximum value.", _t);
-            var whereExpressions = new WhereExpression[] { Where.NotNull(_t).And(new CSharpType(typeof(IComparable<>), _t)) };
-            var signature = GetSignature("AssertInRange", new[] { value, min, max, _nameParam }, new[] { _t }, whereExpressions);
-            return new MethodProvider(signature, new MethodBodyStatement[]
-            {
-                new IfStatement(GetCompareToExpression(min, value).GreaterThan(Literal(0)))
-                {
-                    Throw(New.ArgumentOutOfRangeException(_nameParam, "Value is less than the minimum allowed.", false))
-                },
-                new IfStatement(GetCompareToExpression(max, value).LessThan(Literal(0)))
-                {
-                    Throw(New.ArgumentOutOfRangeException(_nameParam, "Value is greater than the maximum allowed.", false))
-                }
-            },
-            this);
-        }
-
-        private ValueExpression GetCompareToExpression(ValueExpression left, ValueExpression right)
-        {
-            return left.Invoke("CompareTo", right);
-        }
-
-        private MethodProvider BuildAssertNotDefault()
-        {
-            var value = new ParameterProvider("value", $"The value.", _t);
-            var valueParamWithRef = value.WithRef(); ;
-            var whereExpressions = new WhereExpression[] { Where.Struct(_t).And(new CSharpType(typeof(IEquatable<>), _t)) };
-            var signature = GetSignature("AssertNotDefault", [valueParamWithRef, _nameParam], [_t], whereExpressions);
-            return new MethodProvider(signature, new MethodBodyStatement[]
-            {
-                new IfStatement(value.Invoke("Equals", Default))
-                {
-                    ThrowArgumentException("Value cannot be empty.")
-                }
-            },
-            this);
-        }
-
-        private MethodProvider BuildAssertNotNullOrWhiteSpace()
-        {
-            var valueParam = new ParameterProvider("value", $"The value.", typeof(string));
-            var signature = GetSignature(AssertNotNullOrWhiteSpaceMethodName, [valueParam, _nameParam]);
-            return new MethodProvider(signature, new MethodBodyStatement[]
-            {
-                AssertNotNullSnippet(valueParam),
-                new IfStatement(StringSnippets.IsNullOrWhiteSpace(valueParam.As<string>()))
-                {
-                    ThrowArgumentException("Value cannot be empty or contain only white-space characters.")
-                }
-            },
-            this);
         }
 
         private MethodProvider BuildAssertNotNullOrEmptyString()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
@@ -15,8 +15,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public ConstructorSignature Signature { get; private set; }
         public MethodBodyStatement? BodyStatements { get; private set; }
         public ValueExpression? BodyExpression { get; private set; }
-        public XmlDocProvider? XmlDocs => _xmlDocs ??= MethodProviderHelpers.BuildXmlDocs(Signature);
-        private XmlDocProvider? _xmlDocs;
+        public XmlDocProvider XmlDocs { get; private set; }
 
         public TypeProvider EnclosingType { get; }
 
@@ -39,7 +38,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             Signature = signature;
             var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
-            _xmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
+            XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
         }
 
@@ -54,13 +53,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
         {
             Signature = signature;
             BodyExpression = bodyExpression;
-            _xmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
+            XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
-        }
-
-        private XmlDocProvider BuildXmlDocs()
-        {
-            return MethodProviderHelpers.BuildXmlDocs(Signature);
         }
 
         public void Update(
@@ -73,7 +67,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 Signature = signature;
                 // rebuild the XML docs if the signature changed
-                _xmlDocs = BuildXmlDocs();
+                XmlDocs = MethodProviderHelpers.BuildXmlDocs(signature);
             }
             if (bodyExpression != null)
             {
@@ -87,7 +81,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
             if (xmlDocs != null)
             {
-                _xmlDocs = xmlDocs;
+                XmlDocs = xmlDocs;
             }
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public ConstructorSignature Signature { get; private set; }
         public MethodBodyStatement? BodyStatements { get; private set; }
         public ValueExpression? BodyExpression { get; private set; }
-        public XmlDocProvider? XmlDocs => _xmlDocs ??= BuildXmlDocs();
+        public XmlDocProvider? XmlDocs => _xmlDocs ??= MethodProviderHelpers.BuildXmlDocs(Signature);
         private XmlDocProvider? _xmlDocs;
 
         public TypeProvider EnclosingType { get; }
@@ -37,10 +37,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public ConstructorProvider(ConstructorSignature signature, MethodBodyStatement bodyStatements, TypeProvider enclosingType, XmlDocProvider? xmlDocProvider = default)
         {
             Signature = signature;
-            bool skipParamValidation = !signature.Modifiers.HasFlag(MethodSignatureModifiers.Public);
-            var paramHash = MethodProviderHelpers.GetParamHash(signature.Parameters, skipParamValidation);
+            var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
-            _xmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature.Parameters, signature.Description, null, paramHash);
+            _xmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
         }
 
@@ -55,21 +54,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
         {
             Signature = signature;
             BodyExpression = bodyExpression;
-            _xmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature.Parameters, signature.Description, null, null);
+            _xmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
         }
 
-        private XmlDocProvider? BuildXmlDocs()
+        private XmlDocProvider BuildXmlDocs()
         {
-            return MethodProviderHelpers.BuildXmlDocs(
-                Signature.Parameters,
-                Signature.Description,
-                null,
-                BodyStatements != null ?
-                    MethodProviderHelpers.GetParamHash(
-                        Signature.Parameters,
-                        !Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)) :
-                    null);
+            return MethodProviderHelpers.BuildXmlDocs(Signature);
         }
 
         public void Update(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
@@ -16,8 +16,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public MethodBodyStatement? BodyStatements { get; private set;}
         public ValueExpression? BodyExpression { get; private set;}
 
-        public XmlDocProvider? XmlDocs => _xmlDocs ??= BuildXmlDocs();
-        private XmlDocProvider? _xmlDocs;
+        public XmlDocProvider XmlDocs { get; private set; }
 
         public TypeProvider EnclosingType { get; }
 
@@ -40,7 +39,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             Signature = signature;
             var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
-            _xmlDocs = xmlDocProvider;
+            XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
         }
 
@@ -55,13 +54,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
         {
             Signature = signature;
             BodyExpression = bodyExpression;
-            _xmlDocs = xmlDocProvider;
+            XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
-        }
-
-        private XmlDocProvider BuildXmlDocs()
-        {
-            return MethodProviderHelpers.BuildXmlDocs(Signature);
         }
 
         public void Update(
@@ -74,7 +68,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 Signature = signature;
                 // rebuild the XML docs if the signature changes
-                _xmlDocs = BuildXmlDocs();
+                XmlDocs = MethodProviderHelpers.BuildXmlDocs(Signature);
             }
             if (bodyStatements != null)
             {
@@ -88,7 +82,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
             if (xmlDocProvider != null)
             {
-                _xmlDocs = xmlDocProvider;
+                XmlDocs = xmlDocProvider;
             }
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
@@ -38,8 +38,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public MethodProvider(MethodSignature signature, MethodBodyStatement bodyStatements, TypeProvider enclosingType, XmlDocProvider? xmlDocProvider = default)
         {
             Signature = signature;
-            bool skipParamValidation = !signature.Modifiers.HasFlag(MethodSignatureModifiers.Public);
-            var paramHash = MethodProviderHelpers.GetParamHash(signature.Parameters, skipParamValidation);
+            var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
             _xmlDocs = xmlDocProvider;
             EnclosingType = enclosingType;
@@ -60,17 +59,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
             EnclosingType = enclosingType;
         }
 
-        private XmlDocProvider? BuildXmlDocs()
+        private XmlDocProvider BuildXmlDocs()
         {
-            return MethodProviderHelpers.BuildXmlDocs(
-                Signature.Parameters,
-                Signature.Description,
-                Signature.ReturnDescription,
-                BodyStatements != null ?
-                    MethodProviderHelpers.GetParamHash(
-                        Signature.Parameters,
-                        !Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)) :
-                    null);
+            return MethodProviderHelpers.BuildXmlDocs(Signature);
         }
 
         public void Update(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -62,8 +62,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 DefaultValue = Snippet.Default;
             }
             Type = type;
-            Validation = inputParameter.IsRequired && !Type.IsValueType && !Type.IsNullable
-                ? ParameterValidationType.AssertNotNull
+            Validation = inputParameter.IsRequired && Type is { IsValueType: false, IsNullable: false }
+                ? inputParameter.Type is InputPrimitiveType { Kind: InputPrimitiveTypeKind.String } ?
+                    ParameterValidationType.AssertNotNullOrEmpty :
+                    ParameterValidationType.AssertNotNull
                 : ParameterValidationType.None;
             WireInfo = new WireInformation(CodeModelGenerator.Instance.TypeFactory.GetSerializationFormat(inputParameter.Type), inputParameter.NameInRequest);
             Location = inputParameter.Location.ToParameterLocation();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocExceptionStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocExceptionStatement.cs
@@ -17,11 +17,11 @@ namespace Microsoft.TypeSpec.Generator.Statements
 
         private string _reason;
 
-        public XmlDocExceptionStatement(ParameterValidationType validationType, IReadOnlyList<ParameterProvider> parameters)
+        public XmlDocExceptionStatement(Type exceptionType, IReadOnlyList<ParameterProvider> parameters)
         {
-            ExceptionType = GetExceptionType(validationType);
+            ExceptionType = exceptionType;
             Parameters = parameters;
-            _reason = GetText(validationType);
+            _reason = GetText(exceptionType);
         }
 
         public XmlDocExceptionStatement(Type exceptionType, string reason, IReadOnlyList<ParameterProvider> parameters)
@@ -31,18 +31,11 @@ namespace Microsoft.TypeSpec.Generator.Statements
             _reason = reason;
         }
 
-        private static Type GetExceptionType(ParameterValidationType validationType) => validationType switch
+        private static string GetText(Type exceptionType) => exceptionType switch
         {
-            ParameterValidationType.AssertNotNull => typeof(ArgumentNullException),
-            ParameterValidationType.AssertNotNullOrEmpty => typeof(ArgumentException),
-            _ => throw new ArgumentOutOfRangeException(nameof(validationType), validationType, $"Cannot create an XmlDocExceptionStatement with {validationType} validationType")
-        };
-
-        private static string GetText(ParameterValidationType validationType) => validationType switch
-        {
-            ParameterValidationType.AssertNotNull => "is null.",
-            ParameterValidationType.AssertNotNullOrEmpty => "is an empty string, and was expected to be non-empty.",
-            _ => throw new ArgumentOutOfRangeException(nameof(validationType), validationType, $"Cannot create an XmlDocExceptionStatement with {validationType} validationType")
+            { } when exceptionType == typeof(ArgumentNullException) => "is null.",
+            { } when exceptionType == typeof(ArgumentException) => "is an empty string, and was expected to be non-empty.",
+            _ => throw new ArgumentOutOfRangeException(nameof(exceptionType), exceptionType, $"Cannot create an XmlDocExceptionStatement with {exceptionType} exceptionType")
         };
 
         internal override void Write(CodeWriter writer)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocExceptionStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocExceptionStatement.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
 
@@ -15,7 +14,7 @@ namespace Microsoft.TypeSpec.Generator.Statements
         public Type ExceptionType { get; }
         public IReadOnlyList<ParameterProvider> Parameters { get; }
 
-        private string _reason;
+        private readonly string _reason;
 
         public XmlDocExceptionStatement(Type exceptionType, IReadOnlyList<ParameterProvider> parameters)
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/MethodProviderHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/MethodProviderHelpers.cs
@@ -85,7 +85,7 @@ namespace Microsoft.TypeSpec.Generator
                     else if (parameter.Validation == ParameterValidationType.AssertNotNullOrEmpty)
                     {
                         AddArgumentNullException(parameter);
-                        AddArgumenException(parameter);
+                        AddArgumentException(parameter);
                     }
                 }
             }
@@ -115,7 +115,7 @@ namespace Microsoft.TypeSpec.Generator
 
                 exceptionHash[typeof(ArgumentNullException)].Add(parameter);
             }
-            void AddArgumenException(ParameterProvider parameter)
+            void AddArgumentException(ParameterProvider parameter)
             {
                 if (!exceptionHash.ContainsKey(typeof(ArgumentException)))
                 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/MethodProviderHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/MethodProviderHelpers.cs
@@ -12,13 +12,13 @@ namespace Microsoft.TypeSpec.Generator
 {
     internal static class MethodProviderHelpers
     {
-        public static Dictionary<ParameterValidationType, List<ParameterProvider>>? GetParamHash(IEnumerable<ParameterProvider> parameters, bool skipParamValidation)
+        public static Dictionary<ParameterValidationType, List<ParameterProvider>>? GetParamHash(MethodSignatureBase signature)
         {
             Dictionary<ParameterValidationType, List<ParameterProvider>>? paramHash = null;
-            if (!skipParamValidation)
+            if (!ShouldSkipParameterValidation(signature))
             {
                 paramHash = new();
-                foreach (var parameter in parameters)
+                foreach (var parameter in signature.Parameters)
                 {
                     if (parameter.Validation == ParameterValidationType.None)
                         continue;
@@ -65,30 +65,71 @@ namespace Microsoft.TypeSpec.Generator
             return statements;
         }
 
-        public static XmlDocProvider? BuildXmlDocs(IEnumerable<ParameterProvider> parameters, FormattableString? description, FormattableString? returnDescription, Dictionary<ParameterValidationType, List<ParameterProvider>>? paramHash)
+        public static XmlDocProvider BuildXmlDocs(MethodSignatureBase signature)
         {
             var parametersList = new List<XmlDocParamStatement>();
-            foreach (var parameter in parameters)
+            foreach (var parameter in signature.Parameters)
             {
                 parametersList.Add(new XmlDocParamStatement(parameter));
             }
 
-            var exceptions = new List<XmlDocExceptionStatement>();
-            if (paramHash is not null)
+            var exceptionHash = new Dictionary<Type, List<ParameterProvider>>();
+            if (!ShouldSkipParameterValidation(signature))
             {
-                foreach (var kvp in paramHash)
+                foreach (var parameter in signature.Parameters)
                 {
-                    exceptions.Add(new XmlDocExceptionStatement(kvp.Key, kvp.Value));
+                    if (parameter.Validation == ParameterValidationType.AssertNotNull)
+                    {
+                        AddArgumentNullException(parameter);
+                    }
+                    else if (parameter.Validation == ParameterValidationType.AssertNotNullOrEmpty)
+                    {
+                        AddArgumentNullException(parameter);
+                        AddArgumenException(parameter);
+                    }
                 }
             }
 
+            var exceptions = new List<XmlDocExceptionStatement>();
+            foreach (var kvp in exceptionHash)
+            {
+                exceptions.Add(new XmlDocExceptionStatement(kvp.Key, kvp.Value));
+            }
+
+            var returnDescription = (signature as MethodSignature)?.ReturnDescription;
+
             var docs = new XmlDocProvider(
-                description is null ? null : new XmlDocSummaryStatement([description]),
+                signature.Description is null ? null : new XmlDocSummaryStatement([signature.Description]),
                 parametersList,
                 exceptions,
                 returnDescription is null ? null : new XmlDocReturnsStatement(returnDescription));
 
             return docs;
+
+            void AddArgumentNullException(ParameterProvider parameter)
+            {
+                if (!exceptionHash.ContainsKey(typeof(ArgumentNullException)))
+                {
+                    exceptionHash[typeof(ArgumentNullException)] = [];
+                }
+
+                exceptionHash[typeof(ArgumentNullException)].Add(parameter);
+            }
+            void AddArgumenException(ParameterProvider parameter)
+            {
+                if (!exceptionHash.ContainsKey(typeof(ArgumentException)))
+                {
+                    exceptionHash[typeof(ArgumentException)] = [];
+                }
+
+                exceptionHash[typeof(ArgumentException)].Add(parameter);
+            }
+        }
+
+        private static bool ShouldSkipParameterValidation(MethodSignatureBase signature)
+        {
+            // Skip parameter validation for private methods, as they are not exposed to the public API.
+            return !signature.Modifiers.HasFlag(MethodSignatureModifiers.Public);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ArgumentTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ArgumentTests.cs
@@ -40,26 +40,6 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         }
 
         [Test]
-        public void NotNullOrEmptyCollection()
-        {
-            string[] value = { "test" };
-            Argument.AssertNotNullOrEmpty(value, "value");
-        }
-
-        [Test]
-        public void NotNullOrEmptyCollectionThrowsOnNull()
-        {
-            string[]? value = null;
-            Assert.Throws<ArgumentNullException>(() => Argument.AssertNotNullOrEmpty(value, "value"));
-        }
-
-        [TestCaseSource(nameof(GetNotNullOrEmptyCollectionThrowsOnEmptyCollectionData))]
-        public void NotNullOrEmptyCollectionThrowsOnEmptyCollection(IEnumerable<string>? value)
-        {
-            Assert.Throws<ArgumentException>(() => Argument.AssertNotNullOrEmpty(value, "value"));
-        }
-
-        [Test]
         public void NotNullOrEmptyString()
         {
             string value = "test";
@@ -77,91 +57,6 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         public void NotNullOrEmptyStringThrowsOnEmpty()
         {
             Assert.Throws<ArgumentException>(() => Argument.AssertNotNullOrEmpty(string.Empty, "value"));
-        }
-
-        [Test]
-        public void NotNullOrWhiteSpace()
-        {
-            string value = "test";
-            Argument.AssertNotNullOrWhiteSpace(value, "value");
-        }
-
-        [Test]
-        public void NotNullOrWhiteSpaceThrowsOnNull()
-        {
-            Assert.Throws<ArgumentNullException>(() => Argument.AssertNotNullOrWhiteSpace(null, "value"));
-        }
-
-        [Test]
-        public void NotNullOrWhiteSpaceThrowsOnEmpty()
-        {
-            Assert.Throws<ArgumentException>(() => Argument.AssertNotNullOrWhiteSpace(string.Empty, "value"));
-        }
-
-        [Test]
-        public void NotNullOrWhiteSpaceThrowsOnWhiteSpace()
-        {
-            Assert.Throws<ArgumentException>(() => Argument.AssertNotNullOrWhiteSpace(string.Empty, " "));
-        }
-
-        [Test]
-        public void NotDefault()
-        {
-            TestStructure value = new TestStructure("test", 1);
-            Argument.AssertNotDefault(ref value, "value");
-        }
-
-        [Test]
-        public void NotDefaultThrows()
-        {
-            TestStructure value = default;
-            Assert.Throws<ArgumentException>(() => Argument.AssertNotDefault(ref value, "value"));
-        }
-
-        [TestCase(0, 0, 2)]
-        [TestCase(1, 0, 2)]
-        [TestCase(2, 0, 2)]
-        public void InRangeInt32(int value, int minimum, int maximum)
-        {
-            Argument.AssertInRange(value, minimum, maximum, "value");
-        }
-
-        [TestCase(-1, 0, 2)]
-        [TestCase(3, 0, 2)]
-        public void InRangeInt32Throws(int value, int minimum, int maximum)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Argument.AssertInRange(value, minimum, maximum, "value"));
-        }
-
-        [Test]
-        public void CheckNotNull()
-        {
-            var value = "test";
-            var checkedValue = Argument.CheckNotNull(value, "value");
-
-            Assert.AreEqual(value, checkedValue);
-        }
-
-        [Test]
-        public void CheckNotNullOrEmptyString()
-        {
-            string value = "test";
-            var checkedValue = Argument.CheckNotNullOrEmpty(value, "value");
-
-            Assert.AreEqual(value, checkedValue);
-        }
-
-        [Test]
-        public void CheckNotNullOrEmptyStringThrowsOnNull()
-        {
-            string? value = null;
-            Assert.Throws<ArgumentNullException>(() => Argument.CheckNotNullOrEmpty(value, "value"));
-        }
-
-        [Test]
-        public void CheckNotNullOrEmptyStringThrowsOnEmpty()
-        {
-            Assert.Throws<ArgumentException>(() => Argument.CheckNotNullOrEmpty(string.Empty, "value"));
         }
 
         private readonly struct TestStructure : IEquatable<TestStructure>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/MethodProviderHelpersTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/MethodProviderHelpersTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Providers
+{
+    public class MethodProviderHelpersTests
+    {
+        [Test]
+        public void BuildXmlDocsAddsCorrectExceptions()
+        {
+            var method = new MethodSignature(
+                "Test",
+                $"some description",
+                MethodSignatureModifiers.Public,
+                null,
+                $"return desccription",
+                [
+                    new ParameterProvider("param1", $"description for param1", typeof(string), validation: ParameterValidationType.AssertNotNullOrEmpty),
+                    new ParameterProvider("param2", $"description for param2", typeof(int?), validation: ParameterValidationType.AssertNotNull)
+                ]);
+
+            var xmlDocs = MethodProviderHelpers.BuildXmlDocs(method);
+
+            Assert.AreEqual(2, xmlDocs.Exceptions.Count);
+            Assert.AreEqual(
+                "/// <exception cref=\"global::System.ArgumentNullException\"> <paramref name=\"param1\"/> or <paramref name=\"param2\"/> is null. </exception>\n",
+                xmlDocs.Exceptions[0].ToDisplayString());
+            Assert.AreEqual(
+                "/// <exception cref=\"global::System.ArgumentException\"> <paramref name=\"param1\"/> is an empty string, and was expected to be non-empty. </exception>\n",
+                xmlDocs.Exceptions[1].ToDisplayString());
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ParameterProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ParameterProviderTests.cs
@@ -161,16 +161,16 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.IsTrue(invokeExpression.TypeArguments![0].Equals(typeof(string)));
         }
 
-        [TestCase(InputPrimitiveTypeKind.String, ParameterValidationType.AssertNotNullOrEmpty, true)]
-        [TestCase(InputPrimitiveTypeKind.String, ParameterValidationType.None, false)]
-        [TestCase(InputPrimitiveTypeKind.Int32, ParameterValidationType.None, true)]
-        [TestCase(InputPrimitiveTypeKind.Int32, ParameterValidationType.None, false)]
-        [TestCase(InputPrimitiveTypeKind.Url, ParameterValidationType.AssertNotNull, true)]
-        [TestCase(InputPrimitiveTypeKind.Url, ParameterValidationType.None, false)]
+        [TestCase(InputPrimitiveTypeKind.String, true, ParameterValidationType.AssertNotNullOrEmpty)]
+        [TestCase(InputPrimitiveTypeKind.String, false, ParameterValidationType.None)]
+        [TestCase(InputPrimitiveTypeKind.Int32, true, ParameterValidationType.None)]
+        [TestCase(InputPrimitiveTypeKind.Int32, false, ParameterValidationType.None)]
+        [TestCase(InputPrimitiveTypeKind.Url, true, ParameterValidationType.AssertNotNull)]
+        [TestCase(InputPrimitiveTypeKind.Url, false, ParameterValidationType.None)]
         public void CorrectValidationIsAppliedToParameter(
             InputPrimitiveTypeKind primitiveType,
-            ParameterValidationType expectedValidation,
-            bool isRequired)
+            bool isRequired,
+            ParameterValidationType expectedValidation)
         {
             MockHelpers.LoadMockGenerator();
             var inputTypeInstance = InputFactory.Parameter("testParam", new InputPrimitiveType(primitiveType, "foo", "bar"), isRequired: isRequired);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ParameterProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ParameterProviderTests.cs
@@ -160,5 +160,24 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.IsNotNull(invokeExpression.TypeArguments);
             Assert.IsTrue(invokeExpression.TypeArguments![0].Equals(typeof(string)));
         }
+
+        [TestCase(InputPrimitiveTypeKind.String, ParameterValidationType.AssertNotNullOrEmpty, true)]
+        [TestCase(InputPrimitiveTypeKind.String, ParameterValidationType.None, false)]
+        [TestCase(InputPrimitiveTypeKind.Int32, ParameterValidationType.None, true)]
+        [TestCase(InputPrimitiveTypeKind.Int32, ParameterValidationType.None, false)]
+        [TestCase(InputPrimitiveTypeKind.Url, ParameterValidationType.AssertNotNull, true)]
+        [TestCase(InputPrimitiveTypeKind.Url, ParameterValidationType.None, false)]
+        public void CorrectValidationIsAppliedToParameter(
+            InputPrimitiveTypeKind primitiveType,
+            ParameterValidationType expectedValidation,
+            bool isRequired)
+        {
+            MockHelpers.LoadMockGenerator();
+            var inputTypeInstance = InputFactory.Parameter("testParam", new InputPrimitiveType(primitiveType, "foo", "bar"), isRequired: isRequired);
+            var parameter = CodeModelGenerator.Instance.TypeFactory.CreateParameter(inputTypeInstance);
+
+            Assert.IsNotNull(parameter);
+            Assert.AreEqual(expectedValidation, parameter!.Validation);
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/MethodProviderHelpersTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/MethodProviderHelpersTests.cs
@@ -5,7 +5,7 @@ using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using NUnit.Framework;
 
-namespace Microsoft.TypeSpec.Generator.Tests.Providers
+namespace Microsoft.TypeSpec.Generator.Tests.Utilities
 {
     public class MethodProviderHelpersTests
     {
@@ -17,7 +17,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
                 $"some description",
                 MethodSignatureModifiers.Public,
                 null,
-                $"return desccription",
+                $"return description",
                 [
                     new ParameterProvider("param1", $"description for param1", typeof(string), validation: ParameterValidationType.AssertNotNullOrEmpty),
                     new ParameterProvider("param2", $"description for param2", typeof(int?), validation: ParameterValidationType.AssertNotNull)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Internal/Argument.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Internal/Argument.cs
@@ -6,8 +6,6 @@
 #nullable disable
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace SampleTypeSpec
 {
@@ -36,29 +34,6 @@ namespace SampleTypeSpec
 
         /// <param name="value"> The value. </param>
         /// <param name="name"> The name. </param>
-        public static void AssertNotNullOrEmpty<T>(IEnumerable<T> value, string name)
-        {
-            if (value is null)
-            {
-                throw new ArgumentNullException(name);
-            }
-            if (value is ICollection<T> collectionOfT && collectionOfT.Count == 0)
-            {
-                throw new ArgumentException("Value cannot be an empty collection.", name);
-            }
-            if (value is ICollection collection && collection.Count == 0)
-            {
-                throw new ArgumentException("Value cannot be an empty collection.", name);
-            }
-            using IEnumerator<T> e = value.GetEnumerator();
-            if (!e.MoveNext())
-            {
-                throw new ArgumentException("Value cannot be an empty collection.", name);
-            }
-        }
-
-        /// <param name="value"> The value. </param>
-        /// <param name="name"> The name. </param>
         public static void AssertNotNullOrEmpty(string value, string name)
         {
             if (value is null)
@@ -68,87 +43,6 @@ namespace SampleTypeSpec
             if (value.Length == 0)
             {
                 throw new ArgumentException("Value cannot be an empty string.", name);
-            }
-        }
-
-        /// <param name="value"> The value. </param>
-        /// <param name="name"> The name. </param>
-        public static void AssertNotNullOrWhiteSpace(string value, string name)
-        {
-            if (value is null)
-            {
-                throw new ArgumentNullException(name);
-            }
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                throw new ArgumentException("Value cannot be empty or contain only white-space characters.", name);
-            }
-        }
-
-        /// <param name="value"> The value. </param>
-        /// <param name="name"> The name. </param>
-        public static void AssertNotDefault<T>(ref T value, string name)
-            where T : struct, IEquatable<T>
-        {
-            if (value.Equals(default))
-            {
-                throw new ArgumentException("Value cannot be empty.", name);
-            }
-        }
-
-        /// <param name="value"> The value. </param>
-        /// <param name="minimum"> The minimum value. </param>
-        /// <param name="maximum"> The maximum value. </param>
-        /// <param name="name"> The name. </param>
-        public static void AssertInRange<T>(T value, T minimum, T maximum, string name)
-            where T : notnull, IComparable<T>
-        {
-            if (minimum.CompareTo(value) > 0)
-            {
-                throw new ArgumentOutOfRangeException(name, "Value is less than the minimum allowed.");
-            }
-            if (maximum.CompareTo(value) < 0)
-            {
-                throw new ArgumentOutOfRangeException(name, "Value is greater than the maximum allowed.");
-            }
-        }
-
-        /// <param name="enumType"> The enum value. </param>
-        /// <param name="value"> The value. </param>
-        /// <param name="name"> The name. </param>
-        public static void AssertEnumDefined(Type enumType, object value, string name)
-        {
-            if (!Enum.IsDefined(enumType, value))
-            {
-                throw new ArgumentException($"Value not defined for {enumType.FullName}.", name);
-            }
-        }
-
-        /// <param name="value"> The value. </param>
-        /// <param name="name"> The name. </param>
-        public static T CheckNotNull<T>(T value, string name)
-            where T : class
-        {
-            AssertNotNull(value, name);
-            return value;
-        }
-
-        /// <param name="value"> The value. </param>
-        /// <param name="name"> The name. </param>
-        public static string CheckNotNullOrEmpty(string value, string name)
-        {
-            AssertNotNullOrEmpty(value, name);
-            return value;
-        }
-
-        /// <param name="value"> The value. </param>
-        /// <param name="name"> The name. </param>
-        /// <param name="message"> The message. </param>
-        public static void AssertNull<T>(T value, string name, string message = null)
-        {
-            if (value != null)
-            {
-                throw new ArgumentException(message ?? "Value must be null.", name);
             }
         }
     }

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
@@ -72,12 +72,13 @@ namespace SampleTypeSpec
         /// <param name="optionalQuery"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual ClientResult SayHi(string headParameter, string queryParameter, string optionalQuery, RequestOptions options)
         {
-            Argument.AssertNotNull(headParameter, nameof(headParameter));
-            Argument.AssertNotNull(queryParameter, nameof(queryParameter));
+            Argument.AssertNotNullOrEmpty(headParameter, nameof(headParameter));
+            Argument.AssertNotNullOrEmpty(queryParameter, nameof(queryParameter));
 
             using PipelineMessage message = CreateSayHiRequest(headParameter, queryParameter, optionalQuery, options);
             return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
@@ -96,12 +97,13 @@ namespace SampleTypeSpec
         /// <param name="optionalQuery"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<ClientResult> SayHiAsync(string headParameter, string queryParameter, string optionalQuery, RequestOptions options)
         {
-            Argument.AssertNotNull(headParameter, nameof(headParameter));
-            Argument.AssertNotNull(queryParameter, nameof(queryParameter));
+            Argument.AssertNotNullOrEmpty(headParameter, nameof(headParameter));
+            Argument.AssertNotNullOrEmpty(queryParameter, nameof(queryParameter));
 
             using PipelineMessage message = CreateSayHiRequest(headParameter, queryParameter, optionalQuery, options);
             return ClientResult.FromResponse(await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false));
@@ -113,11 +115,12 @@ namespace SampleTypeSpec
         /// <param name="optionalQuery"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult<Thing> SayHi(string headParameter, string queryParameter, string optionalQuery = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(headParameter, nameof(headParameter));
-            Argument.AssertNotNull(queryParameter, nameof(queryParameter));
+            Argument.AssertNotNullOrEmpty(headParameter, nameof(headParameter));
+            Argument.AssertNotNullOrEmpty(queryParameter, nameof(queryParameter));
 
             ClientResult result = SayHi(headParameter, queryParameter, optionalQuery, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
             return ClientResult.FromValue((Thing)result, result.GetRawResponse());
@@ -129,11 +132,12 @@ namespace SampleTypeSpec
         /// <param name="optionalQuery"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="headParameter"/> or <paramref name="queryParameter"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult<Thing>> SayHiAsync(string headParameter, string queryParameter, string optionalQuery = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(headParameter, nameof(headParameter));
-            Argument.AssertNotNull(queryParameter, nameof(queryParameter));
+            Argument.AssertNotNullOrEmpty(headParameter, nameof(headParameter));
+            Argument.AssertNotNullOrEmpty(queryParameter, nameof(queryParameter));
 
             ClientResult result = await SayHiAsync(headParameter, queryParameter, optionalQuery, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
             return ClientResult.FromValue((Thing)result, result.GetRawResponse());
@@ -152,12 +156,13 @@ namespace SampleTypeSpec
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p2"/>, <paramref name="p1"/> or <paramref name="content"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p2"/> or <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual ClientResult HelloAgain(string p2, string p1, BinaryContent content, RequestOptions options = null)
         {
-            Argument.AssertNotNull(p2, nameof(p2));
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p2, nameof(p2));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
             Argument.AssertNotNull(content, nameof(content));
 
             using PipelineMessage message = CreateHelloAgainRequest(p2, p1, content, options);
@@ -177,12 +182,13 @@ namespace SampleTypeSpec
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p2"/>, <paramref name="p1"/> or <paramref name="content"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p2"/> or <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<ClientResult> HelloAgainAsync(string p2, string p1, BinaryContent content, RequestOptions options = null)
         {
-            Argument.AssertNotNull(p2, nameof(p2));
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p2, nameof(p2));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
             Argument.AssertNotNull(content, nameof(content));
 
             using PipelineMessage message = CreateHelloAgainRequest(p2, p1, content, options);
@@ -195,11 +201,12 @@ namespace SampleTypeSpec
         /// <param name="action"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p2"/>, <paramref name="p1"/> or <paramref name="action"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p2"/> or <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult<RoundTripModel> HelloAgain(string p2, string p1, RoundTripModel action, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(p2, nameof(p2));
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p2, nameof(p2));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
             Argument.AssertNotNull(action, nameof(action));
 
             ClientResult result = HelloAgain(p2, p1, action, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
@@ -212,11 +219,12 @@ namespace SampleTypeSpec
         /// <param name="action"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p2"/>, <paramref name="p1"/> or <paramref name="action"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p2"/> or <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult<RoundTripModel>> HelloAgainAsync(string p2, string p1, RoundTripModel action, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(p2, nameof(p2));
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p2, nameof(p2));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
             Argument.AssertNotNull(action, nameof(action));
 
             ClientResult result = await HelloAgainAsync(p2, p1, action, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
@@ -236,12 +244,13 @@ namespace SampleTypeSpec
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p2"/>, <paramref name="p1"/> or <paramref name="content"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p2"/> or <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual ClientResult NoContentType(string p2, string p1, BinaryContent content, RequestOptions options = null)
         {
-            Argument.AssertNotNull(p2, nameof(p2));
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p2, nameof(p2));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
             Argument.AssertNotNull(content, nameof(content));
 
             using PipelineMessage message = CreateNoContentTypeRequest(p2, p1, content, options);
@@ -261,12 +270,13 @@ namespace SampleTypeSpec
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p2"/>, <paramref name="p1"/> or <paramref name="content"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p2"/> or <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<ClientResult> NoContentTypeAsync(string p2, string p1, BinaryContent content, RequestOptions options = null)
         {
-            Argument.AssertNotNull(p2, nameof(p2));
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p2, nameof(p2));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
             Argument.AssertNotNull(content, nameof(content));
 
             using PipelineMessage message = CreateNoContentTypeRequest(p2, p1, content, options);
@@ -637,13 +647,14 @@ namespace SampleTypeSpec
         /// <param name="optionalNullableList"> optional nullable collection. </param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/>, <paramref name="requiredUnion"/>, <paramref name="requiredLiteralString"/> or <paramref name="requiredBadDescription"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="name"/> or <paramref name="requiredBadDescription"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult<Thing> AnonymousBody(string name, BinaryData requiredUnion, string requiredLiteralString, string requiredNullableString, int requiredLiteralInt, float requiredLiteralFloat, bool requiredLiteralBool, string requiredBadDescription, IEnumerable<int> requiredNullableList, string optionalNullableString = default, string optionalLiteralString = default, int? optionalLiteralInt = default, float? optionalLiteralFloat = default, bool? optionalLiteralBool = default, IEnumerable<int> optionalNullableList = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
             Argument.AssertNotNull(requiredUnion, nameof(requiredUnion));
             Argument.AssertNotNull(requiredLiteralString, nameof(requiredLiteralString));
-            Argument.AssertNotNull(requiredBadDescription, nameof(requiredBadDescription));
+            Argument.AssertNotNullOrEmpty(requiredBadDescription, nameof(requiredBadDescription));
 
             Thing spreadModel = new Thing(
                 requiredUnion,
@@ -684,13 +695,14 @@ namespace SampleTypeSpec
         /// <param name="optionalNullableList"> optional nullable collection. </param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/>, <paramref name="requiredUnion"/>, <paramref name="requiredLiteralString"/> or <paramref name="requiredBadDescription"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="name"/> or <paramref name="requiredBadDescription"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult<Thing>> AnonymousBodyAsync(string name, BinaryData requiredUnion, string requiredLiteralString, string requiredNullableString, int requiredLiteralInt, float requiredLiteralFloat, bool requiredLiteralBool, string requiredBadDescription, IEnumerable<int> requiredNullableList, string optionalNullableString = default, string optionalLiteralString = default, int? optionalLiteralInt = default, float? optionalLiteralFloat = default, bool? optionalLiteralBool = default, IEnumerable<int> optionalNullableList = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
             Argument.AssertNotNull(requiredUnion, nameof(requiredUnion));
             Argument.AssertNotNull(requiredLiteralString, nameof(requiredLiteralString));
-            Argument.AssertNotNull(requiredBadDescription, nameof(requiredBadDescription));
+            Argument.AssertNotNullOrEmpty(requiredBadDescription, nameof(requiredBadDescription));
 
             Thing spreadModel = new Thing(
                 requiredUnion,
@@ -759,10 +771,11 @@ namespace SampleTypeSpec
         /// <param name="name"> name of the NotFriend. </param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="name"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult<Friend> FriendlyModel(string name, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
 
             Friend spreadModel = new Friend(name, null);
             ClientResult result = FriendlyModel(spreadModel, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
@@ -773,10 +786,11 @@ namespace SampleTypeSpec
         /// <param name="name"> name of the NotFriend. </param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="name"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult<Friend>> FriendlyModelAsync(string name, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
 
             Friend spreadModel = new Friend(name, null);
             ClientResult result = await FriendlyModelAsync(spreadModel, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
@@ -879,10 +893,11 @@ namespace SampleTypeSpec
         /// <param name="name"> name of the ModelWithClientName. </param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="name"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult<RenamedModelCustom> ProjectedNameModel(string name, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
 
             RenamedModelCustom spreadModel = new RenamedModelCustom(name, null);
             ClientResult result = ProjectedNameModel(spreadModel, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
@@ -893,10 +908,11 @@ namespace SampleTypeSpec
         /// <param name="name"> name of the ModelWithClientName. </param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="name"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult<RenamedModelCustom>> ProjectedNameModelAsync(string name, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
 
             RenamedModelCustom spreadModel = new RenamedModelCustom(name, null);
             ClientResult result = await ProjectedNameModelAsync(spreadModel, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
@@ -966,11 +982,12 @@ namespace SampleTypeSpec
         /// <param name="accept"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="accept"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="accept"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual ClientResult GetUnknownValue(string accept, RequestOptions options)
         {
-            Argument.AssertNotNull(accept, nameof(accept));
+            Argument.AssertNotNullOrEmpty(accept, nameof(accept));
 
             using PipelineMessage message = CreateGetUnknownValueRequest(accept, options);
             return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
@@ -987,11 +1004,12 @@ namespace SampleTypeSpec
         /// <param name="accept"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="accept"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="accept"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<ClientResult> GetUnknownValueAsync(string accept, RequestOptions options)
         {
-            Argument.AssertNotNull(accept, nameof(accept));
+            Argument.AssertNotNullOrEmpty(accept, nameof(accept));
 
             using PipelineMessage message = CreateGetUnknownValueRequest(accept, options);
             return ClientResult.FromResponse(await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false));
@@ -1001,10 +1019,11 @@ namespace SampleTypeSpec
         /// <param name="accept"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="accept"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="accept"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult<string> GetUnknownValue(string accept, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(accept, nameof(accept));
+            Argument.AssertNotNullOrEmpty(accept, nameof(accept));
 
             ClientResult result = GetUnknownValue(accept, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
             return ClientResult.FromValue(result.GetRawResponse().Content.ToString(), result.GetRawResponse());
@@ -1014,10 +1033,11 @@ namespace SampleTypeSpec
         /// <param name="accept"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="accept"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="accept"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult<string>> GetUnknownValueAsync(string accept, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(accept, nameof(accept));
+            Argument.AssertNotNullOrEmpty(accept, nameof(accept));
 
             ClientResult result = await GetUnknownValueAsync(accept, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
             return ClientResult.FromValue(result.GetRawResponse().Content.ToString(), result.GetRawResponse());
@@ -1152,11 +1172,12 @@ namespace SampleTypeSpec
         /// <param name="id"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="id"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="id"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual ClientResult HeadAsBoolean(string id, RequestOptions options)
         {
-            Argument.AssertNotNull(id, nameof(id));
+            Argument.AssertNotNullOrEmpty(id, nameof(id));
 
             using PipelineMessage message = CreateHeadAsBooleanRequest(id, options);
             return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
@@ -1173,11 +1194,12 @@ namespace SampleTypeSpec
         /// <param name="id"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="id"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="id"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<ClientResult> HeadAsBooleanAsync(string id, RequestOptions options)
         {
-            Argument.AssertNotNull(id, nameof(id));
+            Argument.AssertNotNullOrEmpty(id, nameof(id));
 
             using PipelineMessage message = CreateHeadAsBooleanRequest(id, options);
             return ClientResult.FromResponse(await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false));
@@ -1187,10 +1209,11 @@ namespace SampleTypeSpec
         /// <param name="id"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="id"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="id"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult HeadAsBoolean(string id, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(id, nameof(id));
+            Argument.AssertNotNullOrEmpty(id, nameof(id));
 
             return HeadAsBoolean(id, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
         }
@@ -1199,10 +1222,11 @@ namespace SampleTypeSpec
         /// <param name="id"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="id"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="id"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult> HeadAsBooleanAsync(string id, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(id, nameof(id));
+            Argument.AssertNotNullOrEmpty(id, nameof(id));
 
             return await HeadAsBooleanAsync(id, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
         }
@@ -1218,11 +1242,12 @@ namespace SampleTypeSpec
         /// <param name="p1"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p1"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual ClientResult WithApiVersion(string p1, RequestOptions options)
         {
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
 
             using PipelineMessage message = CreateWithApiVersionRequest(p1, options);
             return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
@@ -1239,11 +1264,12 @@ namespace SampleTypeSpec
         /// <param name="p1"></param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p1"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<ClientResult> WithApiVersionAsync(string p1, RequestOptions options)
         {
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
 
             using PipelineMessage message = CreateWithApiVersionRequest(p1, options);
             return ClientResult.FromResponse(await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false));
@@ -1253,10 +1279,11 @@ namespace SampleTypeSpec
         /// <param name="p1"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p1"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual ClientResult WithApiVersion(string p1, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
 
             return WithApiVersion(p1, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
         }
@@ -1265,10 +1292,11 @@ namespace SampleTypeSpec
         /// <param name="p1"></param>
         /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="p1"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="p1"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         public virtual async Task<ClientResult> WithApiVersionAsync(string p1, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(p1, nameof(p1));
+            Argument.AssertNotNullOrEmpty(p1, nameof(p1));
 
             return await WithApiVersionAsync(p1, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
         }
@@ -1488,12 +1516,13 @@ namespace SampleTypeSpec
         /// <param name="optionalQuery"> optional query parameter. </param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="requiredHeader"/>, <paramref name="requiredQuery"/> or <paramref name="content"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="requiredHeader"/> or <paramref name="requiredQuery"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual ClientResult EmbeddedParameters(string requiredHeader, string requiredQuery, BinaryContent content, string optionalHeader = default, string optionalQuery = default, RequestOptions options = null)
         {
-            Argument.AssertNotNull(requiredHeader, nameof(requiredHeader));
-            Argument.AssertNotNull(requiredQuery, nameof(requiredQuery));
+            Argument.AssertNotNullOrEmpty(requiredHeader, nameof(requiredHeader));
+            Argument.AssertNotNullOrEmpty(requiredQuery, nameof(requiredQuery));
             Argument.AssertNotNull(content, nameof(content));
 
             using PipelineMessage message = CreateEmbeddedParametersRequest(requiredHeader, requiredQuery, content, optionalHeader, optionalQuery, options);
@@ -1515,12 +1544,13 @@ namespace SampleTypeSpec
         /// <param name="optionalQuery"> optional query parameter. </param>
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="requiredHeader"/>, <paramref name="requiredQuery"/> or <paramref name="content"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="requiredHeader"/> or <paramref name="requiredQuery"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<ClientResult> EmbeddedParametersAsync(string requiredHeader, string requiredQuery, BinaryContent content, string optionalHeader = default, string optionalQuery = default, RequestOptions options = null)
         {
-            Argument.AssertNotNull(requiredHeader, nameof(requiredHeader));
-            Argument.AssertNotNull(requiredQuery, nameof(requiredQuery));
+            Argument.AssertNotNullOrEmpty(requiredHeader, nameof(requiredHeader));
+            Argument.AssertNotNullOrEmpty(requiredQuery, nameof(requiredQuery));
             Argument.AssertNotNull(content, nameof(content));
 
             using PipelineMessage message = CreateEmbeddedParametersRequest(requiredHeader, requiredQuery, content, optionalHeader, optionalQuery, options);


### PR DESCRIPTION
Required strings should use Argument.AssertNotNullOrEmpty.
Also removes a bunch of unused generated argument methods.