### PR TITLE
Templates skip lib check

### DIFF
--- a/.chronus/changes/template-skip-lib-check-2025-5-10-16-43-45.md
+++ b/.chronus/changes/template-skip-lib-check-2025-5-10-16-43-45.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+
+Templates skip lib check

--- a/packages/compiler/templates/__snapshots__/emitter-ts/tsconfig.json
+++ b/packages/compiler/templates/__snapshots__/emitter-ts/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
+    "skipLibCheck": true,
 
     /* Linting */
     "strict": true

--- a/packages/compiler/templates/__snapshots__/library-ts/tsconfig.json
+++ b/packages/compiler/templates/__snapshots__/library-ts/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
+    "skipLibCheck": true,
 
     /* Linting */
     "strict": true

--- a/packages/compiler/templates/emitter-ts/tsconfig.json
+++ b/packages/compiler/templates/emitter-ts/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
+    "skipLibCheck": true,
 
     /* Linting */
     "strict": true

--- a/packages/compiler/templates/library-ts/tsconfig.json
+++ b/packages/compiler/templates/library-ts/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
+    "skipLibCheck": true,
 
     /* Linting */
     "strict": true


### PR DESCRIPTION
Some failure is currently blocking CI 


```
packages/compiler test:e2e: node_modules/vscode-jsonrpc/lib/common/linkedMap.d.ts(28,5): error TS2416: Property 'forEach' in type 'LinkedMap<K, V>' is not assignable to the same property in base type 'Map<K, V>'.
packages/compiler test:e2e:   Type '(callbackfn: (value: V, key: K, map: LinkedMap<K, V>) => void, thisArg?: any) => void' is not assignable to type '(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any) => void'.
packages/compiler test:e2e:     Types of parameters 'callbackfn' and 'callbackfn' are incompatible.
packages/compiler test:e2e:       Types of parameters 'map' and 'map' are incompatible.
packages/compiler test:e2e:         Type 'LinkedMap<K, V>' is not assignable to type 'Map<K, V>'.
packages/compiler test:e2e:           The types returned by 'entries()' are incompatible between these types.
packages/compiler test:e2e:             Property '[Symbol.dispose]' is missing in type 'IterableIterator<[K, V]>' but required in type 'MapIterator<[K, V]>'.
packages/compiler test:e2e: node_modules/vscode-jsonrpc/lib/common/linkedMap.d.ts(29,5): error TS2416: Property 'keys' in type 'LinkedMap<K, V>' is not assignable to the same property in base type 'Map<K, V>'.
packages/compiler test:e2e:   Type '() => IterableIterator<K>' is not assignable to type '() => MapIterator<K>'.
packages/compiler test:e2e:     Property '[Symbol.dispose]' is missing in type 'IterableIterator<K>' but required in type 'MapIterator<K>'.
packages/compiler test:e2e: node_modules/vscode-jsonrpc/lib/common/linkedMap.d.ts(30,5): error TS2416: Property 'values' in type 'LinkedMap<K, V>' is not assignable to the same property in base type 'Map<K, V>'.
packages/compiler test:e2e:   Type '() => IterableIterator<V>' is not assignable to type '() => MapIterator<V>'.
packages/compiler test:e2e:     Property '[Symbol.dispose]' is missing in type 'IterableIterator<V>' but required in type 'MapIterator<V>'.
packages/compiler test:e2e: node_modules/vscode-jsonrpc/lib/common/linkedMap.d.ts(31,5): error TS2416: Property 'entries' in type 'LinkedMap<K, V>' is not assignable to the same property in base type 'Map<K, V>'.
packages/compiler test:e2e:   Type '() => IterableIterator<[K, V]>' is not assignable to type '() => MapIterator<[K, V]>'.
packages/compiler test:e2e:     Property '[Symbol.dispose]' is missing in type 'IterableIterator<[K, V]>' but required in type 'MapIterator<[K, V]>'.
packages/compiler test:e2e: node_modules/vscode-jsonrpc/lib/common/linkedMap.d.ts(32,5): error TS2416: Property '[Symbol.iterator]' in type 'LinkedMap<K, V>' is not assignable to the same property in base type 'Map<K, V>'.
packages/compiler test:e2e:   Type '() => IterableIterator<[K, V]>' is not assignable to type '() => MapIterator<[K, V]>'.
packages/compiler test:e2e:     Property '[Symbol.dispose]' is missing in type 'IterableIterator<[K, V]>' but required in type 'MapIterator<[K, V]>'.

```

probably good to enable that anyway 