### PR TITLE
http-client-java, avoid generate sample file on duplicate name

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/FluentGen.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/FluentGen.java
@@ -50,6 +50,7 @@ import com.microsoft.typespec.http.client.generator.mgmt.util.FluentJavaSettings
 import com.microsoft.typespec.http.client.generator.mgmt.util.FluentUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -343,7 +344,8 @@ public class FluentGen extends Javagen {
             // Samples
             List<JavaFile> sampleJavaFiles = new ArrayList<>();
             for (FluentExample example : fluentClient.getExamples()) {
-                sampleJavaFiles.add(javaPackage.addSample(example));
+                Optional<JavaFile> file = javaPackage.addSample(example);
+                file.ifPresent(sampleJavaFiles::add);
             }
 
             // Readme and Changelog

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/javamodel/FluentJavaPackage.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/javamodel/FluentJavaPackage.java
@@ -32,6 +32,7 @@ import com.microsoft.typespec.http.client.generator.mgmt.template.ReadmeTemplate
 import com.microsoft.typespec.http.client.generator.mgmt.template.ResourceManagerUtilsTemplate;
 import com.microsoft.typespec.http.client.generator.mgmt.template.SampleTemplate;
 import java.util.List;
+import java.util.Optional;
 
 public class FluentJavaPackage extends JavaPackage {
 
@@ -96,11 +97,15 @@ public class FluentJavaPackage extends JavaPackage {
         addJavaFile(javaFile);
     }
 
-    public final JavaFile addSample(FluentExample example) {
+    public final Optional<JavaFile> addSample(FluentExample example) {
         JavaFile javaFile = getJavaFileFactory().createSampleFile(example.getPackageName(), example.getClassName());
         FluentExampleTemplate.getInstance().write(example, javaFile);
-        addJavaFile(javaFile);
-        return javaFile;
+        if (!checkDuplicateFile(javaFile.getFilePath())) {
+            addJavaFile(javaFile);
+            return Optional.of(javaFile);
+        } else {
+            return Optional.empty();
+        }
     }
 
     public void addOperationUnitTest(FluentMethodMockUnitTest unitTest) {


### PR DESCRIPTION
tested locally
```
python eng/automation/generate.py -r specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/readme.md --service kubernetesconfiguration --suffix privatelinkscopes --use='/c/github/autorest.java/'
```