### PR TITLE
Improvement: In emitter:service:csharp add CancellationToken to method definition as it is common in ASP.NET APIs

### DIFF
--- a/packages/http-server-csharp/src/lib/service.ts
+++ b/packages/http-server-csharp/src/lib/service.ts
@@ -881,7 +881,7 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
         [${getOperationVerbDecorator(httpOperation)}]
         [Route("${httpOperation.path}")]
         ${this.emitter.emitOperationReturnType(operation)}
-        public virtual async Task<IActionResult> ${operationName}(${declParams})
+        public virtual async Task<IActionResult> ${operationName}(${declParams}, CancellationToken cancel)
         {
           ${
             hasResponseValue
@@ -901,7 +901,7 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
         [Route("${httpOperation.path}")]
         [Consumes("multipart/form-data")]
         ${this.emitter.emitOperationReturnType(operation)}
-        public virtual async Task<IActionResult> ${operationName}(${declParams})
+        public virtual async Task<IActionResult> ${operationName}(${declParams}, CancellationToken cancel)
         {
           var boundary = Request.GetMultipartBoundary();
           if (boundary == null)
@@ -963,7 +963,7 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
         [${getOperationVerbDecorator(httpOperation)}]
         [Route("${httpOperation.path}")]
         ${this.emitter.emitOperationReturnType(operation)}
-        public virtual async Task<IActionResult> ${operationName}(${declParams})
+        public virtual async Task<IActionResult> ${operationName}(${declParams}, CancellationToken cancel)
         {
           ${
             hasResponseValue


### PR DESCRIPTION
**What?**
Add CancellationToken to emitter:service:csharp in method definitions

**Why?**
All methods created by default by the ASP.NET Web APIs include Cancellation tokens as the last parameter.

**How?**
Add the correct token in the c# code template