### PR TITLE
Move `@typespec/asset-emitter` to `peerDependencies`

### DIFF
--- a/.chronus/changes/main-2025-5-13-14-20-5.md
+++ b/.chronus/changes/main-2025-5-13-14-20-5.md
@@ -1,0 +1,9 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-server-csharp"
+  - "@typespec/json-schema"
+  - "@typespec/openapi3"
+---
+
+Move `@typespec/asset-emitter` to `peerDependencies`

--- a/packages/http-server-csharp/package.json
+++ b/packages/http-server-csharp/package.json
@@ -56,6 +56,7 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
+    "@typespec/asset-emitter": "workspace:^",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/rest": "workspace:^",
@@ -63,7 +64,6 @@
     "@typespec/json-schema": "workspace:^"
   },
   "dependencies": {
-    "@typespec/asset-emitter": "workspace:^",
     "change-case": "~5.4.4",
     "cross-spawn": "^7.0.6",
     "picocolors": "~1.1.1",
@@ -74,6 +74,7 @@
     "@types/cross-spawn": "~6.0.6",
     "@types/node": "~22.13.11",
     "@types/yargs": "~17.0.33",
+    "@typespec/asset-emitter": "workspace:^",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/http-specs": "workspace:^",

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -54,10 +54,12 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
+    "@typespec/asset-emitter": "workspace:^",
     "@typespec/compiler": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "~22.13.11",
+    "@typespec/asset-emitter": "workspace:^",
     "@typespec/compiler": "workspace:^",
     "@typespec/internal-build-utils": "workspace:^",
     "@typespec/library-linter": "workspace:^",
@@ -72,7 +74,6 @@
     "vitest": "^3.1.2"
   },
   "dependencies": {
-    "@typespec/asset-emitter": "workspace:^",
     "yaml": "~2.7.0"
   }
 }

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -60,11 +60,11 @@
   ],
   "dependencies": {
     "@apidevtools/swagger-parser": "~10.1.1",
-    "@typespec/asset-emitter": "workspace:^",
     "openapi-types": "~12.1.3",
     "yaml": "~2.7.0"
   },
   "peerDependencies": {
+    "@typespec/asset-emitter": "workspace:^",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/json-schema": "workspace:^",
@@ -85,6 +85,7 @@
   "devDependencies": {
     "@types/node": "~22.13.11",
     "@types/yargs": "~17.0.33",
+    "@typespec/asset-emitter": "workspace:^",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/json-schema": "workspace:^",


### PR DESCRIPTION
As specified in [the documentation](https://typespec.io/docs/extending-typespec/basics/#step-3-defining-dependencies):
> Use `peerDependencies` for all TypeSpec libraries (and the compiler) that you use in your own library or emitter.

Following the pattern for other libraries, we also define `asset-emitter` in `devDependencies` where needed.