### PR TITLE
Fix EMU grammar errors related to template strings

### DIFF
--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -156,28 +156,28 @@ StringLiteral :
     `"""` TripleQuotedStringCharacters? `"""`
     StringTemplate
 
-StringTemplate : 
-  TemplateHead Expression TemplateSpans
+StringTemplate :
+  StringTemplateHead Expression StringTemplateSpans
 
-TemplateSpans : 
-  TemplateTail
-  TemplateMiddleList TemplateTail
+StringTemplateSpans :
+  StringTemplateTail
+  StringTemplateMiddleList StringTemplateTail
 
-TemplateMiddleList : 
-  StringTemplateMiddle Expression 
-  StringTemplateMiddle Expression TemplateMiddleList
+StringTemplateMiddleList :
+  StringTemplateMiddle Expression
+  StringTemplateMiddle Expression StringTemplateMiddleList
 
 StringTemplateHead :
     `"` StringCharacters? `${`
     `"""` TripleQuotedStringCharacters? `${`
-      
-StringTemplateMiddle :
-      `}` TemplateCharacters? `${`
 
+StringTemplateMiddle :
+    `}` StringCharacters? `${`
+    `}` TripleQuotedStringCharacters? `${`
 
 StringTemplateTail :
-      `}` TemplateCharacters? `"`
-      `}` TemplateCharacters? `"""`
+    `}` StringCharacters? `"`
+    `}` TripleQuotedStringCharacters? `"""`
 
 StringCharacters :
     StringCharacter StringCharacters?

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -157,15 +157,15 @@ StringLiteral :
     StringTemplate
 
 StringTemplate :
-  StringTemplateHead Expression StringTemplateSpans
+    StringTemplateHead Expression StringTemplateSpans
 
 StringTemplateSpans :
-  StringTemplateTail
-  StringTemplateMiddleList StringTemplateTail
+    StringTemplateTail
+    StringTemplateMiddleList StringTemplateTail
 
 StringTemplateMiddleList :
-  StringTemplateMiddle Expression
-  StringTemplateMiddle Expression StringTemplateMiddleList
+    StringTemplateMiddle Expression
+    StringTemplateMiddle Expression StringTemplateMiddleList
 
 StringTemplateHead :
     `"` StringCharacters? `${`


### PR DESCRIPTION
- Renames some production rules for consistency with the others:
  - `TemplateSpans` to `StringTemplateSpans`
  - `TemplateMiddleList` to `StringTemplateMiddleList`
- fix typos in  definitions for `StringTemplate` + `StringTemplateSpans`
- make definition of `StringTemplateTail` + `StringTemplateMiddle` consistent with `StringTemplateHead`