### PR TITLE
Revert "[http-client-csharp] add operators for collection types"

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ScmTypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ScmTypeFactory.cs
@@ -79,14 +79,13 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
                     // Include both service method and operation responses for output types
                     // Service methods will have the public response type for things like LROs, while operation responses
                     // will have the internal response types for paging operations
-                    if (response?.BodyType is { } bodyType)
+                    if (response?.BodyType is InputModelType inputModelType)
                     {
-                        AddRootModel(bodyType, _rootOutputModels);
+                        _rootOutputModels.Add(inputModelType);
                     }
-
-                    if (method.Response.Type is { } responseType)
+                    if (method.Response.Type is InputModelType outputModelType)
                     {
-                        AddRootModel(responseType, _rootOutputModels);
+                        _rootOutputModels.Add(outputModelType);
                     }
 
                     if (operation.GenerateConvenienceMethod)
@@ -94,7 +93,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
                         // For parameters, the operation parameters are sufficient.
                         foreach (var parameter in operation.Parameters)
                         {
-                            AddRootModel(parameter.Type, _rootInputModels);
+                            if (parameter.Type is InputModelType modelType)
+                            {
+                                _rootInputModels.Add(modelType);
+                            }
                         }
                     }
                 }
@@ -200,21 +202,5 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
             ScopedApi<ModelReaderWriterOptions> mrwOptionsParameter,
             SerializationFormat serializationFormat)
             => MrwSerializationTypeDefinition.SerializeJsonValueCore(valueType, value, utf8JsonWriter, mrwOptionsParameter, serializationFormat);
-
-        private static void AddRootModel(InputType type, HashSet<InputModelType> rootModels)
-        {
-            InputModelType? modelToAdd = type switch
-            {
-                InputModelType model => model,
-                InputArrayType { ValueType: InputModelType model } => model,
-                InputDictionaryType { ValueType: InputModelType model } => model,
-                _ => null
-            };
-
-            if (modelToAdd != null)
-            {
-                rootModels.Add(modelToAdd);
-            }
-        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
@@ -708,47 +708,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
         }
 
         [Test]
-        public void TestBuildExplicitFromClientResult_ArrayOfModels()
-        {
-            var inputModel = InputFactory.Model("mockInputModel", usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json);
-            var modelArray = InputFactory.Array(inputModel);
-            var inputOperation = InputFactory.Operation("bar", responses: [InputFactory.OperationResponse(bodytype: modelArray)]);
-            var inputServiceResponse = InputFactory.ServiceMethodResponse(modelArray, null);
-            var inputClient = InputFactory.Client("fooClient", methods: [InputFactory.BasicServiceMethod("bar", inputOperation, response: inputServiceResponse)]);
-            MockHelpers.LoadMockGenerator(
-                inputModels: () => [inputModel],
-                clients: () => [inputClient]);
-            var outputLibrary = ScmCodeModelGenerator.Instance.OutputLibrary;
-            var modelProvider = outputLibrary.TypeProviders.OfType<ModelProvider>().FirstOrDefault(t => t.Name == "MockInputModel");
-            Assert.IsNotNull(modelProvider);
-
-            var serializationProvider = modelProvider!.SerializationProviders.FirstOrDefault();
-            Assert.IsNotNull(serializationProvider);
-            var methods = serializationProvider!.Methods;
-
-            Assert.IsTrue(methods.Count > 0);
-
-            var method = methods.FirstOrDefault(m => m.Signature.Name == "MockInputModel");
-
-            Assert.IsNotNull(method);
-
-            var methodSignature = method?.Signature;
-            Assert.IsNotNull(methodSignature);
-
-            var expectedModifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static | MethodSignatureModifiers.Explicit | MethodSignatureModifiers.Operator;
-            Assert.AreEqual(inputModel.Name.ToIdentifierName(), methodSignature?.Name);
-            Assert.AreEqual(expectedModifiers, methodSignature?.Modifiers);
-
-            var methodParameters = methodSignature?.Parameters;
-            Assert.AreEqual(1, methodParameters?.Count);
-            var clientResultParameter = methodParameters?[0];
-            Assert.AreEqual(new CSharpType(typeof(ClientResult)), clientResultParameter?.Type);
-
-            var methodBody = method?.BodyStatements;
-            Assert.IsNotNull(methodBody);
-        }
-
-        [Test]
         public void TestExplicitFromClientResultNotGeneratedForNonRootOutputModel()
         {
             var inputModel = InputFactory.Model("mockInputModel");

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/pageable/src/Generated/Models/Pet.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/pageable/src/Generated/Models/Pet.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -30,7 +29,5 @@ namespace Payload.Pageable
         protected virtual Pet PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options) => throw null;
 
         string IPersistableModel<Pet>.GetFormatFromOptions(ModelReaderWriterOptions options) => throw null;
-
-        public static explicit operator Pet(ClientResult result) => throw null;
     }
 }

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/array/src/Generated/Models/InnerModel.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/array/src/Generated/Models/InnerModel.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -30,9 +29,5 @@ namespace _Type._Array
         protected virtual InnerModel PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options) => throw null;
 
         string IPersistableModel<InnerModel>.GetFormatFromOptions(ModelReaderWriterOptions options) => throw null;
-
-        public static implicit operator BinaryContent(InnerModel innerModel) => throw null;
-
-        public static explicit operator InnerModel(ClientResult result) => throw null;
     }
 }

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/dictionary/src/Generated/Models/InnerModel.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/dictionary/src/Generated/Models/InnerModel.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -30,9 +29,5 @@ namespace _Type.Dictionary
         protected virtual InnerModel PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options) => throw null;
 
         string IPersistableModel<InnerModel>.GetFormatFromOptions(ModelReaderWriterOptions options) => throw null;
-
-        public static implicit operator BinaryContent(InnerModel innerModel) => throw null;
-
-        public static explicit operator InnerModel(ClientResult result) => throw null;
     }
 }


### PR DESCRIPTION
Reverts microsoft/typespec#7646

We don't really need the explicit operators for collection types as the ClientResult will have multiple elements so casting to the type won't work. We can add these by hand for the OAI use case.