### PR TITLE
[emitter-framework] Add support for c# xml docs

### DIFF
--- a/packages/emitter-framework/package.json
+++ b/packages/emitter-framework/package.json
@@ -39,17 +39,17 @@
   "description": "",
   "peerDependencies": {
     "@alloy-js/core": "^0.17.0",
-    "@alloy-js/typescript": "^0.17.0",
     "@alloy-js/csharp": "^0.17.0",
+    "@alloy-js/typescript": "^0.17.0",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/rest": "workspace:^"
   },
   "devDependencies": {
     "@alloy-js/cli": "^0.17.0",
+    "@alloy-js/core": "0.18.0-dev.5",
     "@alloy-js/rollup-plugin": "^0.1.0",
-    "@alloy-js/core": "^0.17.0",
-    "@alloy-js/typescript": "^0.17.0",
+    "@alloy-js/typescript": "0.18.0-dev.4",
     "@types/minimist": "^1.2.5",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
@@ -57,13 +57,13 @@
     "concurrently": "^9.1.2",
     "minimist": "^1.2.8",
     "prettier": "~3.5.3",
-    "web-tree-sitter": "^0.25.4",
     "tree-sitter-c-sharp": "^0.23.0",
     "tree-sitter-java": "^0.23.2",
     "tree-sitter-javascript": "^0.23.0",
     "tree-sitter-python": "^0.23.2",
     "tree-sitter-typescript": "^0.23.0",
     "typescript": "~5.8.2",
-    "vitest": "^3.1.2"
+    "vitest": "^3.1.2",
+    "web-tree-sitter": "^0.25.4"
   }
 }

--- a/packages/emitter-framework/package.json
+++ b/packages/emitter-framework/package.json
@@ -39,17 +39,17 @@
   "description": "",
   "peerDependencies": {
     "@alloy-js/core": "^0.17.0",
-    "@alloy-js/csharp": "^0.17.0",
     "@alloy-js/typescript": "^0.17.0",
+    "@alloy-js/csharp": "^0.17.0",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/rest": "workspace:^"
   },
   "devDependencies": {
     "@alloy-js/cli": "^0.17.0",
-    "@alloy-js/core": "0.18.0-dev.5",
     "@alloy-js/rollup-plugin": "^0.1.0",
-    "@alloy-js/typescript": "0.18.0-dev.4",
+    "@alloy-js/core": "^0.17.0",
+    "@alloy-js/typescript": "^0.17.0",
     "@types/minimist": "^1.2.5",
     "@typespec/compiler": "workspace:^",
     "@typespec/http": "workspace:^",
@@ -57,13 +57,13 @@
     "concurrently": "^9.1.2",
     "minimist": "^1.2.8",
     "prettier": "~3.5.3",
+    "web-tree-sitter": "^0.25.4",
     "tree-sitter-c-sharp": "^0.23.0",
     "tree-sitter-java": "^0.23.2",
     "tree-sitter-javascript": "^0.23.0",
     "tree-sitter-python": "^0.23.2",
     "tree-sitter-typescript": "^0.23.0",
     "typescript": "~5.8.2",
-    "vitest": "^3.1.2",
-    "web-tree-sitter": "^0.25.4"
+    "vitest": "^3.1.2"
   }
 }

--- a/packages/emitter-framework/src/csharp/components/class-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-declaration.tsx
@@ -3,6 +3,7 @@ import * as cs from "@alloy-js/csharp";
 import { Interface, Model } from "@typespec/compiler";
 import { useTsp } from "../../core/index.js";
 import { TypeExpression } from "./type-expression.jsx";
+import { getDocComments } from "./utils/doc-comments.jsx";
 import { declarationRefkeys } from "./utils/refkey.js";
 
 export interface ClassDeclarationProps extends Omit<cs.ClassDeclarationProps, "name"> {
@@ -28,7 +29,12 @@ export function ClassDeclaration(props: ClassDeclarationProps): ay.Children {
 
   return (
     <>
-      <cs.ClassDeclaration {...props} name={className} refkey={refkeys}>
+      <cs.ClassDeclaration
+        {...props}
+        name={className}
+        refkey={refkeys}
+        doc={getDocComments($, props.type)}
+      >
         {$.model.is(props.type) && <ClassProperties type={props.type} />}
         {props.type.kind === "Interface" && <ClassMethods type={props.type} />}
       </cs.ClassDeclaration>
@@ -37,16 +43,18 @@ export function ClassDeclaration(props: ClassDeclarationProps): ay.Children {
 }
 
 function ClassProperties(props: ClassPropertiesProps): ay.Children {
+  const { $ } = useTsp();
   const namePolicy = cs.useCSharpNamePolicy();
 
   const classProperties: ay.Children = [];
-  for (const [name, prop] of props.type.properties) {
+  for (const [name, property] of props.type.properties) {
     classProperties.push(
       <>
         <cs.ClassMember
           name={namePolicy.getName(name, "class-member-public")}
-          type={<TypeExpression type={prop.type} />}
+          type={<TypeExpression type={property.type} />}
           public
+          doc={getDocComments($, property)}
         />{" "}
         <ay.Block newline>
           <ay.StatementList children={["get", "set"]} />
@@ -63,22 +71,24 @@ function ClassProperties(props: ClassPropertiesProps): ay.Children {
 }
 
 function ClassMethods(props: ClassMethodsProps): ay.Children {
+  const { $ } = useTsp();
   const namePolicy = cs.useCSharpNamePolicy();
 
   const abstractMethods: ay.Children = [];
-  for (const [name, prop] of props.type.operations) {
+  for (const [name, method] of props.type.operations) {
     abstractMethods.push(
       <cs.ClassMethod
         name={namePolicy.getName(name, "class-method")}
         abstract
-        parameters={[...prop.parameters.properties.entries()].map(([name, prop]) => {
+        parameters={[...method.parameters.properties.entries()].map(([name, prop]) => {
           return {
             name: namePolicy.getName(name, "type-parameter"),
             type: <TypeExpression type={prop.type} />,
           };
         })}
         public
-        returns={<TypeExpression type={prop.returnType} />}
+        doc={getDocComments($, method)}
+        returns={<TypeExpression type={method.returnType} />}
       />,
     );
   }

--- a/packages/emitter-framework/src/csharp/components/class-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-declaration.tsx
@@ -28,7 +28,7 @@ export function ClassDeclaration(props: ClassDeclarationProps): ay.Children {
 
   return (
     <>
-      <cs.ClassDeclaration {...props} name={className}  refkey={refkeys}>
+      <cs.ClassDeclaration {...props} name={className} refkey={refkeys}>
         {$.model.is(props.type) && <ClassProperties type={props.type} />}
         {props.type.kind === "Interface" && <ClassMethods type={props.type} />}
       </cs.ClassDeclaration>

--- a/packages/emitter-framework/src/csharp/components/enum-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/enum-declaration.tsx
@@ -3,6 +3,7 @@ import * as cs from "@alloy-js/csharp";
 import { Enum, Union } from "@typespec/compiler";
 import { useTsp } from "../../core/index.js";
 import { reportDiagnostic } from "../../lib.js";
+import { getDocComments } from "./utils/doc-comments.jsx";
 import { declarationRefkeys, efRefkey } from "./utils/refkey.js";
 
 export interface EnumDeclarationProps extends Omit<cs.EnumDeclarationProps, "name"> {
@@ -30,19 +31,26 @@ export function EnumDeclaration(props: EnumDeclarationProps): ay.Children {
   const members = Array.from(type.members.entries());
 
   return (
-    <cs.EnumDeclaration name={name} refkey={refkeys} {...props}>
-      <ay.For each={members} joiner={",\n"}>
-        {([key, value]) => {
-          return (
-            <cs.EnumMember
-              name={cs.useCSharpNamePolicy().getName(key, "enum-member")}
-              refkey={
-                $.union.is(props.type) ? efRefkey(props.type.variants.get(key)) : efRefkey(value)
-              }
-            />
-          );
-        }}
-      </ay.For>
-    </cs.EnumDeclaration>
+    <>
+      <cs.EnumDeclaration name={name} refkey={refkeys} {...props}>
+        <ay.For each={members} joiner={",\n"}>
+          {([key, value]) => {
+            return (
+              <>
+                <cs.DocWhen doc={getDocComments($, value)} />
+                <cs.EnumMember
+                  name={cs.useCSharpNamePolicy().getName(key, "enum-member")}
+                  refkey={
+                    $.union.is(props.type)
+                      ? efRefkey(props.type.variants.get(key))
+                      : efRefkey(value)
+                  }
+                />
+              </>
+            );
+          }}
+        </ay.For>
+      </cs.EnumDeclaration>
+    </>
   );
 }

--- a/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
+++ b/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
@@ -13,13 +13,47 @@ import { Typekit } from "@typespec/compiler/typekit";
  * @returns A DocSummary component containing the rendered doc string, or undefined if no doc is available.
  */
 export function getDocComments($: Typekit, type: Type): ay.Children {
-  const doc = $.type.getDoc(type);
-  if (!doc) {
+  const typeDoc = $.type.getDoc(type);
+  if (!typeDoc) {
     return undefined;
   }
-  return (
+
+  const typeDocElement = (
     <cs.DocSummary>
-      <cs.DocFromMarkdown markdown={doc}></cs.DocFromMarkdown>
+      <cs.DocFromMarkdown markdown={typeDoc}></cs.DocFromMarkdown>
     </cs.DocSummary>
+  );
+
+  const paramDocs =
+    $.operation.is(type) &&
+    Array.from(type.parameters.properties.values())
+      .map((p) => {
+        const paramDoc = $.type.getDoc(p);
+        return paramDoc ? (
+          <cs.DocParam name={p.name}>
+            <cs.DocFromMarkdown markdown={paramDoc}></cs.DocFromMarkdown>
+          </cs.DocParam>
+        ) : undefined;
+      })
+      .filter(Boolean);
+
+  let returnDocs = undefined;
+  if ($.operation.is(type) && type.returnType) {
+    const returnDoc = $.type.getDoc(type.returnType);
+    if (returnDoc) {
+      returnDocs = (
+        <cs.DocReturns>
+          <cs.DocFromMarkdown markdown={returnDoc}></cs.DocFromMarkdown>
+        </cs.DocReturns>
+      );
+    }
+  }
+
+  return (
+    <ay.List>
+      {typeDocElement}
+      {paramDocs}
+      {returnDocs}
+    </ay.List>
   );
 }

--- a/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
+++ b/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
@@ -1,0 +1,25 @@
+import * as ay from "@alloy-js/core";
+import * as cs from "@alloy-js/csharp";
+import { Type } from "@typespec/compiler";
+import { Typekit } from "@typespec/compiler/typekit";
+
+/**
+ * Helper to render a doc string for a given TypeSpec type.
+ *
+ * This is not a JSX component as it is need to returns null if the doc is undefined.
+ *
+ * @param doc The doc string to render.
+ *
+ * @returns A DocSummary component containing the rendered doc string, or undefined if no doc is available.
+ */
+export function getDocComments($: Typekit, type: Type): ay.Children {
+  const doc = $.type.getDoc(type);
+  if (!doc) {
+    return undefined;
+  }
+  return (
+    <cs.DocSummary>
+      <cs.DocFromMarkdown markdown={doc}></cs.DocFromMarkdown>
+    </cs.DocSummary>
+  );
+}

--- a/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
+++ b/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
@@ -1,6 +1,6 @@
 import * as ay from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
-import { Type } from "@typespec/compiler";
+import { getReturnsDoc, Type } from "@typespec/compiler";
 import { Typekit } from "@typespec/compiler/typekit";
 
 /**
@@ -44,15 +44,13 @@ export function getDocComments($: Typekit, type: Type): ay.Children {
     docElements.push(...paramDocs);
 
     // Add return documentation
-    if (type.returnType) {
-      const returnDoc = $.type.getDoc(type.returnType);
-      if (returnDoc) {
-        docElements.push(
-          <cs.DocReturns>
-            <cs.DocFromMarkdown markdown={returnDoc} />
-          </cs.DocReturns>,
-        );
-      }
+    const returnDoc = getReturnsDoc($.program, type);
+    if (returnDoc) {
+      docElements.push(
+        <cs.DocReturns>
+          <cs.DocFromMarkdown markdown={returnDoc} />
+        </cs.DocReturns>,
+      );
     }
   }
 

--- a/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
+++ b/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
@@ -30,20 +30,17 @@ export function getDocComments($: Typekit, type: Type): ay.Children {
   // Add operation-specific documentation if applicable
   if ($.operation.is(type)) {
     // Add parameter documentation
-    const paramDocs = Array.from(type.parameters.properties.values()).reduce((allDocs, param) => {
+    const paramDocs = [];
+    for (const param of type.parameters.properties.values()) {
       const paramDoc = $.type.getDoc(param);
-
       if (paramDoc) {
-        allDocs.push(
+        paramDocs.push(
           <cs.DocParam name={param.name}>
             <cs.DocFromMarkdown markdown={paramDoc} />
           </cs.DocParam>,
         );
       }
-
-      return allDocs;
-    }, [] as ay.Children[]);
-
+    }
     docElements.push(...paramDocs);
 
     // Add return documentation

--- a/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
+++ b/packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx
@@ -30,16 +30,19 @@ export function getDocComments($: Typekit, type: Type): ay.Children {
   // Add operation-specific documentation if applicable
   if ($.operation.is(type)) {
     // Add parameter documentation
-    const paramDocs = Array.from(type.parameters.properties.values())
-      .map((param) => {
-        const paramDoc = $.type.getDoc(param);
-        return paramDoc ? (
+    const paramDocs = Array.from(type.parameters.properties.values()).reduce((allDocs, param) => {
+      const paramDoc = $.type.getDoc(param);
+
+      if (paramDoc) {
+        allDocs.push(
           <cs.DocParam name={param.name}>
             <cs.DocFromMarkdown markdown={paramDoc} />
-          </cs.DocParam>
-        ) : null;
-      })
-      .filter((doc) => doc !== null);
+          </cs.DocParam>,
+        );
+      }
+
+      return allDocs;
+    }, [] as ay.Children[]);
 
     docElements.push(...paramDocs);
 

--- a/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
@@ -200,7 +200,7 @@ describe("from an interface", () => {
       {
           class TestInterface
           {
-              public abstract string GetName(string id) {}
+              public abstract string GetName(string id);
           }
       }
     `,
@@ -279,7 +279,7 @@ it("renders a class with enum members", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum
+          enum TestEnum
           {
               Value1,
               Value2
@@ -325,7 +325,7 @@ it("renders a class with string enums", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum
+          enum TestEnum
           {
               Value1,
               Value2

--- a/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
@@ -393,6 +393,7 @@ describe("with doc comments", () => {
     @doc("This is a test interface")
     @test interface TestInterface {
       @doc("This is a test operation")
+      @returnsDoc("The name of the item")
       op getName(id: string): string;
     }
   `)) as { TestInterface: Interface };
@@ -422,7 +423,7 @@ describe("with doc comments", () => {
               /// </summary>
               ///
               /// <returns>
-              /// A sequence of textual characters.
+              /// The name of the item
               /// </returns>
               public abstract string GetName(string id);
           }

--- a/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
@@ -342,3 +342,88 @@ it("renders a class with string enums", async () => {
     `,
   );
 });
+
+describe("with doc comments", () => {
+  it("renders a model with docs", async () => {
+    const { TestModel } = (await runner.compile(`
+    @doc("This is a test model")
+    @test model TestModel {
+      @doc("This is a test property")
+        prop1: string;
+      }
+    
+  `)) as { TestModel: Model };
+
+    const res = render(
+      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestModel} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+      namespace TestNamespace
+      {
+          /// <summary>
+          /// This is a test model
+          /// </summary>
+          class TestModel
+          {
+              /// <summary>
+              /// This is a test property
+              /// </summary>
+              public string Prop1
+              {
+                  get;
+                  set;
+              }
+          }
+      }
+    `,
+    );
+  });
+
+  it("renders an interface with docs", async () => {
+    const { TestInterface } = (await runner.compile(`
+    @doc("This is a test interface")
+    @test interface TestInterface {
+      @doc("This is a test operation")
+      op getName(id: string): string;
+    }
+  `)) as { TestInterface: Interface };
+
+    const res = render(
+      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestInterface} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+      namespace TestNamespace
+      {
+          /// <summary>
+          /// This is a test interface
+          /// </summary>
+          class TestInterface
+          {
+              /// <summary>
+              /// This is a test operation
+              /// </summary>
+              public abstract string GetName(string id);
+          }
+      }
+    `,
+    );
+  });
+});

--- a/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
@@ -420,6 +420,10 @@ describe("with doc comments", () => {
               /// <summary>
               /// This is a test operation
               /// </summary>
+              ///
+              /// <returns>
+              /// A sequence of textual characters.
+              /// </returns>
               public abstract string GetName(string id);
           }
       }

--- a/packages/emitter-framework/test/csharp/components/enum-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/enum-declaration.test.tsx
@@ -294,3 +294,44 @@ it("renders multiple enums in the same namespace", async () => {
     `,
   );
 });
+
+it("renders an enum with doc comments", async () => {
+  const { TestEnum } = (await runner.compile(`
+    @test enum TestEnum {
+      @doc("This is value one")
+      Value1;
+      /** This is value two */
+      Value2;
+    }
+  `)) as { TestEnum: Enum };
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <EnumDeclaration type={TestEnum} />
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+      namespace TestNamespace
+      {
+          enum TestEnum
+          {
+              /// <summary>
+              /// This is value one
+              /// </summary>
+              Value1,
+              /// <summary>
+              /// This is value two
+              /// </summary>
+              Value2
+          }
+      }
+    `,
+  );
+});

--- a/packages/emitter-framework/test/csharp/components/enum-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/enum-declaration.test.tsx
@@ -40,7 +40,7 @@ it("renders a basic enum declaration", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum
+          enum TestEnum
           {
               Value1,
               Value2,
@@ -71,7 +71,7 @@ it("renders an empty enum declaration", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum
+          enum TestEnum
           {
 
           }
@@ -103,7 +103,7 @@ it("can override enum name", async () => {
     d`
       namespace TestNamespace
       {
-          public enum CustomEnumName
+          enum CustomEnumName
           {
               Value1,
               Value2
@@ -170,7 +170,7 @@ it("renders enum with C# naming conventions", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum
+          enum TestEnum
           {
               ValueOne,
               ValueTwo,
@@ -203,7 +203,7 @@ it("renders enum with single value", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum
+          enum TestEnum
           {
               OnlyValue
           }
@@ -237,7 +237,7 @@ it("renders enum with numeric-like member names", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum
+          enum TestEnum
           {
               Value0,
               Value1,
@@ -279,12 +279,12 @@ it("renders multiple enums in the same namespace", async () => {
     d`
       namespace TestNamespace
       {
-          public enum TestEnum1
+          enum TestEnum1
           {
               Value1,
               Value2
           }
-          public enum TestEnum2
+          enum TestEnum2
           {
               OptionA,
               OptionB,


### PR DESCRIPTION
This pull request introduces several enhancements to the `emitter-framework` package, focusing on improved handling of documentation comments, updates to dependencies, and adjustments to test cases for better alignment with C# conventions. The most important changes include adding support for rendering doc comments in C# components, updating dependencies in `package.json`, and modifying test cases to reflect these updates.

### Enhancements to documentation handling:

* [`packages/emitter-framework/src/csharp/components/utils/doc-comments.tsx`](diffhunk://#diff-087e1aeed57c139171681aa254ec8bd9ecfeebf1f1dfbae69428068224016c25R1-R59): Added a new utility function `getDocComments` to render doc strings for TypeSpec types, including support for parameter and return type documentation.
* [`packages/emitter-framework/src/csharp/components/class-declaration.tsx`](diffhunk://#diff-658c1a3f2ea2971e306337f9b3c86cb81840dde47224f9a629d4614e1ab47e68R6): Integrated `getDocComments` into class declarations, properties, and methods to include documentation in the rendered C# output. [[1]](diffhunk://#diff-658c1a3f2ea2971e306337f9b3c86cb81840dde47224f9a629d4614e1ab47e68R6) [[2]](diffhunk://#diff-658c1a3f2ea2971e306337f9b3c86cb81840dde47224f9a629d4614e1ab47e68L31-R37) [[3]](diffhunk://#diff-658c1a3f2ea2971e306337f9b3c86cb81840dde47224f9a629d4614e1ab47e68R46-R57) [[4]](diffhunk://#diff-658c1a3f2ea2971e306337f9b3c86cb81840dde47224f9a629d4614e1ab47e68R74-R91)
* [`packages/emitter-framework/src/csharp/components/enum-declaration.tsx`](diffhunk://#diff-aa0ae1a229f62db1a9eea50d4faf0479377289ddcd02e32bcdaf753ed166738fR6): Added support for rendering doc comments for enum members using the `getDocComments` utility. [[1]](diffhunk://#diff-aa0ae1a229f62db1a9eea50d4faf0479377289ddcd02e32bcdaf753ed166738fR6) [[2]](diffhunk://#diff-aa0ae1a229f62db1a9eea50d4faf0479377289ddcd02e32bcdaf753ed166738fR34-R54)

Resolves #7680