### PR TITLE
[emitter-framework] Add ClassMethod component to csharp

### DIFF
--- a/packages/emitter-framework/src/csharp/components/class-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-declaration.tsx
@@ -76,5 +76,5 @@ function ClassProperties(props: ClassPropertiesProps): ay.Children {
 function ClassMethods(props: ClassMethodsProps): ay.Children {
   const operations = Array.from(props.type.operations.values());
 
-  return operations.map((o) => <ClassMethod type={o} />);
+  return operations.map((o) => <ClassMethod type={o} public />);
 }

--- a/packages/emitter-framework/src/csharp/components/class-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-declaration.tsx
@@ -2,6 +2,7 @@ import * as ay from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
 import { Interface, Model } from "@typespec/compiler";
 import { useTsp } from "../../core/index.js";
+import { ClassMethod } from "./class-method.jsx";
 import { TypeExpression } from "./type-expression.jsx";
 import { getDocComments } from "./utils/doc-comments.jsx";
 import { declarationRefkeys } from "./utils/refkey.js";
@@ -71,27 +72,12 @@ function ClassProperties(props: ClassPropertiesProps): ay.Children {
 }
 
 function ClassMethods(props: ClassMethodsProps): ay.Children {
-  const { $ } = useTsp();
-  const namePolicy = cs.useCSharpNamePolicy();
-
-  const abstractMethods: ay.Children = [];
-  for (const [name, method] of props.type.operations) {
-    abstractMethods.push(
-      <cs.ClassMethod
-        name={namePolicy.getName(name, "class-method")}
-        abstract
-        parameters={[...method.parameters.properties.entries()].map(([name, prop]) => {
-          return {
-            name: namePolicy.getName(name, "type-parameter"),
-            type: <TypeExpression type={prop.type} />,
-          };
-        })}
-        public
-        doc={getDocComments($, method)}
-        returns={<TypeExpression type={method.returnType} />}
-      />,
+  const classMethods: ay.Children = [];
+  for (const method of props.type.operations.values()) {
+    classMethods.push(
+      <ClassMethod type={method} public abstract />, // TODO: this probably ain't right, will revisit tomorrow!
     );
   }
 
-  return <>{abstractMethods}</>;
+  return <>{classMethods}</>;
 }

--- a/packages/emitter-framework/src/csharp/components/class-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-declaration.tsx
@@ -72,12 +72,9 @@ function ClassProperties(props: ClassPropertiesProps): ay.Children {
 }
 
 function ClassMethods(props: ClassMethodsProps): ay.Children {
-  const classMethods: ay.Children = [];
-  for (const method of props.type.operations.values()) {
-    classMethods.push(
-      <ClassMethod type={method} public abstract />, // TODO: this probably ain't right, will revisit tomorrow!
-    );
-  }
+  const operations = Array.from(props.type.operations.values());
 
-  return <>{classMethods}</>;
+  return operations.map((o) => (
+    <ClassMethod type={o} public abstract /> // TODO: this probably ain't right, will revisit tomorrow!
+  ));
 }

--- a/packages/emitter-framework/src/csharp/components/class-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-declaration.tsx
@@ -23,21 +23,23 @@ interface ClassMethodsProps {
 export function ClassDeclaration(props: ClassDeclarationProps): ay.Children {
   const { $ } = useTsp();
 
-  const namePolicy = cs.useCSharpNamePolicy();
-  const className = props.name ?? namePolicy.getName(props.type.name, "class");
+  const [efProps, updateProps, forwardProps] = ay.splitProps(props, ["type"], ["name", "refkey"]);
 
-  const refkeys = declarationRefkeys(props.refkey, props.type)[0]; // TODO: support multiple refkeys for declarations in alloy
+  const namePolicy = cs.useCSharpNamePolicy();
+  const className = updateProps.name ?? namePolicy.getName(efProps.type.name, "class");
+
+  const refkeys = declarationRefkeys(updateProps.refkey, props.type)[0]; // TODO: support multiple refkeys for declarations in alloy
 
   return (
     <>
       <cs.ClassDeclaration
-        {...props}
+        {...forwardProps}
         name={className}
         refkey={refkeys}
         doc={getDocComments($, props.type)}
       >
-        {$.model.is(props.type) && <ClassProperties type={props.type} />}
-        {props.type.kind === "Interface" && <ClassMethods type={props.type} />}
+        {$.model.is(efProps.type) && <ClassProperties type={efProps.type} />}
+        {efProps.type.kind === "Interface" && <ClassMethods type={efProps.type} />}
       </cs.ClassDeclaration>
     </>
   );
@@ -74,7 +76,5 @@ function ClassProperties(props: ClassPropertiesProps): ay.Children {
 function ClassMethods(props: ClassMethodsProps): ay.Children {
   const operations = Array.from(props.type.operations.values());
 
-  return operations.map((o) => (
-    <ClassMethod type={o} public abstract /> // TODO: this probably ain't right, will revisit tomorrow!
-  ));
+  return operations.map((o) => <ClassMethod type={o} />);
 }

--- a/packages/emitter-framework/src/csharp/components/class-declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-declaration.tsx
@@ -23,7 +23,11 @@ interface ClassMethodsProps {
 export function ClassDeclaration(props: ClassDeclarationProps): ay.Children {
   const { $ } = useTsp();
 
-  const [efProps, updateProps, forwardProps] = ay.splitProps(props, ["type"], ["name", "refkey"]);
+  const [efProps, updateProps, forwardProps] = ay.splitProps(
+    props,
+    ["type"],
+    ["name", "refkey", "abstract"],
+  );
 
   const namePolicy = cs.useCSharpNamePolicy();
   const className = updateProps.name ?? namePolicy.getName(efProps.type.name, "class");
@@ -34,6 +38,7 @@ export function ClassDeclaration(props: ClassDeclarationProps): ay.Children {
     <>
       <cs.ClassDeclaration
         {...forwardProps}
+        abstract={updateProps.abstract ?? efProps.type.kind === "Interface"}
         name={className}
         refkey={refkeys}
         doc={getDocComments($, props.type)}
@@ -76,5 +81,5 @@ function ClassProperties(props: ClassPropertiesProps): ay.Children {
 function ClassMethods(props: ClassMethodsProps): ay.Children {
   const operations = Array.from(props.type.operations.values());
 
-  return operations.map((o) => <ClassMethod type={o} public />);
+  return operations.map((o) => <ClassMethod type={o} public abstract />);
 }

--- a/packages/emitter-framework/src/csharp/components/class-method.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-method.tsx
@@ -27,7 +27,7 @@ export function ClassMethod(props: ClassMethodProps): ay.Children {
   const [efProps, updateProps, forwardProps] = ay.splitProps(
     props,
     ["type"],
-    ["async", "name", "refkey"],
+    ["async", "name", "refkey", "doc"],
   );
 
   const namePolicy = cs.useCSharpNamePolicy();
@@ -35,6 +35,7 @@ export function ClassMethod(props: ClassMethodProps): ay.Children {
   // Generate method name
   const methodName = updateProps.name ?? namePolicy.getName(props.type.name, "class-method");
   const refkeys = declarationRefkeys(updateProps.refkey, props.type)[0]; // TODO: support multiple refkeys for declarations in alloy
+  const doc = updateProps.doc ?? getDocComments($, efProps.type);
 
   // Generate parameters from operation
   const operationParameters = [...efProps.type.parameters.properties.entries()].map(
@@ -70,7 +71,7 @@ export function ClassMethod(props: ClassMethodProps): ay.Children {
       parameters={operationParameters}
       returns={returnType}
       async={updateProps.async}
-      doc={getDocComments($, efProps.type)}
+      doc={doc}
     ></cs.ClassMethod>
   );
 }

--- a/packages/emitter-framework/src/csharp/components/class-method.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-method.tsx
@@ -1,0 +1,76 @@
+import * as ay from "@alloy-js/core";
+import * as cs from "@alloy-js/csharp";
+import { Operation, Type } from "@typespec/compiler";
+import { useTsp } from "../../core/index.js";
+import { TypeExpression } from "./type-expression.jsx";
+import { getDocComments } from "./utils/doc-comments.jsx";
+import { declarationRefkeys } from "./utils/refkey.js";
+
+export interface ClassMethodProps extends Omit<cs.ClassMethodProps, "name"> {
+  /**
+   * The name of the method. If not provided, will use the operation name.
+   */
+  name?: string;
+
+  /**
+   * The TypeSpec operation to generate the method from.
+   */
+  type: Operation;
+}
+
+function isVoidType(type: Type): boolean {
+  return type.kind === "Intrinsic" && type.name === "void";
+}
+
+export function ClassMethod(props: ClassMethodProps): ay.Children {
+  const { $ } = useTsp();
+  const [efProps, updateProps, forwardProps] = ay.splitProps(
+    props,
+    ["type"],
+    ["async", "name", "refkey"],
+  );
+
+  const namePolicy = cs.useCSharpNamePolicy();
+
+  // Generate method name
+  const methodName = updateProps.name ?? namePolicy.getName(props.type.name, "class-method");
+  const refkeys = declarationRefkeys(updateProps.refkey, props.type)[0]; // TODO: support multiple refkeys for declarations in alloy
+
+  // Generate parameters from operation
+  const operationParameters = [...efProps.type.parameters.properties.entries()].map(
+    ([name, param]) => {
+      return {
+        name: namePolicy.getName(name, "parameter"),
+        type: <TypeExpression type={param.type} />,
+        required: !param.optional,
+      };
+    },
+  );
+
+  // Generate return type
+  let returnType: ay.Children;
+  if (updateProps.async) {
+    const baseReturnType = <TypeExpression type={efProps.type.returnType} />;
+    if (isVoidType(efProps.type.returnType)) {
+      returnType = "Task";
+    } else {
+      returnType = ay.code`Task<${baseReturnType}>`;
+    }
+  } else if (isVoidType(efProps.type.returnType)) {
+    returnType = undefined;
+  } else {
+    returnType = <TypeExpression type={efProps.type.returnType} />;
+  }
+
+  return (
+    <cs.ClassMethod
+      {...forwardProps}
+      name={methodName}
+      refkey={refkeys}
+      parameters={operationParameters}
+      returns={returnType}
+      async={updateProps.async}
+      doc={getDocComments($, efProps.type)}
+    ></cs.ClassMethod>
+  );
+}

--- a/packages/emitter-framework/src/csharp/components/class-method.tsx
+++ b/packages/emitter-framework/src/csharp/components/class-method.tsx
@@ -27,7 +27,7 @@ export function ClassMethod(props: ClassMethodProps): ay.Children {
   const [efProps, updateProps, forwardProps] = ay.splitProps(
     props,
     ["type"],
-    ["async", "name", "refkey", "doc"],
+    ["async", "name", "refkey", "doc", "returns"],
   );
 
   const namePolicy = cs.useCSharpNamePolicy();
@@ -50,7 +50,9 @@ export function ClassMethod(props: ClassMethodProps): ay.Children {
 
   // Generate return type
   let returnType: ay.Children;
-  if (updateProps.async) {
+  if (updateProps.returns) {
+    returnType = updateProps.returns;
+  } else if (updateProps.async) {
     const baseReturnType = <TypeExpression type={efProps.type.returnType} />;
     if (isVoidType(efProps.type.returnType)) {
       returnType = "Task";

--- a/packages/emitter-framework/src/csharp/components/index.ts
+++ b/packages/emitter-framework/src/csharp/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./class-declaration.jsx";
+export * from "./class-method.jsx";
 export * from "./enum-declaration.jsx";
 export * from "./type-expression.jsx";

--- a/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
@@ -200,7 +200,7 @@ describe("from an interface", () => {
       {
           class TestInterface
           {
-              public abstract string GetName(string id);
+              string GetName(string id) {}
           }
       }
     `,
@@ -425,7 +425,7 @@ describe("with doc comments", () => {
               /// <returns>
               /// The name of the item
               /// </returns>
-              public abstract string GetName(string id);
+              string GetName(string id) {}
           }
       }
     `,

--- a/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
@@ -200,7 +200,7 @@ describe("from an interface", () => {
       {
           class TestInterface
           {
-              string GetName(string id) {}
+              public string GetName(string id) {}
           }
       }
     `,
@@ -425,7 +425,7 @@ describe("with doc comments", () => {
               /// <returns>
               /// The name of the item
               /// </returns>
-              string GetName(string id) {}
+              public string GetName(string id) {}
           }
       }
     `,

--- a/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-declaration.test.tsx
@@ -16,24 +16,25 @@ beforeEach(async () => {
   runner = await createEmitterFrameworkTestRunner();
 });
 
-it("renders an empty class declaration", async () => {
-  const { TestModel } = (await runner.compile(`
+describe("from a model", () => {
+  it("renders an empty class declaration", async () => {
+    const { TestModel } = (await runner.compile(`
     @test model TestModel {}
   `)) as { TestModel: Model };
 
-  const res = render(
-    <Output program={runner.program}>
-      <Namespace name="TestNamespace">
-        <SourceFile path="test.cs">
-          <ClassDeclaration type={TestModel} />
-        </SourceFile>
-      </Namespace>
-    </Output>,
-  );
+    const res = render(
+      <Output program={runner.program}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestModel} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
 
-  assertFileContents(
-    res,
-    d`
+    assertFileContents(
+      res,
+      d`
       namespace TestNamespace
       {
           class TestModel
@@ -42,30 +43,30 @@ it("renders an empty class declaration", async () => {
           }
       }
     `,
-  );
-});
+    );
+  });
 
-it("renders a class declaration with properties", async () => {
-  const { TestModel } = (await runner.compile(`
+  it("renders a class declaration with properties", async () => {
+    const { TestModel } = (await runner.compile(`
     @test model TestModel {
       @test Prop1: string;
       @test Prop2: int32;
     }
   `)) as { TestModel: Model };
 
-  const res = render(
-    <Output program={runner.program}>
-      <Namespace name="TestNamespace">
-        <SourceFile path="test.cs">
-          <ClassDeclaration type={TestModel} />
-        </SourceFile>
-      </Namespace>
-    </Output>,
-  );
+    const res = render(
+      <Output program={runner.program}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestModel} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
 
-  assertFileContents(
-    res,
-    d`
+    assertFileContents(
+      res,
+      d`
       namespace TestNamespace
       {
           class TestModel
@@ -83,27 +84,27 @@ it("renders a class declaration with properties", async () => {
           }
       }
     `,
-  );
-});
+    );
+  });
 
-it("can override class name", async () => {
-  const { TestModel } = (await runner.compile(`
+  it("can override class name", async () => {
+    const { TestModel } = (await runner.compile(`
     @test model TestModel {}
   `)) as { TestModel: Model };
 
-  const res = render(
-    <Output program={runner.program}>
-      <Namespace name="TestNamespace">
-        <SourceFile path="test.cs">
-          <ClassDeclaration type={TestModel} name="CustomClassName" />
-        </SourceFile>
-      </Namespace>
-    </Output>,
-  );
+    const res = render(
+      <Output program={runner.program}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestModel} name="CustomClassName" />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
 
-  assertFileContents(
-    res,
-    d`
+    assertFileContents(
+      res,
+      d`
       namespace TestNamespace
       {
           class CustomClassName
@@ -112,28 +113,28 @@ it("can override class name", async () => {
           }
       }
     `,
-  );
-});
+    );
+  });
 
-it("renders a class with access modifiers", async () => {
-  const { TestModel } = (await runner.compile(`
+  it("renders a class with access modifiers", async () => {
+    const { TestModel } = (await runner.compile(`
     @test model TestModel {
     }
   `)) as { TestModel: Model };
 
-  const res = render(
-    <Output program={runner.program}>
-      <Namespace name="TestNamespace">
-        <SourceFile path="test.cs">
-          <ClassDeclaration type={TestModel} protected />
-        </SourceFile>
-      </Namespace>
-    </Output>,
-  );
+    const res = render(
+      <Output program={runner.program}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestModel} protected />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
 
-  assertFileContents(
-    res,
-    d`
+    assertFileContents(
+      res,
+      d`
       namespace TestNamespace
       {
           protected class TestModel
@@ -142,74 +143,11 @@ it("renders a class with access modifiers", async () => {
           }
       }
     `,
-  );
-});
-
-describe("from an interface", () => {
-  it("renders an empty class", async () => {
-    const { TestInterface } = (await runner.compile(`
-    @test interface TestInterface {
-    }
-  `)) as { TestInterface: Interface };
-
-    const res = render(
-      <Output program={runner.program}>
-        <Namespace name="TestNamespace">
-          <SourceFile path="test.cs">
-            <ClassDeclaration type={TestInterface} />
-          </SourceFile>
-        </Namespace>
-      </Output>,
-    );
-
-    assertFileContents(
-      res,
-      d`
-      namespace TestNamespace
-      {
-          class TestInterface
-          {
-
-          }
-      }
-    `,
     );
   });
 
-  it("renders a class with operations", async () => {
-    const { TestInterface } = (await runner.compile(`
-    @test interface TestInterface {
-      op getName(id: string): string;
-    }
-  `)) as { TestInterface: Interface };
-
-    const res = render(
-      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
-        <Namespace name="TestNamespace">
-          <SourceFile path="test.cs">
-            <ClassDeclaration type={TestInterface} />
-          </SourceFile>
-        </Namespace>
-      </Output>,
-    );
-
-    assertFileContents(
-      res,
-      d`
-      namespace TestNamespace
-      {
-          class TestInterface
-          {
-              public string GetName(string id) {}
-          }
-      }
-    `,
-    );
-  });
-});
-
-it("renders a class with model members", async () => {
-  const { TestModel, TestReference } = (await runner.compile(`
+  it("renders a class with model members", async () => {
+    const { TestModel, TestReference } = (await runner.compile(`
     @test model TestReference {
     }
     @test model TestModel {
@@ -217,21 +155,21 @@ it("renders a class with model members", async () => {
     }
   `)) as { TestModel: Model; TestReference: Model };
 
-  const res = render(
-    <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
-      <Namespace name="TestNamespace">
-        <SourceFile path="test.cs">
-          <ClassDeclaration type={TestReference} />
-          <hbr />
-          <ClassDeclaration type={TestModel} />
-        </SourceFile>
-      </Namespace>
-    </Output>,
-  );
+    const res = render(
+      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestReference} />
+            <hbr />
+            <ClassDeclaration type={TestModel} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
 
-  assertFileContents(
-    res,
-    d`
+    assertFileContents(
+      res,
+      d`
       namespace TestNamespace
       {
           class TestReference
@@ -248,11 +186,11 @@ it("renders a class with model members", async () => {
           }
       }
     `,
-  );
-});
+    );
+  });
 
-it("renders a class with enum members", async () => {
-  const { TestModel, TestEnum } = (await runner.compile(`
+  it("renders a class with enum members", async () => {
+    const { TestModel, TestEnum } = (await runner.compile(`
     @test enum TestEnum {
       Value1;
       Value2;
@@ -262,21 +200,21 @@ it("renders a class with enum members", async () => {
     }
   `)) as { TestModel: Model; TestEnum: Enum };
 
-  const res = render(
-    <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
-      <Namespace name="TestNamespace">
-        <SourceFile path="test.cs">
-          <EnumDeclaration type={TestEnum} />
-          <hbr />
-          <ClassDeclaration type={TestModel} />
-        </SourceFile>
-      </Namespace>
-    </Output>,
-  );
+    const res = render(
+      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <EnumDeclaration type={TestEnum} />
+            <hbr />
+            <ClassDeclaration type={TestModel} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
 
-  assertFileContents(
-    res,
-    d`
+    assertFileContents(
+      res,
+      d`
       namespace TestNamespace
       {
           enum TestEnum
@@ -294,11 +232,11 @@ it("renders a class with enum members", async () => {
           }
       }
     `,
-  );
-});
+    );
+  });
 
-it("renders a class with string enums", async () => {
-  const { TestModel, TestEnum } = (await runner.compile(`
+  it("renders a class with string enums", async () => {
+    const { TestModel, TestEnum } = (await runner.compile(`
     @test enum TestEnum {
       Value1;
       Value2;
@@ -308,21 +246,21 @@ it("renders a class with string enums", async () => {
     }
   `)) as { TestModel: Model; TestEnum: Enum };
 
-  const res = render(
-    <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
-      <Namespace name="TestNamespace">
-        <SourceFile path="test.cs">
-          <EnumDeclaration type={TestEnum} />
-          <hbr />
-          <ClassDeclaration type={TestModel} />
-        </SourceFile>
-      </Namespace>
-    </Output>,
-  );
+    const res = render(
+      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <EnumDeclaration type={TestEnum} />
+            <hbr />
+            <ClassDeclaration type={TestModel} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
 
-  assertFileContents(
-    res,
-    d`
+    assertFileContents(
+      res,
+      d`
       namespace TestNamespace
       {
           enum TestEnum
@@ -340,10 +278,9 @@ it("renders a class with string enums", async () => {
           }
       }
     `,
-  );
-});
+    );
+  });
 
-describe("with doc comments", () => {
   it("renders a model with docs", async () => {
     const { TestModel } = (await runner.compile(`
     @doc("This is a test model")
@@ -387,6 +324,69 @@ describe("with doc comments", () => {
     `,
     );
   });
+});
+
+describe("from an interface", () => {
+  it("renders an empty class", async () => {
+    const { TestInterface } = (await runner.compile(`
+    @test interface TestInterface {
+    }
+  `)) as { TestInterface: Interface };
+
+    const res = render(
+      <Output program={runner.program}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestInterface} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+      namespace TestNamespace
+      {
+          abstract class TestInterface
+          {
+
+          }
+      }
+    `,
+    );
+  });
+
+  it("renders a class with operations", async () => {
+    const { TestInterface } = (await runner.compile(`
+    @test interface TestInterface {
+      op getName(id: string): string;
+    }
+  `)) as { TestInterface: Interface };
+
+    const res = render(
+      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestInterface} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+      namespace TestNamespace
+      {
+          abstract class TestInterface
+          {
+              public abstract string GetName(string id);
+          }
+      }
+    `,
+    );
+  });
 
   it("renders an interface with docs", async () => {
     const { TestInterface } = (await runner.compile(`
@@ -416,7 +416,7 @@ describe("with doc comments", () => {
           /// <summary>
           /// This is a test interface
           /// </summary>
-          class TestInterface
+          abstract class TestInterface
           {
               /// <summary>
               /// This is a test operation
@@ -425,7 +425,38 @@ describe("with doc comments", () => {
               /// <returns>
               /// The name of the item
               /// </returns>
-              public string GetName(string id) {}
+              public abstract string GetName(string id);
+          }
+      }
+    `,
+    );
+  });
+
+  it("renders a non-abstract class", async () => {
+    const { TestInterface } = (await runner.compile(`
+    @test interface TestInterface {
+      op getName(id: string): string;
+    }
+  `)) as { TestInterface: Interface };
+
+    const res = render(
+      <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+        <Namespace name="TestNamespace">
+          <SourceFile path="test.cs">
+            <ClassDeclaration type={TestInterface} abstract={false} />
+          </SourceFile>
+        </Namespace>
+      </Output>,
+    );
+
+    assertFileContents(
+      res,
+      d`
+      namespace TestNamespace
+      {
+          class TestInterface
+          {
+              public abstract string GetName(string id);
           }
       }
     `,

--- a/packages/emitter-framework/test/csharp/components/class-method.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-method.test.tsx
@@ -1,0 +1,282 @@
+import { render } from "@alloy-js/core";
+import { d } from "@alloy-js/core/testing";
+import * as cs from "@alloy-js/csharp";
+import { Namespace, SourceFile } from "@alloy-js/csharp";
+import { Operation } from "@typespec/compiler";
+import { BasicTestRunner } from "@typespec/compiler/testing";
+import { beforeEach, it } from "vitest";
+import { Output } from "../../../src/core/index.js";
+import { ClassMethod } from "../../../src/csharp/index.js";
+import { createEmitterFrameworkTestRunner } from "../test-host.js";
+import { assertFileContents } from "../utils.js";
+
+let runner: BasicTestRunner;
+
+beforeEach(async () => {
+  runner = await createEmitterFrameworkTestRunner();
+});
+
+it("renders a void method with no parameters", async () => {
+  const result = await runner.compile(`
+      @test op TestOp(): void;
+    `);
+  const testOp = result.TestOp as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={testOp} public />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                public void TestOp() {}
+            }
+        }
+      `,
+  );
+});
+
+it("renders a method with return type and parameters", async () => {
+  const result = await runner.compile(`
+      @test op GetUserById(id: string, includeProfile?: boolean): string;
+    `);
+  const getUserById = result.GetUserById as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={getUserById} public />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                public string GetUserById(string id, bool includeProfile) {}
+            }
+        }
+      `,
+  );
+});
+
+it("renders an async method with Task return type", async () => {
+  const result = await runner.compile(`
+      @test op FetchData(): string;
+    `);
+  const fetchData = result.FetchData as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={fetchData} async public />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                public async Task<string> FetchData() {}
+            }
+        }
+      `,
+  );
+});
+
+it("renders an async void method with Task return type", async () => {
+  const result = await runner.compile(`
+      @test op ProcessData(): void;
+    `);
+  const processData = result.ProcessData as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={processData} async public />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                public async Task ProcessData() {}
+            }
+        }
+      `,
+  );
+});
+
+it("renders a method with custom name", async () => {
+  const result = await runner.compile(`
+      @test op SomeMethod(): string;
+    `);
+  const someMethod = result.SomeMethod as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={someMethod} name="CustomMethodName" public />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                public string CustomMethodName() {}
+            }
+        }
+      `,
+  );
+});
+
+it("renders an abstract method", async () => {
+  const result = await runner.compile(`
+      @test op AbstractMethod(data: string): boolean;
+    `);
+  const abstractMethod = result.AbstractMethod as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass" abstract>
+            <ClassMethod type={abstractMethod} abstract public />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            abstract class TestClass
+            {
+                public abstract bool AbstractMethod(string data);
+            }
+        }
+      `,
+  );
+});
+
+it("renders a method with body content", async () => {
+  const result = await runner.compile(`
+      @test op Calculate(x: int32, y: int32): int32;
+    `);
+  const calculate = result.Calculate as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={calculate} public>
+              return x + y;
+            </ClassMethod>
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                public int Calculate(int x, int y)
+                {
+                    return x + y;
+                }
+            }
+        }
+      `,
+  );
+});
+
+it("renders a method with docs", async () => {
+  const result = await runner.compile(`
+      @doc("Gets information.")
+      @test op GetInfo(): string;
+    `);
+  const getInfo = result.GetInfo as Operation;
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={getInfo} public />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                /// <summary>
+                /// Gets information.
+                /// </summary>
+                public string GetInfo() {}
+            }
+        }
+      `,
+  );
+});

--- a/packages/emitter-framework/test/csharp/components/class-method.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-method.test.tsx
@@ -272,3 +272,34 @@ it("renders a method with docs", async () => {
       `,
   );
 });
+
+it("renders a method with a custom return type", async () => {
+  const { GetCustomData } = (await runner.compile(`
+      @test op GetCustomData(): string;
+    `)) as { GetCustomData: Operation };
+
+  const res = render(
+    <Output program={runner.program}>
+      <Namespace name="TestNamespace">
+        <SourceFile path="test.cs">
+          <cs.ClassDeclaration name="TestClass">
+            <ClassMethod type={GetCustomData} public returns="Custom" />
+          </cs.ClassDeclaration>
+        </SourceFile>
+      </Namespace>
+    </Output>,
+  );
+
+  assertFileContents(
+    res,
+    d`
+        namespace TestNamespace
+        {
+            class TestClass
+            {
+                public Custom GetCustomData() {}
+            }
+        }
+      `,
+  );
+});

--- a/packages/emitter-framework/test/csharp/components/class-method.test.tsx
+++ b/packages/emitter-framework/test/csharp/components/class-method.test.tsx
@@ -17,17 +17,16 @@ beforeEach(async () => {
 });
 
 it("renders a void method with no parameters", async () => {
-  const result = await runner.compile(`
+  const { TestOp } = (await runner.compile(`
       @test op TestOp(): void;
-    `);
-  const testOp = result.TestOp as Operation;
+    `)) as { TestOp: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass">
-            <ClassMethod type={testOp} public />
+            <ClassMethod type={TestOp} public />
           </cs.ClassDeclaration>
         </SourceFile>
       </Namespace>
@@ -49,17 +48,16 @@ it("renders a void method with no parameters", async () => {
 });
 
 it("renders a method with return type and parameters", async () => {
-  const result = await runner.compile(`
+  const { GetUserById } = (await runner.compile(`
       @test op GetUserById(id: string, includeProfile?: boolean): string;
-    `);
-  const getUserById = result.GetUserById as Operation;
+    `)) as { GetUserById: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass">
-            <ClassMethod type={getUserById} public />
+            <ClassMethod type={GetUserById} public />
           </cs.ClassDeclaration>
         </SourceFile>
       </Namespace>
@@ -81,17 +79,16 @@ it("renders a method with return type and parameters", async () => {
 });
 
 it("renders an async method with Task return type", async () => {
-  const result = await runner.compile(`
+  const { FetchData } = (await runner.compile(`
       @test op FetchData(): string;
-    `);
-  const fetchData = result.FetchData as Operation;
+    `)) as { FetchData: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass">
-            <ClassMethod type={fetchData} async public />
+            <ClassMethod type={FetchData} async public />
           </cs.ClassDeclaration>
         </SourceFile>
       </Namespace>
@@ -113,17 +110,16 @@ it("renders an async method with Task return type", async () => {
 });
 
 it("renders an async void method with Task return type", async () => {
-  const result = await runner.compile(`
+  const { ProcessData } = (await runner.compile(`
       @test op ProcessData(): void;
-    `);
-  const processData = result.ProcessData as Operation;
+    `)) as { ProcessData: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass">
-            <ClassMethod type={processData} async public />
+            <ClassMethod type={ProcessData} async public />
           </cs.ClassDeclaration>
         </SourceFile>
       </Namespace>
@@ -145,17 +141,16 @@ it("renders an async void method with Task return type", async () => {
 });
 
 it("renders a method with custom name", async () => {
-  const result = await runner.compile(`
+  const { SomeMethod } = (await runner.compile(`
       @test op SomeMethod(): string;
-    `);
-  const someMethod = result.SomeMethod as Operation;
+    `)) as { SomeMethod: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass">
-            <ClassMethod type={someMethod} name="CustomMethodName" public />
+            <ClassMethod type={SomeMethod} name="CustomMethodName" public />
           </cs.ClassDeclaration>
         </SourceFile>
       </Namespace>
@@ -177,17 +172,16 @@ it("renders a method with custom name", async () => {
 });
 
 it("renders an abstract method", async () => {
-  const result = await runner.compile(`
+  const { AbstractMethod } = (await runner.compile(`
       @test op AbstractMethod(data: string): boolean;
-    `);
-  const abstractMethod = result.AbstractMethod as Operation;
+    `)) as { AbstractMethod: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass" abstract>
-            <ClassMethod type={abstractMethod} abstract public />
+            <ClassMethod type={AbstractMethod} abstract public />
           </cs.ClassDeclaration>
         </SourceFile>
       </Namespace>
@@ -209,17 +203,16 @@ it("renders an abstract method", async () => {
 });
 
 it("renders a method with body content", async () => {
-  const result = await runner.compile(`
+  const { Calculate } = (await runner.compile(`
       @test op Calculate(x: int32, y: int32): int32;
-    `);
-  const calculate = result.Calculate as Operation;
+    `)) as { Calculate: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass">
-            <ClassMethod type={calculate} public>
+            <ClassMethod type={Calculate} public>
               return x + y;
             </ClassMethod>
           </cs.ClassDeclaration>
@@ -246,18 +239,17 @@ it("renders a method with body content", async () => {
 });
 
 it("renders a method with docs", async () => {
-  const result = await runner.compile(`
+  const { GetInfo } = (await runner.compile(`
       @doc("Gets information.")
       @test op GetInfo(): string;
-    `);
-  const getInfo = result.GetInfo as Operation;
+    `)) as { GetInfo: Operation };
 
   const res = render(
     <Output program={runner.program}>
       <Namespace name="TestNamespace">
         <SourceFile path="test.cs">
           <cs.ClassDeclaration name="TestClass">
-            <ClassMethod type={getInfo} public />
+            <ClassMethod type={GetInfo} public />
           </cs.ClassDeclaration>
         </SourceFile>
       </Namespace>


### PR DESCRIPTION
This pull request introduces a new `ClassMethod` component to the `emitter-framework` package, which simplifies the generation of C# class methods from TypeSpec operations. The changes include refactoring existing code to use this new component, adding comprehensive tests, and updating exports to make the component accessible.

### Refactoring and Component Addition:
* Added the `ClassMethod` component (`packages/emitter-framework/src/csharp/components/class-method.tsx`) to encapsulate logic for generating C# class methods, including handling method names, parameters, return types, and documentation.
* Refactored `ClassMethods` in `class-declaration.tsx` to use the new `ClassMethod` component, simplifying the code and improving maintainability.
