### PR TITLE
Fixes related to identifier naming

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -68,6 +68,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         public ClientProvider(InputClient inputClient)
         {
+            CleanOperationNames(inputClient);
+
             _inputClient = inputClient;
             _inputAuth = ScmCodeModelGenerator.Instance.InputLibrary.InputNamespace.Auth;
             _endpointParameter = BuildClientEndpointParameter();
@@ -152,6 +154,27 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             _clientParameters = new(GetClientParameters);
             _subClients = new(GetSubClients);
             _allClientParameters = GetAllClientParameters();
+        }
+
+        private static void CleanOperationNames(InputClient inputClient)
+        {
+            foreach (var serviceMethod in inputClient.Methods)
+            {
+                var updatedOperationName = GetCleanOperationName(serviceMethod);
+                serviceMethod.Update(name: updatedOperationName);
+                serviceMethod.Operation.Update(name: updatedOperationName);
+            }
+        }
+
+        private static string GetCleanOperationName(InputServiceMethod serviceMethod)
+        {
+            var operationName = serviceMethod.Operation.Name.ToIdentifierName();
+            // Replace List with Get as .NET convention is to use Get for list operations.
+            if (operationName.StartsWith("List", StringComparison.Ordinal))
+            {
+                operationName = $"Get{operationName.Substring(4)}";
+            }
+            return operationName;
         }
 
         private string? _namespace;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -64,10 +64,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             ServiceMethod = serviceMethod;
             EnclosingType = enclosingType;
 
-            var updatedOperationName = GetCleanOperationName(serviceMethod);
-            ServiceMethod.Update(name: updatedOperationName);
-            ServiceMethod.Operation.Update(name: updatedOperationName);
-
             Client = enclosingType as ClientProvider ?? throw new InvalidOperationException("Scm methods can only be built for client types.");
             _createRequestMethod = Client.RestClient.GetCreateRequestMethod(ServiceMethod.Operation);
             _generateConvenienceMethod = ServiceMethod.Operation is
@@ -77,17 +73,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 _pagingServiceMethod = pagingServiceMethod;
             }
-        }
-
-        private static string GetCleanOperationName(InputServiceMethod serviceMethod)
-        {
-            var operationName = serviceMethod.Operation.Name.ToIdentifierName();
-            // Replace List with Get as .NET convention is to use Get for list operations.
-            if (operationName.StartsWith("List", StringComparison.Ordinal))
-            {
-                operationName = $"Get{operationName.Substring(4)}";
-            }
-            return operationName;
         }
 
         protected virtual IReadOnlyList<ScmMethodProvider> BuildMethods()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/NextLinkTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/CollectionResultDefinitions/NextLinkTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
@@ -152,6 +153,35 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.CollectionRes
                 t => t is CollectionResultDefinition && t.Name == "FelineClientGetCatsCollectionResult");
             Assert.IsNotNull(felineClientCollectionResult);
             Assert.AreEqual("Felines", felineClientCollectionResult!.Type.Namespace);
+        }
+
+        [Test]
+        public void UsesValidIdentifierNames()
+        {
+            MockHelpers.LoadMockGenerator();
+            var inputModel = InputFactory.Model("cat", properties:
+            [
+                InputFactory.Property("color", InputPrimitiveType.String, isRequired: true),
+            ]);
+            var pagingMetadata = InputFactory.NextLinkPagingMetadata("cats", "nextCat", InputResponseLocation.Body);
+            var response = InputFactory.OperationResponse(
+                [200],
+                InputFactory.Model(
+                    "page",
+                    properties: [InputFactory.Property("cats", InputFactory.Array(inputModel)), InputFactory.Property("nextCat", InputPrimitiveType.Url)]));
+            IReadOnlyList<InputParameter> parameters = [InputFactory.Parameter("$foo", InputPrimitiveType.String, isRequired: true, location: InputRequestLocation.Header)];
+            var operation = InputFactory.Operation("getCats", responses: [response], parameters: parameters);
+            var inputServiceMethod = InputFactory.PagingServiceMethod("getCats", operation, pagingMetadata: pagingMetadata, parameters: parameters);
+            var catClient = InputFactory.Client("catClient", methods: [inputServiceMethod], clientNamespace: "Cats");
+            var clientProvider = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(catClient);
+            var modelType = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputModel);
+            var collectionResultDefinition = new CollectionResultDefinition(clientProvider!, inputServiceMethod, modelType!.Type, false);
+            var constructor =
+                collectionResultDefinition.Constructors.FirstOrDefault(c =>
+                    c.Signature.Parameters.Any(p => p.Name == "foo"));
+            Assert.IsNotNull(constructor);
+            var fields = collectionResultDefinition.Fields;
+            Assert.IsTrue(fields.Any(f => f.Name == "_foo"));
         }
 
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
         private static bool IsWordSeparator(char c) => !SyntaxFacts.IsIdentifierPartCharacter(c) || c == '_';
 
         [return: NotNullIfNotNull("name")]
-        public static string ToIdentifierName(this string name, bool isCamelCase = true)
+        public static string ToIdentifierName(this string name, bool useCamelCase = false)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -45,12 +45,12 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
                     continue;
                 }
 
-                if (nameBuilder.Length == 0 && isCamelCase)
+                if (nameBuilder.Length == 0 && !useCamelCase)
                 {
                     c = char.ToUpper(c);
                     upperCase = false;
                 }
-                else if (nameBuilder.Length < firstWordLength && !isCamelCase)
+                else if (nameBuilder.Length < firstWordLength && useCamelCase)
                 {
                     c = char.ToLower(c);
                     upperCase = false;
@@ -77,6 +77,9 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
         }
 
         [return: NotNullIfNotNull(nameof(name))]
-        public static string ToVariableName(this string name) => name.ToIdentifierName(isCamelCase: false);
+        public static string ToVariableName(this string name) => name.ToIdentifierName(useCamelCase: true);
+
+        [return: NotNullIfNotNull(nameof(name))]
+        public static string ToParameterName(this string name) => name.ToIdentifierName(useCamelCase: true);
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         /// <param name="inputParameter">The <see cref="InputParameter"/> to convert.</param>
         public ParameterProvider(InputParameter inputParameter)
         {
-            Name = inputParameter.Name;
+            Name = inputParameter.Name.ToParameterName();
             Description = DocHelpers.GetFormattableDescription(inputParameter.Summary, inputParameter.Doc) ?? FormattableStringHelpers.Empty;
             var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(inputParameter.Type) ?? throw new InvalidOperationException($"Failed to create CSharpType for {inputParameter.Type}");
             if (!inputParameter.IsRequired)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.RestClient.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.RestClient.cs
@@ -336,7 +336,7 @@ namespace SampleTypeSpec
             return message;
         }
 
-        internal PipelineMessage CreateListWithNextLinkRequest(RequestOptions options)
+        internal PipelineMessage CreateGetWithNextLinkRequest(RequestOptions options)
         {
             PipelineMessage message = Pipeline.CreateMessage();
             message.ResponseClassifier = PipelineMessageClassifier200;
@@ -351,7 +351,7 @@ namespace SampleTypeSpec
             return message;
         }
 
-        internal PipelineMessage CreateNextListWithNextLinkRequest(Uri nextPage, RequestOptions options)
+        internal PipelineMessage CreateNextGetWithNextLinkRequest(Uri nextPage, RequestOptions options)
         {
             PipelineMessage message = Pipeline.CreateMessage();
             message.ResponseClassifier = PipelineMessageClassifier200;
@@ -365,7 +365,7 @@ namespace SampleTypeSpec
             return message;
         }
 
-        internal PipelineMessage CreateListWithContinuationTokenRequest(string token, RequestOptions options)
+        internal PipelineMessage CreateGetWithContinuationTokenRequest(string token, RequestOptions options)
         {
             PipelineMessage message = Pipeline.CreateMessage();
             message.ResponseClassifier = PipelineMessageClassifier200;
@@ -384,7 +384,7 @@ namespace SampleTypeSpec
             return message;
         }
 
-        internal PipelineMessage CreateListWithContinuationTokenHeaderResponseRequest(string token, RequestOptions options)
+        internal PipelineMessage CreateGetWithContinuationTokenHeaderResponseRequest(string token, RequestOptions options)
         {
             PipelineMessage message = Pipeline.CreateMessage();
             message.ResponseClassifier = PipelineMessageClassifier200;
@@ -403,7 +403,7 @@ namespace SampleTypeSpec
             return message;
         }
 
-        internal PipelineMessage CreateListWithPagingRequest(RequestOptions options)
+        internal PipelineMessage CreateGetWithPagingRequest(RequestOptions options)
         {
             PipelineMessage message = Pipeline.CreateMessage();
             message.ResponseClassifier = PipelineMessageClassifier200;

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenAsyncCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenAsyncCollectionResult.cs
@@ -33,7 +33,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -45,7 +45,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenAsyncCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenAsyncCollectionResultOfT.cs
@@ -34,7 +34,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -46,7 +46,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenCollectionResult.cs
@@ -33,7 +33,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -45,7 +45,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenCollectionResultOfT.cs
@@ -33,7 +33,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -45,7 +45,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResult.cs
@@ -33,7 +33,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenHeaderResponseRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -48,7 +48,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenHeaderResponseRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseAsyncCollectionResultOfT.cs
@@ -34,7 +34,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenHeaderResponseRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -49,7 +49,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenHeaderResponseRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResult.cs
@@ -33,7 +33,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenHeaderResponseRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -48,7 +48,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenHeaderResponseRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithContinuationTokenHeaderResponseCollectionResultOfT.cs
@@ -33,7 +33,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithContinuationTokenHeaderResponseRequest(_token, _options);
+            PipelineMessage message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(_token, _options);
             string nextToken = null;
             while (true)
             {
@@ -48,7 +48,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateListWithContinuationTokenHeaderResponseRequest(nextToken, _options);
+                message = _client.CreateGetWithContinuationTokenHeaderResponseRequest(nextToken, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkAsyncCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkAsyncCollectionResult.cs
@@ -30,7 +30,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithNextLinkRequest(_options);
+            PipelineMessage message = _client.CreateGetWithNextLinkRequest(_options);
             Uri nextPageUri = null;
             while (true)
             {
@@ -42,7 +42,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateNextListWithNextLinkRequest(nextPageUri, _options);
+                message = _client.CreateNextGetWithNextLinkRequest(nextPageUri, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkAsyncCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkAsyncCollectionResultOfT.cs
@@ -31,7 +31,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithNextLinkRequest(_options);
+            PipelineMessage message = _client.CreateGetWithNextLinkRequest(_options);
             Uri nextPageUri = null;
             while (true)
             {
@@ -43,7 +43,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateNextListWithNextLinkRequest(nextPageUri, _options);
+                message = _client.CreateNextGetWithNextLinkRequest(nextPageUri, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkCollectionResult.cs
@@ -30,7 +30,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithNextLinkRequest(_options);
+            PipelineMessage message = _client.CreateGetWithNextLinkRequest(_options);
             Uri nextPageUri = null;
             while (true)
             {
@@ -42,7 +42,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateNextListWithNextLinkRequest(nextPageUri, _options);
+                message = _client.CreateNextGetWithNextLinkRequest(nextPageUri, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithNextLinkCollectionResultOfT.cs
@@ -30,7 +30,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithNextLinkRequest(_options);
+            PipelineMessage message = _client.CreateGetWithNextLinkRequest(_options);
             Uri nextPageUri = null;
             while (true)
             {
@@ -42,7 +42,7 @@ namespace SampleTypeSpec
                 {
                     yield break;
                 }
-                message = _client.CreateNextListWithNextLinkRequest(nextPageUri, _options);
+                message = _client.CreateNextGetWithNextLinkRequest(nextPageUri, _options);
             }
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingAsyncCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingAsyncCollectionResult.cs
@@ -29,7 +29,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithPagingRequest(_options);
+            PipelineMessage message = _client.CreateGetWithPagingRequest(_options);
             yield return ClientResult.FromResponse(await _client.Pipeline.ProcessMessageAsync(message, _options).ConfigureAwait(false));
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingAsyncCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingAsyncCollectionResultOfT.cs
@@ -30,7 +30,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override async IAsyncEnumerable<ClientResult> GetRawPagesAsync()
         {
-            PipelineMessage message = _client.CreateListWithPagingRequest(_options);
+            PipelineMessage message = _client.CreateGetWithPagingRequest(_options);
             yield return ClientResult.FromResponse(await _client.Pipeline.ProcessMessageAsync(message, _options).ConfigureAwait(false));
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingCollectionResult.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingCollectionResult.cs
@@ -29,7 +29,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithPagingRequest(_options);
+            PipelineMessage message = _client.CreateGetWithPagingRequest(_options);
             yield return ClientResult.FromResponse(_client.Pipeline.ProcessMessage(message, _options));
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingCollectionResultOfT.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClientGetWithPagingCollectionResultOfT.cs
@@ -29,7 +29,7 @@ namespace SampleTypeSpec
         /// <returns> The raw pages of the collection. </returns>
         public override IEnumerable<ClientResult> GetRawPages()
         {
-            PipelineMessage message = _client.CreateListWithPagingRequest(_options);
+            PipelineMessage message = _client.CreateGetWithPagingRequest(_options);
             yield return ClientResult.FromResponse(_client.Pipeline.ProcessMessage(message, _options));
         }
 


### PR DESCRIPTION
- Updates List -> Get up front so that all downstream methods/types are named with Get
- Fixes parameter (and downstream field) naming so that valid identifiers are used