### PR TITLE
Add reset method

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -389,12 +389,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
             TypeSignatureModifiers? modifiers = null,
             string? name = null,
             string? @namespace = null,
-            string? relativeFilePath = null,
-            bool allowNulls = false)
+            string? relativeFilePath = null)
         {
-            if (methods != null || allowNulls)
+            if (methods != null)
             {
-                _methods = (methods as IReadOnlyList<MethodProvider>) ?? methods?.ToList();
+                _methods = (methods as IReadOnlyList<MethodProvider>) ?? methods.ToList();
             }
             if (properties != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
     public abstract class TypeProvider
     {
         private Lazy<TypeProvider?> _customCodeView;
-        private readonly Lazy<TypeProvider?> _lastContractView;
+        private Lazy<TypeProvider?> _lastContractView;
         private Lazy<CanonicalTypeProvider> _canonicalView;
         private readonly InputType? _inputType;
 
@@ -351,6 +351,33 @@ namespace Microsoft.TypeSpec.Generator.Providers
         protected abstract string BuildRelativeFilePath();
         protected abstract string BuildName();
 
+        /// <summary>
+        /// Resets the type provider to its initial state, clearing all cached properties and fields.
+        /// This allows for the type provider to rebuild its state on subsequent calls to its properties.
+        /// </summary>
+        public void Reset()
+        {
+            _methods = null;
+            _properties = null;
+            _fields = null;
+            _constructors = null;
+            _serializationProviders = null;
+            _nestedTypes = null;
+            _xmlDocs = null;
+            _declarationModifiers = null;
+            _relativeFilePath = null;
+            _customCodeView = new(() => GetCustomCodeView());
+            _canonicalView = new(BuildCanonicalView);
+            _lastContractView = new(GetLastContractView);
+            _enumValues = null;
+            _enumUnderlyingType = null;
+            _attributes = null;
+            _deprecated = null;
+            _description = null;
+            _type = null;
+            _arguments = null;
+        }
+
         public void Update(
             IEnumerable<MethodProvider>? methods = null,
             IEnumerable<ConstructorProvider>? constructors = null,
@@ -362,11 +389,12 @@ namespace Microsoft.TypeSpec.Generator.Providers
             TypeSignatureModifiers? modifiers = null,
             string? name = null,
             string? @namespace = null,
-            string? relativeFilePath = null)
+            string? relativeFilePath = null,
+            bool allowNulls = false)
         {
-            if (methods != null)
+            if (methods != null || allowNulls)
             {
-                _methods = (methods as IReadOnlyList<MethodProvider>) ?? methods.ToList();
+                _methods = (methods as IReadOnlyList<MethodProvider>) ?? methods?.ToList();
             }
             if (properties != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
@@ -79,5 +79,23 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             var expectedCount = isNestedTypeAnEnum ? 0 : 1;
             Assert.AreEqual(expectedCount, nestedTypes.Count);
         }
+
+        [Test]
+        public void CanResetTypeProvider()
+        {
+            var typeProvider = new TestTypeProvider(name: "OriginalName",
+                methods: [new MethodProvider(
+                new MethodSignature("TestMethod", $"", MethodSignatureModifiers.Public, null, $"", []),
+                Snippet.Throw(Snippet.Null), new TestTypeProvider())]);
+            typeProvider.Update(name: "UpdatedName", methods: []);
+            Assert.AreEqual("UpdatedName", typeProvider.Name);
+            Assert.AreEqual(0, typeProvider.Methods.Count);
+
+            typeProvider.Reset();
+
+            // The BuildX methods should be called again, which will return the original state.
+            Assert.AreEqual("OriginalName", typeProvider.Name);
+            Assert.AreEqual(1, typeProvider.Methods.Count);
+        }
     }
 }


### PR DESCRIPTION
This is a solution for the problem of not being able to use the Update method to reset properties to null. Resetting properties to null is useful to force cache invalidation of the TypeProvider properties.