### PR TITLE
[http-client-java] fix generation failure when there are same paging operation under different clients

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/tranformer/Transformer.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/tranformer/Transformer.java
@@ -533,8 +533,6 @@ public class Transformer {
                             });
                     }
                 }
-                operation.getExtensions().getXmsPageable().setNextOperation(nextOperation);
-                nextOperation.getExtensions().getXmsPageable().setNextOperation(nextOperation);
                 operationNextPageOperationMap.put(operationSignature, nextOperation);
             } else {
                 // In case the same operation instance is processed more than once(both in "transformOperationGroups"
@@ -542,6 +540,9 @@ public class Transformer {
                 // we share the same next-page operation for the same operation instance.
                 nextOperation = operationNextPageOperationMap.get(operationSignature);
             }
+            operation.getExtensions().getXmsPageable().setNextOperation(nextOperation);
+            nextOperation.getExtensions().getXmsPageable().setNextOperation(nextOperation);
+
             operationGroup.getOperations().add(nextOperation);
         } else {
             Operation nextOperation = operationGroup.getOperations()


### PR DESCRIPTION
Backgrounds in this pr: https://github.com/Azure/azure-rest-api-specs/pull/35335

Tested using Communication.Messages, it passed. But duplicate `ServiceVersion` created after fixing this bug. Track an issue first:
https://github.com/microsoft/typespec/issues/7734

autorest.java validation: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5012574&view=results