### PR TITLE
[OpenAPI 3] Fix bug where namespace name was not part of array component schema name for nested namespaces

### DIFF
--- a/.chronus/changes/oa3-fix-array-nested-2025-5-25-11-57-12.md
+++ b/.chronus/changes/oa3-fix-array-nested-2025-5-25-11-57-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Prepends namespace name to array declarations in nested namespaces.

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -301,8 +301,7 @@ export class OpenAPI3SchemaEmitterBase<
       items: this.emitter.emitTypeReference(elementType),
     });
 
-    const name =
-      getOpenAPITypeName(this.emitter.getProgram(), array, this.#typeNameOptions());
+    const name = getOpenAPITypeName(this.emitter.getProgram(), array, this.#typeNameOptions());
     return this.#createDeclaration(array, name, this.applyConstraints(array, schema as any));
   }
 

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -295,12 +295,14 @@ export class OpenAPI3SchemaEmitterBase<
     return this.unionDeclaration(union, name);
   }
 
-  arrayDeclaration(array: Model, name: string, elementType: Type): EmitterOutput<object> {
+  arrayDeclaration(array: Model, _: string, elementType: Type): EmitterOutput<object> {
     const schema = new ObjectBuilder({
       type: "array",
       items: this.emitter.emitTypeReference(elementType),
     });
 
+    const name =
+      getOpenAPITypeName(this.emitter.getProgram(), array, this.#typeNameOptions());
     return this.#createDeclaration(array, name, this.applyConstraints(array, schema as any));
   }
 

--- a/packages/openapi3/test/array.test.ts
+++ b/packages/openapi3/test/array.test.ts
@@ -68,6 +68,37 @@ worksFor(["3.0.0", "3.1.0"], ({ oapiForModel, openApiFor }) => {
     });
   });
 
+  it("define named arrays with envelope names", async () => {
+    const res = await openApiFor(
+      `
+      @service
+      namespace Sample;
+      namespace One {
+        model PetNames is string[];
+      }
+      namespace Two {
+        model PetNames is string[];
+      }
+      model Pets {
+        one: One.PetNames;
+        two: Two.PetNames;
+      }
+      `,
+    );
+    deepStrictEqual(res.components.schemas["One.PetNames"], {
+      type: "array",
+      items: { type: "string" },
+    });
+    deepStrictEqual(res.components.schemas["Two.PetNames"], {
+      type: "array",
+      items: { type: "string" },
+    });
+    deepStrictEqual(res.components.schemas.Pets.properties, {
+      one: { $ref: "#/components/schemas/One.PetNames" },
+      two: { $ref: "#/components/schemas/Two.PetNames" },
+    });
+  });
+
   it("named array applies doc", async () => {
     const res = await oapiForModel(
       "Pet",


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/7720