### PR TITLE
build: ignore build failure in sdk-for-net pr creation

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -147,16 +147,22 @@ try {
         
         # Run npm run build
         Write-Host "Running npm run build in eng/packages/http-client-csharp..."
+        $shouldRunGenerate = $true
         Invoke "npm run build" $httpClientDir
         if ($LASTEXITCODE -ne 0) {
-            throw "npm run build failed"
+            # log a warning as we still want to create the PR but not run Generate.ps1
+            Write-Warning "npm run build failed, skipping Generate.ps1"
+            $shouldRunGenerate = $false
         }
         
         # Run Generate.ps1 from the package root
-        Write-Host "Running eng/packages/http-client-csharp/eng/scripts/Generate.ps1..."
-        & (Join-Path $tempDir "eng/packages/http-client-csharp/eng/scripts/Generate.ps1")
-        if ($LASTEXITCODE -ne 0) {
-            throw "Generate.ps1 failed"
+        if ($shouldRunGenerate -eq $true)
+        {
+            Write-Host "Running eng/packages/http-client-csharp/eng/scripts/Generate.ps1..."
+            & (Join-Path $tempDir "eng/packages/http-client-csharp/eng/scripts/Generate.ps1")
+            if ($LASTEXITCODE -ne 0) {
+                throw "Generate.ps1 failed"
+            }
         }
     }
     


### PR DESCRIPTION
This pr updates the script to bump the generator version in the sdk-for-net repo by ignoring any build failures that occur in that repo when bumping the version. This is to ensure the PR is still created even if there are breaking changes as in [this pipeline run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5015539&view=logs&j=bb16106d-22e7-5110-6a98-db4aff7298af&t=0d9e1118-c27c-5a98-3b56-2f38b75838d3).