### PR TITLE
[http-client-csharp] support attributes for fields, props, & ctors

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
@@ -41,14 +41,14 @@ namespace Microsoft.TypeSpec.Generator.Providers
             MethodBodyStatement bodyStatements,
             TypeProvider enclosingType,
             XmlDocProvider? xmlDocProvider = default,
-            IReadOnlyList<AttributeStatement>? attributes = default)
+            IEnumerable<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
-            Attributes = attributes ?? [];
+            Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
         }
 
         /// <summary>
@@ -64,13 +64,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
             ValueExpression bodyExpression,
             TypeProvider enclosingType,
             XmlDocProvider? xmlDocProvider = default,
-            IReadOnlyList<AttributeStatement>? attributes = default)
+            IEnumerable<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             BodyExpression = bodyExpression;
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
-            Attributes = attributes ?? [];
+            Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
         }
 
         public void Update(
@@ -78,7 +78,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             ConstructorSignature? signature = null,
             ValueExpression? bodyExpression = null,
             XmlDocProvider? xmlDocs = null,
-            IReadOnlyList<AttributeStatement>? attributes = default)
+            IEnumerable<AttributeStatement>? attributes = default)
         {
             if (signature != null)
             {
@@ -102,7 +102,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
             if (attributes != null)
             {
-                Attributes = attributes;
+                Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [.. attributes];
             }
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ConstructorProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -18,6 +19,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public XmlDocProvider XmlDocs { get; private set; }
 
         public TypeProvider EnclosingType { get; }
+        public IReadOnlyList<AttributeStatement> Attributes { get; private set; }
 
         // for mocking
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -33,13 +35,20 @@ namespace Microsoft.TypeSpec.Generator.Providers
         /// <param name="bodyStatements">The method body.</param>
         /// <param name="enclosingType">The enclosing type.</param>
         /// <param name="xmlDocProvider">The XML documentation provider.</param>
-        public ConstructorProvider(ConstructorSignature signature, MethodBodyStatement bodyStatements, TypeProvider enclosingType, XmlDocProvider? xmlDocProvider = default)
+        /// <param name="attributes"> The attributes for the method.</param>
+        public ConstructorProvider(
+            ConstructorSignature signature,
+            MethodBodyStatement bodyStatements,
+            TypeProvider enclosingType,
+            XmlDocProvider? xmlDocProvider = default,
+            IReadOnlyList<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
+            Attributes = attributes ?? [];
         }
 
         /// <summary>
@@ -49,19 +58,27 @@ namespace Microsoft.TypeSpec.Generator.Providers
         /// <param name="bodyExpression">The method body expression.</param>
         /// <param name="enclosingType">The enclosing type.</param>
         /// <param name="xmlDocProvider">The XML documentation provider.</param>
-        public ConstructorProvider(ConstructorSignature signature, ValueExpression bodyExpression, TypeProvider enclosingType, XmlDocProvider? xmlDocProvider = default)
+        /// <param name="attributes"> The attributes for the method.</param>
+        public ConstructorProvider(
+            ConstructorSignature signature,
+            ValueExpression bodyExpression,
+            TypeProvider enclosingType,
+            XmlDocProvider? xmlDocProvider = default,
+            IReadOnlyList<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             BodyExpression = bodyExpression;
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
+            Attributes = attributes ?? [];
         }
 
         public void Update(
             MethodBodyStatement? bodyStatements = null,
             ConstructorSignature? signature = null,
             ValueExpression? bodyExpression = null,
-            XmlDocProvider? xmlDocs = null)
+            XmlDocProvider? xmlDocs = null,
+            IReadOnlyList<AttributeStatement>? attributes = default)
         {
             if (signature != null)
             {
@@ -82,6 +99,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
             if (xmlDocs != null)
             {
                 XmlDocs = xmlDocs;
+            }
+            if (attributes != null)
+            {
+                Attributes = attributes;
             }
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
@@ -15,12 +15,12 @@ namespace Microsoft.TypeSpec.Generator.Providers
     {
         private VariableExpression? _variable;
         private Lazy<ParameterProvider> _parameter;
-        public FormattableString? Description { get; }
+        public FormattableString? Description { get; private set; }
         public FieldModifiers Modifiers { get; set; }
         public CSharpType Type { get; internal set; }
-        public string Name { get; }
-        public ValueExpression? InitializationValue { get; }
-        public XmlDocProvider? XmlDocs { get; }
+        public string Name { get; private set; }
+        public ValueExpression? InitializationValue { get; private set; }
+        public XmlDocProvider? XmlDocs { get; private set; }
         public PropertyWireInformation? WireInfo { get; internal set; }
 
         private CodeWriterDeclaration? _declaration;
@@ -36,8 +36,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         public ValueExpression AsValueExpression => this;
 
-        public TypeProvider EnclosingType { get; }
-        public IReadOnlyList<AttributeStatement> Attributes { get; }
+        public TypeProvider EnclosingType { get; private set; }
+        public IReadOnlyList<AttributeStatement> Attributes { get; private set; }
 
         internal string? OriginalName { get; init; }
 
@@ -56,7 +56,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             FormattableString? description = null,
             ValueExpression? initializationValue = null,
             PropertyWireInformation? wireInfo = null,
-            IReadOnlyList<AttributeStatement>? attributes = default)
+            IEnumerable<AttributeStatement>? attributes = default)
         {
             Modifiers = modifiers;
             Type = type;
@@ -66,9 +66,69 @@ namespace Microsoft.TypeSpec.Generator.Providers
             XmlDocs = Description is not null ? new XmlDocProvider(new XmlDocSummaryStatement([Description])) : null;
             EnclosingType = enclosingType;
             WireInfo = wireInfo;
-            Attributes = attributes ?? [];
+            Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
 
             InitializeParameter();
+        }
+
+        /// <summary>
+        /// Updates the field with new values.
+        /// </summary>
+        public void Update(
+            FieldModifiers? modifiers = null,
+            CSharpType? type = null,
+            string? name = null,
+            FormattableString? description = null,
+            ValueExpression? initializationValue = null,
+            PropertyWireInformation? wireInfo = null,
+            TypeProvider? enclosingType = null,
+            IEnumerable<AttributeStatement>? attributes = null)
+        {
+            if (modifiers != null)
+            {
+                Modifiers = modifiers.Value;
+            }
+
+            if (type != null)
+            {
+                Type = type;
+                _variable?.Update(type: type);
+            }
+
+            if (name != null)
+            {
+                Name = name;
+                _variable?.Update(name: name);
+                _asMember?.Update(memberName: name);
+                _declaration = null;
+                InitializeParameter();
+            }
+
+            if (description != null)
+            {
+                Description = description;
+                XmlDocs = new XmlDocProvider(new XmlDocSummaryStatement([description]));
+            }
+
+            if (initializationValue != null)
+            {
+                InitializationValue = initializationValue;
+            }
+
+            if (wireInfo != null)
+            {
+                WireInfo = wireInfo;
+            }
+
+            if (enclosingType != null)
+            {
+                EnclosingType = enclosingType;
+            }
+
+            if (attributes != null)
+            {
+                Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
+            }
         }
 
         [MemberNotNull(nameof(_parameter))]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FieldProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
@@ -36,6 +37,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public ValueExpression AsValueExpression => this;
 
         public TypeProvider EnclosingType { get; }
+        public IReadOnlyList<AttributeStatement> Attributes { get; }
 
         internal string? OriginalName { get; init; }
 
@@ -53,7 +55,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             TypeProvider enclosingType,
             FormattableString? description = null,
             ValueExpression? initializationValue = null,
-            PropertyWireInformation? wireInfo = null)
+            PropertyWireInformation? wireInfo = null,
+            IReadOnlyList<AttributeStatement>? attributes = default)
         {
             Modifiers = modifiers;
             Type = type;
@@ -63,6 +66,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             XmlDocs = Description is not null ? new XmlDocProvider(new XmlDocSummaryStatement([Description])) : null;
             EnclosingType = enclosingType;
             WireInfo = wireInfo;
+            Attributes = attributes ?? [];
 
             InitializeParameter();
         }
@@ -71,7 +75,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private void InitializeParameter()
         {
             _parameter = new(() => new ParameterProvider(
-                Name.ToVariableName(), Description ?? FormattableStringHelpers.Empty, Type, field: this, wireInfo: WireInfo));
+                Name.ToVariableName(), Description ?? FormattableStringHelpers.Empty, Type, field: this, wireInfo: WireInfo, attributes: Attributes));
         }
 
         private MemberExpression? _asMember;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
@@ -42,14 +42,14 @@ namespace Microsoft.TypeSpec.Generator.Providers
             MethodBodyStatement bodyStatements,
             TypeProvider enclosingType,
             XmlDocProvider? xmlDocProvider = default,
-            IReadOnlyList<AttributeStatement>? attributes = default)
+            IEnumerable<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
-            Attributes = attributes ?? [];
+            Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
         }
 
         /// <summary>
@@ -65,13 +65,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
             ValueExpression bodyExpression,
             TypeProvider enclosingType,
             XmlDocProvider? xmlDocProvider = default,
-            IReadOnlyList<AttributeStatement>? attributes = default)
+            IEnumerable<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             BodyExpression = bodyExpression;
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
-            Attributes = attributes ?? [];
+            Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
         }
 
         public void Update(
@@ -79,7 +79,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             MethodBodyStatement? bodyStatements = null,
             ValueExpression? bodyExpression = null,
             XmlDocProvider? xmlDocProvider = null,
-            IReadOnlyList<AttributeStatement>? attributes = default)
+            IEnumerable<AttributeStatement>? attributes = default)
         {
             if (signature != null)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
             if (attributes != null)
             {
-                Attributes = attributes;
+                Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
             }
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -19,6 +20,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public XmlDocProvider XmlDocs { get; private set; }
 
         public TypeProvider EnclosingType { get; }
+        public IReadOnlyList<AttributeStatement> Attributes { get; private set; }
 
         // for mocking
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -34,13 +36,20 @@ namespace Microsoft.TypeSpec.Generator.Providers
         /// <param name="bodyStatements">The method body.</param>
         /// <param name="enclosingType">The enclosing type.</param>
         /// <param name="xmlDocProvider">The XML documentation provider.</param>
-        public MethodProvider(MethodSignature signature, MethodBodyStatement bodyStatements, TypeProvider enclosingType, XmlDocProvider? xmlDocProvider = default)
+        /// <param name="attributes"> The attributes for the method.</param>
+        public MethodProvider(
+            MethodSignature signature,
+            MethodBodyStatement bodyStatements,
+            TypeProvider enclosingType,
+            XmlDocProvider? xmlDocProvider = default,
+            IReadOnlyList<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             var paramHash = MethodProviderHelpers.GetParamHash(signature);
             BodyStatements = MethodProviderHelpers.GetBodyStatementWithValidation(signature.Parameters, bodyStatements, paramHash);
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
+            Attributes = attributes ?? [];
         }
 
         /// <summary>
@@ -50,19 +59,27 @@ namespace Microsoft.TypeSpec.Generator.Providers
         /// <param name="bodyExpression">The method body expression.</param>
         /// <param name="enclosingType">The enclosing type.</param>
         /// <param name="xmlDocProvider">The XML documentation provider.</param>
-        public MethodProvider(MethodSignature signature, ValueExpression bodyExpression, TypeProvider enclosingType, XmlDocProvider? xmlDocProvider = default)
+        /// <param name="attributes"> The attributes for the method.</param>
+        public MethodProvider(
+            MethodSignature signature,
+            ValueExpression bodyExpression,
+            TypeProvider enclosingType,
+            XmlDocProvider? xmlDocProvider = default,
+            IReadOnlyList<AttributeStatement>? attributes = default)
         {
             Signature = signature;
             BodyExpression = bodyExpression;
             XmlDocs = xmlDocProvider ?? MethodProviderHelpers.BuildXmlDocs(signature);
             EnclosingType = enclosingType;
+            Attributes = attributes ?? [];
         }
 
         public void Update(
             MethodSignature? signature = null,
             MethodBodyStatement? bodyStatements = null,
             ValueExpression? bodyExpression = null,
-            XmlDocProvider? xmlDocProvider = null)
+            XmlDocProvider? xmlDocProvider = null,
+            IReadOnlyList<AttributeStatement>? attributes = default)
         {
             if (signature != null)
             {
@@ -84,6 +101,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 XmlDocs = xmlDocProvider;
             }
+            if (attributes != null)
+            {
+                Attributes = attributes;
+            }
         }
 
         internal virtual MethodProvider? Accept(LibraryVisitor visitor)
@@ -100,6 +121,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             Signature = updated.Signature;
+            Attributes = updated.Attributes;
 
             if (BodyExpression != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             bool isRef = false,
             bool isOut = false,
             bool isParams = false,
-            IReadOnlyList<AttributeStatement>? attributes = null,
+            IEnumerable<AttributeStatement>? attributes = null,
             PropertyProvider? property = null,
             FieldProvider? field = null,
             ValueExpression? initializationValue = null,
@@ -97,7 +97,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             IsOut = isOut;
             IsParams = isParams;
             DefaultValue = defaultValue;
-            Attributes = attributes ?? [];
+            Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
             Property = property;
             Field = field;
             Validation = validation ?? GetParameterValidation();
@@ -252,7 +252,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             bool? isRef = null,
             bool? isOut = null,
             bool? isParams = null,
-            IReadOnlyList<AttributeStatement>? attributes = null,
+            IEnumerable<AttributeStatement>? attributes = null,
             PropertyProvider? property = null,
             FieldProvider? field = null,
             ValueExpression? initializationValue = null,
@@ -300,7 +300,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
             if (attributes is not null)
             {
-                Attributes = attributes;
+                Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
             }
 
             if (property is not null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public bool IsOut { get; private set; }
         public bool IsParams { get; private set; }
 
-        internal IReadOnlyList<AttributeStatement> Attributes { get; private set; } = [];
+        public IReadOnlyList<AttributeStatement> Attributes { get; private set; }
         public WireInformation WireInfo { get; private set; }
         public ParameterLocation Location { get; private set; }
 
@@ -69,6 +69,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 : ParameterValidationType.None;
             WireInfo = new WireInformation(CodeModelGenerator.Instance.TypeFactory.GetSerializationFormat(inputParameter.Type), inputParameter.NameInRequest);
             Location = inputParameter.Location.ToParameterLocation();
+            Attributes = [];
         }
 
         public ParameterProvider(
@@ -96,7 +97,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             IsOut = isOut;
             IsParams = isParams;
             DefaultValue = defaultValue;
-            Attributes = attributes ?? Array.Empty<AttributeStatement>();
+            Attributes = attributes ?? [];
             Property = property;
             Field = field;
             Validation = validation ?? GetParameterValidation();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -114,7 +114,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             TypeProvider enclosingType,
             CSharpType? explicitInterface = null,
             PropertyWireInformation? wireInfo = null,
-            IReadOnlyList<AttributeStatement>? attributes = null)
+            IEnumerable<AttributeStatement>? attributes = null)
         {
             Modifiers = modifiers;
             Type = type;
@@ -124,7 +124,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
             WireInfo = wireInfo;
             EnclosingType = enclosingType;
-            Attributes = attributes ?? [];
+            Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
 
             InitializeParameter(description ?? FormattableStringHelpers.Empty);
             _customDescription = description;
@@ -264,7 +264,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             CSharpType? explicitInterface = null,
             PropertyWireInformation? wireInfo = null,
             XmlDocProvider? xmlDocs = null,
-            IReadOnlyList<AttributeStatement>? attributes = null)
+            IEnumerable<AttributeStatement>? attributes = null)
         {
             if (description != null)
             {
@@ -300,7 +300,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
             if (attributes != null)
             {
-                Attributes = attributes;
+                Attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [];
             }
             if (xmlDocs != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
@@ -42,6 +43,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public ParameterProvider AsParameter => _parameter.Value;
 
         public TypeProvider EnclosingType { get; private set; }
+
+        public IReadOnlyList<AttributeStatement> Attributes { get; private set; }
 
         public string? OriginalName { get; internal init; }
 
@@ -96,6 +99,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             Body = new AutoPropertyBody(propHasSetter, setterModifier, GetPropertyInitializationValue(propertyType, inputProperty));
 
             WireInfo = new PropertyWireInformation(inputProperty);
+            Attributes = [];
 
             InitializeParameter(DocHelpers.GetFormattableDescription(inputProperty.Summary, inputProperty.Doc) ?? FormattableStringHelpers.Empty);
             BuildDocs();
@@ -109,7 +113,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             PropertyBody body,
             TypeProvider enclosingType,
             CSharpType? explicitInterface = null,
-            PropertyWireInformation? wireInfo = null)
+            PropertyWireInformation? wireInfo = null,
+            IReadOnlyList<AttributeStatement>? attributes = null)
         {
             Modifiers = modifiers;
             Type = type;
@@ -119,6 +124,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
             WireInfo = wireInfo;
             EnclosingType = enclosingType;
+            Attributes = attributes ?? [];
 
             InitializeParameter(description ?? FormattableStringHelpers.Empty);
             _customDescription = description;
@@ -257,7 +263,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             TypeProvider? enclosingType = null,
             CSharpType? explicitInterface = null,
             PropertyWireInformation? wireInfo = null,
-            XmlDocProvider? xmlDocs = null)
+            XmlDocProvider? xmlDocs = null,
+            IReadOnlyList<AttributeStatement>? attributes = null)
         {
             if (description != null)
             {
@@ -290,6 +297,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
             if (wireInfo != null)
             {
                 WireInfo = wireInfo;
+            }
+            if (attributes != null)
+            {
+                Attributes = attributes;
             }
             if (xmlDocs != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -412,6 +412,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             IEnumerable<FieldProvider>? fields = null,
             IEnumerable<TypeProvider>? serializations = null,
             IEnumerable<TypeProvider>? nestedTypes = null,
+            IEnumerable<AttributeStatement>? attributes = default,
             XmlDocProvider? xmlDocs = null,
             TypeSignatureModifiers? modifiers = null,
             string? name = null,
@@ -458,6 +459,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
             if (relativeFilePath != null)
             {
                 _relativeFilePath = relativeFilePath;
+            }
+            if (attributes != null)
+            {
+                _attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [.. attributes];
             }
 
             if (name != null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
@@ -183,6 +184,15 @@ namespace Microsoft.TypeSpec.Generator
 
             using (WriteXmlDocs(method.XmlDocs))
             {
+                if (method.Attributes.Count > 0)
+                {
+                    method.Attributes[0].Write(this);
+                    for (int i = 1; i < method.Attributes.Count; i++)
+                    {
+                        method.Attributes[i].Write(this);
+                    }
+                }
+
                 if (method.BodyStatements is { } body)
                 {
                     using (WriteMethodDeclaration(method.Signature))
@@ -208,6 +218,15 @@ namespace Microsoft.TypeSpec.Generator
 
             using (WriteXmlDocs(ctor.XmlDocs))
             {
+                if (ctor.Attributes.Count > 0)
+                {
+                    ctor.Attributes[0].Write(this);
+                    for (int i = 1; i < ctor.Attributes.Count; i++)
+                    {
+                        ctor.Attributes[i].Write(this);
+                    }
+                }
+
                 if (ctor.BodyStatements is { } body)
                 {
                     using (WriteMethodDeclaration(ctor.Signature))
@@ -274,6 +293,15 @@ namespace Microsoft.TypeSpec.Generator
         public void WriteProperty(PropertyProvider property)
         {
             WriteXmlDocsNoScope(property.XmlDocs);
+
+            if (property.Attributes.Count > 0)
+            {
+                property.Attributes[0].Write(this);
+                for (int i = 1; i < property.Attributes.Count; i++)
+                {
+                    property.Attributes[i].Write(this);
+                }
+            }
 
             CodeScope? indexerScope = null;
 
@@ -433,6 +461,15 @@ namespace Microsoft.TypeSpec.Generator
         public CodeWriter WriteField(FieldProvider field)
         {
             WriteXmlDocsNoScope(field.XmlDocs);
+
+            if (field.Attributes.Count > 0)
+            {
+                field.Attributes[0].Write(this);
+                for (int i = 1; i < field.Attributes.Count; i++)
+                {
+                    field.Attributes[i].Write(this);
+                }
+            }
 
             var modifiers = field.Modifiers;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -186,8 +186,7 @@ namespace Microsoft.TypeSpec.Generator
             {
                 if (method.Attributes.Count > 0)
                 {
-                    method.Attributes[0].Write(this);
-                    for (int i = 1; i < method.Attributes.Count; i++)
+                    for (int i = 0; i < method.Attributes.Count; i++)
                     {
                         method.Attributes[i].Write(this);
                     }
@@ -220,8 +219,7 @@ namespace Microsoft.TypeSpec.Generator
             {
                 if (ctor.Attributes.Count > 0)
                 {
-                    ctor.Attributes[0].Write(this);
-                    for (int i = 1; i < ctor.Attributes.Count; i++)
+                    for (int i = 0; i < ctor.Attributes.Count; i++)
                     {
                         ctor.Attributes[i].Write(this);
                     }
@@ -296,8 +294,7 @@ namespace Microsoft.TypeSpec.Generator
 
             if (property.Attributes.Count > 0)
             {
-                property.Attributes[0].Write(this);
-                for (int i = 1; i < property.Attributes.Count; i++)
+                for (int i = 0; i < property.Attributes.Count; i++)
                 {
                     property.Attributes[i].Write(this);
                 }
@@ -464,8 +461,7 @@ namespace Microsoft.TypeSpec.Generator
 
             if (field.Attributes.Count > 0)
             {
-                field.Attributes[0].Write(this);
-                for (int i = 1; i < field.Attributes.Count; i++)
+                for (int i = 0; i < field.Attributes.Count; i++)
                 {
                     field.Attributes[i].Write(this);
                 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -186,9 +186,9 @@ namespace Microsoft.TypeSpec.Generator
             {
                 if (method.Attributes.Count > 0)
                 {
-                    for (int i = 0; i < method.Attributes.Count; i++)
+                    foreach (var attr in method.Attributes)
                     {
-                        method.Attributes[i].Write(this);
+                        attr.Write(this);
                     }
                 }
 
@@ -219,9 +219,9 @@ namespace Microsoft.TypeSpec.Generator
             {
                 if (ctor.Attributes.Count > 0)
                 {
-                    for (int i = 0; i < ctor.Attributes.Count; i++)
+                    foreach (var attr in ctor.Attributes)
                     {
-                        ctor.Attributes[i].Write(this);
+                        attr.Write(this);
                     }
                 }
 
@@ -294,9 +294,9 @@ namespace Microsoft.TypeSpec.Generator
 
             if (property.Attributes.Count > 0)
             {
-                for (int i = 0; i < property.Attributes.Count; i++)
+                foreach (var attr in property.Attributes)
                 {
-                    property.Attributes[i].Write(this);
+                    attr.Write(this);
                 }
             }
 
@@ -461,9 +461,9 @@ namespace Microsoft.TypeSpec.Generator
 
             if (field.Attributes.Count > 0)
             {
-                for (int i = 0; i < field.Attributes.Count; i++)
+                foreach (var attr in field.Attributes)
                 {
-                    field.Attributes[i].Write(this);
+                    attr.Write(this);
                 }
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/OutputLibraryVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/OutputLibraryVisitorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
@@ -106,7 +107,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
                 .Returns([mockSerializationProvider.Object]);
             var sig = new MethodSignature("Test", $"", MethodSignatureModifiers.Public, null, $"", []);
             var mockMethodProvider = new Mock<MethodProvider>(MockBehavior.Default, sig, MethodBodyStatement.Empty,
-                mockSerializationProvider.Object, new XmlDocProvider())
+                mockSerializationProvider.Object, new XmlDocProvider(), new List<AttributeStatement>())
             {
                 CallBase = true
             };

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ConstructorProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ConstructorProviderTests.cs
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Statements;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
@@ -12,11 +16,15 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
 {
     public class ConstructorProviderTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator();
+        }
+
         [Test]
         public void ValidateScope()
         {
-            MockHelpers.LoadMockGenerator();
-
             List<ParameterProvider> parameters = new List<ParameterProvider>
             {
                 new ParameterProvider("intParam", $"intParam", typeof(int)),
@@ -37,6 +45,51 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             using var codeWriter = new CodeWriter();
             codeWriter.WriteConstructor(constructorProvider);
             Assert.AreEqual(Helpers.GetExpectedFromFile(), codeWriter.ToString(false));
+        }
+
+        [Test]
+        public void TestAttributes()
+        {
+            List<ParameterProvider> parameters = new List<ParameterProvider>
+            {
+                new ParameterProvider("intParam", $"intParam", typeof(int)),
+                new ParameterProvider("stringParam", $"stringParam", typeof(string))
+            };
+            var attributes = new List<AttributeStatement>
+            {
+                 new(typeof(ObsoleteAttribute)),
+                 new(typeof(ObsoleteAttribute), Literal("This is obsolete")),
+                 new(typeof(ExperimentalAttribute), Literal("001"))
+            };
+            ConstructorProvider constructor = new ConstructorProvider(
+              new ConstructorSignature(
+                  typeof(ConstructorProviderTests),
+                  $"TestClass",
+                  MethodSignatureModifiers.Public,
+                  parameters,
+                  Initializer: new ConstructorInitializer(false, parameters)),
+              ThrowExpression(Null),
+              new TestTypeProvider(),
+              new XmlDocProvider(),
+              attributes: attributes);
+
+            Assert.IsNotNull(constructor.Attributes);
+            Assert.AreEqual(attributes.Count, constructor.Attributes.Count);
+            for (int i = 0; i < attributes.Count; i++)
+            {
+                Assert.AreEqual(attributes[i].Type, constructor.Attributes[i].Type);
+                Assert.IsTrue(constructor.Attributes[i].Arguments.SequenceEqual(attributes[i].Arguments));
+            }
+
+            // validate the attributes are written correctly
+            using var writer = new CodeWriter();
+            writer.WriteConstructor(constructor);
+            var expectedString = "[global::System.ObsoleteAttribute]\n" +
+                "[global::System.ObsoleteAttribute(\"This is obsolete\")]\n" +
+                "[global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute(\"001\")]\n" +
+                "public ConstructorProviderTests(";
+            var result = writer.ToString(false);
+            Assert.IsTrue(result.StartsWith(expectedString));
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/FieldProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/FieldProviderTests.cs
@@ -1,9 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Snippets;
+using Microsoft.TypeSpec.Generator.Statements;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 
@@ -11,6 +17,12 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
 {
     public class FieldProviderTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator();
+        }
+
         [Test]
         public void AsParameterRespectsChangesToFieldType()
         {
@@ -20,6 +32,40 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             var parameter = field.AsParameter;
 
             Assert.IsTrue(parameter.Type.Equals(typeof(string)));
+        }
+
+        [Test]
+        public void TestAttributes()
+        {
+            var attributes = new List<AttributeStatement>
+            {
+                 new(typeof(ObsoleteAttribute)),
+                 new(typeof(ObsoleteAttribute), Snippet.Literal("This is obsolete")),
+                 new(typeof(ExperimentalAttribute), Snippet.Literal("001"))
+            };
+            var field = new FieldProvider(
+                FieldModifiers.Private,
+                new CSharpType(typeof(int)),
+                "_name",
+                new TestTypeProvider(),
+                attributes: attributes);
+
+            Assert.IsNotNull(field.Attributes);
+            Assert.AreEqual(attributes.Count, field.Attributes.Count);
+            for (int i = 0; i < attributes.Count; i++)
+            {
+                Assert.AreEqual(attributes[i].Type, field.Attributes[i].Type);
+                Assert.IsTrue(field.Attributes[i].Arguments.SequenceEqual(attributes[i].Arguments));
+            }
+
+            // validate the attributes are written correctly
+            using var writer = new CodeWriter();
+            writer.WriteField(field);
+            var expectedString = "[global::System.ObsoleteAttribute]\n" +
+                "[global::System.ObsoleteAttribute(\"This is obsolete\")]\n" +
+                "[global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute(\"001\")]\n" +
+                "private int _name;\n";
+            Assert.AreEqual(expectedString, writer.ToString(false));
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/FieldProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/FieldProviderTests.cs
@@ -35,6 +35,49 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         }
 
         [Test]
+        public void CanUpdateFieldProvider()
+        {
+            var field = new FieldProvider(FieldModifiers.Private, new CSharpType(typeof(int)), "name", new TestTypeProvider());
+            var attributes = new List<AttributeStatement>
+            {
+                 new(typeof(ObsoleteAttribute)),
+                 new(typeof(ObsoleteAttribute), Snippet.Literal("This is obsolete")),
+                 new(typeof(ExperimentalAttribute), Snippet.Literal("001"))
+            };
+
+            field.Update(
+                modifiers: field.Modifiers | FieldModifiers.ReadOnly,
+                description: $"foo",
+                type: new CSharpType(typeof(string)),
+                name: "_newName",
+                enclosingType: new TestTypeProvider(),
+                attributes: attributes);
+
+            Assert.AreEqual("_newName", field.Name);
+            Assert.AreEqual("foo", field.Description!.ToString());
+            Assert.AreEqual(FieldModifiers.Private | FieldModifiers.ReadOnly, field.Modifiers);
+            Assert.AreEqual(new CSharpType(typeof(string)), field.Type);
+
+            Assert.IsNotNull(field.Attributes);
+            Assert.AreEqual(attributes.Count, field.Attributes.Count);
+            for (int i = 0; i < attributes.Count; i++)
+            {
+                Assert.AreEqual(attributes[i].Type, field.Attributes[i].Type);
+                Assert.IsTrue(field.Attributes[i].Arguments.SequenceEqual(attributes[i].Arguments));
+            }
+
+            // validate the attributes are written correctly
+            using var writer = new CodeWriter();
+            writer.WriteField(field);
+            var expectedString = "[global::System.ObsoleteAttribute]\n" +
+                "[global::System.ObsoleteAttribute(\"This is obsolete\")]\n" +
+                "[global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute(\"001\")]\n" +
+                "private readonly string _newName;\n";
+            var result = writer.ToString(false);
+            Assert.AreEqual(expectedString, result);
+        }
+
+        [Test]
         public void TestAttributes()
         {
             var attributes = new List<AttributeStatement>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/MethodProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/MethodProviderTests.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Statements;
 using NUnit.Framework;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
@@ -12,10 +16,15 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
 {
     public class MethodProviderTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator();
+        }
+
         [Test]
         public void CorrectUsingIsAppliedForImplicitOperatorMethod()
         {
-            MockHelpers.LoadMockGenerator();
             var enclosingType = new TestTypeProvider();
             var writer = new TypeProviderWriter(enclosingType);
             var file = writer.Write();
@@ -52,7 +61,6 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         [Test]
         public void TestUpdate()
         {
-            MockHelpers.LoadMockGenerator();
             var typeProvider = new TestTypeProvider();
             var methodProvider = new MethodProvider(
                 new MethodSignature("Test", $"", MethodSignatureModifiers.Public, null, $"", []),
@@ -61,7 +69,21 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             typeProvider.Update(methods: [methodProvider]);
 
             // now update the method and check if the type provider reflects the change
-            methodProvider.Update(new MethodSignature("Updated", $"", MethodSignatureModifiers.Public, null, $"", [new ParameterProvider("foo", $"Foo description", typeof(int))]));
+            var attributes = new List<AttributeStatement>
+            {
+                 new(typeof(ObsoleteAttribute)),
+                 new(typeof(ObsoleteAttribute), Literal("This is obsolete")),
+                 new(typeof(ExperimentalAttribute), Literal("001"))
+            };
+            methodProvider.Update(
+                new MethodSignature(
+                    "Updated",
+                    $"",
+                    MethodSignatureModifiers.Public,
+                    null,
+                    $"",
+                    [new ParameterProvider("foo", $"Foo description", typeof(int))]),
+                attributes: attributes);
             var updatedMethods = typeProvider.CanonicalView.Methods;
             Assert.IsNotNull(updatedMethods);
             Assert.AreEqual(1, updatedMethods!.Count);
@@ -81,6 +103,57 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.IsNotNull(xmlDocParamStatement);
             Assert.AreEqual(parameter, xmlDocParamStatement.Parameter);
             Assert.AreEqual("/// <param name=\"foo\"> Foo description. </param>\n", xmlDocParamStatement.ToDisplayString());
+
+            // Validate that the attributes are updated
+            Assert.IsNotNull(updatedMethod.Attributes);
+            Assert.AreEqual(attributes.Count, updatedMethod.Attributes.Count);
+            for (int i = 0; i < attributes.Count; i++)
+            {
+                Assert.AreEqual(attributes[i].Type, updatedMethod.Attributes[i].Type);
+                Assert.IsTrue(updatedMethod.Attributes[i].Arguments.SequenceEqual(attributes[i].Arguments));
+            }
+
+            using var writer = new CodeWriter();
+            writer.WriteMethod(updatedMethod);
+            var expectedMethodString = "[global::System.ObsoleteAttribute]\n" +
+                "[global::System.ObsoleteAttribute(\"This is obsolete\")]\n" +
+                "[global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute(\"001\")]\n" +
+                "public void Updated(int foo)\n";
+            Assert.IsTrue(writer.ToString(false).StartsWith(expectedMethodString));
+        }
+
+        [Test]
+        public void TestAttributes()
+        {
+            var attributes = new List<AttributeStatement>
+            {
+                 new(typeof(ObsoleteAttribute)),
+                 new(typeof(ObsoleteAttribute), Literal("This is obsolete")),
+                 new(typeof(ExperimentalAttribute), Literal("001"))
+            };
+            var typeProvider = new TestTypeProvider();
+            var method = new MethodProvider(
+                new MethodSignature("Test", $"", MethodSignatureModifiers.Public, null, $"", []),
+                Throw(Null),
+                typeProvider,
+                attributes: attributes);
+
+            Assert.IsNotNull(method.Attributes);
+            Assert.AreEqual(attributes.Count, method.Attributes.Count);
+            for (int i = 0; i < attributes.Count; i++)
+            {
+                Assert.AreEqual(attributes[i].Type, method.Attributes[i].Type);
+                Assert.IsTrue(method.Attributes[i].Arguments.SequenceEqual(attributes[i].Arguments));
+            }
+
+            // validate the attributes are written correctly
+            using var writer = new CodeWriter();
+            writer.WriteMethod(method);
+            var expectedMethodString = "[global::System.ObsoleteAttribute]\n" +
+                "[global::System.ObsoleteAttribute(\"This is obsolete\")]\n" +
+                "[global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute(\"001\")]\n" +
+                "public void Test()\n";
+            Assert.IsTrue(writer.ToString(false).StartsWith(expectedMethodString));
         }
 
         private class TestTypeProvider : TypeProvider

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
+using Microsoft.TypeSpec.Generator.Statements;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 
@@ -96,6 +99,40 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
 
             var nestedTypes = typeProvider.NestedTypes;
             Assert.AreEqual(0, nestedTypes.Count);
+        }
+
+        [Test]
+        public void CanUpdateTypeProvider()
+        {
+            var typeProvider = new TestTypeProvider(name: "OriginalName",
+                methods: [new MethodProvider(
+                new MethodSignature("TestMethod", $"", MethodSignatureModifiers.Public, null, $"", []),
+                Snippet.Throw(Snippet.Null), new TestTypeProvider())]);
+            var attributes = new List<AttributeStatement>
+            {
+                 new(typeof(ObsoleteAttribute)),
+                 new(typeof(ObsoleteAttribute), Snippet.Literal("This is obsolete")),
+                 new(typeof(ExperimentalAttribute), Snippet.Literal("001"))
+            };
+            typeProvider.Update(name: "UpdatedName", methods: [], attributes: attributes);
+            Assert.AreEqual("UpdatedName", typeProvider.Name);
+            Assert.AreEqual(0, typeProvider.Methods.Count);
+
+            // Check that the attributes are updated correctly
+            Assert.IsNotNull(typeProvider.Attributes);
+            Assert.AreEqual(attributes.Count, typeProvider.Attributes.Count);
+            for (int i = 0; i < attributes.Count; i++)
+            {
+                Assert.AreEqual(attributes[i].Type, typeProvider.Attributes[i].Type);
+                Assert.IsTrue(typeProvider.Attributes[i].Arguments.SequenceEqual(attributes[i].Arguments));
+            }
+
+
+            typeProvider.Reset();
+
+            // The BuildX methods should be called again, which will return the original state.
+            Assert.AreEqual("OriginalName", typeProvider.Name);
+            Assert.AreEqual(1, typeProvider.Methods.Count);
         }
 
         [Test]


### PR DESCRIPTION
This PR adds support for attributes in fields, properties, and constructors.

fixes: https://github.com/microsoft/typespec/issues/7762