### PR TITLE
Revert dependency upgrades

### DIFF
--- a/packages/http-client-csharp/generator/Packages.Data.props
+++ b/packages/http-client-csharp/generator/Packages.Data.props
@@ -8,13 +8,13 @@
     <PackageReference Update="BenchmarkDotNet" Version="0.13.4" />
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.4" />
     <PackageReference Update="CommandLineParser" Version="2.9.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
-    <PackageReference Update="Microsoft.Build" Version="17.11.31" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Update="Microsoft.Build" Version="17.9.5" />
     <PackageReference Update="NuGet.Configuration" Version="6.14.0" />
     <PackageReference Update="NuGet.Versioning" Version="6.14.0" />
     <PackageReference Update="NuGet.Protocol" Version="6.14.0" />
-    <PackageReference Update="System.ComponentModel.Composition" Version="9.0.6" />
-    <PackageReference Update="System.ClientModel" Version="1.4.2" />
-    <PackageReference Update="System.Memory.Data" Version="9.0.6" />
+    <PackageReference Update="System.ComponentModel.Composition" Version="8.0.0" />
+    <PackageReference Update="System.ClientModel" Version="1.4.1" />
+    <PackageReference Update="System.Memory.Data" Version="8.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There is some incompatibility when upgrading to 9.x BCL deps and using the Azure generator. Since most of the azure-sdk-for-net repo is still depending on 8.x versions, we don't need to upgrade now. I'm also reverting the SCM upgrade just to ensure that the state is consistent to what it was prior to https://github.com/microsoft/typespec/pull/7794 and https://github.com/microsoft/typespec/pull/7789