### PR TITLE
[python] update min dev of `azure-core` to `1.35.0`

### DIFF
--- a/.chronus/changes/python-updateCore-2025-6-3-12-21-36.md
+++ b/.chronus/changes/python-updateCore-2025-6-3-12-21-36.md
@@ -1,0 +1,7 @@
+---
+changeKind: dependencies
+packages:
+  - "@typespec/http-client-python"
+---
+
+Bump min dep of generated sdks on `azure-core` to `1.35.0` for backcompat serialization methods

--- a/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
@@ -20,7 +20,7 @@ VERSION_MAP = {
     "msrest": "0.7.1",
     "isodate": "0.6.1",
     "azure-mgmt-core": "1.5.0",
-    "azure-core": "1.30.0",
+    "azure-core": "1.35.0",
     "typing-extensions": "4.6.0",
     "corehttp": "1.0.0b6",
 }


### PR DESCRIPTION
Bump deep of generated sdks to support new backcompat serialization methods