### PR TITLE
Add HttpRequestClientIdPropertyName to HttpRequestApi

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/Abstractions/HttpRequestApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/Abstractions/HttpRequestApi.cs
@@ -24,6 +24,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         public abstract ValueExpression Content();
         public abstract HttpRequestApi FromExpression(ValueExpression original);
         public abstract HttpRequestApi ToExpression();
-        public abstract string? HttpRequestClientIdPropertyName { get; }
+        public abstract string? ClientRequestIdPropertyName { get; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/PipelineRequestProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/PipelineRequestProvider.cs
@@ -38,6 +38,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             => Original.Property("Uri").Assign(value.As<ClientUriBuilderDefinition>().ToUri()).Terminate();
 
         public override HttpRequestApi ToExpression() => this;
-        public override string? HttpRequestClientIdPropertyName => null;
+        public override string? ClientRequestIdPropertyName => null;
     }
 }


### PR DESCRIPTION
This PR updates the HttpRequestApi to include a new API for setting the RequestClientId property name for http request types.

contributes to https://github.com/Azure/azure-sdk-for-net/issues/50627