### PR TITLE
openapi3: don't apply Item visibility for array declarations

### DIFF
--- a/.chronus/changes/witemple-msft-openapi3-no-item-array-decl-2025-6-9-14-51-33.md
+++ b/.chronus/changes/witemple-msft-openapi3-no-item-array-decl-2025-6-9-14-51-33.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Fixed a bug that caused `model M is T[]` declarations to be renamed to `MItem` incorrectly.

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -305,12 +305,6 @@ export class OpenAPI3SchemaEmitterBase<
     return this.#createDeclaration(array, name, this.applyConstraints(array, schema as any));
   }
 
-  arrayDeclarationReferenceContext(array: Model, name: string, elementType: Type): Context {
-    return {
-      visibility: this.#getVisibilityContext() | Visibility.Item,
-    };
-  }
-
   arrayLiteral(array: Model, elementType: Type): EmitterOutput<object> {
     return this.#inlineType(
       array,


### PR DESCRIPTION
This appears to have been an oversight where we were applying Item visibility in array declarations, where we only want to apply it to array _items_.

closes #7781 