### PR TITLE
http-client-java, bug fix, param in protocol method

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/tranformer/Transformer.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/tranformer/Transformer.java
@@ -171,7 +171,11 @@ public class Transformer {
                     request.setParameters(newParameters.collect(Collectors.toList()));
                     Stream<Parameter> newSignatureParameters = Stream
                         .concat(operation.getSignatureParameters().stream(), request.getSignatureParameters().stream());
-                    newSignatureParameters = newSignatureParameters.filter(param -> param.getGroupedBy() == null);
+                    if (!JavaSettings.getInstance().isDataPlaneClient()) {
+                        // For DPG, grouping or flattening has no effect on the protocol method.
+                        // For convenience method, it would be handled in "operation.getConvenienceApi()".
+                        newSignatureParameters = newSignatureParameters.filter(param -> param.getGroupedBy() == null);
+                    }
                     request.setSignatureParameters(newSignatureParameters.collect(Collectors.toList()));
                     for (int i = 0; i < request.getParameters().size(); i++) {
                         Parameter parameter = request.getParameters().get(i);


### PR DESCRIPTION
bug reproduced from test on override
https://github.com/Azure/typespec-azure/blob/main/packages/azure-http-specs/specs/azure/client-generator-core/override/client.tsp#L22-L29

It generates protocol method without required parameter `param1` and `param2`.

For DPG, the signature of protocol method should not change, regardless on there is / isn't a convenience method (and whether there is grouping on the convenience method).

The signature of the convenience method would be on `op.convenienceApi`.