### PR TITLE
hsjs: Fixed two bugs in JSON serialization

### DIFF
--- a/.chronus/changes/witemple-msft-hsjs-dogfood-fixes-2025-6-16-17-40-23.md
+++ b/.chronus/changes/witemple-msft-hsjs-dogfood-fixes-2025-6-16-17-40-23.md
@@ -1,0 +1,10 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-js"
+---
+
+Fixed an issue where JSON serialization would not correctly handle optional properties in some cases.
+
+Fixed an issue where body serialization would sometimes fail to name anonymous response items, even if a name is required
+to dispatch serialization code.

--- a/packages/http-server-js/src/common/serialization/json.ts
+++ b/packages/http-server-js/src/common/serialization/json.ts
@@ -160,6 +160,7 @@ function* emitToJson(
         const propertyName = keywordSafe(parseCase(property.name).camelCase);
 
         let expr: string = access("input", propertyName);
+        const primitiveExpr = expr;
 
         const encoding = getEncode(ctx.program, property);
 
@@ -192,6 +193,9 @@ function* emitToJson(
           expr = transposeExpressionToJson(ctx, property.type, expr, module);
         }
 
+        if (property.optional && requiresJsonSerialization(ctx, module, property.type)) {
+          expr = `(${primitiveExpr}) !== undefined ? ${expr} : undefined`;
+        }
         yield `  ${objectLiteralProperty(encodedName)}: ${expr},`;
       }
 
@@ -393,6 +397,7 @@ function* emitFromJson(
           resolveEncodedName(ctx.program, property, "application/json") ?? property.name;
 
         let expr = access("input", encodedName);
+        const primitiveExpr = expr;
 
         const encoding = getEncode(ctx.program, property);
 
@@ -428,6 +433,10 @@ function* emitFromJson(
         }
 
         const propertyName = keywordSafe(parseCase(property.name).camelCase);
+
+        if (property.optional && requiresJsonSerialization(ctx, module, property.type)) {
+          expr = `(${primitiveExpr}) !== undefined ? ${expr} : undefined`;
+        }
 
         yield `  ${propertyName}: ${expr},`;
       }


### PR DESCRIPTION
This PR arises from some dogfooding of the JS server generator. It fixes two issues with the serialization code:

- Optional properties were not being handled correctly when custom active serializers were triggered. The fix correctly wraps serialization expressions in undefined checks if the property is declared optional.
- `requireDeclaration` (which forces anonymous types to receive a declaration) was sometimes being provided without an altName. In cases where an anonymous response object was in a union, the type would be treated _as if_ a declaration was required, but failing to provide an `altName` caused the emitter to render the anonymous model as if it were a type name. The change creates a "Namer" for each operation and passes it around, which can be used to create unique names with a monotonically incrementing counter for different altname strategies, and it uses this to create unambiguous names for anonymous types when declarations are required for serialization.