### PR TITLE
playground: Added some debug items to the console

### DIFF
--- a/.chronus/changes/witemple-msft-playground-console-debug-items-2025-6-17-11-19-47.md
+++ b/.chronus/changes/witemple-msft-playground-console-debug-items-2025-6-17-11-19-47.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/playground"
+---
+
+Exposed some debugging variables in the playground console, including the Program, a bound Typekit, and the compiler host.

--- a/packages/playground/src/core.ts
+++ b/packages/playground/src/core.ts
@@ -1,3 +1,5 @@
+import { debugGlobals, debugLibs } from "./react/debug.js";
+
 /**
  * Options for importing libraries.
  */
@@ -12,7 +14,11 @@ export interface LibraryImportOptions {
 export async function importTypeSpecCompiler(
   config: LibraryImportOptions,
 ): Promise<typeof import("@typespec/compiler")> {
-  return (await importLibrary("@typespec/compiler", config)) as any;
+  const compiler = (await importLibrary("@typespec/compiler", config)) as any;
+
+  debugGlobals().compiler = compiler;
+
+  return compiler;
 }
 
 /**
@@ -20,9 +26,13 @@ export async function importTypeSpecCompiler(
  * @returns Promise with the loaded module.
  */
 export async function importLibrary(name: string, config: LibraryImportOptions): Promise<unknown> {
-  return config.useShim
+  const lib = await (config.useShim
     ? importShim(name)
-    : import(/* @vite-ignore */ /* webpackIgnore: true */ name);
+    : import(/* @vite-ignore */ /* webpackIgnore: true */ name));
+
+  debugLibs()[name] = lib;
+
+  return lib;
 }
 
 /**

--- a/packages/playground/src/react/debug.ts
+++ b/packages/playground/src/react/debug.ts
@@ -8,9 +8,30 @@ import type { BrowserHost } from "../types.js";
 /* eslint-disable no-console */
 
 export interface DebugGlobals {
+  /**
+   * The current TypeSpec program.
+   */
   program: Program | undefined;
+
+  /**
+   * The compiler host.
+   */
   host: BrowserHost | undefined;
+
+  /**
+   * The TypeSpec compiler API.
+   */
+  compiler: typeof import("@typespec/compiler") | undefined;
+
+  /**
+   * Global Typekit instance bound to the current program.
+   */
   $$: Typekit | undefined;
+
+  /**
+   * A map of all loaded TypeSpec libraries.
+   */
+  libs: Record<string, unknown> | undefined;
 }
 
 /**
@@ -23,7 +44,9 @@ export function printDebugInfo() {
   );
   console.info(" - `program`: The current TypeSpec program.");
   console.info(" - `host`: The current compiler host.");
+  console.info(" - `compiler`: The TypeSpec compiler API.");
   console.info(" - `$$`: A Typekit instance bound to the current program.");
+  console.info(" - `libs`: A map of all loaded TypeSpec libraries.");
 }
 
 /**
@@ -31,4 +54,11 @@ export function printDebugInfo() {
  */
 export function debugGlobals(): DebugGlobals {
   return window as unknown as DebugGlobals;
+}
+
+/**
+ * Gets the global debug libraries
+ */
+export function debugLibs(): Record<string, unknown> {
+  return ((window as unknown as DebugGlobals).libs ??= {});
 }

--- a/packages/playground/src/react/debug.ts
+++ b/packages/playground/src/react/debug.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import type { Program } from "@typespec/compiler";
+import type { Typekit } from "@typespec/compiler/typekit";
+import type { BrowserHost } from "../types.js";
+
+/* eslint-disable no-console */
+
+export interface DebugGlobals {
+  program: Program | undefined;
+  host: BrowserHost | undefined;
+  $$: Typekit | undefined;
+}
+
+/**
+ * Prints debug information to the console.
+ */
+export function printDebugInfo() {
+  console.info("TypeSpec Playground");
+  console.info(
+    "Some variables are bound to the `window` object in the browser console for debugging.",
+  );
+  console.info(" - `program`: The current TypeSpec program.");
+  console.info(" - `host`: The current compiler host.");
+  console.info(" - `$$`: A Typekit instance bound to the current program.");
+}
+
+/**
+ * Get the global debug variables bound to the `window` object.
+ */
+export function debugGlobals(): DebugGlobals {
+  return window as unknown as DebugGlobals;
+}


### PR DESCRIPTION
This PR adds `program`, `host`, and `$$` (a bound typekit -- we don't want to use `$` because it override the browser dev tools' builtin JQuery) to the window object and prints some information about them to the console when the Playground component is mounted.