### PR TITLE
Remove warning when LSP cannot find compiler root

### DIFF
--- a/.chronus/changes/remove-dead-code-2025-6-18-19-49-50.md
+++ b/.chronus/changes/remove-dead-code-2025-6-18-19-49-50.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+
+Remove dead code in serverlib

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -64,8 +64,6 @@ import { getNodeAtPosition, getNodeAtPositionDetail, visitChildren } from "../co
 import {
   ensureTrailingDirectorySeparator,
   getDirectoryPath,
-  joinPaths,
-  normalizePath,
   resolvePath,
 } from "../core/path-utils.js";
 import type { Program } from "../core/program.js";
@@ -313,15 +311,6 @@ export function createServer(
       validateInitProjectTemplate: true,
       internalCompile: true,
     };
-    // the file path is expected to be .../@typespec/compiler/dist/src/server/serverlib.js
-    const curFile = normalizePath(compilerHost.fileURLToPath(import.meta.url));
-    const SERVERLIB_PATH_ENDWITH = "/dist/src/server/serverlib.js";
-    let compilerRootFolder = undefined;
-    if (!curFile.endsWith(SERVERLIB_PATH_ENDWITH)) {
-      log({ level: "warning", message: `Unexpected path for serverlib found: ${curFile}` });
-    } else {
-      compilerRootFolder = curFile.slice(0, curFile.length - SERVERLIB_PATH_ENDWITH.length);
-    }
     const result: ServerInitializeResult = {
       serverInfo: {
         name: "TypeSpec Language Server",
@@ -329,10 +318,6 @@ export function createServer(
       },
       capabilities,
       customCapacities,
-      compilerRootFolder,
-      compilerCliJsPath: compilerRootFolder
-        ? joinPaths(compilerRootFolder, "cmd", "tsp.js")
-        : undefined,
     };
     return result;
   }

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -64,6 +64,8 @@ import { getNodeAtPosition, getNodeAtPositionDetail, visitChildren } from "../co
 import {
   ensureTrailingDirectorySeparator,
   getDirectoryPath,
+  joinPaths,
+  normalizePath,
   resolvePath,
 } from "../core/path-utils.js";
 import type { Program } from "../core/program.js";
@@ -311,6 +313,15 @@ export function createServer(
       validateInitProjectTemplate: true,
       internalCompile: true,
     };
+    // the file path is expected to be .../@typespec/compiler/dist/src/server/serverlib.js
+    const curFile = normalizePath(compilerHost.fileURLToPath(import.meta.url));
+    const SERVERLIB_PATH_ENDWITH = "/dist/src/server/serverlib.js";
+    let compilerRootFolder = undefined;
+    if (!curFile.endsWith(SERVERLIB_PATH_ENDWITH)) {
+      // Ignore this could be the playground or standalone cli
+    } else {
+      compilerRootFolder = curFile.slice(0, curFile.length - SERVERLIB_PATH_ENDWITH.length);
+    }
     const result: ServerInitializeResult = {
       serverInfo: {
         name: "TypeSpec Language Server",
@@ -318,6 +329,10 @@ export function createServer(
       },
       capabilities,
       customCapacities,
+      compilerRootFolder,
+      compilerCliJsPath: compilerRootFolder
+        ? joinPaths(compilerRootFolder, "cmd", "tsp.js")
+        : undefined,
     };
     return result;
   }

--- a/packages/compiler/src/server/types.ts
+++ b/packages/compiler/src/server/types.ts
@@ -189,8 +189,6 @@ export interface ServerCustomCapacities {
 
 export interface ServerInitializeResult extends InitializeResult {
   customCapacities?: ServerCustomCapacities;
-  compilerRootFolder?: string;
-  compilerCliJsPath?: string;
 }
 
 export interface InitProjectContext {

--- a/packages/compiler/src/server/types.ts
+++ b/packages/compiler/src/server/types.ts
@@ -189,6 +189,8 @@ export interface ServerCustomCapacities {
 
 export interface ServerInitializeResult extends InitializeResult {
   customCapacities?: ServerCustomCapacities;
+  compilerRootFolder?: string;
+  compilerCliJsPath?: string;
 }
 
 export interface InitProjectContext {


### PR DESCRIPTION
fix #7958

Stops logging that warning in the playground 