### PR TITLE
Revert prettier sh to format in vscode

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -57,9 +57,12 @@ grammars/
 # auto generated code model files
 **/tspCodeModel.json
 
+# C# Client generated files
+packages/http-client-csharp/generator/**/TestProjects/**/*.json
+
 # auto generated api view properties files
-packages/http-client-java/generator/http-client-generator-test/src/main/**/*.json
-packages/http-client-java/generator/http-client-generator-clientcore-test/src/main/**/*.json
+packages/http-client-java/generator/http-client-generator-test/**/*.json
+packages/http-client-java/generator/http-client-generator-clientcore-test/**/*.json
 
 # Files with invalid sh syntax
 packages/http-client-java/**/*.properties

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,7 +57,5 @@
   "typescript.tsdk": "./node_modules/typescript/lib",
   "git.ignoreLimitWarning": true,
   "vitest.workspaceConfig": "./vitest.config.ts",
-  "prettier.prettierPath": "./node_modules/prettier/index.cjs",
-  "prettier.documentSelectors": ["**/*.tsp", "**/*.astro"],
   "typespec.tsp-server.path": "${workspaceFolder}/packages/compiler"
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prettier": "~3.6.2",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-organize-imports": "~4.2.0",
-    "prettier-plugin-sh": "^0.18.0",
+    "prettier-plugin-sh": "0.17.2",
     "rimraf": "~6.0.1",
     "syncpack": "^13.0.3",
     "tsx": "^4.19.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prettier": "~3.6.2",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-organize-imports": "~4.2.0",
-    "prettier-plugin-sh": "0.17.2",
+    "prettier-plugin-sh": "^0.17.4",
     "rimraf": "~6.0.1",
     "syncpack": "^13.0.3",
     "tsx": "^4.19.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ~4.2.0
         version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       prettier-plugin-sh:
-        specifier: ^0.18.0
-        version: 0.18.0(prettier@3.6.2)
+        specifier: 0.17.2
+        version: 0.17.2(prettier@3.6.2)
       rimraf:
         specifier: ~6.0.1
         version: 6.0.1
@@ -10954,11 +10954,11 @@ packages:
       vue-tsc:
         optional: true
 
-  prettier-plugin-sh@0.18.0:
-    resolution: {integrity: sha512-cW1XL27FOJQ/qGHOW6IHwdCiNWQsAgK+feA8V6+xUTaH0cD3Mh+tFAtBvEEWvuY6hTDzRV943Fzeii+qMOh7nQ==}
+  prettier-plugin-sh@0.17.2:
+    resolution: {integrity: sha512-7+dEo/IYbhrUj4qP+1QXj41/5Hv9ZkxBuEatI1jywrcAlVF1aGhdYJF4Sn+M67nkA16iRL53W4FSRe1bitTdmQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      prettier: ^3.6.0
+      prettier: ^3.0.3
 
   prettier@2.8.7:
     resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
@@ -24617,7 +24617,7 @@ snapshots:
       prettier: 3.6.2
       typescript: 5.8.3
 
-  prettier-plugin-sh@0.18.0(prettier@3.6.2):
+  prettier-plugin-sh@0.17.2(prettier@3.6.2):
     dependencies:
       '@reteps/dockerfmt': 0.3.6
       prettier: 3.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ~4.2.0
         version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       prettier-plugin-sh:
-        specifier: 0.17.2
-        version: 0.17.2(prettier@3.6.2)
+        specifier: ^0.17.4
+        version: 0.17.4(prettier@3.6.2)
       rimraf:
         specifier: ~6.0.1
         version: 6.0.1
@@ -10954,8 +10954,8 @@ packages:
       vue-tsc:
         optional: true
 
-  prettier-plugin-sh@0.17.2:
-    resolution: {integrity: sha512-7+dEo/IYbhrUj4qP+1QXj41/5Hv9ZkxBuEatI1jywrcAlVF1aGhdYJF4Sn+M67nkA16iRL53W4FSRe1bitTdmQ==}
+  prettier-plugin-sh@0.17.4:
+    resolution: {integrity: sha512-aAVKXZ7GTEMZdZsIPSwMwddwPvt2ibMbRGd4OJAP0G7QoeYZV+mPNg2Oln3R53sZ4PVjeAA7Xzi/PuI0QlHHfQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       prettier: ^3.0.3
@@ -24617,7 +24617,7 @@ snapshots:
       prettier: 3.6.2
       typescript: 5.8.3
 
-  prettier-plugin-sh@0.17.2(prettier@3.6.2):
+  prettier-plugin-sh@0.17.4(prettier@3.6.2):
     dependencies:
       '@reteps/dockerfmt': 0.3.6
       prettier: 3.6.2


### PR DESCRIPTION
also fix #7961 (reduce files its trying to format
Latest is causing this error

```
["ERROR" - 10:35:12 AM] Error handling text editor change
{}
```