### PR TITLE
http-client-java, remove pagedResult

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-test/tsp/arm-stream-style-serialization.tsp
+++ b/packages/http-client-java/generator/http-client-generator-test/tsp/arm-stream-style-serialization.tsp
@@ -254,12 +254,12 @@ interface Priorities {
 interface Items {
   // op of LRO + pageable
   @get
+  @list
   list(): ListResult & ArmLroLocationHeader;
 }
 
-@pagedResult
 model ListResult {
-  @items
+  @pageItems
   items: Result[];
 
   @nextLink

--- a/packages/http-client-java/generator/http-client-generator-test/tsp/response.tsp
+++ b/packages/http-client-java/generator/http-client-generator-test/tsp/response.tsp
@@ -81,9 +81,8 @@ model OperationDetails2 {
   lroResult?: Resource;
 }
 
-@pagedResult
 model StringsList {
-  @items
+  @pageItems
   @clientName("items", "java")
   @encodedName("application/json", "items_value")
   value: string[];
@@ -94,15 +93,13 @@ model StringsList {
   next?: string;
 }
 
-@pagedResult
 model Int32sList {
-  @items
+  @pageItems
   value: int32[];
 }
 
-@pagedResult
 model DateTimesList {
-  @items
+  @pageItems
   value: utcDateTime[];
 }
 
@@ -194,12 +191,15 @@ interface ResponseOp {
   >;
 
   @route("/paged-string")
+  @list
   listStrings(): StringsList;
 
   @route("/paged-int32")
+  @list
   listIntegers(): Int32sList;
 
   // @route("/paged-datetime")
+  // @list
   // listDateTimes(): DateTimesList;
 
   @route("/json-utf8-response")


### PR DESCRIPTION
For the deprecation of `@pagedResult` + `items`, and moving to `@list` + `@pageItems`

(there is a bug in tcgc https://github.com/Azure/typespec-azure/issues/3061, if run with dev libs)