### PR TITLE
Fix circular reference in http

### DIFF
--- a/.chronus/changes/fix-http-circular-refs-2025-6-28-15-51-45.md
+++ b/.chronus/changes/fix-http-circular-refs-2025-6-28-15-51-45.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+
+Fix circular reference in http

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -38,13 +38,10 @@ import {
   PutDecorator,
   QueryDecorator,
   QueryOptions,
-  RouteDecorator,
   ServerDecorator,
-  SharedRouteDecorator,
   StatusCodeDecorator,
 } from "../generated-defs/TypeSpec.Http.js";
 import { HttpStateKeys, createDiagnostic, reportDiagnostic } from "./lib.js";
-import { setRoute, setSharedRoute } from "./route.js";
 import { getStatusCodesFromType } from "./status-codes.js";
 import {
   Authentication,
@@ -654,41 +651,3 @@ export function getAuthentication(
 ): Authentication | undefined {
   return program.stateMap(HttpStateKeys.authentication).get(entity);
 }
-
-/**
- * `@route` defines the relative route URI for the target operation
- *
- * The first argument should be a URI fragment that may contain one or more path parameter fields.
- * If the namespace or interface that contains the operation is also marked with a `@route` decorator,
- * it will be used as a prefix to the route URI of the operation.
- *
- * `@route` can only be applied to operations, namespaces, and interfaces.
- */
-export const $route: RouteDecorator = (
-  context: DecoratorContext,
-  entity: Type,
-  path: string,
-  parameters?: Type,
-) => {
-  validateDecoratorUniqueOnNode(context, entity, $route);
-
-  setRoute(context, entity, {
-    path,
-    shared: false,
-  });
-};
-
-/**
- * `@sharedRoute` marks the operation as sharing a route path with other operations.
- *
- * When an operation is marked with `@sharedRoute`, it enables other operations to share the same
- * route path as long as those operations are also marked with `@sharedRoute`.
- *
- * `@sharedRoute` can only be applied directly to operations.
- */
-export const $sharedRoute: SharedRouteDecorator = (
-  context: DecoratorContext,
-  entity: Operation,
-) => {
-  setSharedRoute(context.program, entity);
-};

--- a/packages/http/src/decorators/route.ts
+++ b/packages/http/src/decorators/route.ts
@@ -1,0 +1,62 @@
+import {
+  validateDecoratorUniqueOnNode,
+  type DecoratorContext,
+  type Interface,
+  type Namespace,
+  type Operation,
+} from "@typespec/compiler";
+import { useStateMap } from "@typespec/compiler/utils";
+import { RouteDecorator } from "../../generated-defs/TypeSpec.Http.js";
+import { setSharedRoute } from "../index.js";
+import { HttpStateKeys, reportDiagnostic } from "../lib.js";
+import type { RoutePath } from "../types.js";
+
+const [getRouteState, setRouteState] = useStateMap<Operation | Interface | Namespace, string>(
+  HttpStateKeys.routes,
+);
+
+// export { setRoute };
+
+/**
+ * `@route` defines the relative route URI for the target operation
+ *
+ * The first argument should be a URI fragment that may contain one or more path parameter fields.
+ * If the namespace or interface that contains the operation is also marked with a `@route` decorator,
+ * it will be used as a prefix to the route URI of the operation.
+ *
+ * `@route` can only be applied to operations, namespaces, and interfaces.
+ */
+export const $route: RouteDecorator = (
+  context: DecoratorContext,
+  entity: Operation | Namespace | Interface,
+  path: string,
+) => {
+  validateDecoratorUniqueOnNode(context, entity, $route);
+
+  setRoute(context, entity, {
+    path,
+    shared: false,
+  });
+};
+
+export function setRoute(
+  context: DecoratorContext,
+  entity: Operation | Namespace | Interface,
+  details: RoutePath,
+) {
+  const existingPath: string | undefined = getRouteState(context.program, entity);
+  if (existingPath && entity.kind === "Namespace") {
+    if (existingPath !== details.path) {
+      reportDiagnostic(context.program, {
+        code: "duplicate-route-decorator",
+        messageId: "namespace",
+        target: entity,
+      });
+    }
+  } else {
+    setRouteState(context.program, entity, details.path);
+    if (entity.kind === "Operation" && details.shared) {
+      setSharedRoute(context.program, entity);
+    }
+  }
+}

--- a/packages/http/src/decorators/shared-route.ts
+++ b/packages/http/src/decorators/shared-route.ts
@@ -1,0 +1,29 @@
+import type { DecoratorContext, Operation, Program } from "@typespec/compiler";
+import { useStateMap } from "@typespec/compiler/utils";
+import { SharedRouteDecorator } from "../../generated-defs/TypeSpec.Http.js";
+import { HttpStateKeys } from "../lib.js";
+
+const [getSharedRoute, setSharedRouteFor] = useStateMap(HttpStateKeys.sharedRoutes);
+
+export function setSharedRoute(program: Program, operation: Operation) {
+  setSharedRouteFor(program, operation, true);
+}
+
+export function isSharedRoute(program: Program, operation: Operation): boolean {
+  return getSharedRoute(program, operation) === true;
+}
+
+/**
+ * `@sharedRoute` marks the operation as sharing a route path with other operations.
+ *
+ * When an operation is marked with `@sharedRoute`, it enables other operations to share the same
+ * route path as long as those operations are also marked with `@sharedRoute`.
+ *
+ * `@sharedRoute` can only be applied directly to operations.
+ */
+export const $sharedRoute: SharedRouteDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+) => {
+  setSharedRoute(context.program, entity);
+};

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -16,9 +16,7 @@ export {
   $post,
   $put,
   $query,
-  $route,
   $server,
-  $sharedRoute,
   $statusCode,
   $useAuth,
   getAuthentication,
@@ -47,6 +45,8 @@ export {
   setAuthentication,
   type HttpServer,
 } from "./decorators.js";
+export { $route, setRoute } from "./decorators/route.js";
+export { $sharedRoute, isSharedRoute, setSharedRoute } from "./decorators/shared-route.js";
 export { $lib } from "./lib.js";
 export { $linter } from "./linter.js";
 /** @internal */
@@ -87,10 +87,7 @@ export {
   getRouteOptionsForNamespace,
   getRoutePath,
   getUriTemplatePathParam,
-  isSharedRoute,
   joinPathSegments,
-  setRoute,
-  setSharedRoute,
 } from "./route.js";
 
 export type {

--- a/packages/http/src/metadata.ts
+++ b/packages/http/src/metadata.ts
@@ -28,13 +28,13 @@ import {
   isQueryParam,
   isStatusCode,
 } from "./decorators.js";
-import { getHttpOperation } from "./operations.js";
 import { HttpVerb, OperationParameterOptions } from "./types.js";
 
 // Used in @link JsDoc tag.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { PatchOptions } from "../generated-defs/TypeSpec.Http.js";
 import { includeInapplicableMetadataInPayload } from "./private.decorators.js";
+import { resolvePathAndParameters } from "./route.js";
 
 /**
  * Flags enum representation of well-known visibilities that are used in
@@ -339,9 +339,9 @@ export function HttpVisibilityProvider(
           getOperationVerb(program, operation));
 
       if (!verb) {
-        const [httpOperation] = getHttpOperation(program, operation);
+        const [{ parameters }] = resolvePathAndParameters(program, operation, undefined, {});
 
-        verb = httpOperation.verb;
+        verb = parameters.verb;
       }
 
       return visibilityToFilter(program, getDefaultVisibilityForVerb(verb));

--- a/packages/http/src/operations.ts
+++ b/packages/http/src/operations.ts
@@ -13,9 +13,10 @@ import {
 } from "@typespec/compiler";
 import { getAuthenticationForOperation } from "./auth.js";
 import { getAuthentication } from "./decorators.js";
+import { isSharedRoute } from "./decorators/shared-route.js";
 import { createDiagnostic, reportDiagnostic } from "./lib.js";
 import { getResponsesForOperation } from "./responses.js";
-import { isSharedRoute, resolvePathAndParameters } from "./route.js";
+import { resolvePathAndParameters } from "./route.js";
 import {
   HttpOperation,
   HttpService,

--- a/packages/http/src/status-codes.ts
+++ b/packages/http/src/status-codes.ts
@@ -11,7 +11,7 @@ import {
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import { createDiagnostic } from "./lib.js";
-import { HttpStatusCodeRange, HttpStatusCodes } from "./types.js";
+import type { HttpStatusCodeRange, HttpStatusCodes } from "./types.js";
 
 function error(target: DiagnosticTarget): [HttpStatusCodes, readonly Diagnostic[]] {
   return [

--- a/packages/http/src/tsp-index.ts
+++ b/packages/http/src/tsp-index.ts
@@ -15,12 +15,12 @@ import {
   $post,
   $put,
   $query,
-  $route,
   $server,
-  $sharedRoute,
   $statusCode,
   $useAuth,
 } from "./decorators.js";
+import { $route } from "./decorators/route.js";
+import { $sharedRoute } from "./decorators/shared-route.js";
 import { $applyMergePatch, $mergePatchModel, $mergePatchProperty } from "./merge-patch.js";
 import {
   $httpFile,

--- a/packages/http/src/validate.ts
+++ b/packages/http/src/validate.ts
@@ -9,9 +9,9 @@ import {
   isMultipartBodyProperty,
   isStatusCode,
 } from "./decorators.js";
+import { isSharedRoute } from "./decorators/shared-route.js";
 import { HttpStateKeys, reportDiagnostic } from "./lib.js";
 import { getAllHttpServices } from "./operations.js";
-import { isSharedRoute } from "./route.js";
 import { HttpOperation, HttpService } from "./types.js";
 
 export function $onValidate(program: Program) {


### PR DESCRIPTION
Fix issue where loading http library in tester would get stuck in vitest

Reduce circular links between files which is causing the issue.


Main change is to not use `getHttpOperation` but resolveOperationParameters` in the visibility provider(as the only goal was to get the verb). This not only resolve the issue but also simplify things as it won't be calling that visibility resolution twice(as getHttpOperation would call it back again)