### PR TITLE
add discriminator value to models for type narrowing and correct serialisation

### DIFF
--- a/packages/http-client-js/src/components/transforms/json/json-transform-discriminator.tsx
+++ b/packages/http-client-js/src/components/transforms/json/json-transform-discriminator.tsx
@@ -33,7 +33,10 @@ export function JsonTransformDiscriminator(props: JsonTransformDiscriminatorProp
     (name, variant) => {
       return code`
     if( discriminatorValue === ${JSON.stringify(name)}) {
-      return ${(<JsonTransform type={variant} target={props.target} itemRef={itemRef} />)}!
+      return {
+        ${props.discriminator.propertyName}: ${JSON.stringify(name)},
+        ...${(<JsonTransform type={variant} target={props.target} itemRef={itemRef} />)}!,
+      };
     }
     `;
     },

--- a/packages/http-client-js/test/scenarios/models/inheritance_2_discriminators.md
+++ b/packages/http-client-js/test/scenarios/models/inheritance_2_discriminators.md
@@ -129,11 +129,17 @@ export function jsonFishToTransportDiscriminator(input_?: Fish): any {
   }
   const discriminatorValue = input_.kind;
   if (discriminatorValue === "shark") {
-    return jsonSharkToTransportTransform(input_ as any)!;
+    return {
+      kind: "shark",
+      ...jsonSharkToTransportTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "salmon") {
-    return jsonSalmonToTransportTransform(input_ as any)!;
+    return {
+      kind: "salmon",
+      ...jsonSalmonToTransportTransform(input_ as any)!,
+    };
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;
@@ -154,11 +160,17 @@ export function jsonFishToApplicationDiscriminator(input_?: any): Fish {
   }
   const discriminatorValue = input_.kind;
   if (discriminatorValue === "shark") {
-    return jsonSharkToApplicationTransform(input_ as any)!;
+    return {
+      kind: "shark",
+      ...jsonSharkToApplicationTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "salmon") {
-    return jsonSalmonToApplicationTransform(input_ as any)!;
+    return {
+      kind: "salmon",
+      ...jsonSalmonToApplicationTransform(input_ as any)!,
+    };
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;
@@ -179,11 +191,17 @@ export function jsonSharkToTransportDiscriminator(input_?: Shark): any {
   }
   const discriminatorValue = input_.sharktype;
   if (discriminatorValue === "saw") {
-    return jsonSawSharkToTransportTransform(input_ as any)!;
+    return {
+      sharktype: "saw",
+      ...jsonSawSharkToTransportTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "goblin") {
-    return jsonGoblinSharkToTransportTransform(input_ as any)!;
+    return {
+      sharktype: "goblin",
+      ...jsonGoblinSharkToTransportTransform(input_ as any)!,
+    };
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;
@@ -205,11 +223,17 @@ export function jsonSharkToApplicationDiscriminator(input_?: any): Shark {
   }
   const discriminatorValue = input_.sharktype;
   if (discriminatorValue === "saw") {
-    return jsonSawSharkToApplicationTransform(input_ as any)!;
+    return {
+      sharktype: "saw",
+      ...jsonSawSharkToApplicationTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "goblin") {
-    return jsonGoblinSharkToApplicationTransform(input_ as any)!;
+    return {
+      sharktype: "goblin",
+      ...jsonGoblinSharkToApplicationTransform(input_ as any)!,
+    };
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;

--- a/packages/http-client-js/test/scenarios/serializers/discriminated_union.md
+++ b/packages/http-client-js/test/scenarios/serializers/discriminated_union.md
@@ -56,11 +56,17 @@ export function jsonWidgetDataToTransportDiscriminator(input_?: WidgetData): any
   }
   const discriminatorValue = input_.kind;
   if (discriminatorValue === "kind0") {
-    return jsonWidgetData0ToTransportTransform(input_ as any)!;
+    return {
+      kind: "kind0",
+      ...jsonWidgetData0ToTransportTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "kind1") {
-    return jsonWidgetData1ToTransportTransform(input_ as any)!;
+    return {
+      kind: "kind1",
+      ...jsonWidgetData1ToTransportTransform(input_ as any)!,
+    };
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;
@@ -74,11 +80,17 @@ export function jsonWidgetDataToApplicationDiscriminator(input_?: any): WidgetDa
   }
   const discriminatorValue = input_.kind;
   if (discriminatorValue === "kind0") {
-    return jsonWidgetData0ToApplicationTransform(input_ as any)!;
+    return {
+      kind: "kind0",
+      ...jsonWidgetData0ToApplicationTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "kind1") {
-    return jsonWidgetData1ToApplicationTransform(input_ as any)!;
+    return {
+      kind: "kind1",
+      ...jsonWidgetData1ToApplicationTransform(input_ as any)!,
+    };
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;

--- a/packages/http-client-js/test/scenarios/serializers/discriminated_union_spread.md
+++ b/packages/http-client-js/test/scenarios/serializers/discriminated_union_spread.md
@@ -85,11 +85,17 @@ export function jsonWidgetDataToApplicationDiscriminator(input_?: any): WidgetDa
   }
   const discriminatorValue = input_.kind;
   if (discriminatorValue === "kind0") {
-    return jsonWidgetData0ToApplicationTransform(input_ as any)!;
+    return {
+      kind: "kind0",
+      ...jsonWidgetData0ToApplicationTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "kind1") {
-    return jsonWidgetData1ToApplicationTransform(input_ as any)!;
+    return {
+      kind: "kind1",
+      ...jsonWidgetData1ToApplicationTransform(input_ as any)!,
+    }
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;
@@ -103,11 +109,17 @@ export function jsonWidgetDataToTransportDiscriminator(input_?: WidgetData): any
   }
   const discriminatorValue = input_.kind;
   if (discriminatorValue === "kind0") {
-    return jsonWidgetData0ToTransportTransform(input_ as any)!;
+    return {
+      kind: "kind0",
+      ...jsonWidgetData0ToTransportTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "kind1") {
-    return jsonWidgetData1ToTransportTransform(input_ as any)!;
+    return {
+      kind: "kind1",
+      ...jsonWidgetData1ToTransportTransform(input_ as any)!,
+    }
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;

--- a/packages/http-client-js/test/scenarios/serializers/polymorphic_single_level_inheritance.md
+++ b/packages/http-client-js/test/scenarios/serializers/polymorphic_single_level_inheritance.md
@@ -53,19 +53,31 @@ export function jsonBirdToTransportDiscriminator(input_?: Bird): any {
   }
   const discriminatorValue = input_.kind;
   if (discriminatorValue === "seagull") {
-    return jsonSeaGullToTransportTransform(input_ as any)!;
+    return {
+      kind: "seagull",
+      ...jsonSeaGullToTransportTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "sparrow") {
-    return jsonSparrowToTransportTransform(input_ as any)!;
+    return {
+      kind: "sparrow",
+      ...jsonSparrowToTransportTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "goose") {
-    return jsonGooseToTransportTransform(input_ as any)!;
+    return {
+      kind: "goose",
+      ...jsonGooseToTransportTransform(input_ as any)!,
+    };
   }
 
   if (discriminatorValue === "eagle") {
-    return jsonEagleToTransportTransform(input_ as any)!;
+    return {
+      kind: "eagle",
+      ...jsonEagleToTransportTransform(input_ as any)!,
+    };
   }
   console.warn(`Received unknown kind: ` + discriminatorValue);
   return input_ as any;


### PR DESCRIPTION
Beforehand the discriminator was not added to deserialised models which created errors in the generated code which expects the discriminator value.

Also when discriminated unions are serialised they should have the discriminator value in the transport layer.