### PR TITLE
[python] don't hardcode `emit-cross-language-definition-file` as `true` for azure

### DIFF
--- a/.chronus/changes/python-unhardcodeCLDF-2025-7-4-14-35-35.md
+++ b/.chronus/changes/python-unhardcodeCLDF-2025-7-4-14-35-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Don't hardcode `emit-cross-language-definition-file` as `true` for azure generations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,8 @@ cspell.yaml
 ######################
 # Python
 ######################
-/packages/http-client-python/                @iscai-msft @tadelesh @msyyc @timotheeguerin @lmazuel
-/website/src/content/docs/docs/emitters/clients/http-client-python/               @iscai-msft @tadelesh @msyyc @timotheeguerin @lmazuel
+/packages/http-client-python/                @iscai-msft @tadelesh @msyyc @timotheeguerin @lmazuel @kristapratico @swathipil @catalinaperalta
+/website/src/content/docs/docs/emitters/clients/http-client-python/               @iscai-msft @tadelesh @msyyc @timotheeguerin @lmazuel @kristapratico @swathipil @catalinaperalta
 
 ######################
 # JavaScript

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -157,9 +157,6 @@ async function onEmitMain(context: EmitContext<PythonEmitterOptions>) {
   if (sdkContext.arm === true) {
     commandArgs["azure-arm"] = "true";
   }
-  if ((resolvedOptions as any).flavor === "azure") {
-    commandArgs["emit-cross-language-definition-file"] = "true";
-  }
   commandArgs["from-typespec"] = "true";
   commandArgs["models-mode"] = (resolvedOptions as any)["models-mode"] ?? "dpg";
 

--- a/packages/http-client-python/generator/pygen/__init__.py
+++ b/packages/http-client-python/generator/pygen/__init__.py
@@ -25,7 +25,6 @@ class OptionsDict(MutableMapping):
         "azure-arm": False,
         "basic-setup-py": False,
         "client-side-validation": False,
-        "emit-cross-language-definition-file": False,
         "flavor": "azure",  # need to default to azure in shared code so we don't break swagger generation
         "from-typespec": False,
         "generate-sample": False,
@@ -107,6 +106,8 @@ class OptionsDict(MutableMapping):
                 models_mode_default = "dpg"
             # switch to falsy value for easier code writing
             return models_mode_default
+        if key == "emit-cross-language-definition-file":
+            return self.get("flavor") == "azure"
         return self.DEFAULTS[key]
 
     def _validate_combinations(self) -> None:


### PR DESCRIPTION
Instead, we default to `true` for azure and `false` for unbranded