### PR TITLE
Fix to property sorting for models

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Generate.ps1
+++ b/packages/http-client-csharp/eng/scripts/Generate.ps1
@@ -7,6 +7,9 @@ param(
 
 Import-Module "$PSScriptRoot\Generation.psm1" -DisableNameChecking -Force;
 
+# Start overall timer
+$totalStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
 $packageRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
 $solutionDir = Join-Path $packageRoot 'generator'
 
@@ -212,3 +215,10 @@ if ($null -eq $filter) {
     # Write the launch settings to the launchSettings.json file
     Set-LaunchSettings $sortedLaunchSettings
 }
+
+# Stop total timer
+$totalStopwatch.Stop()
+
+# Display timing summary
+Write-Host "`n==================== TIMING SUMMARY ====================" -ForegroundColor Cyan
+Write-Host "Total execution time: $($totalStopwatch.Elapsed.ToString('hh\:mm\:ss\.ff'))" -ForegroundColor Yellow

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangePropertySerializedName.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/SerializationCustomizationTests/CanChangePropertySerializedName.cs
@@ -31,15 +31,15 @@ namespace Sample.Models
                 writer.WritePropertyName("customName"u8);
                 writer.WriteStringValue(Name);
             }
-            if (global::Sample.Optional.IsDefined(Flavor))
-            {
-                writer.WritePropertyName("flavor"u8);
-                writer.WriteStringValue(Flavor);
-            }
             if (global::Sample.Optional.IsDefined(CustomColor))
             {
                 writer.WritePropertyName("customColor2"u8);
                 writer.WriteStringValue(CustomColor);
+            }
+            if (global::Sample.Optional.IsDefined(Flavor))
+            {
+                writer.WritePropertyName("flavor"u8);
+                writer.WriteStringValue(Flavor);
             }
             if (((options.Format != "W") && (_additionalBinaryDataProperties != null)))
             {
@@ -78,8 +78,8 @@ namespace Sample.Models
                 return null;
             }
             string name = default;
-            string flavor = default;
             string customColor = default;
+            string flavor = default;
             global::System.Collections.Generic.IDictionary<string, global::System.BinaryData> additionalBinaryDataProperties = new global::Sample.ChangeTrackingDictionary<string, global::System.BinaryData>();
             foreach (var prop in element.EnumerateObject())
             {
@@ -88,14 +88,14 @@ namespace Sample.Models
                     name = prop.Value.GetString();
                     continue;
                 }
-                if (prop.NameEquals("flavor"u8))
-                {
-                    flavor = prop.Value.GetString();
-                    continue;
-                }
                 if (prop.NameEquals("customColor2"u8))
                 {
                     customColor = prop.Value.GetString();
+                    continue;
+                }
+                if (prop.NameEquals("flavor"u8))
+                {
+                    flavor = prop.Value.GetString();
                     continue;
                 }
                 if ((options.Format != "W"))
@@ -103,7 +103,7 @@ namespace Sample.Models
                     additionalBinaryDataProperties.Add(prop.Name, global::System.BinaryData.FromString(prop.Value.GetRawText()));
                 }
             }
-            return new global::Sample.Models.MockInputModel(name, flavor, customColor, additionalBinaryDataProperties);
+            return new global::Sample.Models.MockInputModel(name, customColor, flavor, additionalBinaryDataProperties);
         }
 
         global::System.BinaryData global::System.ClientModel.Primitives.IPersistableModel<global::Sample.Models.MockInputModel>.Write(global::System.ClientModel.Primitives.ModelReaderWriterOptions options) => this.PersistableModelWriteCore(options);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
@@ -145,8 +145,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 foreach (var prop in customProperties)
                 {
                     // Check if custom property is in spec
-                    if (_specPropertiesMap.TryGetValue(prop.Name, out var specProp) ||
-                        prop.OriginalName != null && _specPropertiesMap.TryGetValue(prop.OriginalName, out specProp))
+                    if ((_specPropertiesMap.TryGetValue(prop.Name, out var specProp) ||
+                        (prop.OriginalName != null && _specPropertiesMap.TryGetValue(prop.OriginalName, out specProp))) &&
+                        !inputProperties.Contains(specProp))
                     {
                         inputProperties.Add(specProp);
                     }
@@ -156,10 +157,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     }
                 }
 
-                // Build final array with exact size
                 var specCount = _specProperties.Count(p => inputProperties.Contains(p));
-                var result = new PropertyProvider[specCount + nonSpecProperties.Count];
-                var index = 0;
+                var result = new List<PropertyProvider>(specCount + nonSpecProperties.Count);
 
                 // Add spec properties in order
                 foreach (var specProp in _specProperties)
@@ -167,14 +166,14 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     if (inputProperties.Contains(specProp) &&
                         _propertyProviderMap.TryGetValue(specProp, out var provider))
                     {
-                        result[index++] = provider;
+                        result.Add(provider);
                     }
                 }
 
-                // Copy non-spec properties
-                nonSpecProperties.CopyTo(result, index);
+                // Add non-spec properties
+                result.AddRange(nonSpecProperties);
 
-                return result;
+                return [..result];
             }
 
             // For other types, there is no canonical order, so we can just return generated followed by custom properties.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/CanonicalTypeProvider.cs
@@ -145,9 +145,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 foreach (var prop in customProperties)
                 {
                     // Check if custom property is in spec
-                    if ((_specPropertiesMap.TryGetValue(prop.Name, out var specProp) ||
-                        (prop.OriginalName != null && _specPropertiesMap.TryGetValue(prop.OriginalName, out specProp))) &&
-                        !inputProperties.Contains(specProp))
+                    if (_specPropertiesMap.TryGetValue(prop.Name, out var specProp) ||
+                        (prop.OriginalName != null && _specPropertiesMap.TryGetValue(prop.OriginalName, out specProp)))
                     {
                         inputProperties.Add(specProp);
                     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -20,7 +20,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
     {
         private VariableExpression? _variable;
         private Lazy<ParameterProvider> _parameter;
-        private readonly InputProperty? _inputProperty;
+        internal InputProperty? InputProperty { get; }
+
         private readonly SerializationFormat _serializationFormat;
         private FormattableString? _customDescription;
 
@@ -79,7 +80,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private PropertyProvider(InputProperty inputProperty, CSharpType propertyType, TypeProvider enclosingType)
         {
-            _inputProperty = inputProperty;
+            InputProperty = inputProperty;
             if (!inputProperty.IsRequired && !propertyType.IsCollection)
             {
                 propertyType = propertyType.WithNullable(true);
@@ -133,9 +134,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private void BuildDocs()
         {
-            if (_inputProperty != null)
+            if (InputProperty != null)
             {
-                Description = DocHelpers.GetFormattableDescription(_inputProperty.Summary, _inputProperty.Doc) ??
+                Description = DocHelpers.GetFormattableDescription(InputProperty.Summary, InputProperty.Doc) ??
                               PropertyDescriptionBuilder.CreateDefaultPropertyDescription(Name, !Body.HasSetter);
                 XmlDocs = new XmlDocProvider(PropertyDescriptionBuilder.BuildPropertyDescription(
                     Type,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/TypeSymbolExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/TypeSymbolExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Primitives;
 
@@ -165,6 +166,7 @@ namespace Microsoft.TypeSpec.Generator
                 // Special case for types that would not be defined in corlib, but should still be considered framework types.
                 "System.BinaryData" => typeof(BinaryData),
                 "System.Uri" => typeof(Uri),
+                "System.Text.Json.JsonElement" => typeof(JsonElement),
                 _ => Type.GetType(fullyQualifiedName)
             };
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/CanonicalTypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/CanonicalTypeProviderTests.cs
@@ -145,28 +145,6 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
                 ValidatePropertyAttributes(expected, actual);
                 Assert.IsNull(actual.WireInfo);
             }
-
-            foreach (var expected in _namedSymbol.Properties)
-            {
-                var actual = properties[expected.Name];
-
-                Assert.IsTrue(properties.ContainsKey(expected.Name));
-                Assert.AreEqual(expected.Name, actual.Name);
-                Assert.IsNotNull(actual.Description);
-                Assert.AreEqual($"{expected.Description}.", actual.Description!.ToString()); // the writer adds a period
-                Assert.AreEqual(expected.Modifiers, actual.Modifiers);
-                Assert.AreEqual(expected.Type, actual.Type);
-                Assert.AreEqual(expected.Body.GetType(), actual.Body.GetType());
-                Assert.AreEqual(expected.Body.HasSetter, actual.Body.HasSetter);
-            }
-            // int, spec, nullWireInfo are all spec properties and they should have serialized name
-            Assert.AreEqual("intProperty", properties["IntProperty"].WireInfo!.SerializedName);
-            Assert.AreEqual("stringProperty", properties["StringProperty"].WireInfo!.SerializedName);
-            Assert.AreEqual("NullWireInfoProperty", properties["NullWireInfoProperty"].WireInfo!.SerializedName);
-
-            // pure customization code properties should not have serialized name
-            Assert.IsNull(properties["InternalStringProperty"].WireInfo);
-            Assert.IsNull(properties["PropertyTypeProperty"].WireInfo);
         }
 
         private void ValidatePropertyAttributes(PropertyProvider expected, PropertyProvider actual)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/CanonicalTypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/CanonicalTypeProviderTests.cs
@@ -78,6 +78,13 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.AreEqual(7, properties.Count);
             Assert.AreEqual(2, _typeProvider.Properties.Count);
             Assert.AreEqual(5, _typeProvider.CustomCodeView!.Properties.Count);
+
+            // Validate the exact order
+            // IntProperty
+            // StringProperty
+            // InternalStringProperty
+            // PropertyTypeProperty
+            // NullWireInfo property
             foreach (var expected in _namedSymbol.Properties)
             {
                 var actual = properties[expected.Name];

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -104,13 +104,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.IsNull(modelTypeProvider.CustomCodeView.Properties[1].WireInfo);
 
             // validate canonical view
-            Assert.AreEqual(2, modelTypeProvider.CanonicalView!.Properties.Count);
+            Assert.AreEqual(1, modelTypeProvider.CanonicalView!.Properties.Count);
             Assert.AreEqual("Prop2", modelTypeProvider.CanonicalView.Properties[0].Name);
-            Assert.AreEqual("Prop1", modelTypeProvider.CanonicalView.Properties[1].Name);
             wireInfo = modelTypeProvider.CanonicalView.Properties[0].WireInfo;
             Assert.IsNotNull(wireInfo);
-            Assert.AreEqual("prop1", wireInfo!.SerializedName);
-            Assert.IsNull(modelTypeProvider.CanonicalView.Properties[1].WireInfo);
 
             Assert.AreEqual(0, modelTypeProvider.Properties.Count);
         }

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/Thing.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/Thing.Serialization.cs
@@ -39,6 +39,8 @@ namespace SampleTypeSpec
             {
                 throw new FormatException($"The model {nameof(Thing)} does not support writing '{format}' format.");
             }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Rename);
             writer.WritePropertyName("requiredUnion"u8);
 #if NET6_0_OR_GREATER
             writer.WriteRawValue(RequiredUnion);
@@ -116,8 +118,6 @@ namespace SampleTypeSpec
             {
                 writer.WriteNull("requiredNullableList"u8);
             }
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Rename);
             if (options.Format != "W" && _additionalBinaryDataProperties != null)
             {
                 foreach (var item in _additionalBinaryDataProperties)
@@ -160,6 +160,7 @@ namespace SampleTypeSpec
             {
                 return null;
             }
+            string rename = default;
             BinaryData requiredUnion = default;
             string requiredLiteralString = default;
             string requiredNullableString = default;
@@ -174,10 +175,14 @@ namespace SampleTypeSpec
             string requiredBadDescription = default;
             IList<int> optionalNullableList = default;
             IList<int> requiredNullableList = default;
-            string rename = default;
             IDictionary<string, BinaryData> additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
             foreach (var prop in element.EnumerateObject())
             {
+                if (prop.NameEquals("name"u8))
+                {
+                    rename = prop.Value.GetString();
+                    continue;
+                }
                 if (prop.NameEquals("requiredUnion"u8))
                 {
                     requiredUnion = BinaryData.FromString(prop.Value.GetRawText());
@@ -289,17 +294,13 @@ namespace SampleTypeSpec
                     requiredNullableList = array;
                     continue;
                 }
-                if (prop.NameEquals("name"u8))
-                {
-                    rename = prop.Value.GetString();
-                    continue;
-                }
                 if (options.Format != "W")
                 {
                     additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
                 }
             }
             return new Thing(
+                rename,
                 requiredUnion,
                 requiredLiteralString,
                 requiredNullableString,
@@ -314,7 +315,6 @@ namespace SampleTypeSpec
                 requiredBadDescription,
                 optionalNullableList ?? new ChangeTrackingList<int>(),
                 requiredNullableList,
-                rename,
                 additionalBinaryDataProperties);
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/Thing.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/Thing.cs
@@ -19,27 +19,28 @@ namespace SampleTypeSpec
         private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;
 
         /// <summary> Initializes a new instance of <see cref="Thing"/>. </summary>
+        /// <param name="rename"></param>
         /// <param name="requiredUnion"> required Union. </param>
         /// <param name="requiredNullableString"> required nullable string. </param>
         /// <param name="requiredBadDescription"> description with xml &lt;|endoftext|&gt;. </param>
         /// <param name="requiredNullableList"> required nullable collection. </param>
-        /// <param name="rename"></param>
-        /// <exception cref="ArgumentNullException"> <paramref name="requiredUnion"/>, <paramref name="requiredBadDescription"/> or <paramref name="rename"/> is null. </exception>
-        public Thing(BinaryData requiredUnion, string requiredNullableString, string requiredBadDescription, IEnumerable<int> requiredNullableList, string rename)
+        /// <exception cref="ArgumentNullException"> <paramref name="rename"/>, <paramref name="requiredUnion"/> or <paramref name="requiredBadDescription"/> is null. </exception>
+        public Thing(string rename, BinaryData requiredUnion, string requiredNullableString, string requiredBadDescription, IEnumerable<int> requiredNullableList)
         {
+            Argument.AssertNotNull(rename, nameof(rename));
             Argument.AssertNotNull(requiredUnion, nameof(requiredUnion));
             Argument.AssertNotNull(requiredBadDescription, nameof(requiredBadDescription));
-            Argument.AssertNotNull(rename, nameof(rename));
 
+            Rename = rename;
             RequiredUnion = requiredUnion;
             RequiredNullableString = requiredNullableString;
             RequiredBadDescription = requiredBadDescription;
             OptionalNullableList = new ChangeTrackingList<int>();
             RequiredNullableList = requiredNullableList?.ToList();
-            Rename = rename;
         }
 
         /// <summary> Initializes a new instance of <see cref="Thing"/>. </summary>
+        /// <param name="rename"></param>
         /// <param name="requiredUnion"> required Union. </param>
         /// <param name="requiredLiteralString"> required literal string. </param>
         /// <param name="requiredNullableString"> required nullable string. </param>
@@ -54,10 +55,10 @@ namespace SampleTypeSpec
         /// <param name="requiredBadDescription"> description with xml &lt;|endoftext|&gt;. </param>
         /// <param name="optionalNullableList"> optional nullable collection. </param>
         /// <param name="requiredNullableList"> required nullable collection. </param>
-        /// <param name="rename"></param>
         /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
-        internal Thing(BinaryData requiredUnion, string requiredLiteralString, string requiredNullableString, string optionalNullableString, int requiredLiteralInt, float requiredLiteralFloat, bool requiredLiteralBool, string optionalLiteralString, int? optionalLiteralInt, float? optionalLiteralFloat, bool? optionalLiteralBool, string requiredBadDescription, IList<int> optionalNullableList, IList<int> requiredNullableList, string rename, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        internal Thing(string rename, BinaryData requiredUnion, string requiredLiteralString, string requiredNullableString, string optionalNullableString, int requiredLiteralInt, float requiredLiteralFloat, bool requiredLiteralBool, string optionalLiteralString, int? optionalLiteralInt, float? optionalLiteralFloat, bool? optionalLiteralBool, string requiredBadDescription, IList<int> optionalNullableList, IList<int> requiredNullableList, IDictionary<string, BinaryData> additionalBinaryDataProperties)
         {
+            Rename = rename;
             RequiredUnion = requiredUnion;
             RequiredLiteralString = requiredLiteralString;
             RequiredNullableString = requiredNullableString;
@@ -72,7 +73,6 @@ namespace SampleTypeSpec
             RequiredBadDescription = requiredBadDescription;
             OptionalNullableList = optionalNullableList;
             RequiredNullableList = requiredNullableList;
-            Rename = rename;
             _additionalBinaryDataProperties = additionalBinaryDataProperties;
         }
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
@@ -687,6 +687,7 @@ namespace SampleTypeSpec
             Argument.AssertNotNullOrEmpty(requiredBadDescription, nameof(requiredBadDescription));
 
             Thing spreadModel = new Thing(
+                null,
                 requiredUnion,
                 requiredLiteralString,
                 requiredNullableString,
@@ -701,7 +702,6 @@ namespace SampleTypeSpec
                 requiredBadDescription,
                 optionalNullableList?.ToList() as IList<int> ?? new ChangeTrackingList<int>(),
                 requiredNullableList?.ToList() as IList<int> ?? new ChangeTrackingList<int>(),
-                null,
                 null);
             ClientResult result = AnonymousBody(spreadModel, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null);
             return ClientResult.FromValue((Thing)result, result.GetRawResponse());
@@ -735,6 +735,7 @@ namespace SampleTypeSpec
             Argument.AssertNotNullOrEmpty(requiredBadDescription, nameof(requiredBadDescription));
 
             Thing spreadModel = new Thing(
+                null,
                 requiredUnion,
                 requiredLiteralString,
                 requiredNullableString,
@@ -749,7 +750,6 @@ namespace SampleTypeSpec
                 requiredBadDescription,
                 optionalNullableList?.ToList() as IList<int> ?? new ChangeTrackingList<int>(),
                 requiredNullableList?.ToList() as IList<int> ?? new ChangeTrackingList<int>(),
-                null,
                 null);
             ClientResult result = await AnonymousBodyAsync(spreadModel, cancellationToken.CanBeCanceled ? new RequestOptions { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
             return ClientResult.FromValue((Thing)result, result.GetRawResponse());

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecModelFactory.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecModelFactory.cs
@@ -16,6 +16,7 @@ namespace SampleTypeSpec
     public static partial class SampleTypeSpecModelFactory
     {
         /// <summary> A model with a few properties of literal types. </summary>
+        /// <param name="rename"></param>
         /// <param name="requiredUnion"> required Union. </param>
         /// <param name="requiredLiteralString"> required literal string. </param>
         /// <param name="requiredNullableString"> required nullable string. </param>
@@ -30,14 +31,14 @@ namespace SampleTypeSpec
         /// <param name="requiredBadDescription"> description with xml &lt;|endoftext|&gt;. </param>
         /// <param name="optionalNullableList"> optional nullable collection. </param>
         /// <param name="requiredNullableList"> required nullable collection. </param>
-        /// <param name="rename"></param>
         /// <returns> A new <see cref="SampleTypeSpec.Thing"/> instance for mocking. </returns>
-        public static Thing Thing(BinaryData requiredUnion = default, string requiredLiteralString = default, string requiredNullableString = default, string optionalNullableString = default, int requiredLiteralInt = default, float requiredLiteralFloat = default, bool requiredLiteralBool = default, string optionalLiteralString = default, int? optionalLiteralInt = default, float? optionalLiteralFloat = default, bool? optionalLiteralBool = default, string requiredBadDescription = default, IEnumerable<int> optionalNullableList = default, IEnumerable<int> requiredNullableList = default, string rename = default)
+        public static Thing Thing(string rename = default, BinaryData requiredUnion = default, string requiredLiteralString = default, string requiredNullableString = default, string optionalNullableString = default, int requiredLiteralInt = default, float requiredLiteralFloat = default, bool requiredLiteralBool = default, string optionalLiteralString = default, int? optionalLiteralInt = default, float? optionalLiteralFloat = default, bool? optionalLiteralBool = default, string requiredBadDescription = default, IEnumerable<int> optionalNullableList = default, IEnumerable<int> requiredNullableList = default)
         {
             optionalNullableList ??= new ChangeTrackingList<int>();
             requiredNullableList ??= new ChangeTrackingList<int>();
 
             return new Thing(
+                rename,
                 requiredUnion,
                 requiredLiteralString,
                 requiredNullableString,
@@ -52,7 +53,6 @@ namespace SampleTypeSpec
                 requiredBadDescription,
                 optionalNullableList.ToList(),
                 requiredNullableList.ToList(),
-                rename,
                 additionalBinaryDataProperties: null);
         }
 


### PR DESCRIPTION
Previously, we would sort generated properties followed by custom properties. We need to honor the spec ordering. Also includes a fix to treat JsonElement as a framework type.

Contributes to https://github.com/Azure/azure-sdk-for-net/issues/51237