### PR TITLE
build: more pr creation script updates

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -151,6 +151,11 @@ try {
         $ErrorActionPreference = "Continue"
         try {
             Invoke "npm install" $httpClientDir
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "npm install failed with exit code $LASTEXITCODE, skipping generation."
+                Write-Host "##vso[task.complete result=SucceededWithIssues;]"
+                $installSucceeded = $false
+            }
         } catch {
             Write-Warning "npm install failed: $($_.Exception.Message), skipping generation."
             $installSucceeded = $false
@@ -195,7 +200,7 @@ try {
     }
     
     # Generate emitter-package.json files using tsp-client if TypeSpec package.json is provided
-    if ($TypeSpecSourcePackageJsonPath -and $installSucceeded -and (Test-Path $TypeSpecSourcePackageJsonPath)) {
+    if ($TypeSpecSourcePackageJsonPath -and (Test-Path $TypeSpecSourcePackageJsonPath)) {
         Write-Host "Generating emitter-package.json files using tsp-client..."
         $configFilesOutputDir = Join-Path $tempDir "eng"
         $emitterPackageJsonPath = Join-Path $configFilesOutputDir "http-client-csharp-emitter-package.json"


### PR DESCRIPTION
This PR updates the pr creation script to also check the last exit code for the `npm install` cmd. It also removes the condition of updating the unbranded emitter artifact in the case that `npm install` fails for the azure generator.