### PR TITLE
fix: do not cache attributes

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -234,7 +234,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         public IReadOnlyList<TypeProvider> SerializationProviders => _serializationProviders ??= BuildSerializationProviders();
 
-        private IReadOnlyList<AttributeStatement>? _attributeStatements;
         private IReadOnlyList<MethodBodyStatement>? _attributes;
 
         public IReadOnlyList<AttributeStatement> Attributes
@@ -242,7 +241,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             get
             {
                 _attributes ??= BuildAttributes();
-                _attributeStatements ??= _attributes
+                return [.. _attributes
                     .Select(a => a switch
                     {
                         SuppressionStatement suppression => suppression.AsStatement<AttributeStatement>() ??
@@ -250,8 +249,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                                                                 $"Unexpected suppression statement in {Name}."),
                         AttributeStatement attribute => attribute,
                         _ => throw new InvalidOperationException($"Unexpected attribute type {a.GetType()} in {Name}.")
-                    }).ToList();
-                return _attributeStatements;
+                    })];
             }
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/TypeProviderTests.cs
@@ -189,5 +189,33 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             // The BuildX methods should be called again, which will return the original state.
             Assert.AreEqual(1, typeProvider.Methods.Count);
         }
+
+        [Test]
+        public void TestCanUpdateAttributes()
+        {
+            var typeProvider = new TestTypeProvider(name: "OriginalName",
+               methods: [new MethodProvider(
+                    new MethodSignature("TestMethod", $"", MethodSignatureModifiers.Public, null, $"", []),
+                    Snippet.Throw(Snippet.Null), new TestTypeProvider())]);
+            typeProvider.Update(attributes: [
+                    new(typeof(ObsoleteAttribute))
+                ]);
+
+            Assert.IsNotNull(typeProvider.Attributes);
+            Assert.AreEqual(1, typeProvider.Attributes.Count);
+            Assert.AreEqual(new CSharpType(typeof(ObsoleteAttribute)), typeProvider.Attributes[0].Type);
+
+            // now reset and validate
+            typeProvider.Reset();
+            Assert.AreEqual(0, typeProvider.Attributes.Count);
+
+            // re-add the attributes
+            typeProvider.Update(attributes: [
+                new(typeof(ObsoleteAttribute))
+            ]);
+
+            Assert.AreEqual(1, typeProvider.Attributes.Count);
+            Assert.AreEqual(new CSharpType(typeof(ObsoleteAttribute)), typeProvider.Attributes[0].Type);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue where we were unintentionally caching the attributes for a typeprovider. This would prevent a visitor from updating the attributes in a given type.