### PR TITLE
fix: do not throw for unhandled serialization

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/BinaryContentHelperDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/BinaryContentHelperDefinition.cs
@@ -4,17 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
-using Microsoft.TypeSpec.Generator.ClientModel.Utilities;
-using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
-using Newtonsoft.Json.Linq;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
@@ -236,27 +232,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 Parameters: [valueParameter],
                 ReturnType: _requestBodyType,
                 Description: null,
-            ReturnDescription: null);
-
-            MethodBodyStatement declaration = Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content);
-            MethodBodyStatement? serialization = content.JsonWriter().WriteObjectValue(valueParameter.As(typeof(object)), ModelSerializationExtensionsSnippets.Wire);
-
-            try
-            {
-                serialization = ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(typeof(object), valueParameter, content.JsonWriter(), ModelSerializationExtensionsSnippets.Wire, SerializationFormat.Default);
-            }
-            catch (NotSupportedException)
-            {
-                ScmCodeModelGenerator.Instance.Emitter.ReportDiagnostic(
-                   DiagnosticCodes.UnsupportedSerialization,
-                   $"Unable to create serialization expression for type {typeof(object).Name}.",
-                   severity: EmitterDiagnosticSeverity.Error);
-            }
+                ReturnDescription: null);
 
             MethodBodyStatement[] body =
             [
-                declaration,
-                serialization,
+                Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content),
+                ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(typeof(object), valueParameter, content.JsonWriter(), ModelSerializationExtensionsSnippets.Wire, SerializationFormat.Default),
                 Return(content)
             ];
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/BinaryContentHelperDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/BinaryContentHelperDefinition.cs
@@ -4,13 +4,17 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using Microsoft.TypeSpec.Generator.ClientModel.Snippets;
+using Microsoft.TypeSpec.Generator.ClientModel.Utilities;
+using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
+using Newtonsoft.Json.Linq;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
@@ -232,12 +236,27 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 Parameters: [valueParameter],
                 ReturnType: _requestBodyType,
                 Description: null,
-                ReturnDescription: null);
+            ReturnDescription: null);
+
+            MethodBodyStatement declaration = Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content);
+            MethodBodyStatement? serialization = content.JsonWriter().WriteObjectValue(valueParameter.As(typeof(object)), ModelSerializationExtensionsSnippets.Wire);
+
+            try
+            {
+                serialization = ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(typeof(object), valueParameter, content.JsonWriter(), ModelSerializationExtensionsSnippets.Wire, SerializationFormat.Default);
+            }
+            catch (NotSupportedException)
+            {
+                ScmCodeModelGenerator.Instance.Emitter.ReportDiagnostic(
+                   DiagnosticCodes.UnsupportedSerialization,
+                   $"Unable to create serialization expression for type {typeof(object).Name}.",
+                   severity: EmitterDiagnosticSeverity.Error);
+            }
 
             MethodBodyStatement[] body =
             [
-                Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content),
-                ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(typeof(object), valueParameter, content.JsonWriter(), ModelSerializationExtensionsSnippets.Wire, SerializationFormat.Default),
+                declaration,
+                serialization,
                 Return(content)
             ];
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Utilities/DiagnosticCodes.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Utilities/DiagnosticCodes.cs
@@ -8,5 +8,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Utilities
         public const string ClientNamespaceConflict = "client-namespace-conflict";
         public const string MissingItemsProperty = "missing-items-property";
         public const string NoMatchingItemsProperty = "no-matching-items-property";
+        public const string UnsupportedSerialization = "unsupported-serialization";
     }
 }


### PR DESCRIPTION
This PR adds error handling when building the serialization statements for unsupported types. The generator will not log a diagnostic rather than throwing.