### PR TITLE
[python] fix to keep some existing parts of pyproject.toml

### DIFF
--- a/.chronus/changes/publish-python-2025-08-14-2025-7-14-12-42-53.md
+++ b/.chronus/changes/publish-python-2025-08-14-2025-7-14-12-42-53.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+fix to keep some existing parts of pyproject.toml

--- a/packages/http-client-python/generator/pygen/__init__.py
+++ b/packages/http-client-python/generator/pygen/__init__.py
@@ -234,9 +234,6 @@ class ReaderAndWriter:
             _LOGGER.warning("Loading python.json file. This behavior will be depreacted")
         self.options.update(python_json)
 
-    def get_output_folder(self) -> Path:
-        return self.output_folder
-
     def read_file(self, path: Union[str, Path]) -> str:
         """Directly reading from disk"""
         # make path relative to output folder

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -264,7 +264,7 @@ class JinjaSerializer(ReaderAndWriter):
                 file_path = self.get_output_folder() / Path(output_name)
                 self.write_file(
                     output_name,
-                    serializer.serialize_package_file(template_name, file_path, **params),
+                    serializer.serialize_package_file(template_name, output_name, **params),
                 )
 
     def _keep_patch_file(self, path_file: Path, env: Environment):

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -256,15 +256,14 @@ class JinjaSerializer(ReaderAndWriter):
             if not self.code_model.is_azure_flavor and template_name == "dev_requirements.txt.jinja2":
                 continue
             file = template_name.replace(".jinja2", "")
-            output_name = root_of_sdk / file
-            if not self.read_file(output_name) or file in _REGENERATE_FILES:
+            output_file = root_of_sdk / file
+            if not self.read_file(output_file) or file in _REGENERATE_FILES:
                 if self.keep_version_file and file == "setup.py" and not self.code_model.options["azure-arm"]:
                     # don't regenerate setup.py file if the version file is more up to date for data-plane
                     continue
-                file_path = self.get_output_folder() / Path(output_name)
                 self.write_file(
-                    output_name,
-                    serializer.serialize_package_file(template_name, output_name, **params),
+                    output_file,
+                    serializer.serialize_package_file(template_name, output_file, **params),
                 )
 
     def _keep_patch_file(self, path_file: Path, env: Environment):

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -261,9 +261,10 @@ class JinjaSerializer(ReaderAndWriter):
                 if self.keep_version_file and file == "setup.py" and not self.code_model.options["azure-arm"]:
                     # don't regenerate setup.py file if the version file is more up to date for data-plane
                     continue
+                file_content = self.read_file(output_file) if file == "pyproject.toml" else ""
                 self.write_file(
                     output_file,
-                    serializer.serialize_package_file(template_name, self.output_folder / output_file, **params),
+                    serializer.serialize_package_file(template_name, file_content, **params),
                 )
 
     def _keep_patch_file(self, path_file: Path, env: Environment):

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -222,7 +222,7 @@ class JinjaSerializer(ReaderAndWriter):
     # path where README.md is
     @property
     def _root_of_sdk(self) -> Path:
-        root_of_sdk = Path(".")
+        root_of_sdk = self.output_folder
         if self.code_model.options["no-namespace-folders"]:
             compensation = Path("../" * (self.code_model.namespace.count(".") + 1))
             root_of_sdk = root_of_sdk / compensation

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -222,7 +222,7 @@ class JinjaSerializer(ReaderAndWriter):
     # path where README.md is
     @property
     def _root_of_sdk(self) -> Path:
-        root_of_sdk = self.output_folder
+        root_of_sdk = Path(".")
         if self.code_model.options["no-namespace-folders"]:
             compensation = Path("../" * (self.code_model.namespace.count(".") + 1))
             root_of_sdk = root_of_sdk / compensation
@@ -263,7 +263,7 @@ class JinjaSerializer(ReaderAndWriter):
                     continue
                 self.write_file(
                     output_file,
-                    serializer.serialize_package_file(template_name, output_file, **params),
+                    serializer.serialize_package_file(template_name, self.output_folder / output_file, **params),
                 )
 
     def _keep_patch_file(self, path_file: Path, env: Environment):

--- a/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
@@ -19,9 +19,6 @@ from ..models.utils import NamespaceType
 from .client_serializer import ClientSerializer, ConfigSerializer
 from .base_serializer import BaseSerializer
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 VERSION_MAP = {
     "msrest": "0.7.1",
     "isodate": "0.6.1",

--- a/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
@@ -60,12 +60,11 @@ class GeneralSerializer(BaseSerializer):
         m = re.search(r"[>=]=?([\d.]+(?:[a-z]+\d+)?)", s)
         return parse_version(m.group(1)) if m else parse_version("0")
 
-    def _keep_pyproject_fields(self, file_path: "Path") -> dict:
+    def _keep_pyproject_fields(self, file_content: str) -> dict:
         # Load the pyproject.toml file if it exists and extract fields to keep.
         result: dict = {"KEEP_FIELDS": {}}
         try:
-            with open(file_path, "rb") as f:
-                loaded_pyproject_toml = tomllib.load(f)
+            loaded_pyproject_toml = tomllib.loads(file_content)
         except Exception:  # pylint: disable=broad-except
             # If parsing the pyproject.toml fails, we assume the it does not exist or is incorrectly formatted.
             return result
@@ -108,12 +107,12 @@ class GeneralSerializer(BaseSerializer):
 
         return result
 
-    def serialize_package_file(self, template_name: str, file_path: "Path", **kwargs: Any) -> str:
+    def serialize_package_file(self, template_name: str, file_content: str, **kwargs: Any) -> str:
         template = self.env.get_template(template_name)
 
         # Add fields to keep from an existing pyproject.toml
-        if template_name == "pyproject.toml.jinja2":
-            params = self._keep_pyproject_fields(file_path)
+        if template_name == "pyproject.toml.jinja2" and file_content:
+            params = self._keep_pyproject_fields(file_content)
         else:
             params = {}
 

--- a/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import json
-from typing import Any, List, TYPE_CHECKING
+from typing import Any, List
 import re
 import tomli as tomllib
 from packaging.version import parse as parse_version

--- a/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
@@ -108,7 +108,7 @@ class GeneralSerializer(BaseSerializer):
         template = self.env.get_template(template_name)
 
         # Add fields to keep from an existing pyproject.toml
-        if template_name == "pyproject.toml.jinja2" and file_content:
+        if template_name == "pyproject.toml.jinja2":
             params = self._keep_pyproject_fields(file_content)
         else:
             params = {}

--- a/packages/http-client-python/generator/pygen/codegen/templates/packaging_templates/pyproject.toml.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/packaging_templates/pyproject.toml.jinja2
@@ -111,3 +111,10 @@ pytyped = ["py.typed"]
 {{ key }} = {{ val|tojson }}
 {% endfor %}
 {% endif %}
+{% if KEEP_FIELDS and KEEP_FIELDS.get('packaging') %}
+
+[packaging]
+{% for key, val in KEEP_FIELDS.get('packaging').items() %}
+{{ key }} = {{ val|tojson }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
fix output folder to make sure codegen could find right position of existing pyproject.toml

add test case in https://github.com/Azure/autorest.python/pull/3174/files#diff-5fa7ea68bc2d31e09e995e5f522a9e4f58572767f393937a1cf6baf35fa16664 to cover this scenario.