### PR TITLE
WIP http: Rework HTTP analysis APIs to accept VisibilityFilter

### DIFF
--- a/packages/http/src/http-property.ts
+++ b/packages/http/src/http-property.ts
@@ -4,6 +4,7 @@ import {
   DiagnosticResult,
   Model,
   Type,
+  VisibilityFilter,
   walkPropertiesInherited,
   type Diagnostic,
   type ModelProperty,
@@ -225,7 +226,7 @@ function getHttpProperty(
 export function resolvePayloadProperties(
   program: Program,
   type: Type,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
   disposition: HttpPayloadDisposition,
   options: GetHttpPropertyOptions = {},
 ): DiagnosticResult<HttpProperty[]> {

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -52,11 +52,21 @@ export { $linter } from "./linter.js";
 /** @internal */
 export { setStatusCode } from "./decorators.js";
 export type { HttpProperty } from "./http-property.js";
+
+import { Visibility as HttpVisibility } from "./metadata.js";
+
+/**
+ * Flag enum representation of well-known visibilities that are used in REST APIs.
+ *
+ * @deprecated Prefer using `VisibilityFilter` from `@typespec/compiler` instead.
+ */
+export const Visibility = HttpVisibility;
+export type Visibility = HttpVisibility;
+
 export {
-  HttpVisibilityProvider,
-  Visibility,
   createMetadataInfo,
   getVisibilitySuffix,
+  HttpVisibilityProvider,
   isApplicableMetadata,
   isApplicableMetadataOrBody,
   isMetadata,
@@ -75,9 +85,9 @@ export {
 } from "./operations.js";
 export { getOperationParameters } from "./parameters.js";
 export {
-  HttpPart,
   getHttpFileModel,
   getHttpPart,
+  HttpPart,
   isHttpFile,
   isOrExtendsHttpFile,
 } from "./private.decorators.js";
@@ -132,11 +142,11 @@ export type {
   ImplicitFlow,
   NoAuth,
   NoHttpAuthRef,
+  Oauth2Auth,
   OAuth2Flow,
   OAuth2FlowType,
   OAuth2HttpAuthRef,
   OAuth2Scope,
-  Oauth2Auth,
   OpenIDConnectAuth,
   OperationContainer,
   OperationVerbSelector,

--- a/packages/http/src/payload.ts
+++ b/packages/http/src/payload.ts
@@ -9,6 +9,7 @@ import {
   Tuple,
   Type,
   Union,
+  VisibilityFilter,
   createDiagnosticCollector,
   filterModelProperties,
   getDiscriminator,
@@ -68,7 +69,7 @@ export enum HttpPayloadDisposition {
 export function resolveHttpPayload(
   program: Program,
   type: Type,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
   disposition: HttpPayloadDisposition,
   options: ExtractBodyAndMetadataOptions = {},
 ): DiagnosticResult<HttpPayload> {
@@ -102,7 +103,7 @@ function resolveBody(
   program: Program,
   requestOrResponseType: Type,
   metadata: HttpProperty[],
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
   disposition: HttpPayloadDisposition,
 ): DiagnosticResult<HttpPayloadBody | undefined> {
   const diagnostics = createDiagnosticCollector();
@@ -227,7 +228,7 @@ function resolveExplicitBodyProperty(
   program: Program,
   metadata: HttpProperty[],
   contentTypeProperty: HttpProperty | undefined,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
   disposition: HttpPayloadDisposition,
 ): DiagnosticResult<HttpPayloadBody | undefined> {
   const diagnostics = createDiagnosticCollector();
@@ -381,7 +382,7 @@ function resolveMultiPartBody(
   program: Program,
   property: ModelProperty,
   contentTypeProperty: HttpProperty | undefined,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
 ): DiagnosticResult<HttpOperationMultipartBody | undefined> {
   const diagnostics = createDiagnosticCollector();
 
@@ -421,7 +422,7 @@ function resolveMultiPartBodyFromModel(
   property: ModelProperty,
   type: Model,
   contentTypeProperty: HttpProperty | undefined,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
 ): DiagnosticResult<HttpOperationMultipartBody | undefined> {
   const diagnostics = createDiagnosticCollector();
   const parts: HttpOperationModelPart[] = [];
@@ -468,7 +469,7 @@ function resolveMultiPartBodyFromTuple(
   property: ModelProperty,
   type: Tuple,
   contentTypeProperty: HttpProperty | undefined,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
 ): DiagnosticResult<HttpOperationMultipartBody | undefined> {
   const diagnostics = createDiagnosticCollector();
   const parts: HttpOperationTuplePart[] = [];
@@ -513,7 +514,7 @@ function resolveMultiPartBodyFromTuple(
 function resolvePartOrParts(
   program: Program,
   type: Type,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
   property?: ModelProperty,
 ): DiagnosticResult<HttpOperationPartCommon | undefined> {
   if (type.kind === "Model" && isArrayModelType(program, type)) {
@@ -530,7 +531,7 @@ function resolvePartOrParts(
 function resolvePart(
   program: Program,
   type: Type,
-  visibility: Visibility,
+  visibility: Visibility | VisibilityFilter,
   property?: ModelProperty,
 ): DiagnosticResult<HttpOperationPartCommon | undefined> {
   const diagnostics = createDiagnosticCollector();

--- a/packages/http/src/responses.ts
+++ b/packages/http/src/responses.ts
@@ -5,6 +5,7 @@ import {
   getDoc,
   getErrorsDoc,
   getReturnsDoc,
+  getReturnTypeVisibilityFilter,
   isErrorModel,
   isNullType,
   isVoidType,
@@ -18,7 +19,7 @@ import { $ } from "@typespec/compiler/typekit";
 import { getStatusCodeDescription, getStatusCodesWithDiagnostics } from "./decorators.js";
 import { HttpProperty } from "./http-property.js";
 import { HttpStateKeys, reportDiagnostic } from "./lib.js";
-import { Visibility } from "./metadata.js";
+import { HttpVisibilityProvider } from "./metadata.js";
 import { HttpPayloadDisposition, resolveHttpPayload } from "./payload.js";
 import { HttpOperationResponse, HttpStatusCodes, HttpStatusCodesEntry } from "./types.js";
 
@@ -82,9 +83,20 @@ function processResponseType(
   responses: ResponseIndex,
   responseType: Type,
 ) {
+  const returnTypeVisibility = getReturnTypeVisibilityFilter(
+    program,
+    operation,
+    HttpVisibilityProvider(),
+  );
+
   // Get body
   let { body: resolvedBody, metadata } = diagnostics.pipe(
-    resolveHttpPayload(program, responseType, Visibility.Read, HttpPayloadDisposition.Response),
+    resolveHttpPayload(
+      program,
+      responseType,
+      returnTypeVisibility,
+      HttpPayloadDisposition.Response,
+    ),
   );
   // Get explicity defined status codes
   const statusCodes: HttpStatusCodes = diagnostics.pipe(


### PR DESCRIPTION
This work-in-progress PR is an attempt to fix returnTypeVisibility/parameterVisibility by changing the HTTP library to use VisibilityFilter instances internally instead of `Visibility` flags. The public API is extended to accept VisibilityFilter everywhere that Visibility was required, and the API converts from Visibility to VisbilityFilter more eagerly.

This (provisionally, for the purposes of being able to easily identify where the flags type is used -- we may or may not decide to go forward with this) deprecates `Visibility` and the old signature for `getVisibilitySuffix` in favor of APIs that consume VisibilityFilter instances directly.

This hasn't quite fixed the issues with returnTypeVisibility but it's a step in the right direction.