### PR TITLE
fix: include all types that implement mrw for mrw buildable attributes

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestHelpers/MockHelpers.cs
@@ -68,6 +68,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
             HttpMessageApi? httpMessageApi = null,
             RequestContentApi? requestContentApi = null,
             Func<InputAuth>? auth = null,
+            Func<OutputLibrary>? createOutputLibrary = null,
             bool includeXmlDocs = false,
             Func<InputType, bool>? createCSharpTypeCoreFallback = null,
             Func<InputModelType, ModelProvider?>? createModelCore = null)
@@ -175,6 +176,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
             if (createInputLibrary is not null)
             {
                 mockGeneratorInstance.Setup(p => p.InputLibrary).Returns(createInputLibrary);
+            }
+
+            if (createOutputLibrary != null)
+            {
+                mockGeneratorInstance.Setup(p => p.OutputLibrary).Returns(createOutputLibrary);
             }
 
             var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(null, null)) { CallBase = true };


### PR DESCRIPTION
This PR fixes issues related to the building of the model context. If an extending generator / plugin adds additional types to the output library that don't derive from `ModelProvider` but still implement the MRW serialization interfaces, then these were not being considered. This PR adjusts that conditioning to account for all type providers that implement these interfaces.

contributes to https://github.com/microsoft/typespec/issues/7988