### PR TITLE
eng, copilot prompt, fix link to http-client-java

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,4 +21,4 @@ This document serves as an index to task-specific instructions for GitHub Copilo
 
 - [Testserver Generation](./prompts/testserver-generation.md): Instructions for generating TypeSpec HTTP spec test servers
 - [http-client-csharp Development](./prompts/http-client-csharp-development.md): Instructions for developing the C# HTTP client
-- [http-client-java Development](../packages/http-client-java/.github/copilot-instructions.md): Instructions for developing the TypeSpec library for Java client.
+- [http-client-java Development](./prompts/http-client-java-development.md): Instructions for developing the TypeSpec library for Java client.


### PR DESCRIPTION
Fix a mistaken when adding this line. It should directly link to the prompt in prompts folder.