### PR TITLE
Make ModelReaderWriterContextDefinition public

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -14,7 +14,7 @@ using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 {
-    internal class ModelReaderWriterContextDefinition : TypeProvider
+    public class ModelReaderWriterContextDefinition : TypeProvider
     {
         internal static readonly string s_name = $"{RemovePeriods(ScmCodeModelGenerator.Instance.TypeFactory.PrimaryNamespace)}Context";
 


### PR DESCRIPTION
This PR exposes the ModelReaderWriterContextDefinition type so visitor authors can more easily consume and edit the type in a plugin.

fixes: https://github.com/microsoft/typespec/issues/8212