### PR TITLE
tsp-openapi3: handle missing operationIds

### DIFF
--- a/.chronus/changes/tsp-to-oa3-missing-oid-2025-7-22-15-13-53.md
+++ b/.chronus/changes/tsp-to-oa3-missing-oid-2025-7-22-15-13-53.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+tsp-openapi3: log warnings when operationId is missing from Open API spec, and generate an operation name

--- a/packages/openapi3/src/cli/actions/convert/convert-file.ts
+++ b/packages/openapi3/src/cli/actions/convert/convert-file.ts
@@ -13,7 +13,7 @@ export async function convertAction(host: CliHost, args: ConvertCliArgs) {
   const fullPath = resolvePath(process.cwd(), args.path);
   const parser = new OpenAPIParser();
   const model = await parser.bundle(fullPath);
-  const context = createContext(parser, model as OpenAPI3Document);
+  const context = createContext(parser, model as OpenAPI3Document, console);
   const program = transform(context);
   let mainTsp: string;
   try {

--- a/packages/openapi3/src/cli/actions/convert/convert.ts
+++ b/packages/openapi3/src/cli/actions/convert/convert.ts
@@ -23,7 +23,7 @@ export async function convertOpenAPI3Document(
       }
     : {};
   await parser.bundle(document as any, bundleOptions);
-  const context = createContext(parser, document);
+  const context = createContext(parser, document, console);
   const program = transform(context);
   const content = generateMain(program, context);
   try {

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-operation.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-operation.ts
@@ -28,6 +28,10 @@ export function generateOperation(operation: TypeSpecOperation, context: Context
 
   const responses = generateOperationReturnType(operation, context);
 
+  if (operation.fixmes?.length) {
+    definitions.push("\n", ...operation.fixmes.map((f) => `// FIXME: ${f}\n`));
+  }
+
   definitions.push(`op ${operation.name}(${parameters.join(", ")}): ${responses};`);
 
   return definitions.join(" ");

--- a/packages/openapi3/src/cli/actions/convert/interfaces.ts
+++ b/packages/openapi3/src/cli/actions/convert/interfaces.ts
@@ -39,6 +39,7 @@ export interface TypeSpecDeclaration {
   doc?: string;
   decorators: TypeSpecDecorator[];
   scope: string[];
+  fixmes?: string[];
 }
 
 export interface TypeSpecNamespace {

--- a/packages/openapi3/src/cli/actions/convert/utils/context.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/context.ts
@@ -1,11 +1,13 @@
 import type OpenAPIParser from "@apidevtools/swagger-parser";
 import { OpenAPI3Document, OpenAPI3Schema, Refable } from "../../../../types.js";
+import { Logger } from "../../../types.js";
 import { SchemaToExpressionGenerator } from "../generators/generate-types.js";
 import { generateNamespaceName } from "./generate-namespace-name.js";
 
 export interface Context {
   readonly openApi3Doc: OpenAPI3Document;
   readonly rootNamespace: string;
+  readonly logger: Logger;
 
   generateTypeFromRefableSchema(schema: Refable<OpenAPI3Schema>, callingScope: string[]): string;
   getRefName(ref: string, callingScope: string[]): string;
@@ -17,13 +19,25 @@ export type Parser = {
   $refs: OpenAPIParser["$refs"];
 };
 
-export function createContext(parser: Parser, openApi3Doc: OpenAPI3Document): Context {
+export function createContext(
+  parser: Parser,
+  openApi3Doc: OpenAPI3Document,
+  logger?: Logger,
+): Context {
   const rootNamespace = generateNamespaceName(openApi3Doc.info.title);
   const schemaExpressionGenerator = new SchemaToExpressionGenerator(rootNamespace);
+
+  // Create a default no-op logger if none provided
+  const defaultLogger: Logger = {
+    trace: () => {},
+    warn: () => {},
+    error: () => {},
+  };
 
   const context: Context = {
     openApi3Doc,
     rootNamespace,
+    logger: logger ?? defaultLogger,
     getRefName(ref: string, callingScope: string[]) {
       return schemaExpressionGenerator.getRefName(ref, callingScope);
     },

--- a/packages/openapi3/src/cli/actions/convert/utils/generate-operation-id.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/generate-operation-id.ts
@@ -1,0 +1,32 @@
+/**
+ * Generates an operationId when one is missing from the OpenAPI operation.
+ * @param method The HTTP method (GET, POST, etc.)
+ * @param path The path pattern from the OpenAPI spec
+ * @param usedIds Set of already used operation IDs to ensure uniqueness
+ * @returns A generated operationId
+ */
+export function generateOperationId(method: string, path: string, usedIds: Set<string>): string {
+  // Remove leading slash and clean path
+  const cleanPath = path
+    .replace(/^\//, "")
+    .replace(/\//g, "_")
+    .replace(/[{}]/g, "")
+    .replace(/[^a-zA-Z0-9_]/g, "_");
+
+  // Combine method and path
+  const baseId = `${method.toLowerCase()}_${cleanPath || "root"}`;
+
+  // Remove consecutive underscores and trailing underscores
+  let operationId = baseId.replace(/_+/g, "_").replace(/_$/, "");
+
+  // Ensure uniqueness by adding suffix if needed
+  let suffix = 1;
+  const originalId = operationId;
+  while (usedIds.has(operationId)) {
+    operationId = `${originalId}_${suffix}`;
+    suffix++;
+  }
+
+  usedIds.add(operationId);
+  return operationId;
+}

--- a/packages/openapi3/test/tsp-openapi3/missing-operation-id.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/missing-operation-id.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { transformPaths } from "../../src/cli/actions/convert/transforms/transform-paths.js";
+import { createContext, Parser } from "../../src/cli/actions/convert/utils/context.js";
+import { convertOpenAPI3Document } from "../../src/index.js";
+
+describe("Convert OpenAPI3 with missing operationId", () => {
+  const mockParser: Parser = {
+    $refs: {
+      get: () => undefined,
+    } as any,
+  };
+
+  // Mock logger to capture warnings
+  const mockLogger = {
+    trace: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should generate operationId and show warning when missing", async () => {
+    const openApiDoc = {
+      info: { title: "Test", version: "1.0.0" },
+      openapi: "3.0.0",
+      paths: {
+        "/users": {
+          get: {
+            // This one is missing operationId
+            parameters: [],
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/users/{id}": {
+          post: {
+            operationId: "createUser", // This one has an operationId
+            parameters: [],
+            responses: {
+              "201": {
+                description: "Created",
+              },
+            },
+          },
+          get: {
+            // This one is missing operationId
+            parameters: [],
+            responses: {
+              "200": {
+                description: "Success",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const context = createContext(mockParser, openApiDoc as any, mockLogger);
+    const operations = transformPaths(openApiDoc.paths, context);
+
+    // Should have 3 operations
+    expect(operations.length).toBe(3);
+
+    // Check that warnings were logged for missing operationIds
+    expect(mockLogger.warn.mock.calls.length).toBe(2);
+    expect(mockLogger.warn.mock.calls[0][0]).toBe(
+      "Open API operation 'GET /users' is missing an operationId. Generated: 'get_users'",
+    );
+    expect(mockLogger.warn.mock.calls[1][0]).toBe(
+      "Open API operation 'GET /users/{id}' is missing an operationId. Generated: 'get_users_id'",
+    );
+
+    // Check generated operationIds
+    const getUsersOp = operations.find((op) => op.operationId === "get_users");
+    const createUserOp = operations.find((op) => op.operationId === "createUser");
+    const getUserByIdOp = operations.find((op) => op.operationId === "get_users_id");
+
+    expect(getUsersOp?.name).toBe("get_users");
+    expect(createUserOp?.name).toBe("createUser");
+    expect(getUserByIdOp?.name).toBe("get_users_id");
+  });
+
+  it("should clean special characters from paths", async () => {
+    const openApiDoc = {
+      info: { title: "Test", version: "1.0.0" },
+      openapi: "3.0.0",
+      paths: {
+        "/api/v1/users/{user-id}/profile": {
+          get: {
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+        "/": {
+          get: {
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    };
+
+    const context = createContext(mockParser, openApiDoc as any, mockLogger);
+    const operations = transformPaths(openApiDoc.paths, context);
+
+    // Should have 2 operations
+    expect(operations.length).toBe(2);
+
+    // Check generated operationIds
+    const complexPathOp = operations.find(
+      (op) => op.operationId === "get_api_v1_users_user_id_profile",
+    );
+    const rootOp = operations.find((op) => op.operationId === "get_root");
+
+    expect(complexPathOp?.name).toBe("get_api_v1_users_user_id_profile");
+    expect(rootOp?.name).toBe("get_root");
+
+    // Check warnings
+    expect(mockLogger.warn.mock.calls.length).toBe(2);
+    expect(mockLogger.warn.mock.calls[0][0]).toBe(
+      "Open API operation 'GET /api/v1/users/{user-id}/profile' is missing an operationId. Generated: 'get_api_v1_users_user_id_profile'",
+    );
+    expect(mockLogger.warn.mock.calls[1][0]).toBe(
+      "Open API operation 'GET /' is missing an operationId. Generated: 'get_root'",
+    );
+  });
+
+  it("should work with full document conversion", async () => {
+    const tsp = await convertOpenAPI3Document({
+      info: {
+        title: "Test Service",
+        version: "1.0.0",
+      },
+      openapi: "3.0.0",
+      paths: {
+        "/users": {
+          get: {
+            summary: "List users",
+            parameters: [],
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Should contain the generated operation name
+    expect(tsp.includes("op get_users")).toBe(true);
+    expect(tsp.includes('@route("/users")')).toBe(true);
+    expect(tsp.includes("@get")).toBe(true);
+  });
+});

--- a/packages/openapi3/test/tsp-openapi3/output/missing-operation-id/main.tsp
+++ b/packages/openapi3/test/tsp-openapi3/output/missing-operation-id/main.tsp
@@ -1,0 +1,40 @@
+import "@typespec/http";
+import "@typespec/openapi";
+import "@typespec/openapi3";
+
+using Http;
+using OpenAPI;
+
+@service(#{ title: "(title)" })
+@info(#{ version: "0.0.0" })
+namespace title;
+
+@route("/")
+@get
+// FIXME: Open API operation 'GET /' is missing an operationId. Generated: 'get_root'
+op get_root(): OkResponse | {
+  @statusCode
+  @minValue(400)
+  @maxValue(499)
+  statusCode: int32;
+} | {
+  @statusCode
+  @minValue(500)
+  @maxValue(599)
+  statusCode: int32;
+};
+
+@route("/foo")
+@put
+// FIXME: Open API operation 'PUT /foo' is missing an operationId. Generated: 'put_foo'
+op put_foo(): OkResponse | {
+  @statusCode
+  @minValue(400)
+  @maxValue(499)
+  statusCode: int32;
+} | {
+  @statusCode
+  @minValue(500)
+  @maxValue(599)
+  statusCode: int32;
+};

--- a/packages/openapi3/test/tsp-openapi3/specs/missing-operation-id/service.yml
+++ b/packages/openapi3/test/tsp-openapi3/specs/missing-operation-id/service.yml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: (title)
+  version: 0.0.0
+paths:
+  /:
+    get:
+      parameters: []
+      responses:
+        "200":
+          description: The request has succeeded.
+        4XX:
+          description: Client error
+        5XX:
+          description: Server error
+  /foo:
+    put:
+      parameters: []
+      responses:
+        "200":
+          description: The request has succeeded.
+        4XX:
+          description: Client error
+        5XX:
+          description: Server error

--- a/packages/openapi3/test/tsp-openapi3/utils/generate-operation-id.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/utils/generate-operation-id.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { generateOperationId } from "../../../src/cli/actions/convert/utils/generate-operation-id.js";
+
+describe("basic functionality", () => {
+  it("should generate operation ID for simple path", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/users", usedIds);
+
+    expect(result).toBe("get_users");
+  });
+
+  it("should generate operation ID for root path", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/", usedIds);
+
+    expect(result).toBe("get_root");
+  });
+});
+
+describe("HTTP methods", () => {
+  it.each(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"])(
+    "should handle %s HTTP method",
+    (method) => {
+      const usedIds = new Set<string>();
+      const result = generateOperationId(method, "/test", usedIds);
+      expect(result).toBe(`${method.toLowerCase()}_test`);
+    },
+  );
+
+  it("should handle lowercase HTTP methods", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("get", "/users", usedIds);
+
+    expect(result).toBe("get_users");
+  });
+
+  it("should handle mixed case HTTP methods", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GeT", "/users", usedIds);
+
+    expect(result).toBe("get_users");
+  });
+});
+
+describe("path transformations", () => {
+  it("should replace slashes with underscores", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/api/v1/users", usedIds);
+
+    expect(result).toBe("get_api_v1_users");
+  });
+
+  it("should include path parameters", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/users/{id}", usedIds);
+
+    expect(result).toBe("get_users_id");
+  });
+
+  it("should handle hyphenated path parameters", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/users/{user-id}/posts/{post-id}", usedIds);
+
+    expect(result).toBe("get_users_user_id_posts_post_id");
+  });
+
+  it("should replace special characters with underscores", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/api/v1.0/users-list", usedIds);
+
+    expect(result).toBe("get_api_v1_0_users_list");
+  });
+
+  it("should handle multiple consecutive special characters", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/api--v1..0//users", usedIds);
+
+    expect(result).toBe("get_api_v1_0_users");
+  });
+
+  it("should remove trailing underscores", () => {
+    const usedIds = new Set<string>();
+    const result = generateOperationId("GET", "/users/", usedIds);
+
+    expect(result).toBe("get_users");
+  });
+});
+
+describe("uniqueness handling", () => {
+  it("should generate unique IDs when duplicates exist", () => {
+    const usedIds = new Set<string>();
+
+    const first = generateOperationId("GET", "/users", usedIds);
+    const second = generateOperationId("GET", "/users", usedIds);
+    const third = generateOperationId("GET", "/users", usedIds);
+
+    expect(first).toBe("get_users");
+    expect(second).toBe("get_users_1");
+    expect(third).toBe("get_users_2");
+
+    expect(usedIds.size).toBe(3);
+    expect(usedIds.has("get_users")).toBe(true);
+    expect(usedIds.has("get_users_1")).toBe(true);
+    expect(usedIds.has("get_users_2")).toBe(true);
+  });
+
+  it("should handle pre-existing IDs in the set", () => {
+    const usedIds = new Set(["get_users", "get_users_1"]);
+
+    const result = generateOperationId("GET", "/users", usedIds);
+
+    expect(result).toBe("get_users_2");
+    expect(usedIds.has("get_users_2")).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/6085

With this PR, if an operation is missing an operationId, 3 things will happen:
1. A warning is logged to the console
2. A TypeSpec operation name will be generated based on the HTTP method/path
3. a `// FIXME:` comment will be added to the generated TypeSpec operation that matches the warning