### PR TITLE
fix: include generated-defs in published emitter pkg

### DIFF
--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/emitter/src/**",
+    "dist/generated-defs/**",
     "dist/generator/**"
   ],
   "peerDependencies": {


### PR DESCRIPTION
This PR fixes the issue where the generated-defs were not being included in the published emitter package, resulting in the azure emitter running into this error on building:

 `node_modules/@typespec/http-client-csharp/dist/emitter/src/index.d.ts(13,44): error TS2307: Cannot find module '../../generated-defs/TypeSpec.HttpClient.CSharp.js' or its corresponding type declarations`.

contributes to : https://github.com/microsoft/typespec/issues/8292