### PR TITLE
Use azure identity auth for vs marketplace publishing 

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -185,6 +185,7 @@ words:
   - proto
   - protobuf
   - protoc
+  - pscore
   - psscriptanalyzer
   - ptvsd
   - pwsh
@@ -219,8 +220,8 @@ words:
   - safeint
   - sdkcore
   - segmentof
-  - setuppy
   - serde
+  - setuppy
   - sfixed
   - shiki
   - sint
@@ -269,6 +270,7 @@ words:
   - vitest
   - VNEXT
   - vsix
+  - vsmarketplace
   - VSSDK
   - Vsts
   - vswhere

--- a/eng/tsp-core/pipelines/jobs/publish-vs.yml
+++ b/eng/tsp-core/pipelines/jobs/publish-vs.yml
@@ -48,11 +48,13 @@ jobs:
           scriptLocation: inlineScript
           workingDirectory: packages/typespec-vs
           inlineScript: |
+            # 499b84ac-1321-427f-aa17-267ca6975798 is ADO resource id.
+            $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
             Install-Module VSSetup -Force
             $vsixPublisher = Join-Path -Path (Get-VSSetupInstance -All | Select-VSSetupInstance -Latest).installationPath -ChildPath "VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" -Resolve
             $vsixPath = Resolve-Path "$(Pipeline.Workspace)/vs-extension-signed/Microsoft.Typespec.VS.vsix"  
             echo "Path to vsix: $vsixPath"
-            $stdout = (& $vsixPublisher publish -payload $vsixPath -publishManifest "publishManifest.json" -personalAccessToken $(azuresdk-devdiv-openapi-extension-marketplace-devops-pat)  -ignoreWarnings "VSIXValidatorWarning01,VSIXValidatorWarning02,VSIXValidatorWarning08"  2>&1)
+            $stdout = (& $vsixPublisher publish -payload $vsixPath -publishManifest "publishManifest.json" -personalAccessToken $aadToken -ignoreWarnings "VSIXValidatorWarning01,VSIXValidatorWarning02,VSIXValidatorWarning08"  2>&1)
             Write-Output $stdout
             if ($LASTEXITCODE -eq 0) {
               Write-Output "Successfully published VSIX"

--- a/eng/tsp-core/pipelines/jobs/publish-vs.yml
+++ b/eng/tsp-core/pipelines/jobs/publish-vs.yml
@@ -40,22 +40,25 @@ jobs:
         artifact: vs-extension-signed
         displayName: Download VS extension(.vsix) from pipeline artifacts
 
-      - pwsh: |
-          Install-Module VSSetup -Force
-          $vsixPublisher = Join-Path -Path (Get-VSSetupInstance -All | Select-VSSetupInstance -Latest).installationPath -ChildPath "VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" -Resolve
-          $vsixPath = Resolve-Path "$(Pipeline.Workspace)/vs-extension-signed/Microsoft.Typespec.VS.vsix"  
-          echo "Path to vsix: $vsixPath"
-          $stdout = (& $vsixPublisher publish -payload $vsixPath -publishManifest "publishManifest.json" -personalAccessToken $(azuresdk-devdiv-openapi-extension-marketplace-devops-pat)  -ignoreWarnings "VSIXValidatorWarning01,VSIXValidatorWarning02,VSIXValidatorWarning08"  2>&1)
-          Write-Output $stdout
-          if ($LASTEXITCODE -eq 0) {
-            Write-Output "Successfully published VSIX"
-          } elseif ($stdout -match "^VSSDK: error VsixPub0029 :") {
-            Write-Output "Version already exists, skipping publish"
-            exit 0
-          } else {
-            exit 1
-          }
+      - task: AzureCLI@2
         displayName: Publish
-        workingDirectory: packages/typespec-vs
-        env:
-          VSCE_PAT: $(azuresdk-devdiv-openapi-extension-marketplace-devops-pat)
+        inputs:
+          azureSubscription: azure-sdk-vsmarketplace
+          scriptType: pscore
+          scriptLocation: inlineScript
+          workingDirectory: packages/typespec-vs
+          inlineScript: |
+            Install-Module VSSetup -Force
+            $vsixPublisher = Join-Path -Path (Get-VSSetupInstance -All | Select-VSSetupInstance -Latest).installationPath -ChildPath "VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" -Resolve
+            $vsixPath = Resolve-Path "$(Pipeline.Workspace)/vs-extension-signed/Microsoft.Typespec.VS.vsix"  
+            echo "Path to vsix: $vsixPath"
+            $stdout = (& $vsixPublisher publish -payload $vsixPath -publishManifest "publishManifest.json" -personalAccessToken $(azuresdk-devdiv-openapi-extension-marketplace-devops-pat)  -ignoreWarnings "VSIXValidatorWarning01,VSIXValidatorWarning02,VSIXValidatorWarning08"  2>&1)
+            Write-Output $stdout
+            if ($LASTEXITCODE -eq 0) {
+              Write-Output "Successfully published VSIX"
+            } elseif ($stdout -match "^VSSDK: error VsixPub0029 :") {
+              Write-Output "Version already exists, skipping publish"
+              exit 0
+            } else {
+              exit 1
+            }

--- a/eng/tsp-core/pipelines/jobs/publish-vscode.yml
+++ b/eng/tsp-core/pipelines/jobs/publish-vscode.yml
@@ -42,8 +42,12 @@ jobs:
 
       - template: /eng/tsp-core/pipelines/templates/install.yml
 
-      - script: npm run deploy -- --skip-duplicate --packagePath $(Pipeline.Workspace)/vscode-extension-signed/typespec-vscode-*.vsix
+      - task: AzureCLI@2
         displayName: Publish
-        workingDirectory: packages/typespec-vscode
-        env:
-          VSCE_PAT: $(azuresdk-devdiv-openapi-extension-marketplace-devops-pat)
+        inputs:
+          azureSubscription: azure-sdk-vsmarketplace
+          scriptType: pscore
+          scriptLocation: inlineScript
+          workingDirectory: packages/typespec-vscode
+          inlineScript: |
+            npm run deploy -- --skip-duplicate --packagePath $(Pipeline.Workspace)/vscode-extension-signed/typespec-vscode-*.vsix

--- a/eng/tsp-core/pipelines/jobs/publish-vscode.yml
+++ b/eng/tsp-core/pipelines/jobs/publish-vscode.yml
@@ -50,4 +50,4 @@ jobs:
           scriptLocation: inlineScript
           workingDirectory: packages/typespec-vscode
           inlineScript: |
-            npm run deploy -- --skip-duplicate --packagePath $(Pipeline.Workspace)/vscode-extension-signed/typespec-vscode-*.vsix
+            npm run deploy -- --azure-credential --skip-duplicate --packagePath $(Pipeline.Workspace)/vscode-extension-signed/typespec-vscode-*.vsix


### PR DESCRIPTION
PAT was deleted and shouldn't be used, migrated to using managed identity

passing pipeline https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5273818&view=results