### PR TITLE
fix: properly set ns for dynamicModel decorator

### DIFF
--- a/packages/http-client-csharp/emitter/lib/decorators.tsp
+++ b/packages/http-client-csharp/emitter/lib/decorators.tsp
@@ -1,4 +1,4 @@
-import "../dist/emitter/src/lib/decorators.js";
+import "../../dist/emitter/src/lib/decorators.js";
 
 using TypeSpec.Reflection;
 

--- a/packages/http-client-csharp/emitter/src/lib/decorators.ts
+++ b/packages/http-client-csharp/emitter/src/lib/decorators.ts
@@ -10,6 +10,7 @@ import {
   Operation,
   Program,
   Type,
+  setTypeSpecNamespace,
 } from "@typespec/compiler";
 import type { DynamicModelDecorator } from "../../../generated-defs/TypeSpec.HttpClient.CSharp.js";
 import { ExternalDocs } from "../type/external-docs.js";
@@ -46,6 +47,9 @@ export const $dynamicModel: DynamicModelDecorator = (
 ): void => {
   context.program.stateSet(dynamicModelKey).add(target);
 };
+
+// Set the namespace for the decorator
+setTypeSpecNamespace("TypeSpec.HttpClient.CSharp", $dynamicModel);
 
 /**
  * Check if the given model or namespace is marked as dynamic.

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -48,7 +48,8 @@
   "files": [
     "dist/emitter/src/**",
     "dist/generated-defs/**",
-    "dist/generator/**"
+    "dist/generator/**",
+    "emitter/lib/*.tsp"
   ],
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": ">=0.59.0 <0.60.0 || ~0.60.0-0",


### PR DESCRIPTION
This PR fixes an issue where the dynamicModel decorator declaration and implementation were not being properly linked. For reference, [this](https://typespec.io/docs/extending-typespec/create-decorators/#linking-declaration-and-implementation) official guidance was used. In addition, the decorator spec files were not being included in the packaged emitter.

contributes to https://github.com/microsoft/typespec/issues/8292