### PR TITLE
feat: support deserializing dynamic model decorator

### DIFF
--- a/packages/http-client-csharp/emitter/src/lib/decorators.ts
+++ b/packages/http-client-csharp/emitter/src/lib/decorators.ts
@@ -15,6 +15,13 @@ import {
 import type { DynamicModelDecorator } from "../../../generated-defs/TypeSpec.HttpClient.CSharp.js";
 import { ExternalDocs } from "../type/external-docs.js";
 
+/**
+ * The fully qualified decorator name pattern for the dynamicModel decorator.
+ * This is used in SDK context options to ensure the decorator is properly recognized.
+ * @beta
+ */
+export const DYNAMIC_MODEL_DECORATOR_PATTERN = "TypeSpec\\.HttpClient\\.CSharp\\.@dynamicModel";
+
 const externalDocsKey = Symbol("externalDocs");
 export function getExternalDocs(context: SdkContext, entity: Type): ExternalDocs | undefined {
   return context.program.stateMap(externalDocsKey).get(entity);

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -2,6 +2,7 @@ import { CreateSdkContextOptions } from "@azure-tools/typespec-client-generator-
 import { EmitContext, JSONSchemaType } from "@typespec/compiler";
 import { _defaultGeneratorName } from "./constants.js";
 import { CSharpEmitterContext } from "./index.js";
+import { DYNAMIC_MODEL_DECORATOR_PATTERN } from "./lib/decorators.js";
 import { LoggerLevel } from "./lib/logger-level.js";
 import { CodeModel } from "./type/code-model.js";
 
@@ -160,7 +161,9 @@ export const defaultOptions = {
   logLevel: LoggerLevel.INFO,
   "generator-name": _defaultGeneratorName,
   "update-code-model": (model: CodeModel, context: CSharpEmitterContext) => model,
-  "sdk-context-options": undefined,
+  "sdk-context-options": {
+    additionalDecorators: [DYNAMIC_MODEL_DECORATOR_PATTERN],
+  },
 };
 
 /**

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
@@ -118,6 +118,7 @@ namespace Microsoft.TypeSpec.Generator.Input
         public InputType? AdditionalProperties { get; internal set; }
         public bool IsUnknownDiscriminatorModel { get; init; }
         public bool IsPropertyBag { get; init; }
+        public bool IsDynamicModel { get; internal set; }
         public InputSerializationOptions SerializationOptions { get; internal set; }
 
         public IEnumerable<InputModelType> GetSelfAndBaseModels() => EnumerateBase(this);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputDecoratorInfoConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputDecoratorInfoConverter.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.TypeSpec.Generator.Input;
 
-namespace AutoRest.CSharp.Common.Input
+namespace Microsoft.TypeSpec.Generator.Input
 {
     internal class InputDecoratorInfoConverter : JsonConverter<InputDecoratorInfo>
     {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputModelTypeConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputModelTypeConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -10,6 +11,7 @@ namespace Microsoft.TypeSpec.Generator.Input
 {
     internal sealed class InputModelTypeConverter : JsonConverter<InputModelType>
     {
+        private const string DynamicModelDecorator = "TypeSpec.HttpClient.CSharp.@dynamicModel";
         private readonly TypeSpecReferenceHandler _referenceHandler;
 
         public InputModelTypeConverter(TypeSpecReferenceHandler referenceHandler)
@@ -127,6 +129,7 @@ namespace Microsoft.TypeSpec.Generator.Input
             if (decorators != null)
             {
                 model.Decorators = decorators;
+                model.IsDynamicModel = model.Decorators.Any(d => d.Name.Equals(DynamicModelDecorator));
             }
 
             // if this model has a base, it means this model is a derived model of the base model, add it into the list.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecSerialization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/TypeSpecSerialization.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using AutoRest.CSharp.Common.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 
 namespace Microsoft.TypeSpec.Generator.Input

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TestData/TypeSpecInputConverterTests/LoadsDynamicModel/tspCodeModel.json
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TestData/TypeSpecInputConverterTests/LoadsDynamicModel/tspCodeModel.json
@@ -1,0 +1,43 @@
+{
+    "$id": "1",
+    "kind": "model",
+    "name": "Friend",
+    "namespace": "SampleTypeSpec",
+    "crossLanguageDefinitionId": "SampleTypeSpec.NotFriend",
+    "usage": "Output,Spread,Json",
+    "doc": "this is not a friendly model but with a friendly name",
+    "decorators": [
+      {
+        "name": "TypeSpec.HttpClient.CSharp.@dynamicModel",
+        "arguments": {}
+      }
+    ],
+    "properties": [
+      {
+        "$id": "229",
+        "kind": "property",
+        "name": "name",
+        "serializedName": "name",
+        "doc": "name of the NotFriend",
+        "type": {
+          "$id": "230",
+          "kind": "string",
+          "name": "string",
+          "crossLanguageDefinitionId": "TypeSpec.string",
+          "decorators": []
+        },
+        "optional": false,
+        "readOnly": false,
+        "discriminator": false,
+        "flatten": false,
+        "decorators": [],
+        "crossLanguageDefinitionId": "SampleTypeSpec.NotFriend.name",
+        "serializationOptions": {
+          "json": {
+            "name": "name"
+          }
+        },
+        "isHttpMetadata": false
+      }
+    ]
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputConverterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputConverterTests.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.TypeSpec.Generator.Tests.Common;
@@ -88,6 +87,33 @@ namespace Microsoft.TypeSpec.Generator.Input.Tests
             var inputDuration = inputType as InputDurationType;
             Assert.IsNotNull(inputDuration);
             Assert.AreEqual(DurationKnownEncoding.Constant, inputDuration!.Encode);
+        }
+
+        [Test]
+        public void LoadsDynamicModel()
+        {
+            var directory = Helpers.GetAssetFileOrDirectoryPath(false);
+            // this tspCodeModel.json contains a partial part of the full tspCodeModel.json
+            var content = File.ReadAllText(Path.Combine(directory, "tspCodeModel.json"));
+            var referenceHandler = new TypeSpecReferenceHandler();
+            var options = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                Converters =
+                {
+                    new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
+                    new InputTypeConverter(referenceHandler),
+                    new InputDecoratorInfoConverter(),
+                    new InputModelTypeConverter(referenceHandler),
+                },
+            };
+            var inputType = JsonSerializer.Deserialize<InputType>(content, options);
+
+            Assert.IsNotNull(inputType);
+
+            var inputModel = inputType as InputModelType;
+            Assert.IsNotNull(inputModel);
+            Assert.IsTrue(inputModel!.IsDynamicModel);
         }
     }
 }


### PR DESCRIPTION
This PR adds the initial input type deserialization of the `dynamicModel` decorator. A follow up PR will add the support for reading this option from a namespace.

contributes to: https://github.com/microsoft/typespec/issues/8295