### PR TITLE
http-client-java, add clear-output-folder option, default to false

### DIFF
--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -167,6 +167,9 @@ const { isEqual } = pkg;
 export interface EmitterOptionsDev {
   flavor?: string;
 
+  // utility
+  "clear-output-folder"?: boolean;
+
   // service
   namespace?: string;
   "service-name"?: string;

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/Main.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/Main.java
@@ -112,8 +112,11 @@ public class Main {
         // template
         FluentJavaPackage javaPackage = fluentPlugin.processTemplates(codeModel, client);
 
-        // delete generated Java files
-        deleteGeneratedJavaFiles(emitterOptions.getOutputDir(), javaPackage.getJavaFiles(), JavaSettings.getInstance());
+        if (emitterOptions.getClearOutputFolder() == Boolean.TRUE) {
+            // delete generated Java files
+            deleteGeneratedJavaFiles(emitterOptions.getOutputDir(), javaPackage.getJavaFiles(),
+                JavaSettings.getInstance());
+        }
 
         // write java files
         Postprocessor.writeToFiles(
@@ -155,8 +158,10 @@ public class Main {
         LOGGER.info("Count of XML files: {}", javaPackage.getXmlFiles().size());
         LOGGER.info("Count of text files: {}", javaPackage.getTextFiles().size());
 
-        // delete generated Java files
-        deleteGeneratedJavaFiles(outputDir, javaPackage.getJavaFiles(), settings);
+        if (emitterOptions.getClearOutputFolder() == Boolean.TRUE) {
+            // delete generated Java files
+            deleteGeneratedJavaFiles(outputDir, javaPackage.getJavaFiles(), settings);
+        }
 
         Map<String, String> javaFiles = new ConcurrentHashMap<>();
         javaPackage.getJavaFiles()

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/model/EmitterOptions.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/model/EmitterOptions.java
@@ -40,6 +40,7 @@ public class EmitterOptions implements JsonSerializable<EmitterOptions> {
     private Boolean useRestProxy;
     private Boolean useDefaultHttpStatusCodeToExceptionTypeMapping = true;
     private DevOptions devOptions;
+    private Boolean clearOutputFolder = false;
 
     // mgmt
     private Boolean premium = false;
@@ -194,6 +195,10 @@ public class EmitterOptions implements JsonSerializable<EmitterOptions> {
         return useDefaultHttpStatusCodeToExceptionTypeMapping;
     }
 
+    public Boolean getClearOutputFolder() {
+        return clearOutputFolder;
+    }
+
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         // it does not need to be written to JSON
@@ -266,6 +271,8 @@ public class EmitterOptions implements JsonSerializable<EmitterOptions> {
                 options.resourceCollectionAssociations = reader.readArray(ResourceCollectionAssociation::fromJson);
             } else if ("premium".equals(fieldName)) {
                 options.premium = reader.getNullable(EmitterOptions::getBoolean);
+            } else if ("clear-output-folder".equals(fieldName)) {
+                options.clearOutputFolder = reader.getNullable(EmitterOptions::getBoolean);
             } else {
                 reader.skipChildren();
             }


### PR DESCRIPTION
As discussed, put the "clean up generated java code" behind the `clear-output-folder` option