### PR TITLE
Handle baseType in the csharp class declaration in ef

### DIFF
--- a/.chronus/changes/ef-csharp-basetype-2025-8-3-19-10-22.md
+++ b/.chronus/changes/ef-csharp-basetype-2025-8-3-19-10-22.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/emitter-framework"
+---
+
+[c#] Generate base class and 'virtual'/'new' keywords for property according to the baseType defined in typespec

--- a/packages/emitter-framework/src/csharp/components/class/declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class/declaration.tsx
@@ -41,6 +41,12 @@ export function ClassDeclaration(props: ClassDeclarationProps): Children {
         {...props}
         name={className}
         refkey={refkeys}
+        baseType={
+          props.baseType ??
+          (props.type.kind === "Model" && props.type.baseModel ? (
+            <TypeExpression type={props.type.baseModel} />
+          ) : undefined)
+        }
         doc={getDocComments($, props.type)}
       >
         {props.type.kind === "Model" && (

--- a/packages/emitter-framework/src/csharp/components/property/property.test.tsx
+++ b/packages/emitter-framework/src/csharp/components/property/property.test.tsx
@@ -1,5 +1,5 @@
 import { Tester } from "#test/test-host.js";
-import { type Children } from "@alloy-js/core";
+import { List, type Children } from "@alloy-js/core";
 import { ClassDeclaration, createCSharpNamePolicy, Namespace, SourceFile } from "@alloy-js/csharp";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -134,6 +134,68 @@ describe("jsonAttributes", () => {
           {
               [System.Text.Json.JsonPropertyName("prop_1")]
               public required string Prop1 { get; set; }
+          }
+      }
+  `);
+  });
+
+  it("inherit prop: override, new", async () => {
+    const r = await tester.compile(t.code`
+    model TestModel extends BaseModel {
+      ${t.modelProperty("prop1")}: string;
+      ${t.modelProperty("prop2")}: string | null;
+    }
+    model BaseModel {
+      prop1: string | null;
+      prop2: string | null;
+    }
+  `);
+
+    expect(
+      <Wrapper>
+        <List>
+          <Property type={r.prop1} />
+          <Property type={r.prop2} />
+        </List>
+      </Wrapper>,
+    ).toRenderTo(`
+      namespace TestNamespace
+      {
+          class Test
+          {
+              public new required string Prop1 { get; set; }
+              public override required string? Prop2 { get; set; }
+          }
+      }
+  `);
+  });
+
+  it("inherit prop: virtual", async () => {
+    const r = await tester.compile(t.code`
+    model TestModel extends BaseModel {
+      prop1: string;
+      prop2: string | null;
+    }
+    model BaseModel {
+      ${t.modelProperty("prop1")}: string | null;
+      ${t.modelProperty("prop2")}: string | null;
+    }
+  `);
+
+    expect(
+      <Wrapper>
+        <List>
+          <Property type={r.prop1} />
+          <Property type={r.prop2} />
+        </List>
+      </Wrapper>,
+    ).toRenderTo(`
+      namespace TestNamespace
+      {
+          class Test
+          {
+              public required string? Prop1 { get; set; }
+              public virtual required string? Prop2 { get; set; }
           }
       }
   `);

--- a/packages/emitter-framework/src/csharp/components/property/property.tsx
+++ b/packages/emitter-framework/src/csharp/components/property/property.tsx
@@ -1,12 +1,7 @@
 import { type Children } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
 import { Attribute } from "@alloy-js/csharp";
-import {
-  type ModelProperty,
-  resolveEncodedName,
-  type Type,
-  walkPropertiesInherited,
-} from "@typespec/compiler";
+import { getProperty, type ModelProperty, resolveEncodedName, type Type } from "@typespec/compiler";
 import { useTsp } from "../../../core/index.js";
 import { TypeExpression } from "../type-expression.jsx";
 import { getDocComments } from "../utils/doc-comments.jsx";
@@ -26,18 +21,32 @@ export function Property(props: PropertyProps): Children {
   const { $ } = useTsp();
 
   let overrideType: "" | "override" | "new" = "";
-  if (props.type.model && props.type.model.baseModel) {
-    const base = props.type.model.baseModel;
-    for (const baseProperty of walkPropertiesInherited(base)) {
-      if (baseProperty.name === props.type.name) {
+  let isVirtual = false;
+  if (props.type.model) {
+    if (props.type.model.baseModel) {
+      const base = props.type.model.baseModel;
+      const baseProperty = getProperty(base, props.type.name);
+      if (baseProperty) {
         const baseResult = preprocessPropertyType(baseProperty);
         if (baseResult.nullable === result.nullable && baseResult.type === result.type) {
           overrideType = "override";
         } else {
           overrideType = "new";
         }
-        break;
       }
+    }
+    if (
+      overrideType === "" &&
+      props.type.model.derivedModels &&
+      props.type.model.derivedModels.length > 0
+    ) {
+      isVirtual = props.type.model.derivedModels.some((derived) => {
+        const derivedProperty = derived.properties.get(props.type.name);
+        if (derivedProperty) {
+          const derivedResult = preprocessPropertyType(derivedProperty);
+          return derivedResult.nullable === result.nullable && derivedResult.type === result.type;
+        }
+      });
     }
   }
 
@@ -48,6 +57,7 @@ export function Property(props: PropertyProps): Children {
       override={overrideType === "override"}
       new={overrideType === "new"}
       public
+      virtual={isVirtual}
       required={!props.type.optional}
       nullable={result.nullable}
       doc={getDocComments($, props.type)}

--- a/packages/emitter-framework/src/csharp/components/property/property.tsx
+++ b/packages/emitter-framework/src/csharp/components/property/property.tsx
@@ -36,6 +36,7 @@ export function Property(props: PropertyProps): Children {
         } else {
           overrideType = "new";
         }
+        break;
       }
     }
   }


### PR DESCRIPTION
Generate base class and 'virtual'/'new' keywords for property according to the baseType defined in typespec