### PR TITLE
Add basic perf tracing

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
@@ -23,6 +23,9 @@ namespace Microsoft.TypeSpec.Generator
         /// </summary>
         public async Task ExecuteAsync()
         {
+            CodeModelGenerator.Instance.Emitter.Info("Starting code generation");
+            CodeModelGenerator.Instance.Stopwatch.Start();
+
             GeneratedCodeWorkspace.Initialize();
             var outputPath = CodeModelGenerator.Instance.Configuration.OutputDirectory;
             var generatedSourceOutputPath = CodeModelGenerator.Instance.Configuration.ProjectGeneratedDirectory;
@@ -49,11 +52,21 @@ namespace Microsoft.TypeSpec.Generator
             Directory.CreateDirectory(Path.Combine(generatedSourceOutputPath, "Models"));
             List<Task> generateFilesTasks = new();
 
+            // Build all TypeProviders
+            foreach (var type in output.TypeProviders)
+            {
+                type.EnsureBuilt();
+            }
+
+            CodeModelGenerator.Instance.Emitter.Info($"All generated type providers built. Total Elapsed time: {CodeModelGenerator.Instance.Stopwatch.Elapsed}");
+
             // visit the entire library before generating files
             foreach (var visitor in CodeModelGenerator.Instance.Visitors)
             {
                 visitor.VisitLibrary(output);
             }
+
+            CodeModelGenerator.Instance.Emitter.Info($"All visitors have been applied. Total Elapsed time: {CodeModelGenerator.Instance.Stopwatch.Elapsed}");
 
             foreach (var outputType in output.TypeProviders)
             {
@@ -93,6 +106,8 @@ namespace Microsoft.TypeSpec.Generator
             {
                 await CodeModelGenerator.Instance.TypeFactory.CreateNewProjectScaffolding().Execute();
             }
+
+            CodeModelGenerator.Instance.Emitter.Info($"All files have been written. Total Elapsed time: {CodeModelGenerator.Instance.Stopwatch.Elapsed}");
         }
 
         /// <summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CodeModelGenerator.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CodeModelGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Microsoft.TypeSpec.Generator.Input;
@@ -27,6 +28,7 @@ namespace Microsoft.TypeSpec.Generator
         private static CodeModelGenerator? _instance;
         private List<string> _sharedSourceDirectories = [];
         public const string GeneratorMetadataName = "GeneratorName";
+        internal Stopwatch Stopwatch { get; } = new Stopwatch();
         public static CodeModelGenerator Instance
         {
             get

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/LibraryVisitor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/LibraryVisitor.cs
@@ -17,12 +17,6 @@ namespace Microsoft.TypeSpec.Generator
     {
         protected internal virtual void VisitLibrary(OutputLibrary library)
         {
-            // Ensure all types are built before visiting them
-            foreach (var type in library.TypeProviders)
-            {
-                type.EnsureBuilt();
-            }
-
             var types = new List<TypeProvider>();
             foreach (var typeProvider in library.TypeProviders)
             {


### PR DESCRIPTION
This will help confirm where the bulk of the time is taking for libraries that are taking an excessive amount of time like OpenAI. Most likely it is in the file writing, and there are some parallelization optimizations we can do there.