### PR TITLE
fix: serialize enum dict query parameters in createRequest method

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
@@ -473,14 +473,24 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientPro
         {
             List<string> stringEnum = ["bar"];
             List<int> intEnum = [1, 2, 3];
+            List<float> floatEnum = [1.1f, 2.2f, 3.3f];
+            List<double> doubleEnum = [1.1, 2.2, 3.3];
             var stringEnumValues = stringEnum.Select(a => (a, a));
             var intEnumValues = intEnum.Select(a => (a.ToString(), a));
+            var floatEnumValues = floatEnum.Select(a => (a.ToString(), a));
+            var doubleEnumValues = doubleEnum.Select(a => (a.ToString(), a));
             var inputStringEnum = InputFactory.StringEnum(
                 "foo",
                 stringEnumValues);
             var inputIntEnum = InputFactory.Int32Enum(
                 "intFoo",
                 intEnumValues);
+            var inputFloatEnum = InputFactory.Float32Enum(
+                "floatFoo",
+                floatEnumValues);
+            var inputDoubleEnum = InputFactory.Float64Enum(
+                "doubleFoo",
+                doubleEnumValues);
             List<InputParameter> parameters =
             [
                 InputFactory.QueryParameter("p1Explode", InputFactory.Array(InputPrimitiveType.String), isRequired: true, explode: true),
@@ -492,6 +502,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientPro
                 InputFactory.QueryParameter("p3", InputFactory.Dictionary(InputPrimitiveType.Int32), isRequired: true),
                 InputFactory.QueryParameter("p4Explode", InputFactory.Array(inputStringEnum), isRequired: true, explode: true),
                 InputFactory.QueryParameter("p5Explode", InputFactory.Array(inputIntEnum), isRequired: true, explode: true),
+                InputFactory.QueryParameter("p6Explode", InputFactory.Dictionary(inputStringEnum), isRequired: true, explode: true),
+                InputFactory.QueryParameter("p7Explode", InputFactory.Dictionary(inputIntEnum), isRequired: true, explode: true),
+                InputFactory.QueryParameter("p8Explode", InputFactory.Array(inputFloatEnum), isRequired: true, explode: true),
+                InputFactory.QueryParameter("p9Explode", InputFactory.Array(inputDoubleEnum), isRequired: true, explode: true),
             ];
             var operation = InputFactory.Operation(
                 "sampleOp",

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/TestData/RestClientProviderTests/TestBuildCreateRequestMethodWithQueryParameters.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/TestData/RestClientProviderTests/TestBuildCreateRequestMethodWithQueryParameters.cs
@@ -10,7 +10,7 @@ namespace Sample
 {
     public partial class TestClient
     {
-        internal global::System.ClientModel.Primitives.PipelineMessage CreateSampleOpRequest(global::System.Collections.Generic.IEnumerable<string> p1Explode, global::System.Collections.Generic.IEnumerable<string> p1, global::System.Collections.Generic.IEnumerable<int> p2Explode, global::System.Collections.Generic.IEnumerable<int> p2, global::System.Collections.Generic.IDictionary<string, int> p3Explode, global::System.Collections.Generic.IDictionary<string, int> p3, global::System.Collections.Generic.IEnumerable<global::Sample.Models.Foo> p4Explode, global::System.Collections.Generic.IEnumerable<global::Sample.Models.IntFoo> p5Explode, string optionalParam, global::System.ClientModel.Primitives.RequestOptions options)
+        internal global::System.ClientModel.Primitives.PipelineMessage CreateSampleOpRequest(global::System.Collections.Generic.IEnumerable<string> p1Explode, global::System.Collections.Generic.IEnumerable<string> p1, global::System.Collections.Generic.IEnumerable<int> p2Explode, global::System.Collections.Generic.IEnumerable<int> p2, global::System.Collections.Generic.IDictionary<string, int> p3Explode, global::System.Collections.Generic.IDictionary<string, int> p3, global::System.Collections.Generic.IEnumerable<global::Sample.Models.Foo> p4Explode, global::System.Collections.Generic.IEnumerable<global::Sample.Models.IntFoo> p5Explode, global::System.Collections.Generic.IDictionary<string, global::Sample.Models.Foo> p6Explode, global::System.Collections.Generic.IDictionary<string, global::Sample.Models.IntFoo> p7Explode, global::System.Collections.Generic.IEnumerable<global::Sample.Models.FloatFoo> p8Explode, global::System.Collections.Generic.IEnumerable<global::Sample.Models.DoubleFoo> p9Explode, string optionalParam, global::System.ClientModel.Primitives.RequestOptions options)
         {
             global::Sample.ClientUriBuilder uri = new global::Sample.ClientUriBuilder();
             uri.Reset(_endpoint);
@@ -69,6 +69,34 @@ namespace Sample
                 foreach (var @param in p5Explode)
                 {
                     uri.AppendQuery("p5Explode", ((int)@param), true);
+                }
+            }
+            if (((p6Explode != null) && !((p6Explode is global::Sample.ChangeTrackingDictionary<string, global::Sample.Models.Foo> changeTrackingDictionary1) && changeTrackingDictionary1.IsUndefined)))
+            {
+                foreach (var @param in p6Explode)
+                {
+                    uri.AppendQuery(@param.Key, @param.ToSerialString(), true);
+                }
+            }
+            if (((p7Explode != null) && !((p7Explode is global::Sample.ChangeTrackingDictionary<string, global::Sample.Models.IntFoo> changeTrackingDictionary2) && changeTrackingDictionary2.IsUndefined)))
+            {
+                foreach (var @param in p7Explode)
+                {
+                    uri.AppendQuery(@param.Key, ((int)@param), true);
+                }
+            }
+            if (((p8Explode != null) && !((p8Explode is global::Sample.ChangeTrackingList<global::Sample.Models.FloatFoo> changeTrackingList5) && changeTrackingList5.IsUndefined)))
+            {
+                foreach (var @param in p8Explode)
+                {
+                    uri.AppendQuery("p8Explode", ((float)@param), true);
+                }
+            }
+            if (((p9Explode != null) && !((p9Explode is global::Sample.ChangeTrackingList<global::Sample.Models.DoubleFoo> changeTrackingList6) && changeTrackingList6.IsUndefined)))
+            {
+                foreach (var @param in p9Explode)
+                {
+                    uri.AppendQuery("p9Explode", ((double)@param), true);
                 }
             }
             global::System.ClientModel.Primitives.PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "GET", PipelineMessageClassifier200);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/CSharpTypeSnippets.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/CSharpTypeSnippets.cs
@@ -62,7 +62,10 @@ namespace Microsoft.TypeSpec.Generator.Snippets
             }
             else
             {
-                if (type.UnderlyingEnumType.Equals(typeof(int)) || type.UnderlyingEnumType.Equals(typeof(long)))
+                if (type.UnderlyingEnumType.Equals(typeof(int)) ||
+                    type.UnderlyingEnumType.Equals(typeof(long)) ||
+                    type.UnderlyingEnumType.Equals(typeof(double)) ||
+                    type.UnderlyingEnumType.Equals(typeof(float)))
                 {
                     return variable.CastTo(type.UnderlyingEnumType);
                 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
@@ -23,6 +23,11 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
                 return new InputEnumTypeValue(name, value, InputPrimitiveType.Float32, "", $"{name} description", enumType);
             }
 
+            public static InputEnumTypeValue Float64(string name, double value, InputEnumType enumType)
+            {
+                return new InputEnumTypeValue(name, value, InputPrimitiveType.Float64, "", $"{name} description", enumType);
+            }
+
             public static InputEnumTypeValue String(string name, string value, InputEnumType enumType)
             {
                 return new InputEnumTypeValue(name, value, InputPrimitiveType.String, "", $"{name} description", enumType);
@@ -155,6 +160,32 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
             foreach (var (valueName, value) in values)
             {
                 enumValues.Add(EnumMember.Float32(valueName, value, enumType));
+            }
+
+            return enumType;
+        }
+
+        public static InputEnumType Float64Enum(
+            string name,
+            IEnumerable<(string Name, double Value)> values,
+            string access = "public",
+            InputModelTypeUsage usage = InputModelTypeUsage.Input | InputModelTypeUsage.Output,
+            bool isExtensible = false,
+            string clientNamespace = "Sample.Models")
+        {
+            var enumValues = new List<InputEnumTypeValue>();
+            var enumType = Enum(
+                name,
+                InputPrimitiveType.Float64,
+                enumValues,
+                access: access,
+                usage: usage,
+                isExtensible: isExtensible,
+                clientNamespace: clientNamespace);
+
+            foreach (var (valueName, value) in values)
+            {
+                enumValues.Add(EnumMember.Float64(valueName, value, enumType));
             }
 
             return enumType;


### PR DESCRIPTION
This PR adds more fixes related to constructing exploded query parameters that are enum collection types. It also adds some follow-up cleanup.

contributes to : https://github.com/microsoft/typespec/issues/8390