### PR TITLE
fix: handle union response types

### DIFF
--- a/packages/http-client-csharp/emitter/src/lib/operation-converter.ts
+++ b/packages/http-client-csharp/emitter/src/lib/operation-converter.ts
@@ -906,5 +906,17 @@ function getResponseType(
     return fromSdkType(sdkContext, type.valueType);
   }
 
+  // recursively unwrap union types to get the first non-union variant type
+  if (type.kind === "union" && type.isGeneratedName && type.variantTypes.length > 0) {
+    let currentType = type.variantTypes[0];
+
+    // Keep unwrapping unions until we find a non-union type
+    while (currentType.kind === "union" && currentType.variantTypes.length > 0) {
+      currentType = currentType.variantTypes[0];
+    }
+
+    return fromSdkType(sdkContext, currentType);
+  }
+
   return fromSdkType(sdkContext, type);
 }

--- a/packages/http-client-csharp/emitter/test/Unit/operation-converter.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/operation-converter.test.ts
@@ -252,6 +252,114 @@ describe("Operation Converter", () => {
       });
     });
 
+    describe("With union model response type", () => {
+      it("should convert the first response type variant", async () => {
+        const program = await typeSpecCompile(
+          `
+          model ServerEventSessionAvatarConnecting {
+            server_sdp: string;
+          }
+
+          model ServerEventSessionCreated {
+            session: string;
+          }
+
+          alias ForceModelServerEvent =
+            ServerEventSessionAvatarConnecting |
+            ServerEventSessionCreated;
+
+          @route("foo")
+          op force_models(): ForceModelServerEvent;
+          `,
+          runner,
+        );
+        const context = createEmitterContext(program);
+        const sdkContext = await createCSharpSdkContext(context);
+        const root = createModel(sdkContext);
+
+        strictEqual(root.clients.length, 1);
+        strictEqual(root.clients[0].methods.length, 1);
+
+        const method = root.clients[0].methods[0];
+        ok(method);
+
+        // validate service method response
+        const responseType = method.response.type;
+        ok(responseType);
+        strictEqual(responseType.kind, "model");
+        strictEqual(responseType.name, "ServerEventSessionAvatarConnecting");
+
+        // validate operation response
+        const operation = method.operation;
+        ok(operation);
+        strictEqual(operation.responses.length, 1);
+        const response = operation.responses[0];
+        ok(response);
+        strictEqual(response.bodyType?.kind, "model");
+        strictEqual(response.bodyType?.name, "ServerEventSessionAvatarConnecting");
+      });
+    });
+
+    describe("With nested union response type", () => {
+      it("should recursively unwrap nested union types to get first non-union variant", async () => {
+        const program = await typeSpecCompile(
+          `
+          model ModelA {
+            valueA: string;
+          }
+
+          model ModelB {
+            valueB: int32;
+          }
+
+          model ModelC {
+            valueC: boolean;
+          }
+
+          // Inner union: ModelB | ModelC
+          union InnerUnion {
+            modelB: ModelB,
+            modelC: ModelC,
+          }
+
+          // Outer union: InnerUnion | ModelA
+          union NestedUnion {
+            inner: InnerUnion,
+            modelA: ModelA,
+          }
+
+          @route("/test")
+          op operationWithNestedUnionResponse(): NestedUnion;
+          `,
+          runner,
+        );
+        const context = createEmitterContext(program);
+        const sdkContext = await createCSharpSdkContext(context);
+        const root = createModel(sdkContext);
+
+        strictEqual(root.clients.length, 1);
+        strictEqual(root.clients[0].methods.length, 1);
+
+        const method = root.clients[0].methods[0];
+        ok(method);
+
+        // validate service method response - should be ModelB (first non-union type after recursive unwrapping)
+        const responseType = method.response.type;
+        ok(responseType);
+        strictEqual(responseType.kind, "model");
+        strictEqual(responseType.name, "ModelB");
+
+        // validate operation response
+        const operation = method.operation;
+        ok(operation);
+        strictEqual(operation.responses.length, 1);
+        const response = operation.responses[0];
+        ok(response);
+        strictEqual(response.bodyType?.kind, "model");
+        strictEqual(response.bodyType?.name, "ModelB");
+      });
+    });
+
     describe("With regular enum response type", () => {
       it("should convert regular enum response type normally", async () => {
         const program = await typeSpecCompile(


### PR DESCRIPTION
TCGC no longer defaults to picking the first type in a union response type, so this PR addresses a gap where not all union response types were being handled to maintain the previous behavior.