### PR TITLE
Add @experimental decorator

### DIFF
--- a/.chronus/changes/joheredi-http-client-experimental-2025-8-11-12-59-27.md
+++ b/.chronus/changes/joheredi-http-client-experimental-2025-8-11-12-59-27.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/http-client"
 ---
 
-Introduce @experimental decorator to tag client features as unstable
+Introduce `@experimental` decorator to tag client features as unstable

--- a/.chronus/changes/joheredi-http-client-experimental-2025-8-11-12-59-27.md
+++ b/.chronus/changes/joheredi-http-client-experimental-2025-8-11-12-59-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client"
+---
+
+Introduce @experimental decorator to tag client features as unstable

--- a/packages/http-client/generated-defs/TypeSpec.HttpClient.ts
+++ b/packages/http-client/generated-defs/TypeSpec.HttpClient.ts
@@ -1,0 +1,15 @@
+import type { DecoratorContext, Type } from "@typespec/compiler";
+
+export interface FeatureLifecycleOptions {
+  readonly emitterScope?: string;
+}
+
+export type ExperimentalDecorator = (
+  context: DecoratorContext,
+  target: Type,
+  options?: FeatureLifecycleOptions,
+) => void;
+
+export type TypeSpecHttpClientDecorators = {
+  experimental: ExperimentalDecorator;
+};

--- a/packages/http-client/generated-defs/TypeSpec.HttpClient.ts-test.ts
+++ b/packages/http-client/generated-defs/TypeSpec.HttpClient.ts-test.ts
@@ -1,0 +1,10 @@
+// An error in the imports would mean that the decorator is not exported or
+// doesn't have the right name.
+
+import { $decorators } from "@typespec/http-client";
+import type { TypeSpecHttpClientDecorators } from "./TypeSpec.HttpClient.js";
+
+/**
+ * An error here would mean that the exported decorator is not using the same signature. Make sure to have export const $decName: DecNameDecorator = (...) => ...
+ */
+const _: TypeSpecHttpClientDecorators = $decorators["TypeSpec.HttpClient"];

--- a/packages/http-client/lib/common.tsp
+++ b/packages/http-client/lib/common.tsp
@@ -1,0 +1,9 @@
+namespace TypeSpec.HttpClient;
+
+/**
+ * Specifies the target emitters that the decorator should apply. If not set, the decorator will be applied to all emitters by default.
+ * You can use ”!” to exclude specific emitters, for example: `!@typespec/http-client-js, !@typespec/http-client-csharp`
+ */
+model ClientDecoratorOptions {
+  emitterScope?: string;
+}

--- a/packages/http-client/lib/decorators.tsp
+++ b/packages/http-client/lib/decorators.tsp
@@ -1,0 +1,10 @@
+import "./common.tsp";
+import "../dist/src/tsp-index.js";
+
+namespace TypeSpec.HttpClient;
+
+model FeatureLifecycleOptions {
+  ...ClientDecoratorOptions;
+}
+
+extern dec experimental(target: unknown, options?: valueof FeatureLifecycleOptions);

--- a/packages/http-client/lib/main.tsp
+++ b/packages/http-client/lib/main.tsp
@@ -1,0 +1,4 @@
+import "./decorators.tsp";
+import "../dist/src/tsp-index.js";
+
+namespace TypeSpec.HttpClient;

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "dist/src/index.js",
   "license": "MIT",
-   "tspMain": "./lib/main.tsp",
+  "tspMain": "./lib/main.tsp",
   "exports": {
     ".": {
       "typespec": "./lib/main.tsp",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -4,12 +4,16 @@
   "type": "module",
   "main": "dist/src/index.js",
   "license": "MIT",
+   "tspMain": "./lib/main.tsp",
   "exports": {
     ".": {
-      "import": "./dist/src/index.js"
+      "typespec": "./lib/main.tsp",
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./testing": {
-      "import": "./dist/src/testing/index.js"
+      "types": "./dist/src/testing/index.d.ts",
+      "default": "./dist/src/testing/index.js"
     },
     "./typekit": {
       "import": "./dist/src/typekit/index.js"
@@ -34,14 +38,18 @@
     "@typespec/compiler": "workspace:^",
     "@typespec/emitter-framework": "workspace:^",
     "@typespec/http": "workspace:^",
+    "@typespec/library-linter": "workspace:^",
+    "@typespec/tspd": "workspace:^",
     "eslint": "^9.23.0",
     "prettier": "~3.6.2",
     "typescript": "~5.9.2",
     "vitest": "^3.1.2"
   },
   "scripts": {
-    "build": "alloy build",
+    "build": "npm run gen-extern-signature && alloy build && npm run lint-typespec-library",
+    "lint-typespec-library": "tsp compile . --warn-as-error --import @typespec/library-linter --no-emit",
     "clean": "rimraf ./dist",
+    "gen-extern-signature": "tspd --enable-experimental gen-extern-signature .",
     "watch": "alloy build --watch",
     "test": "vitest run",
     "test:ui": "vitest --ui",

--- a/packages/http-client/src/decorators/experimental.ts
+++ b/packages/http-client/src/decorators/experimental.ts
@@ -1,0 +1,84 @@
+import { createDiagnosticCollector, DiagnosticResult, Program, Type } from "@typespec/compiler";
+import { useStateMap } from "@typespec/compiler/utils";
+import { ExperimentalDecorator } from "../../generated-defs/TypeSpec.HttpClient.js";
+import { createStateSymbol } from "../lib.js";
+import { parseScopeFilter, ScopedValue } from "./scope-cache.js";
+
+const featureLifecycleStateSymbol = createStateSymbol("featureLifecycleState");
+
+export type FeatureLifecycleStage = "Experimental";
+
+const [getFeatureLifecycleState, setFeatureLifecycleState] = useStateMap<
+  Type,
+  ScopedValue<FeatureLifecycleStage>
+>(featureLifecycleStateSymbol);
+
+export const $experimental: ExperimentalDecorator = (context, target, options) => {
+  const scopeFilter = parseScopeFilter(options?.emitterScope);
+  if (scopeFilter.excludedEmitters.length > 0 && scopeFilter.includedEmitters.length > 0) {
+    context.program.reportDiagnostic({
+      code: "include-and-exclude-scopes",
+      message: "The @experimental should only either include or exclude scopes, not both.",
+      severity: "error",
+      target,
+    });
+  }
+  setFeatureLifecycleState(context.program, target, {
+    emitterFilter: scopeFilter,
+    value: "Experimental",
+  });
+};
+
+export interface GetFeatureLifecycleOptions {
+  emitterName?: string;
+}
+export function getClientFeatureLifecycle(
+  program: Program,
+  target: Type,
+  options: GetFeatureLifecycleOptions = {},
+): DiagnosticResult<FeatureLifecycleStage | undefined> {
+  const diagnostics = createDiagnosticCollector();
+
+  const lifecycle = getFeatureLifecycleState(program, target);
+
+  if (!lifecycle) {
+    return diagnostics.wrap(undefined);
+  }
+
+  const emitterScope = options.emitterName;
+  const lifecycleValue = lifecycle.value;
+
+  if (!lifecycle.emitterFilter.isScoped) {
+    return diagnostics.wrap(lifecycleValue);
+  }
+
+  // Lifecycle is scoped but no emitter scope is provided to the query function so we return undefined
+  // this is because we can't determine which emitter the lifecycle is associated with.
+  if (!emitterScope) {
+    diagnostics.add({
+      code: "use-client-context-without-provider",
+      message: "No emitter scope provided to getClientFeatureLifecycle.",
+      target,
+      severity: "warning",
+    });
+    return diagnostics.wrap(undefined);
+  }
+
+  if (lifecycle.emitterFilter.includedEmitters.length) {
+    const value = lifecycle.emitterFilter.includedEmitters.includes(emitterScope)
+      ? lifecycleValue
+      : undefined;
+
+    return diagnostics.wrap(value);
+  }
+
+  if (lifecycle.emitterFilter.excludedEmitters.length) {
+    const value = lifecycle.emitterFilter.excludedEmitters.includes(emitterScope)
+      ? undefined
+      : lifecycleValue;
+
+    return diagnostics.wrap(value);
+  }
+
+  return diagnostics.wrap(undefined);
+}

--- a/packages/http-client/src/decorators/index.ts
+++ b/packages/http-client/src/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from "./experimental.js";

--- a/packages/http-client/src/decorators/scope-cache.ts
+++ b/packages/http-client/src/decorators/scope-cache.ts
@@ -1,0 +1,39 @@
+export interface EmitterFilter {
+  includedEmitters: string[];
+  excludedEmitters: string[];
+  isScoped: boolean;
+}
+
+export interface ScopedValue<T> {
+  emitterFilter: EmitterFilter;
+  value: T;
+}
+
+export function parseScopeFilter(string: string | undefined): EmitterFilter {
+  if (!string) {
+    return {
+      excludedEmitters: [],
+      includedEmitters: [],
+      isScoped: false,
+    };
+  }
+
+  const parts = string.split(",");
+  const includedEmitters: string[] = [];
+  const excludedEmitters: string[] = [];
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith("!")) {
+      excludedEmitters.push(trimmed.substring(1));
+    } else {
+      includedEmitters.push(trimmed);
+    }
+  }
+
+  return {
+    excludedEmitters,
+    includedEmitters,
+    isScoped: true,
+  };
+}

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -2,5 +2,5 @@ export const namespace = "TypeSpec.HttpClient";
 export * from "./context/index.js";
 export type * from "./interfaces.js";
 export { $lib } from "./lib.js";
-export * from "./utils/index.js";
 export { $decorators } from "./tsp-index.js";
+export * from "./utils/index.js";

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -1,4 +1,6 @@
+export const namespace = "TypeSpec.HttpClient";
 export * from "./context/index.js";
 export type * from "./interfaces.js";
 export { $lib } from "./lib.js";
 export * from "./utils/index.js";
+export { $decorators } from "./tsp-index.js";

--- a/packages/http-client/src/lib.ts
+++ b/packages/http-client/src/lib.ts
@@ -39,4 +39,4 @@ export const $lib = createTypeSpecLibrary({
   },
 });
 
-export const { reportDiagnostic, createDiagnostic, stateKeys: StateKeys } = $lib;
+export const { reportDiagnostic, createDiagnostic, stateKeys: StateKeys, createStateSymbol } = $lib;

--- a/packages/http-client/src/testing/index.ts
+++ b/packages/http-client/src/testing/index.ts
@@ -2,7 +2,7 @@ import { resolvePath } from "@typespec/compiler";
 import { createTestLibrary, TypeSpecTestLibrary } from "@typespec/compiler/testing";
 import { fileURLToPath } from "url";
 
-export const TypespecHttpClientLibraryTestLibrary: TypeSpecTestLibrary = createTestLibrary({
-  name: "@typespec/http-client-library",
+export const HttpClientTestLibrary: TypeSpecTestLibrary = createTestLibrary({
+  name: "@typespec/http-client",
   packageRoot: resolvePath(fileURLToPath(import.meta.url), "../../../../"),
 });

--- a/packages/http-client/src/tsp-index.ts
+++ b/packages/http-client/src/tsp-index.ts
@@ -1,0 +1,9 @@
+import { TypeSpecHttpClientDecorators } from "../generated-defs/TypeSpec.HttpClient.js";
+
+import { $experimental } from "./decorators/index.js";
+
+export const $decorators = {
+  "TypeSpec.HttpClient": {
+    experimental: $experimental,
+  } satisfies TypeSpecHttpClientDecorators,
+};

--- a/packages/http-client/src/typekit/kits/client.ts
+++ b/packages/http-client/src/typekit/kits/client.ts
@@ -29,7 +29,7 @@ import { getStringValue } from "../../utils/helpers.js";
 import { NameKit } from "./utils.js";
 
 interface ClientKit extends NameKit<InternalClient> {
-   /**
+  /**
    * Get the feature lifecycle value for a given type
    * @param type The type to get the feature lifecycle for
    * @param options The options to use when getting the feature lifecycle
@@ -111,7 +111,7 @@ export const clientOperationCache = new Map<InternalClient, HttpOperation[]>();
 
 defineKit<TypekitExtension>({
   client: {
-     getFeatureLifecycle: createDiagnosable(function (type, options) {
+    getFeatureLifecycle: createDiagnosable(function (type, options) {
       return getClientFeatureLifecycle(this.program, type, options);
     }),
     getParent(client) {

--- a/packages/http-client/src/types/typespec-augmentations.d.ts
+++ b/packages/http-client/src/types/typespec-augmentations.d.ts
@@ -1,5 +1,5 @@
 import { HttpAuth } from "@typespec/http";
-import { authSchemeSymbol, credentialSymbol } from "./credential-symbol.ts";
+import { authSchemeSymbol, credentialSymbol } from "./credential-symbol.js";
 
 declare module "@typespec/compiler" {
   interface ModelProperty {

--- a/packages/http-client/test/lib/experimental-decorator.test.ts
+++ b/packages/http-client/test/lib/experimental-decorator.test.ts
@@ -1,12 +1,18 @@
-import { expectDiagnostics, t, TesterInstance } from "@typespec/compiler/testing";
+import { resolvePath } from "@typespec/compiler";
+import { createTester, expectDiagnostics, t, TesterInstance } from "@typespec/compiler/testing";
 import { $ } from "@typespec/compiler/typekit";
-import { beforeEach, expect, it } from "vitest";
+import { beforeAll, expect, it } from "vitest";
 import "../../src/typekit/index.js";
-import { Tester } from "../test-host.js";
 
 let runner: TesterInstance;
 
-beforeEach(async () => {
+beforeAll(async () => {
+  const Tester = createTester(resolvePath(import.meta.dirname, "../.."), {
+    libraries: ["@typespec/http", "@typespec/http-client"],
+  })
+    .importLibraries()
+    .using("Http", "HttpClient");
+
   runner = await Tester.createInstance();
 });
 

--- a/packages/http-client/test/lib/experimental-decorator.test.ts
+++ b/packages/http-client/test/lib/experimental-decorator.test.ts
@@ -1,0 +1,160 @@
+import { expectDiagnostics, t, TesterInstance } from "@typespec/compiler/testing";
+import { $ } from "@typespec/compiler/typekit";
+import { beforeEach, expect, it } from "vitest";
+import "../../src/typekit/index.js";
+import { Tester } from "../test-host.js";
+
+let runner: TesterInstance;
+
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
+
+it("should get the feature lifecycle for a model property", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp);
+  expect(featureLifecycle).toBe("Experimental");
+});
+
+it("should get the feature lifecycle for a model property within scope", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental(#{emitterScope: "myEmitter"})
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp, {
+    emitterName: "myEmitter",
+  });
+  expect(featureLifecycle).toBe("Experimental");
+});
+
+it("should get the feature lifecycle for a model property within scope (multiple scopes)", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental(#{emitterScope: "myEmitter, otherEmitter"})
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp, {
+    emitterName: "myEmitter",
+  });
+  expect(featureLifecycle).toBe("Experimental");
+});
+
+it("should get the feature lifecycle for a model property with scope and unscoped decorator", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp, {
+    emitterName: "myEmitter",
+  });
+  expect(featureLifecycle).toBe("Experimental");
+});
+
+it("should not get featureLifecycle when not in scope", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental(#{emitterScope: "notMyEmitter"})
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp, {
+    emitterName: "myEmitter",
+  });
+  expect(featureLifecycle).toBeUndefined();
+});
+
+it("should not get featureLifecycle when no scope passed to query", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental(#{emitterScope: "notMyEmitter"})
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp);
+  expect(featureLifecycle).toBeUndefined();
+});
+
+it("should get featureLifecycle when not in excluded scopes", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental(#{emitterScope: "!notMyEmitter"})
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp, {
+    emitterName: "myEmitter",
+  });
+  expect(featureLifecycle).toBe("Experimental");
+});
+
+it("should not get featureLifecycle when in excluded scopes", async () => {
+  const { betaProp, program } = await runner.compile(t.code`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental(#{emitterScope: "!myEmitter"})
+       ${t.modelProperty("betaProp")}: string;
+    }
+    `);
+
+  const featureLifecycle = $(program).client.getFeatureLifecycle(betaProp, {
+    emitterName: "myEmitter",
+  });
+  expect(featureLifecycle).toBeUndefined();
+});
+
+it("should report diagnostics when both include and exclude are set", async () => {
+  const diagnostics = await runner.diagnose(`
+    namespace Test;
+
+    model MyModel {
+       id: string;
+       @experimental(#{emitterScope: "!myEmitter,otherEmitter"})
+       betaProp: string;
+    }
+    `);
+
+  expectDiagnostics(diagnostics, {
+    code: "include-and-exclude-scopes",
+    message: "The @experimental should only either include or exclude scopes, not both.",
+  });
+});

--- a/packages/http-client/test/test-host.ts
+++ b/packages/http-client/test/test-host.ts
@@ -2,8 +2,7 @@ import { resolvePath } from "@typespec/compiler";
 import { createTester } from "@typespec/compiler/testing";
 
 export const Tester = createTester(resolvePath(import.meta.dirname, ".."), {
-  libraries: ["@typespec/http", "@typespec/http-client"],
+  libraries: ["@typespec/http"],
 })
   .importLibraries()
-  .using("Http", "HttpClient");
-  
+  .using("Http");

--- a/packages/http-client/test/test-host.ts
+++ b/packages/http-client/test/test-host.ts
@@ -2,7 +2,7 @@ import { resolvePath } from "@typespec/compiler";
 import { createTester } from "@typespec/compiler/testing";
 
 export const Tester = createTester(resolvePath(import.meta.dirname, ".."), {
-  libraries: ["@typespec/http"],
+  libraries: ["@typespec/http", "@typespec/http-client"],
 })
-  .import("@typespec/http")
-  .using("Http");
+  .import("@typespec/http", "@typespec/http-client")
+  .using("Http", "HttpClient");

--- a/packages/http-client/test/test-host.ts
+++ b/packages/http-client/test/test-host.ts
@@ -4,5 +4,6 @@ import { createTester } from "@typespec/compiler/testing";
 export const Tester = createTester(resolvePath(import.meta.dirname, ".."), {
   libraries: ["@typespec/http", "@typespec/http-client"],
 })
-  .import("@typespec/http", "@typespec/http-client")
+  .importLibraries()
   .using("Http", "HttpClient");
+  

--- a/packages/http-client/vitest.config.ts
+++ b/packages/http-client/vitest.config.ts
@@ -1,3 +1,4 @@
+import alloyPlugin from "@alloy-js/rollup-plugin";
 import { defineConfig, mergeConfig } from "vitest/config";
 import { defaultTypeSpecVitestConfig } from "../../vitest.config.js";
 
@@ -12,5 +13,6 @@ export default mergeConfig(
       jsx: "preserve",
       sourcemap: "both",
     },
+    plugins: [alloyPlugin()],
   }),
 );

--- a/packages/http-client/vitest.config.ts
+++ b/packages/http-client/vitest.config.ts
@@ -1,53 +1,13 @@
 import alloyPlugin from "@alloy-js/rollup-plugin";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { defineConfig, mergeConfig } from "vitest/config";
 import { defaultTypeSpecVitestConfig } from "../../vitest.config.js";
-
-const here = dirname(fileURLToPath(import.meta.url));
 
 export default mergeConfig(
   defaultTypeSpecVitestConfig,
   defineConfig({
-    // Give this package its own caches so other packages can’t “poison” it.
-    cacheDir: join(here, "node_modules/.vitest-cache"),
-    // If your tests don’t truly need DOM, keep node.
     test: {
       include: ["test/**/*.test.ts"],
       passWithNoTests: true,
-      // Re-enable isolation for THIS package to stop cross-file leakage.
-      isolate: true,
-      // Stabilize runner while you confirm the fix (you can relax later).
-      pool: "forks",
-      maxWorkers: 1,
-      deps: {
-        // Treat sibling workspaces like source (don’t externalize dist)
-        inline: [
-          "@typespec/emitter-framework",
-          "@typespec/react-components",
-          "@typespec/html-program-viewer",
-        ],
-      },
-      hookTimeout: 30_000,
-      testTimeout: 60_000,
-    },
-    // Prevent Vite SSR from externalizing the siblings’ built output.
-    ssr: {
-      noExternal: [
-        "@typespec/emitter-framework",
-        "@typespec/react-components",
-        "@typespec/html-program-viewer",
-      ],
-    },
-    // (Recommended) Alias to sibling *src* so we never import their dist in tests.
-    resolve: {
-      alias: {
-        "@typespec/emitter-framework": fileURLToPath(
-          new URL("../emitter-framework/src/index.ts", import.meta.url),
-        ),
-        // Add more aliases if http-client imports others’ dist.
-        // "@typespec/react-components": fileURLToPath(new URL("../react-components/src/index.ts", import.meta.url)),
-      },
     },
     esbuild: {
       jsx: "preserve",

--- a/packages/http-client/vitest.config.ts
+++ b/packages/http-client/vitest.config.ts
@@ -1,4 +1,3 @@
-import alloyPlugin from "@alloy-js/rollup-plugin";
 import { defineConfig, mergeConfig } from "vitest/config";
 import { defaultTypeSpecVitestConfig } from "../../vitest.config.js";
 
@@ -13,6 +12,5 @@ export default mergeConfig(
       jsx: "preserve",
       sourcemap: "both",
     },
-    plugins: [alloyPlugin()],
   }),
 );

--- a/packages/http-client/vitest.config.ts
+++ b/packages/http-client/vitest.config.ts
@@ -1,13 +1,53 @@
 import alloyPlugin from "@alloy-js/rollup-plugin";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, mergeConfig } from "vitest/config";
 import { defaultTypeSpecVitestConfig } from "../../vitest.config.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 export default mergeConfig(
   defaultTypeSpecVitestConfig,
   defineConfig({
+    // Give this package its own caches so other packages can’t “poison” it.
+    cacheDir: join(here, "node_modules/.vitest-cache"),
+    // If your tests don’t truly need DOM, keep node.
     test: {
       include: ["test/**/*.test.ts"],
       passWithNoTests: true,
+      // Re-enable isolation for THIS package to stop cross-file leakage.
+      isolate: true,
+      // Stabilize runner while you confirm the fix (you can relax later).
+      pool: "forks",
+      maxWorkers: 1,
+      deps: {
+        // Treat sibling workspaces like source (don’t externalize dist)
+        inline: [
+          "@typespec/emitter-framework",
+          "@typespec/react-components",
+          "@typespec/html-program-viewer",
+        ],
+      },
+      hookTimeout: 30_000,
+      testTimeout: 60_000,
+    },
+    // Prevent Vite SSR from externalizing the siblings’ built output.
+    ssr: {
+      noExternal: [
+        "@typespec/emitter-framework",
+        "@typespec/react-components",
+        "@typespec/html-program-viewer",
+      ],
+    },
+    // (Recommended) Alias to sibling *src* so we never import their dist in tests.
+    resolve: {
+      alias: {
+        "@typespec/emitter-framework": fileURLToPath(
+          new URL("../emitter-framework/src/index.ts", import.meta.url),
+        ),
+        // Add more aliases if http-client imports others’ dist.
+        // "@typespec/react-components": fileURLToPath(new URL("../react-components/src/index.ts", import.meta.url)),
+      },
     },
     esbuild: {
       jsx: "preserve",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,6 +681,12 @@ importers:
       '@typespec/http':
         specifier: workspace:^
         version: link:../http
+      '@typespec/library-linter':
+        specifier: workspace:^
+        version: link:../library-linter
+      '@typespec/tspd':
+        specifier: workspace:^
+        version: link:../tspd
       eslint:
         specifier: ^9.23.0
         version: 9.35.0


### PR DESCRIPTION
# Introduce `@experimental` decorator to tag client-side features

| **Status**    | Draft                   |
| :------------ | :---------------------- |
| **Author(s)** | Jose Heredia (joheredi) |
| **Sponsor**   |                         |
| **Updated**   | 2025-08-18              |

## Objective

Define a decorator, `@experimental`, that lets TypeSpec authors mark **client-side** features as experimental. This enables shipping preview helpers, gathering feedback, and promoting features without affecting the **service contract version**.

> **Note:** `@experimental` is solely about client-side feature maturity. It does **not** affect or replace `@typespec/versioning`, which remains the source of truth for service/API versioning.

### Goals

* Introduce `@experimental` with minimal syntax.
* Preserve backward compatibility: if the decorator is not handled by emitters, they keep current behavior.

### Non-Goals

* Modifying `@typespec/versioning`.
* Mandating specific emitter behavior; emitters **may** opt into using this metadata.

## Motivation

`@typespec/versioning` tracks **service API versions** only. SDK teams commonly add higher-level helpers (batching, pagination convenience, analytics wrappers) after the REST surface is GA. Without a standard way to tag those as “experimental,” teams patch generated code manually—costly and inconsistent. A formal decorator:

* Co-locates lifecycle metadata with declarations.
* Gives emitters a single source for warnings, conditional generation, or package splitting.

## User Benefits

* **Spec authors:** one standard way to mark experimental parts of the client API.
* **Emitter authors:** a unified API to query experimental status.
* **Client users:** clear documentation/IDE signals about experimental vs. stable features.

## Design Proposal

### Decorator

* **Name:** `@experimental`

* **Signature**

  ```typespec
  @experimental(options?: { emitterScope?: string })
  ```

  * `emitterScope` (optional): opaque string used by emitters as a lookup key (e.g., `"typescript"`, `"java"`). If omitted, it applies to **all** emitters.

* **Examples**

  ```typespec
  @experimental
  op listFooExperimental(): Foo[];
  ```

  ```typespec
  @experimental(#{ emitterScope: "myEmitter" })
  op listFooExperimental(): Foo[];
  ```

### Lifecycle model & semantics

* **FeatureLifecycle:** `'stable' | 'experimental'`.
* **Default:** if `@experimental` is **absent** → `'stable'`.
* **Scope rules:**

  * If `@experimental` has **no** `emitterScope`, the target is experimental for **all** emitters.
  * If `emitterScope` is present, the target is experimental **only** when the consuming emitter’s scope matches that string. Otherwise it is treated as stable for that emitter.
  * Multiple applications of `@experimental` with different scopes **may** be used on the same target; a match on **any** one marks it experimental for that scope.
* **No inheritance:** there is **no** implicit propagation. Applying `@experimental` to a namespace/interface does **not** make children experimental. Emitters may choose to layer their own inheritance logic, but it is not part of this spec.
* **No wire-protocol impact:** purely metadata; does not change HTTP behavior.

### Discovery API

A small helper will be provided for emitters/tooling:

```ts
function getFeatureLifecycle(
  program: Program,
  target: Type,
  options?: { emitterName?: string }
): string | undefined;

```

* **Location:** exposed alongside the decorator (e.g., in `@typespec/http-client`) and re-exported from the client generator core (TCGC) for convenience.
* **Behavior:** implements the rules above and returns `'experimental'` if any matching `@experimental` applies for the provided scope; otherwise `'undefined'`.

### Guidance for emitters (non-normative)

Emitters **can** adopt one or more patterns:

1. **Package splitting**
   Generate experimental items into a preview package or sub-namespace (e.g., `foo-client-preview`).

2. **Constructor opt-in**
   Provide a client option such as `enablePreviewFeatures: string[]` and surface experimental operations only when opted in.

3. **Conditional compilation**
   Use language-specific flags (e.g., `#if PREVIEW_FEATURES` in C#, `cfg(feature = "preview")` in Rust).

4. **Documentation signals**
   Add doc comments/annotations understood by the ecosystem (e.g., TypeDoc tags, Kotlin opt-in annotations, .NET `RequiresPreviewFeaturesAttribute`) to clearly label experimental APIs.

## Alternatives Considered

* **Reuse `@previewVersion`:** conflates client maturity with service versioning.
* **`@featureLifecycle` (broader enum):** more general but no concrete need today; adds complexity vs. a targeted `@experimental`.
* **External config files:** loses co-location with code and is harder to maintain.

## Performance Implications

* None for the TypeSpec compiler.
* No measurable runtime impact; emitters may ignore this without change in behavior.

## Dependencies

* No new runtime dependencies.
* Lives in `@typespec/http-client` (and re-exported by TCGC for emitter use).

## Engineering Impact

* **TCGC:** register `@experimental` and expose `getFeatureLifecycle`.
* **Emitters:** optional adoption. If ignored, behavior remains unchanged.

## Best Practices

* Tag new preview helpers with `@experimental` early.
* Remove the decorator promptly once the feature is considered stable.

## Compatibility

* Fully backward-compatible: existing specs/emitters unaffected if they ignore the decorator.
* Omitted decorator preserves current “everything is stable” behavior.

## User Impact

* No breaking changes for spec authors or consumers.
* Users of updated emitters may see preview packages, gated features, or clearer docs/IDE hints.

## FAQ

### Q: Why mark a client helper as experimental if the service is already GA?

A: Client helpers (batching, pagination, analytics, etc.) often evolve after the REST API is GA. Marking them experimental lets you ship safely alongside stable features while you validate design and gather feedback.

### Q: Why not mark the service/API as preview instead?

A: Service/API versioning (`@typespec/versioning`) governs the HTTP contract. `@experimental` is strictly for **client SDK features**, so you can ship preview helpers without bumping the service version or impacting existing clients.

### Q: Can I release experimental client APIs without bumping my package version?

A: Yes. Emitters can gate experimental items behind flags or generate them into preview sub-packages/namespaces, while keeping the main package version unchanged.