### PR TITLE
http-client-java, use --no for npx

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/Generate.ps1
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/Generate.ps1
@@ -30,7 +30,7 @@ $generateScript = {
   $tspOptions = "--option ""@typespec/http-client-java.emitter-output-dir={project-root}/tsp-output/$(Get-Random)"""
 
   $tspTrace = "--trace import-resolution --trace projection --trace http-client-java"
-  $tspCommand = "npx --no-install tsp compile $tspFile $tspOptions $tspTrace"
+  $tspCommand = "npx --no tsp compile $tspFile $tspOptions $tspTrace"
 
   # output of "tsp compile" seems trigger powershell error or exit, hence the "2>&1"
   $timer = [Diagnostics.Stopwatch]::StartNew()
@@ -62,7 +62,7 @@ $generateScript = {
 }
 
 function Generate-Compile ($folder) {
-  npx --no-install tsp compile "smoke/$folder/main.tsp" --option "@typespec/http-client-java.emitter-output-dir={project-root}/$folder"
+  npx --no tsp compile "smoke/$folder/main.tsp" --option "@typespec/http-client-java.emitter-output-dir={project-root}/$folder"
 
   Push-Location $folder
   mvn package

--- a/packages/http-client-java/generator/http-client-generator-test/Generate.ps1
+++ b/packages/http-client-java/generator/http-client-generator-test/Generate.ps1
@@ -124,7 +124,7 @@ $generateScript = {
   }
 
   $tspTrace = "--trace import-resolution --trace projection --trace http-client-java"
-  $tspCommand = "npx --no-install tsp compile $tspFile $tspOptions $tspTrace"
+  $tspCommand = "npx --no tsp compile $tspFile $tspOptions $tspTrace"
 
   # output of "tsp compile" seems trigger powershell error or exit, hence the "2>&1"
   $timer = [Diagnostics.Stopwatch]::StartNew()
@@ -185,7 +185,7 @@ try {
   $job | Receive-Job
 
   # partial update test
-  npx --no-install tsp compile ./tsp/partialupdate.tsp --option="@typespec/http-client-java.emitter-output-dir={project-root}/existingcode"
+  npx --no tsp compile ./tsp/partialupdate.tsp --option="@typespec/http-client-java.emitter-output-dir={project-root}/existingcode"
   Copy-Item -Path ./existingcode/src/main/java/tsptest/partialupdate -Destination ./src/main/java/tsptest/partialupdate -Recurse -Force
   Remove-Item ./existingcode -Recurse -Force
 


### PR DESCRIPTION
A minor change, to avoid using deprecated `--no-install` option.

> The --no-install option is deprecated, and will be converted to --no.