### PR TITLE
Pass compiler options correctly in linter tester

### DIFF
--- a/.chronus/changes/fix-linter-tester-new-tester-2025-8-24-20-53-11.md
+++ b/.chronus/changes/fix-linter-tester-new-tester-2025-8-24-20-53-11.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Linter rule tester not passing parseDocs option to new tester instance

--- a/packages/compiler/src/testing/rule-tester.ts
+++ b/packages/compiler/src/testing/rule-tester.ts
@@ -79,7 +79,12 @@ export function createLinterRuleTester(
   }
 
   async function diagnose(code: string): Promise<readonly Diagnostic[]> {
-    await runner.diagnose(code, { parseOptions: { comments: true } });
+    const compilerOptions = { parseOptions: { comments: true } };
+    if ("autoCodeOffset" in runner) {
+      await runner.diagnose(code, compilerOptions);
+    } else {
+      await runner.diagnose(code, { compilerOptions });
+    }
 
     const diagnostics = createDiagnosticCollector();
     const rule = { ...ruleDef, id: `${libraryName}/${ruleDef.name}` };


### PR DESCRIPTION
Parse options were not passed correctly preventing the codefix tester from being used 