### PR TITLE
Fix issue with customized base model having discriminator property

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -1164,15 +1164,14 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         [Test]
         public async Task DiscriminatorPropertyNotGeneratedIfOnCustomizedBase()
         {
-            var modelProp = InputFactory.Property("prop1", InputPrimitiveType.String);
-            var inputModel = InputFactory.Model("mockInputModel", properties: [], usage: InputModelTypeUsage.Json);
+            var childModel = InputFactory.Model("mockInputModel", properties: [InputFactory.Property("prop1", InputPrimitiveType.String, isDiscriminator: true)], usage: InputModelTypeUsage.Json);
             var baseModel = InputFactory.Model(
                 "mockInputModelBase",
-                properties: [modelProp],
+                properties: [InputFactory.Property("prop1", InputPrimitiveType.String)],
                 usage: InputModelTypeUsage.Json);
 
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
-                inputModelTypes: [inputModel, baseModel],
+                inputModelTypes: [childModel, baseModel],
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var modelProvider = mockGenerator.Object.OutputLibrary.TypeProviders.Single(t => t.Name == "MockInputModel");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/DiscriminatorPropertyNotGeneratedIfOnCustomizedBase/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/DiscriminatorPropertyNotGeneratedIfOnCustomizedBase/MockInputModel.cs
@@ -1,0 +1,11 @@
+#nullable disable
+
+using Sample;
+using SampleTypeSpec;
+
+namespace Sample.Models
+{
+    public partial class MockInputModel : MockInputModelBase
+    {
+    }
+}


### PR DESCRIPTION
If a model is customized to inherit from a different model that contains the same property as the discriminator property, we should skip generating the discriminator property on the child model.