### PR TITLE
[Python] add ci check for `peerDependencies`

### DIFF
--- a/.chronus/changes/HEAD-2025-8-25-13-26-40.md
+++ b/.chronus/changes/HEAD-2025-8-25-13-26-40.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-python"
+---
+
+Add check in CI for peerDependencies

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -67,6 +67,9 @@ try {
     Invoke-LoggedCommand "npm pack"
     Copy-Item "typespec-http-client-python-$emitterVersion.tgz" -Destination "$outputPath/packages"
 
+    # install packed emitter to check dependencies
+    Invoke-LoggedCommand "npm install typespec-http-client-python-$emitterVersion.tgz" -GroupOutput
+
     Write-PackageInfo -packageName "typespec-http-client-python" -directoryPath "packages/http-client-python/emitter/src" -version $emitterVersion
 }
 finally {

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -54,7 +54,7 @@
     "emitter"
   ],
   "peerDependencies": {
-    "@azure-tools/typespec-autorest": ">=0.60.0 <1.0.0",
+    "@azure-tools/typespec-autorest": ">=0.60.2 <1.0.0",
     "@azure-tools/typespec-azure-core": ">=0.60.0 <1.0.0",
     "@azure-tools/typespec-azure-resource-manager": ">=0.60.0 <1.0.0",
     "@azure-tools/typespec-azure-rulesets": ">=0.60.0 <1.0.0",

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -54,7 +54,7 @@
     "emitter"
   ],
   "peerDependencies": {
-    "@azure-tools/typespec-autorest": ">=0.60.2 <1.0.0",
+    "@azure-tools/typespec-autorest": ">=0.60.0 <1.0.0",
     "@azure-tools/typespec-azure-core": ">=0.60.0 <1.0.0",
     "@azure-tools/typespec-azure-resource-manager": ">=0.60.0 <1.0.0",
     "@azure-tools/typespec-azure-rulesets": ">=0.60.0 <1.0.0",


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/8537

We could catch the inconsistent peerDependencies error when install the packed emitter package like:
https://dev.azure.com/azure-sdk/public/_build/results?buildId=5382832&view=logs&j=594fe8ce-0eb1-57b3-7b2f-2f92d3590a0e&t=c336caa1-9b25-5c3a-b743-14db0d75dc4f

<img width="1234" height="810" alt="image" src="https://github.com/user-attachments/assets/2a5efbfc-777f-4c80-8520-674d6b9dc0b1" />

I also tried `npm ci` but it doesn't work.