### PR TITLE
fix: propogate dynamicModel for union types

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputModelTypeConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputModelTypeConverter.cs
@@ -183,6 +183,13 @@ namespace Microsoft.TypeSpec.Generator.Input
                     }
                 }
             }
+            else if (inputType is InputUnionType unionType)
+            {
+                foreach (var type in unionType.VariantTypes)
+                {
+                    MarkModelsAsDynamicRecursive(type, visited);
+                }
+            }
             else if (inputType is InputArrayType arrayType)
             {
                 MarkModelsAsDynamicRecursive(arrayType.ValueType, visited);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TestData/TypeSpecInputConverterTests/LoadsDynamicModelWithModelProperties/tspCodeModel.json
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TestData/TypeSpecInputConverterTests/LoadsDynamicModelWithModelProperties/tspCodeModel.json
@@ -153,6 +153,50 @@
                         }
                     },
                     "isHttpMetadata": false
+                },
+                {
+                    "$id": "4278",
+                    "kind": "property",
+                    "name": "NullableUnionDynamicProperty",
+                    "serializedName": "nullableUnionDynamicProperty",
+                    "doc": "Specify which of the MCP server's tools require approval.",
+                    "type": {
+                    "$id": "4279",
+                    "kind": "nullable",
+                    "type": {
+                        "$id": "4280",
+                        "kind": "union",
+                        "name": "MCPToolRequireApproval",
+                        "variantTypes": [
+                        {
+                            "$id": "4281",
+                            "kind": "model",
+                            "name": "MCPToolRequireApproval1",
+                            "namespace": "SampleTypeSpec",
+                            "crossLanguageDefinitionId": "SampleTypeSpec.MCPTool.require_approval.anonymous",
+                            "usage": "Input,Output,Json",
+                            "decorators": [],
+                            "properties": [
+                            ]
+                        }
+                        ],
+                        "namespace": "SampleTypeSpec",
+                        "decorators": []
+                    },
+                    "namespace": "SampleTypeSpec"
+                    },
+                    "optional": true,
+                    "readOnly": false,
+                    "discriminator": false,
+                    "flatten": false,
+                    "decorators": [],
+                    "crossLanguageDefinitionId": "SampleTypeSpec.MCPTool.require_approval",
+                    "serializationOptions": {
+                    "json": {
+                        "name": "require_approval"
+                    }
+                    },
+                    "isHttpMetadata": false
                 }
             ]
         },

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputConverterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputConverterTests.cs
@@ -166,6 +166,21 @@ namespace Microsoft.TypeSpec.Generator.Input.Tests
             var modelProperty = anotherModel.Properties.SingleOrDefault(p => p.Type is InputModelType);
             Assert.IsNotNull(modelProperty);
             Assert.IsTrue(((InputModelType)modelProperty!.Type).IsDynamicModel);
+
+            var nullableModel = inputNamespace!.Models.SingleOrDefault(m => m.Name == "NullableModel");
+            Assert.IsNotNull(nullableModel);
+
+            var nullableUnionProperty = nullableModel!.Properties.SingleOrDefault(p => p.Type is InputNullableType n && p.Name.Equals("NullableUnionDynamicProperty"));
+            Assert.IsNotNull(nullableUnionProperty);
+            var nullableUnionType = nullableUnionProperty!.Type;
+            bool isNullable = nullableUnionType is InputNullableType;
+            Assert.IsTrue(isNullable);
+            Assert.IsTrue((nullableUnionType as InputNullableType)!.Type is InputUnionType);
+            var nullableUnionVariantTypes = ((nullableUnionType as InputNullableType)!.Type as InputUnionType)!.VariantTypes;
+            foreach (var variantType in nullableUnionVariantTypes)
+            {
+                Assert.IsTrue(((InputModelType)variantType).IsDynamicModel);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Fixes an edge case where a dynamic model with a nullable union type property did not have the dynamicModel flag propagated to the union's variant types.