### PR TITLE
Mock process before importing

### DIFF
--- a/packages/compiler/src/server/mock-process.ts
+++ b/packages/compiler/src/server/mock-process.ts
@@ -1,0 +1,50 @@
+import { Buffer } from "node:buffer";
+import { Readable as ReadableStream, Writable as WritableStream } from "node:stream";
+
+export function mockProcess(path: string): NodeJS.Process {
+  return {
+    ...process,
+    exit: () => {
+      throw new Error(`Importing ${path} tried to call process.exit`);
+    },
+    stdin: readableNoopStream() as any,
+    stdout: writableNoopStream() as any,
+    on: (() => {}) as any,
+  };
+}
+
+function readableNoopStream({ size = 0 } = {}) {
+  let producedSize = 0;
+
+  return new ReadableStream({
+    read(readSize) {
+      let shouldEnd = false;
+
+      if (producedSize + readSize >= size) {
+        readSize = size - producedSize;
+        shouldEnd = true;
+      }
+
+      setImmediate(() => {
+        if (size === 0) {
+          this.push(null);
+        }
+
+        producedSize += readSize;
+        this.push(Buffer.alloc(readSize));
+
+        if (shouldEnd) {
+          this.push(null);
+        }
+      });
+    },
+  });
+}
+
+function writableNoopStream() {
+  return new WritableStream({
+    write(chunk, encding, callback) {
+      setImmediate(callback);
+    },
+  });
+}

--- a/packages/compiler/src/server/npm-package-provider.ts
+++ b/packages/compiler/src/server/npm-package-provider.ts
@@ -202,22 +202,8 @@ export class NpmPackage {
         return undefined;
       }
       const entrypoint = module.type === "file" ? module.path : module.mainFile;
-      const oldExit = process.exit;
-      try {
-        // override process.exit to prevent the process from exiting because of it's called in loaded js file
-        let result: any;
-        process.exit = (() => {
-          // for module that calls process.exit when being imported, create an empty object as it's exports to avoid load it again
-          result = {};
-          throw new Error(
-            "process.exit is called unexpectedly when loading js file: " + entrypoint,
-          );
-        }) as any;
-        const [file] = await loadJsFile(host, entrypoint, NoTarget);
-        return result ?? file?.esmExports;
-      } finally {
-        process.exit = oldExit;
-      }
+      const [file] = await loadJsFile(host, entrypoint, NoTarget);
+      return file?.esmExports;
     } catch (e) {
       return undefined;
     }


### PR DESCRIPTION
fix #8624

To prevent bad packages from corrupting the language server mock the process which is something you shouldn't be using anyway