### PR TITLE
fix: do not write null for optional nullable props in dynamic models

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -2021,7 +2021,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             condition = isReadOnly ? _isNotEqualToWireConditionSnippet.And(isDefinedCondition) : isDefinedCondition;
-
             if (isRequired && isNullable)
             {
                 if (shouldCheckJsonPath)
@@ -2045,7 +2044,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     serializedName,
                     condition,
                     writePropertySerializationStatement,
-                    _utf8JsonWriterSnippet.WriteNull(serializedName));
+                    null);
             }
 
             return new IfStatement(condition) { writePropertySerializationStatement };

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteArrayProperties.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteArrayProperties.cs
@@ -58,10 +58,6 @@ namespace Sample
                 Patch.WriteTo(writer, "$.cats"u8);
                 writer.WriteEndArray();
             }
-            else
-            {
-                writer.WriteNull("cats"u8);
-            }
             if (Patch.Contains("$.names"u8))
             {
                 if (!Patch.IsRemoved("$.names"u8))
@@ -117,10 +113,6 @@ namespace Sample
                 }
                 Patch.WriteTo(writer, "$.optionalNames"u8);
                 writer.WriteEndArray();
-            }
-            else
-            {
-                writer.WriteNull("optionalNames"u8);
             }
 
             Patch.WriteTo(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteNestedArrayDictionaryProperties.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteNestedArrayDictionaryProperties.cs
@@ -118,10 +118,6 @@ namespace Sample
                 Patch.WriteTo(writer, "$.propertyWithNestedArray"u8);
                 writer.WriteEndArray();
             }
-            else
-            {
-                writer.WriteNull("propertyWithNestedArray"u8);
-            }
 
             Patch.WriteTo(writer);
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteNestedArrayDynamicModelProperties.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteNestedArrayDynamicModelProperties.cs
@@ -88,10 +88,6 @@ namespace Sample
                 Patch.WriteTo(writer, "$.propertyWithNestedArray"u8);
                 writer.WriteEndArray();
             }
-            else
-            {
-                writer.WriteNull("propertyWithNestedArray"u8);
-            }
 
             Patch.WriteTo(writer);
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteNestedArrayPrimitiveProperties.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteNestedArrayPrimitiveProperties.cs
@@ -93,10 +93,6 @@ namespace Sample
                 Patch.WriteTo(writer, "$.propertyWithNestedArray"u8);
                 writer.WriteEndArray();
             }
-            else
-            {
-                writer.WriteNull("propertyWithNestedArray"u8);
-            }
 
             Patch.WriteTo(writer);
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteReadOnlySpanProperty.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteReadOnlySpanProperty.cs
@@ -58,10 +58,6 @@ namespace Sample.Models
                 Patch.WriteTo(writer, "$.someSpan"u8);
                 writer.WriteEndArray();
             }
-            else
-            {
-                writer.WriteNull("someSpan"u8);
-            }
 
             Patch.WriteTo(writer);
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/DynamicModel.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/DynamicModel.Serialization.cs
@@ -94,10 +94,6 @@ namespace SampleTypeSpec
                 Patch.WriteTo(writer, "$.optionalNullableList"u8);
                 writer.WriteEndArray();
             }
-            else
-            {
-                writer.WriteNull("optionalNullableList"u8);
-            }
             if (Patch.Contains("$.requiredNullableList"u8))
             {
                 if (!Patch.IsRemoved("$.requiredNullableList"u8))


### PR DESCRIPTION
Fixes an edge case where we were defaulting to `null` when serializing optional nullable properties.

fixes: https://github.com/microsoft/typespec/issues/8649