### PR TITLE
fix: do not call Patch.WriteTo for base discriminated model types

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -679,8 +679,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 bool addedWriteToJsonPatch = false;
 #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-                if (_inputModel.DiscriminatedSubtypes.Count == 0
-                    && (DeclarationModifiers & (TypeSignatureModifiers.Abstract | TypeSignatureModifiers.Protected)) == 0)
+                if (_inputModel.DiscriminatedSubtypes.Count == 0)
                 {
                     writePropertiesStatements.AddRange(
                         MethodBodyStatement.EmptyLine,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteDiscriminatedDerivedModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/WriteDiscriminatedDerivedModel.cs
@@ -40,8 +40,6 @@ namespace Sample
                 writer.WritePropertyName("meows"u8);
                 writer.WriteBooleanValue(Meows);
             }
-
-            Patch.WriteTo(writer);
 #pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/SuppressionStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/SuppressionStatement.cs
@@ -10,8 +10,8 @@ namespace Microsoft.TypeSpec.Generator.Statements
         public string Justification { get; }
         public ValueExpression Code { get; }
         public MethodBodyStatement? Inner { get; }
-        internal PragmaWarningDisableStatement DisableStatement { get; }
-        internal PragmaWarningRestoreStatement RestoreStatement { get; }
+        public PragmaWarningDisableStatement DisableStatement { get; }
+        public PragmaWarningRestoreStatement RestoreStatement { get; }
 
         public SuppressionStatement(MethodBodyStatement? inner, ValueExpression code, string justification)
         {


### PR DESCRIPTION
Fixes an edge case where the base model was serializing the patch data, which can be an issue if the subtypes also serialize the json patch property.