### PR TITLE
Allow importing sub path in tester v2

### DIFF
--- a/.chronus/changes/tester-sub-exports-2025-9-6-13-28-43.md
+++ b/.chronus/changes/tester-sub-exports-2025-9-6-13-28-43.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Allow importing of self (e.g. `@typespec/openapi/some/path` when in `@typespec/openapi`) respecting ESM spec.

--- a/.chronus/changes/tester-sub-exports-2025-9-6-13-30-31.md
+++ b/.chronus/changes/tester-sub-exports-2025-9-6-13-30-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+[Tester] Support sub exports without having them being defined as separate libraries

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -35,8 +35,8 @@
       "default": "./dist/src/testing/index.js"
     },
     "./module-resolver": {
-      "types": "./dist/module-resolver/module-resolver.d.ts",
-      "default": "./dist/src/module-resolver/module-resolver.js"
+      "types": "./dist/module-resolver/index.d.ts",
+      "default": "./dist/src/module-resolver/index.js"
     },
     "./ast": {
       "import": "./dist/src/ast/index.js"

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -3,13 +3,12 @@ import { EmitterOptions } from "../config/types.js";
 import { validateEncodedNamesConflicts } from "../lib/encoded-names.js";
 import { validatePagingOperations } from "../lib/paging.js";
 import { MANIFEST } from "../manifest.js";
+import { ResolveModuleError, resolveModule } from "../module-resolver/module-resolver.js";
 import {
   ModuleResolutionResult,
-  ResolveModuleError,
   ResolveModuleHost,
   ResolvedModule,
-  resolveModule,
-} from "../module-resolver/module-resolver.js";
+} from "../module-resolver/types.js";
 import { PackageJson } from "../types/package-json.js";
 import { findProjectRoot } from "../utils/io.js";
 import { deepEquals, isDefined, mapEquals, mutate } from "../utils/misc.js";

--- a/packages/compiler/src/core/source-loader.ts
+++ b/packages/compiler/src/core/source-loader.ts
@@ -4,7 +4,7 @@ import {
   resolveModule,
   ResolveModuleError,
   ResolveModuleHost,
-} from "../module-resolver/module-resolver.js";
+} from "../module-resolver/index.js";
 import { PackageJson } from "../types/package-json.js";
 import { doIO } from "../utils/io.js";
 import { deepEquals, resolveTspMain } from "../utils/misc.js";
@@ -411,7 +411,11 @@ export function moduleResolutionErrorToDiagnostic(
   sourceTarget: DiagnosticTarget | typeof NoTarget,
 ): Diagnostic {
   const target: DiagnosticTarget | typeof NoTarget = e.pkgJson
-    ? { file: createSourceFile(e.pkgJson.file.text, e.pkgJson.file.path), pos: 0, end: 0 }
+    ? {
+        file: createSourceFile(e.pkgJson.file.text, e.pkgJson.file.path),
+        pos: 0,
+        end: 0,
+      }
     : sourceTarget;
   switch (e.code) {
     case "MODULE_NOT_FOUND":

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -1,5 +1,5 @@
 import type { JSONSchemaType as AjvJSONSchemaType } from "ajv";
-import type { ModuleResolutionResult } from "../module-resolver/module-resolver.js";
+import type { ModuleResolutionResult } from "../module-resolver/index.js";
 import type { YamlPathTarget, YamlScript } from "../yaml/types.js";
 import type { Numeric } from "./numeric.js";
 import type { Program } from "./program.js";

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -206,7 +206,7 @@ export {
   type ModuleResolutionResult,
   type ResolveModuleHost,
   type ResolveModuleOptions,
-} from "./module-resolver/module-resolver.js";
+} from "./module-resolver/index.js";
 export {
   CompileResult,
   createServer,

--- a/packages/compiler/src/module-resolver/index.ts
+++ b/packages/compiler/src/module-resolver/index.ts
@@ -1,0 +1,7 @@
+export { ResolveModuleError, resolveModule, type ResolveModuleOptions } from "./module-resolver.js";
+export type {
+  ModuleResolutionResult,
+  ResolveModuleHost,
+  ResolvedFile,
+  ResolvedModule,
+} from "./types.js";

--- a/packages/compiler/src/module-resolver/node-package-resolver.ts
+++ b/packages/compiler/src/module-resolver/node-package-resolver.ts
@@ -1,0 +1,65 @@
+import { joinPaths, resolvePath } from "../core/path-utils.js";
+import { NodePackage, ResolveModuleHost } from "./types.js";
+import { isFile, listDirHierarchy, readPackage } from "./utils.js";
+
+/**
+ * Utility to resolve node packages.
+ */
+export class NodePackageResolver {
+  #host: ResolveModuleHost;
+
+  constructor(host: ResolveModuleHost) {
+    this.#host = host;
+  }
+
+  /**
+   * Resolve a node package with the given specifier from the baseDir.
+   * @param specifier Node package specifier
+   * @returns NodePackage if found or undefined otherwise
+   */
+  async resolve(specifier: string, baseDir: string): Promise<NodePackage | undefined> {
+    return (
+      (await this.resolveSelf(specifier, baseDir)) ??
+      (await this.resolveFromNodeModules(specifier, baseDir))
+    );
+  }
+
+  /**
+   * Resolve the NodePackage for the given specifier
+   * Implementation from LOAD_PACKAGE_SELF minus the exports resolution which is called separately.
+   */
+  async resolveSelf(packageName: string, baseDir: string): Promise<NodePackage | undefined> {
+    for (const dir of listDirHierarchy(baseDir)) {
+      const pkgFile = resolvePath(dir, "package.json");
+      if (!(await isFile(this.#host, pkgFile))) continue;
+      const pkg = await readPackage(this.#host, pkgFile);
+      if (pkg.name === packageName) {
+        return pkg;
+      } else {
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve a node package from `node_modules`. Follows the implementation of LOAD_NODE_MODULES minus following the exports field.
+   */
+  async resolveFromNodeModules(
+    packageName: string,
+    baseDir: string,
+  ): Promise<NodePackage | undefined> {
+    const dirs = listDirHierarchy(baseDir);
+
+    for (const dir of dirs) {
+      const path = joinPaths(dir, "node_modules", packageName);
+      const pkgFile = resolvePath(path, "package.json");
+
+      if (await isFile(this.#host, pkgFile)) {
+        const pkg = await readPackage(this.#host, pkgFile);
+        if (pkg) return pkg;
+      }
+    }
+    return undefined;
+  }
+}

--- a/packages/compiler/src/module-resolver/types.ts
+++ b/packages/compiler/src/module-resolver/types.ts
@@ -1,0 +1,51 @@
+import { PackageJson } from "../types/package-json.js";
+
+export interface ResolveModuleHost {
+  /**
+   * Resolve the real path for the current host.
+   */
+  realpath(path: string): Promise<string>;
+
+  /**
+   * Get information about the given path
+   */
+  stat(path: string): Promise<{ isDirectory(): boolean; isFile(): boolean }>;
+
+  /**
+   * Read a utf-8 encoded file.
+   */
+  readFile(path: string): Promise<string>;
+}
+
+export type ModuleResolutionResult = ResolvedFile | ResolvedModule;
+
+export interface ResolvedFile {
+  type: "file";
+  path: string;
+}
+
+export interface ResolvedModule {
+  type: "module";
+
+  /**
+   * Root of the package. (Same level as package.json)
+   */
+  path: string;
+
+  /**
+   * Resolved main file for the module.
+   */
+  mainFile: string;
+
+  /**
+   * Value of package.json.
+   */
+  manifest: PackageJson;
+}
+
+export interface NodePackage extends PackageJson {
+  readonly file: {
+    readonly path: string;
+    readonly text: string;
+  };
+}

--- a/packages/compiler/src/module-resolver/types.ts
+++ b/packages/compiler/src/module-resolver/types.ts
@@ -44,6 +44,8 @@ export interface ResolvedModule {
 }
 
 export interface NodePackage extends PackageJson {
+  /** Package root dir(Where package.json is located) */
+  readonly dir: string;
   readonly file: {
     readonly path: string;
     readonly text: string;

--- a/packages/compiler/src/module-resolver/utils.ts
+++ b/packages/compiler/src/module-resolver/utils.ts
@@ -1,4 +1,5 @@
 import { dirname } from "path";
+import { getDirectoryPath } from "../core/path-utils.js";
 import type { NodePackage, ResolveModuleHost } from "./types.js";
 
 export interface NodeModuleSpecifier {
@@ -67,4 +68,18 @@ export function fileURLToPath(url: string) {
   }
 
   return decodeURIComponent(pathname);
+}
+
+/**
+ * Returns a list of all the parent directory and the given one.
+ */
+export function listDirHierarchy(baseDir: string): string[] {
+  const paths = [baseDir];
+  let current = getDirectoryPath(baseDir);
+  while (current !== paths[paths.length - 1]) {
+    paths.push(current);
+    current = getDirectoryPath(current);
+  }
+
+  return paths;
 }

--- a/packages/compiler/src/module-resolver/utils.ts
+++ b/packages/compiler/src/module-resolver/utils.ts
@@ -1,3 +1,4 @@
+import { dirname } from "path";
 import type { NodePackage, ResolveModuleHost } from "./types.js";
 
 export interface NodeModuleSpecifier {
@@ -27,6 +28,7 @@ export async function readPackage(host: ResolveModuleHost, pkgfile: string): Pro
   const content = await host.readFile(pkgfile);
   return {
     ...JSON.parse(content),
+    dir: dirname(pkgfile),
     file: {
       path: pkgfile,
       text: content,

--- a/packages/compiler/src/module-resolver/utils.ts
+++ b/packages/compiler/src/module-resolver/utils.ts
@@ -1,4 +1,3 @@
-import { dirname } from "path";
 import { getDirectoryPath } from "../core/path-utils.js";
 import type { NodePackage, ResolveModuleHost } from "./types.js";
 
@@ -29,7 +28,7 @@ export async function readPackage(host: ResolveModuleHost, pkgfile: string): Pro
   const content = await host.readFile(pkgfile);
   return {
     ...JSON.parse(content),
-    dir: dirname(pkgfile),
+    dir: getDirectoryPath(pkgfile),
     file: {
       path: pkgfile,
       text: content,

--- a/packages/compiler/src/module-resolver/utils.ts
+++ b/packages/compiler/src/module-resolver/utils.ts
@@ -1,3 +1,5 @@
+import type { NodePackage, ResolveModuleHost } from "./types.js";
+
 export interface NodeModuleSpecifier {
   readonly packageName: string;
   readonly subPath: string;
@@ -19,4 +21,48 @@ export function parseNodeModuleSpecifier(id: string): NodeModuleSpecifier | null
   // my-package/foo.js -> my-package
   // my-package -> my-package
   return { packageName: split[0], subPath: split.slice(1).join("/") };
+}
+
+export async function readPackage(host: ResolveModuleHost, pkgfile: string): Promise<NodePackage> {
+  const content = await host.readFile(pkgfile);
+  return {
+    ...JSON.parse(content),
+    file: {
+      path: pkgfile,
+      text: content,
+    },
+  };
+}
+
+export async function isFile(host: ResolveModuleHost, path: string) {
+  try {
+    const stats = await host.stat(path);
+    return stats.isFile();
+  } catch (e: any) {
+    if (e.code === "ENOENT" || e.code === "ENOTDIR") {
+      return false;
+    }
+    throw e;
+  }
+}
+export function pathToFileURL(path: string): string {
+  return `file://${path}`;
+}
+
+export function fileURLToPath(url: string) {
+  if (!url.startsWith("file://")) throw new Error("Cannot convert non file: URL to path");
+
+  const pathname = url.slice("file://".length);
+
+  for (let n = 0; n < pathname.length; n++) {
+    if (pathname[n] === "%") {
+      const third = pathname.codePointAt(n + 2)! | 0x20;
+
+      if (pathname[n + 1] === "2" && third === 102) {
+        throw new Error("Invalid url to path: must not include encoded / characters");
+      }
+    }
+  }
+
+  return decodeURIComponent(pathname);
 }

--- a/packages/compiler/src/runner.ts
+++ b/packages/compiler/src/runner.ts
@@ -1,7 +1,7 @@
 import { access, readFile, realpath, stat } from "fs/promises";
 import { join, resolve } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
-import { ResolveModuleHost, resolveModule } from "./module-resolver/module-resolver.js";
+import { ResolveModuleHost, resolveModule } from "./module-resolver/index.js";
 
 /**
  * Run script given by relative path from @typespec/compiler package root.

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -97,7 +97,7 @@ import { validateTemplateDefinitions } from "../init/init-template-validate.js";
 import { InitTemplate } from "../init/init-template.js";
 import { scaffoldNewProject } from "../init/scaffold.js";
 import { typespecVersion } from "../manifest.js";
-import { resolveModule, ResolveModuleHost } from "../module-resolver/module-resolver.js";
+import { resolveModule, ResolveModuleHost } from "../module-resolver/index.js";
 import { listAllFilesInDir } from "../utils/fs-utils.js";
 import { getNormalizedRealPath, resolveTspMain } from "../utils/misc.js";
 import { getSemanticTokens } from "./classify.js";

--- a/packages/compiler/src/testing/test-compiler-host.ts
+++ b/packages/compiler/src/testing/test-compiler-host.ts
@@ -10,8 +10,17 @@ export const StandardTestLibrary: TypeSpecTestLibrary = {
   name: "@typespec/compiler",
   packageRoot: CompilerPackageRoot,
   files: [
-    { virtualPath: "./.tsp/dist/src/lib", realDir: "./dist/src/lib", pattern: "**" },
-    { virtualPath: "./.tsp/lib", realDir: "./lib", pattern: "**" },
+    {
+      virtualPath: "./node_modules/@typespec/compiler/dist/src",
+      realDir: "./dist/src",
+      pattern: "index.js",
+    },
+    {
+      virtualPath: "./node_modules/@typespec/compiler/dist/src/lib",
+      realDir: "./dist/src/lib",
+      pattern: "**",
+    },
+    { virtualPath: "./node_modules/@typespec/compiler/lib", realDir: "./lib", pattern: "**" },
   ],
 };
 
@@ -26,9 +35,9 @@ export function createTestCompilerHost(
   jsImports: Map<string, Record<string, any>>,
   options?: TestHostOptions,
 ): CompilerHost {
-  const libDirs = [resolveVirtualPath(".tsp/lib/std")];
+  const libDirs = [resolveVirtualPath("./node_modules/@typespec/compiler/lib/std")];
   if (!options?.excludeTestLib) {
-    libDirs.push(resolveVirtualPath(".tsp/test-lib"));
+    libDirs.push(resolveVirtualPath("./node_modules/@typespec/compiler/test-lib"));
   }
 
   return {
@@ -84,7 +93,7 @@ export function createTestCompilerHost(
     },
 
     getExecutionRoot() {
-      return resolveVirtualPath(".tsp");
+      return resolveVirtualPath("./node_modules/@typespec/compiler");
     },
 
     async getJsImport(path) {
@@ -146,8 +155,8 @@ export function createTestCompilerHost(
 export function addTestLib(fs: TestFileSystem): Record<string, Type> {
   const testTypes: Record<string, Type> = {};
   // add test decorators
-  fs.add(".tsp/test-lib/main.tsp", 'import "./test.js";');
-  fs.addJsFile(".tsp/test-lib/test.js", {
+  fs.add("./node_modules/@typespec/compiler/test-lib/main.tsp", 'import "./test.js";');
+  fs.addJsFile("./node_modules/@typespec/compiler/test-lib/test.js", {
     namespace: "TypeSpec",
     $test(_: any, target: Type, nameLiteral?: StringLiteral) {
       let name = nameLiteral?.value;

--- a/packages/compiler/src/testing/tester.ts
+++ b/packages/compiler/src/testing/tester.ts
@@ -87,6 +87,26 @@ async function createTesterFs(base: string, options: TesterOptions) {
         resolvePath("node_modules", lib, "package.json"),
         (resolved.manifest as any).file.text,
       );
+
+      if (typeof resolved.manifest.exports === "object" && resolved.manifest.exports !== null) {
+        for (const [key, value] of Object.entries(resolved.manifest.exports)) {
+          if (key === ".") continue; // already handled
+          if (typeof value === "object" && value !== null && "typespec" in value) {
+            await sl.importPath(
+              resolvePath(resolved.path, value["typespec"] as string),
+              NoTarget,
+              lib,
+              {
+                type: "library",
+                metadata: {
+                  type: "module",
+                  name: resolved.manifest.name,
+                },
+              },
+            );
+          }
+        }
+      }
     }
   }
 

--- a/packages/compiler/src/testing/tester.ts
+++ b/packages/compiler/src/testing/tester.ts
@@ -88,7 +88,7 @@ async function createTesterFs(base: string, options: TesterOptions) {
     if (specifier.subPath !== "") {
       // eslint-disable-next-line no-console
       console.warn(
-        `Warning: Defining a subpath of a library is unnecessary. Just import the library. Ignoring the subpath in '${lib}'`,
+        `Warning: Defining a subpath '${lib}' of a library is unnecessary. Just import the library. Ignoring the subpath in '${lib}'`,
       );
       continue;
     }

--- a/packages/compiler/test/libraries/libraries.test.ts
+++ b/packages/compiler/test/libraries/libraries.test.ts
@@ -29,17 +29,17 @@ describe("compiler: libraries", () => {
 
   it("detects compiler version mismatches", async () => {
     const testHost = await createTestHost();
-    testHost.addTypeSpecFile("main.tsp", "");
+    testHost.addTypeSpecFile("other/main.tsp", "");
     testHost.addTypeSpecFile(
-      "./node_modules/@typespec/compiler/package.json",
+      "./other/node_modules/@typespec/compiler/package.json",
       JSON.stringify({
         name: "@typespec/compiler",
         main: "index.js",
         version: "0.1.0-notthesame.1",
       }),
     );
-    testHost.addJsFile("./node_modules/@typespec/compiler/index.js", {});
-    const diagnostics = await testHost.diagnose("main.tsp");
+    testHost.addJsFile("./other/node_modules/@typespec/compiler/index.js", {});
+    const diagnostics = await testHost.diagnose("other/main.tsp");
     expectDiagnostics(diagnostics, {
       code: "compiler-version-mismatch",
       severity: "warning",

--- a/packages/compiler/test/module-resolver/module-resolver.test.ts
+++ b/packages/compiler/test/module-resolver/module-resolver.test.ts
@@ -3,7 +3,7 @@ import {
   resolveModule,
   ResolveModuleError,
   type ResolveModuleHost,
-} from "../../src/module-resolver/module-resolver.js";
+} from "../../src/module-resolver/index.js";
 import { TestHostError } from "../../src/testing/types.js";
 
 function mkFs(files: Record<string, string>): {

--- a/packages/compiler/test/module-resolver/module-resolver.test.ts
+++ b/packages/compiler/test/module-resolver/module-resolver.test.ts
@@ -403,6 +403,27 @@ describe("resolve self", () => {
     });
   });
 
+  it("loads self sub exports", async () => {
+    const { host } = mkFs({
+      "/ws/proj/package.json": JSON.stringify({
+        name: "@scope/proj",
+        exports: { ".": "./entry.js", "./subpath": "./subpath.js" },
+      }),
+      "/ws/proj/entry.js": "",
+      "/ws/proj/subpath.js": "",
+    });
+
+    const resolved = await resolveModule(host, "@scope/proj/subpath", {
+      baseDir: "/ws/proj/node_modules/test-lib/nested",
+    });
+    const path = "/ws/proj";
+    expect(resolved).toMatchObject({
+      type: "module",
+      path,
+      mainFile: `${path}/subpath.js`,
+    });
+  });
+
   it("prioritize local node_modules over self from multiple parent up", async () => {
     const { host } = mkFs({
       "/ws/proj/package.json": JSON.stringify({ name: "@scope/proj", main: "entry.js" }),

--- a/packages/compiler/test/testing/tester-library-discovery.test.ts
+++ b/packages/compiler/test/testing/tester-library-discovery.test.ts
@@ -24,7 +24,7 @@ it("add library base export", async () => {
     "node_modules/mylib/index.js": mockFile.js({}),
     "node_modules/mylib/main.tsp": "model FromMyLib {}",
   });
-  const Tester = createTester(resolveVirtualPath("/test"), {
+  const Tester = createTester(resolveVirtualPath(""), {
     host: fs,
     libraries: ["mylib"],
   });
@@ -44,7 +44,7 @@ it("subpath typespec export get added to the test host", async () => {
     "node_modules/mylib/index.js": mockFile.js({}),
     "node_modules/mylib/subpath.tsp": "",
   });
-  const Tester = createTester(resolveVirtualPath("/test"), {
+  const Tester = createTester(resolveVirtualPath(""), {
     host: fs,
     libraries: ["mylib"],
   });

--- a/packages/compiler/test/testing/tester-library-discovery.test.ts
+++ b/packages/compiler/test/testing/tester-library-discovery.test.ts
@@ -1,0 +1,52 @@
+import { it } from "vitest";
+import { CompilerHost } from "../../src/core/types.js";
+import { createTestFileSystem, mockFile } from "../../src/testing/fs.js";
+import { resolveVirtualPath } from "../../src/testing/test-utils.js";
+import { createTester } from "../../src/testing/tester.js";
+import { MockFile } from "../../src/testing/types.js";
+
+function mkFs(files: Record<string, string | MockFile>): CompilerHost {
+  const fs = createTestFileSystem();
+  for (const [k, v] of Object.entries(files)) {
+    fs.add(k, v);
+  }
+  return fs.compilerHost;
+}
+
+it("add library base export", async () => {
+  const fs = mkFs({
+    "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+    "node_modules/mylib/package.json": JSON.stringify({
+      name: "mylib",
+      version: "1.0.0",
+      exports: { ".": { import: "./index.js", typespec: "./main.tsp" } },
+    }),
+    "node_modules/mylib/index.js": mockFile.js({}),
+    "node_modules/mylib/main.tsp": "model FromMyLib {}",
+  });
+  const Tester = createTester(resolveVirtualPath("/test"), {
+    host: fs,
+    libraries: ["mylib"],
+  });
+  await Tester.compile(`import "mylib";
+    alias Test = FromMyLib;  
+  `);
+});
+
+it("subpath typespec export get added to the test host", async () => {
+  const fs = mkFs({
+    "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+    "node_modules/mylib/package.json": JSON.stringify({
+      name: "mylib",
+      version: "1.0.0",
+      exports: { ".": { import: "./index.js" }, "./subpath": { typespec: "./subpath.tsp" } },
+    }),
+    "node_modules/mylib/index.js": mockFile.js({}),
+    "node_modules/mylib/subpath.tsp": "",
+  });
+  const Tester = createTester(resolveVirtualPath("/test"), {
+    host: fs,
+    libraries: ["mylib"],
+  });
+  await Tester.compile(`import "mylib/subpath";`);
+});

--- a/packages/compiler/test/testing/tester.test.ts
+++ b/packages/compiler/test/testing/tester.test.ts
@@ -1,5 +1,3 @@
-// TODO: rename?
-
 import { strictEqual } from "assert";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { resolvePath } from "../../src/core/path-utils.js";
@@ -11,7 +9,6 @@ import {
   Model,
   navigateProgram,
   ObjectValue,
-  Program,
 } from "../../src/index.js";
 import { mockFile } from "../../src/testing/fs.js";
 import { t } from "../../src/testing/marked-template.js";
@@ -19,26 +16,6 @@ import { resolveVirtualPath } from "../../src/testing/test-utils.js";
 import { createTester } from "../../src/testing/tester.js";
 
 const Tester = createTester(resolvePath(import.meta.dirname, "../.."), { libraries: [] });
-
-it("generic type", async () => {
-  const res = await Tester.compile(t.code`
-      model ${t.model("Foo")} {} 
-      enum ${t.enum("Bar")} {} 
-      union /*Baz*/Baz {} 
-    `);
-  expect(res.Foo.kind).toBe("Model");
-
-  expectTypeOf({
-    Foo: res.Foo,
-    Bar: res.Bar,
-    Baz: res.Baz,
-    program: res.program,
-  }).toExtend<{
-    Foo: Model;
-    Bar: Enum;
-    program: Program;
-  }>();
-});
 
 describe("extract types", () => {
   it("generic type", async () => {

--- a/packages/compiler/test/testing/tester.test.ts
+++ b/packages/compiler/test/testing/tester.test.ts
@@ -1,3 +1,5 @@
+// TODO: rename?
+
 import { strictEqual } from "assert";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { resolvePath } from "../../src/core/path-utils.js";
@@ -9,6 +11,7 @@ import {
   Model,
   navigateProgram,
   ObjectValue,
+  Program,
 } from "../../src/index.js";
 import { mockFile } from "../../src/testing/fs.js";
 import { t } from "../../src/testing/marked-template.js";
@@ -16,6 +19,26 @@ import { resolveVirtualPath } from "../../src/testing/test-utils.js";
 import { createTester } from "../../src/testing/tester.js";
 
 const Tester = createTester(resolvePath(import.meta.dirname, "../.."), { libraries: [] });
+
+it("generic type", async () => {
+  const res = await Tester.compile(t.code`
+      model ${t.model("Foo")} {} 
+      enum ${t.enum("Bar")} {} 
+      union /*Baz*/Baz {} 
+    `);
+  expect(res.Foo.kind).toBe("Model");
+
+  expectTypeOf({
+    Foo: res.Foo,
+    Bar: res.Bar,
+    Baz: res.Baz,
+    program: res.program,
+  }).toExtend<{
+    Foo: Model;
+    Bar: Enum;
+    program: Program;
+  }>();
+});
 
 describe("extract types", () => {
   it("generic type", async () => {

--- a/packages/protobuf/test/scenarios.test.ts
+++ b/packages/protobuf/test/scenarios.test.ts
@@ -129,7 +129,7 @@ describe("protobuf scenarios", function () {
  */
 function removeCoreDiagnostics(diagnostics: string[]): string[] {
   return diagnostics.map((d) => {
-    if (d.startsWith("/test/.tsp")) {
+    if (d.startsWith("/test/node_modules/@typespec/compiler/")) {
       return d.replace(/^[^\s]*:[0-9]+:[0-9]+ - /, "<in core> - ");
     } else return d;
   });


### PR DESCRIPTION
This PR does a few things
- Some refactoring of the module resolver to expose just the node package resolution separately
  -  Fix issue from the spec which didn't allow importing subpath of self
- Tester will load all the typespec entrypoints defines in `exports` 