### PR TITLE
visibility: apply name template to inner mutations in Update transform

### DIFF
--- a/.chronus/changes/main-2025-9-7-12-33-46.md
+++ b/.chronus/changes/main-2025-9-7-12-33-46.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Addressed an issue where applying the `Update` visibility transform would not correctly rename nested models.

--- a/packages/compiler/src/lib/visibility.ts
+++ b/packages/compiler/src/lib/visibility.ts
@@ -480,7 +480,9 @@ export const $withLifecycleUpdate: WithLifecycleUpdateDecorator = (
       any: new Set([lifecycle.members.get("Create")!, lifecycle.members.get("Update")!]),
     };
 
-    const createOrUpdateMutator = createVisibilityFilterMutator(lifecycleCreateOrUpdate);
+    const createOrUpdateMutator = createVisibilityFilterMutator(lifecycleCreateOrUpdate, {
+      nameTemplate,
+    });
 
     mutator = createVisibilityFilterMutator(lifecycleUpdate, {
       recur: createOrUpdateMutator,

--- a/packages/compiler/test/visibility.test.ts
+++ b/packages/compiler/test/visibility.test.ts
@@ -737,31 +737,33 @@ describe("compiler: visibility core", () => {
           @invisible(Lifecycle)
           invisible: string;
 
-          nested: {
-            @visibility(${Lifecycle.Read})
-            r: string;
-
-            cru: string;
-
-            @visibility(${Lifecycle.Create}, ${Lifecycle.Read})
-            cr: string;
-
-            @visibility(${Lifecycle.Create}, ${Lifecycle.Update})
-            cu: string;
-
-            @visibility(${Lifecycle.Create})
-            c: string;
-
-            @visibility(${Lifecycle.Update}, ${Lifecycle.Read})
-            ru: string;
-
-            @visibility(${Lifecycle.Update})
-            u: string;
-
-            @invisible(Lifecycle)
-            invisible: string;
-          };
+          nested: Nested;
         }
+
+        model Nested {
+          @visibility(${Lifecycle.Read})
+          r: string;
+
+          cru: string;
+
+          @visibility(${Lifecycle.Create}, ${Lifecycle.Read})
+          cr: string;
+
+          @visibility(${Lifecycle.Create}, ${Lifecycle.Update})
+          cu: string;
+
+          @visibility(${Lifecycle.Create})
+          c: string;
+
+          @visibility(${Lifecycle.Update}, ${Lifecycle.Read})
+          ru: string;
+
+          @visibility(${Lifecycle.Update})
+          u: string;
+
+          @invisible(Lifecycle)
+          invisible: string;
+        };
 
         // This ensures the transforms are non-side-effecting.
         model ReadExample is Read<Example>;
@@ -1280,6 +1282,7 @@ function validateCreateOrUpdateTransform(
 
   ok(nested);
   ok(nested.type.kind === "Model");
+  ok(nested.type.name === "CreateOrUpdateNested");
 
   const nestedProps = getProperties(nested.type);
 
@@ -1333,6 +1336,7 @@ function validateUpdateTransform(
 
   ok(nested);
   ok(nested.type.kind === "Model");
+  ok(nested.type.name === "UpdateNested");
 
   // Nested properties work differently in Lifecycle Update transforms, requiring nested create-only properties to
   // additionally be visible
@@ -1388,6 +1392,7 @@ function validateCreateTransform(
 
   ok(nested);
   ok(nested.type.kind === "Model");
+  ok(nested.type.name === "CreateNested");
 
   const nestedProps = getProperties(nested.type);
 
@@ -1442,6 +1447,7 @@ function validateReadTransform(
 
   ok(nested);
   ok(nested.type.kind === "Model");
+  ok(nested.type.name === "ReadNested");
 
   const nestedProps = getProperties(nested.type);
 


### PR DESCRIPTION
This was an oversight. The PR corrects the construction of the mutators to pass the name template through the inner mutator and adds tests for regression.

Closes #8653 