### PR TITLE
Fix enum value property customization

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/CSharpTypeExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/CSharpTypeExtensions.cs
@@ -129,6 +129,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             {
                 InputNullableType nullableType => GetInputEnumType(nullableType.Type),
                 InputEnumType enumType => enumType,
+                InputEnumTypeValue enumValueType => enumValueType.EnumType,
                 InputArrayType arrayType => GetInputEnumType(arrayType.ValueType),
                 InputDictionaryType dictionaryType => GetInputEnumType(dictionaryType.ValueType),
                 _ => null

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -1130,8 +1130,8 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         public async Task CanCustomizeLiteralEnumProperty()
         {
             await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
-            var enumVal1 = InputFactory.EnumMember.String("val1", "val1", InputFactory.StringEnum("mockInputEnum", []));
-            var inputModel = InputFactory.Model("mockInputModel", properties: [InputFactory.Property("prop1", enumVal1)]);
+            var enumVal = InputFactory.EnumMember.String("val1", "val1", InputFactory.StringEnum("mockInputEnum", []));
+            var inputModel = InputFactory.Model("mockInputModel", properties: [InputFactory.Property("prop1", enumVal)]);
             var modelTypeProvider = new ModelProvider(inputModel);
 
             var canonicalView = modelTypeProvider.CanonicalView;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -1127,6 +1127,22 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         }
 
         [Test]
+        public async Task CanCustomizeLiteralEnumProperty()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var enumVal1 = InputFactory.EnumMember.String("val1", "val1", InputFactory.StringEnum("mockInputEnum", []));
+            var inputModel = InputFactory.Model("mockInputModel", properties: [InputFactory.Property("prop1", enumVal1)]);
+            var modelTypeProvider = new ModelProvider(inputModel);
+
+            var canonicalView = modelTypeProvider.CanonicalView;
+            Assert.IsNotNull(canonicalView);
+            Assert.AreEqual(1, canonicalView.Properties.Count);
+            Assert.AreEqual("Prop1", canonicalView.Properties[0].Name);
+            Assert.AreEqual("MockInputEnum", canonicalView.Properties[0].Type.Name);
+            Assert.AreEqual("Sample.Models", canonicalView.Properties[0].Type.Namespace);
+        }
+
+        [Test]
         public void CanCustomizeRelativeFilePath()
         {
             MockHelpers.LoadMockGenerator();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeLiteralEnumProperty/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeLiteralEnumProperty/MockInputModel.cs
@@ -1,0 +1,12 @@
+#nullable disable
+
+using Sample;
+using SampleTypeSpec;
+
+namespace Sample.Models
+{
+    public partial class MockInputModel
+    {
+        public MockInputEnum Prop1 { get; } = "val2"
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeLiteralEnumProperty/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CanCustomizeLiteralEnumProperty/MockInputModel.cs
@@ -7,6 +7,6 @@ namespace Sample.Models
 {
     public partial class MockInputModel
     {
-        public MockInputEnum Prop1 { get; } = "val2"
+        public MockInputEnum Prop1 { get; } = "val1"
     }
 }


### PR DESCRIPTION
Fixes issue where customization of a property having a specific enum value was not retaining the namespace