### PR TITLE
Revert "[python] fix indentation error when generating deserialized code for internal error models"

### DIFF
--- a/.chronus/changes/python-indentationError-2025-9-7-15-0-3.md
+++ b/.chronus/changes/python-indentationError-2025-9-7-15-0-3.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@typespec/http-client-python"
----
-
-Fix indentation issue when deserializing internal error model

--- a/packages/http-client-python/generator/pygen/codegen/models/operation.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/operation.py
@@ -201,10 +201,9 @@ class OperationBase(  # pylint: disable=too-many-public-methods,too-many-instanc
             pylint_disable = "  # pylint: disable=protected-access" if exception_schema.internal else ""
             return (
                 exception_schema.type_annotation(skip_quote=True, serialize_namespace=serialize_namespace)
-                + ", "
                 + pylint_disable
             )
-        return None if self.code_model.options["models-mode"] == "dpg" else "'object',"
+        return None if self.code_model.options["models-mode"] == "dpg" else "'object'"
 
     @property
     def non_default_errors(self) -> list[Response]:

--- a/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
@@ -1049,22 +1049,14 @@ class _OperationSerializer(_BuilderBaseSerializer[OperationType]):
                             is_operation_file=True, skip_quote=True, serialize_namespace=self.serialize_namespace
                         )
                         if self.code_model.options["models-mode"] == "dpg":
-                            retval.extend(
-                                [
-                                    "        error = _failsafe_deserialize(",
-                                    f"            {type_annotation},{pylint_disable}",
-                                    "            response,",
-                                    "        )",
-                                ]
+                            retval.append(
+                                f"        error = _failsafe_deserialize({type_annotation},{pylint_disable}\n  response)"
                             )
                         else:
-                            retval.extend(
-                                [
-                                    "        error = self._deserialize.failsafe_deserialize(",
-                                    f"            {type_annotation},{pylint_disable}",
-                                    "            pipeline_response",
-                                    "        )",
-                                ]
+                            retval.append(
+                                "        error = self._deserialize.failsafe_deserialize("
+                                f"{type_annotation},{pylint_disable}\n "
+                                "pipeline_response)"
                             )
                         # add build-in error type
                         # TODO: we should decide whether need to this wrapper for customized error type
@@ -1095,31 +1087,20 @@ class _OperationSerializer(_BuilderBaseSerializer[OperationType]):
                     )
                     if self.code_model.options["models-mode"] == "dpg":
                         if xml_serializable(str(e.default_content_type)):
-                            retval.extend(
-                                [
-                                    "        error = _failsafe_deserialize_xml("
-                                    f"            {type_annotation},{pylint_disable}",
-                                    "            response",
-                                    "        )",
-                                ]
+                            retval.append(
+                                "        error = _failsafe_deserialize_xml("
+                                f"{type_annotation},{pylint_disable}\n  response)"
                             )
                         else:
-                            retval.extend(
-                                [
-                                    "        error = _failsafe_deserialize(",
-                                    f"            {type_annotation},{pylint_disable}",
-                                    "            response",
-                                    "        )",
-                                ]
+                            retval.append(
+                                "        error = _failsafe_deserialize("
+                                f"{type_annotation},{pylint_disable}\n  response)"
                             )
                     else:
-                        retval.extend(
-                            [
-                                "        error = self._deserialize.failsafe_deserialize(",
-                                f"            {type_annotation},{pylint_disable}",
-                                "            pipeline_response",
-                                "        )",
-                            ]
+                        retval.append(
+                            "        error = self._deserialize.failsafe_deserialize("
+                            f"{type_annotation},{pylint_disable}\n  "
+                            "pipeline_response)"
                         )
                     condition = "elif"
         # default error handling
@@ -1130,20 +1111,11 @@ class _OperationSerializer(_BuilderBaseSerializer[OperationType]):
             if builder.non_default_errors:
                 retval.append("    else:")
             if self.code_model.options["models-mode"] == "dpg":
-                retval.extend(
-                    [
-                        f"{indent}error = _failsafe_deserialize(",
-                        f"{indent}   {default_error_deserialization}",
-                        f"{indent}    response,",
-                        f"{indent})",
-                    ]
-                )
+                retval.append(f"{indent}error = _failsafe_deserialize({default_error_deserialization}, response)")
             else:
-                retval.extend(
-                    [
-                        f"{indent}error = self._deserialize.failsafe_deserialize(",
-                        f"{indent}    {default_error_deserialization}," f"{indent}    pipeline_response" f"{indent})",
-                    ]
+                retval.append(
+                    f"{indent}error = self._deserialize.failsafe_deserialize({default_error_deserialization}, "
+                    "pipeline_response)"
                 )
         retval.append(
             "    raise HttpResponseError(response=response{}{})".format(


### PR DESCRIPTION
Reverts microsoft/typespec#8680

This PR will cause regeneration failure in autorest.python : https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5431027&view=logs&j=bdb939de-aec3-5086-18f3-4b01b4ec4195&t=e0b74152-f1d7-5f23-b222-7ca4870e75b0. Since we need to release a bug fix version ASAP to unblock SDK release, we have to revert this PR for now.