### PR TITLE
fix: use enum member name expression when ref custom enum types

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -169,6 +169,15 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
                 // Get the semantic model to evaluate constant values
                 var semanticModel = _compilation.GetSemanticModel(propertySyntax.SyntaxTree);
+                // Check if this is an enum member access
+                var symbolInfo = semanticModel.GetSymbolInfo(initializerValue);
+                if (symbolInfo.Symbol is IFieldSymbol fieldSymbol
+                    && fieldSymbol.ContainingType?.TypeKind == TypeKind.Enum)
+                {
+                    var enumType = fieldSymbol.ContainingType.GetCSharpType();
+                    return new MemberExpression(TypeReferenceExpression.FromType(enumType), fieldSymbol.Name);
+                }
+
                 var constantValue = semanticModel.GetConstantValue(initializerValue);
 
                 if (constantValue.HasValue)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -1205,7 +1205,8 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.AreEqual(0, modelFactoryMethod!.Signature.Parameters.Count);
 
             // default value should be passed in the model factory method body
-            StringAssert.Contains("0,", modelFactoryMethod.BodyStatements!.ToDisplayString());
+            var result = modelFactoryMethod.BodyStatements!.ToDisplayString();
+            StringAssert.Contains("global::Sample.Models.MockInputEnum.Val1", result);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestNamedSymbol.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestNamedSymbol.cs
@@ -22,6 +22,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
         private readonly bool _parameterIsIn;
         private readonly bool _parameterIsOut;
         private readonly bool _parameterIsRef;
+        private readonly bool _initializeEnumProperty;
         protected override string BuildRelativeFilePath() => ".";
 
         protected override string BuildName() => _typeName;
@@ -37,7 +38,8 @@ namespace Microsoft.TypeSpec.Generator.Tests
             bool isStruct = false,
             bool parameterIsIn = false,
             bool parameterIsOut = false,
-            bool parameterIsRef = false)
+            bool parameterIsRef = false,
+            bool initializeEnumProperty = false)
         {
             _propertyType = propertyType;
             _parameterType = parameterType;
@@ -48,6 +50,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
             _parameterIsIn = parameterIsIn;
             _parameterIsOut = parameterIsOut;
             _parameterIsRef = parameterIsRef;
+            _initializeEnumProperty = initializeEnumProperty;
         }
 
         protected override FieldProvider[] BuildFields()
@@ -84,10 +87,41 @@ namespace Microsoft.TypeSpec.Generator.Tests
                 ];
             }
 
+            ValueExpression? initializer = null;
+            CSharpType propertyType = new CSharpType(_propertyType);
+            
+            // If initializeEnumProperty is true and the property type is an enum, create an enum member initializer
+            if (_initializeEnumProperty && _propertyType.IsEnum)
+            {
+                // Get the first enum value to use as the initializer
+                var enumValues = Enum.GetValues(_propertyType);
+                if (enumValues.Length > 0)
+                {
+                    var firstValue = enumValues.GetValue(0);
+                    var firstValueName = Enum.GetName(_propertyType, firstValue!);
+
+                    // Create a CSharpType for the generated enum
+                    var enumType = new CSharpType(
+                        name: _propertyType.Name,
+                        ns: _typeNamespace,
+                        isValueType: true,
+                        isNullable: false,
+                        declaringType: null,
+                        args: [],
+                        isPublic: true,
+                        isStruct: false,
+                        baseType: null,
+                        underlyingEnumType: typeof(int));
+
+                    propertyType = enumType;
+                    initializer = new MemberExpression(TypeReferenceExpression.FromType(enumType), firstValueName!);
+                }
+            }
+
             return
             [
-                new PropertyProvider($"p1", MethodSignatureModifiers.Public, _propertyType, "P1",
-                    new AutoPropertyBody(true), this)
+                new PropertyProvider($"p1", MethodSignatureModifiers.Public, propertyType, "P1",
+                    new AutoPropertyBody(true, InitializationExpression: initializer), this)
             ];
         }
 


### PR DESCRIPTION
Fixes an issue when generating model factory methods,  and enum properties initialized with a default value were incorrectly using the enum's underlying numeric value (e.g., 0, 1) instead of the enum member name (e.g., EnumType.MemberName). This caused issues when the internal constructor accepted the enum type.

contributes to : https://github.com/microsoft/typespec/issues/8710