### PR TITLE
fix: always use custom service version enum members

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
@@ -25,43 +25,74 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected override IReadOnlyList<EnumTypeMember> BuildEnumValues()
         {
-            var customMembers = new HashSet<FieldProvider>(CustomCodeView?.Fields ?? []);
+            IReadOnlyList<FieldProvider> customFields = CustomCodeView?.Fields ?? [];
             List<EnumTypeMember> values = new(AllowedValues.Count);
+            bool shouldUseCustomMembers = customFields.Count > 0
+                && customFields.All(cm => cm.InitializationValue != null);
 
-            for (int i = 0; i < AllowedValues.Count; i++)
+            if (shouldUseCustomMembers)
             {
-                var inputValue = AllowedValues[i];
-                var modifiers = FieldModifiers.Public | FieldModifiers.Static;
-                var name = inputValue.Name.ToApiVersionMemberName();
-
-                // check if the enum member was renamed in custom code
-                string? customMemberName = null;
-                foreach (var customMember in customMembers)
+                values = BuildCustomEnumMembers(customFields);
+            }
+            else
+            {
+                var customMembers = new HashSet<FieldProvider>(customFields);
+                for (int i = 0; i < AllowedValues.Count; i++)
                 {
-                    if (customMember.OriginalName == name)
+                    var inputValue = AllowedValues[i];
+                    var modifiers = FieldModifiers.Public | FieldModifiers.Static;
+                    var name = inputValue.Name.ToApiVersionMemberName();
+
+                    // check if the enum member was renamed in custom code
+                    string? customMemberName = null;
+                    foreach (var customMember in customMembers)
                     {
-                        customMemberName = customMember.Name;
+                        if (customMember.OriginalName == name)
+                        {
+                            customMemberName = customMember.Name;
+                        }
                     }
+
+                    if (customMemberName != null)
+                    {
+                        name = customMemberName;
+                    }
+
+                    ValueExpression? initializationValue = Literal(i + 1);
+                    var field = new FieldProvider(
+                        modifiers,
+                        EnumUnderlyingType,
+                        name,
+                        this,
+                        DocHelpers.GetFormattableDescription(inputValue.Summary, inputValue.Doc) ?? $"{name}",
+                        initializationValue);
+
+                    values.Add(new EnumTypeMember(name, field, inputValue.Value));
                 }
-
-                if (customMemberName != null)
-                {
-                    name = customMemberName;
-                }
-
-                ValueExpression? initializationValue = Literal(i + 1);
-                var field = new FieldProvider(
-                    modifiers,
-                    EnumUnderlyingType,
-                    name,
-                    this,
-                    DocHelpers.GetFormattableDescription(inputValue.Summary, inputValue.Doc) ?? $"{name}",
-                    initializationValue);
-
-                values.Add(new EnumTypeMember(name, field, inputValue.Value));
             }
 
             return BuildApiVersionEnumValuesForBackwardCompatibility(values);
+        }
+
+        private List<EnumTypeMember> BuildCustomEnumMembers(IReadOnlyList<FieldProvider> customMembers)
+        {
+            List<EnumTypeMember> values = new(customMembers.Count);
+            for (int i = 0; i < customMembers.Count; i++)
+            {
+                var member = customMembers[i];
+                var modifiers = FieldModifiers.Public | FieldModifiers.Static;
+                var field = new FieldProvider(
+                    modifiers,
+                    EnumUnderlyingType,
+                    member.Name,
+                    this,
+                    $"",
+                    member.InitializationValue);
+
+                values.Add(new EnumTypeMember(member.Name, field, member.InitializationValue!));
+            }
+
+            return values;
         }
 
         private List<EnumTypeMember> BuildApiVersionEnumValuesForBackwardCompatibility(List<EnumTypeMember> currentApiVersions)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -120,7 +120,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
                         fieldSymbol.Type.GetCSharpType(),
                         fieldSymbol.Name,
                         this,
-                        GetSymbolXmlDoc(fieldSymbol, "summary"))
+                        GetSymbolXmlDoc(fieldSymbol, "summary"),
+                        initializationValue: GetFieldInitializer(fieldSymbol))
                     {
                         OriginalName = GetOriginalName(fieldSymbol)
                     };
@@ -188,6 +189,20 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // For non-constant expressions, return the expression text
                 return Literal(initializerValue.ToString());
             }
+            return null;
+        }
+
+        private static ValueExpression? GetFieldInitializer(IFieldSymbol fieldSymbol)
+        {
+            if (fieldSymbol.ContainingType?.TypeKind == TypeKind.Enum)
+            {
+                if (fieldSymbol.HasConstantValue && fieldSymbol.ConstantValue != null)
+                {
+                    return Literal(fieldSymbol.ConstantValue);
+                }
+                return null;
+            }
+
             return null;
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/ApiVersionEnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/ApiVersionEnumProviderTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using System.Threading.Tasks;
 using Moq;
 using Moq.Protected;
+using Microsoft.TypeSpec.Generator.Expressions;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Providers.EnumProviders
 {
@@ -108,6 +109,35 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.EnumProviders
             Assert.That(provider.Name, Is.EqualTo("ServiceVersion"));
             Assert.That(provider.EnumValues.Count, Is.EqualTo(3));
             Assert.IsTrue(provider.EnumValues.Select(v => v.Name).SequenceEqual(["V1_0_0", "V2_0_0", "V3_0_0"]));
+        }
+
+        [Test]
+        public async Task CustomEnumMembers()
+        {
+            string[] apiVersions = ["2.0.0", "3.0.0"];
+            var input = InputFactory.Int32Enum(
+                "mockInputEnum",
+                apiVersions.Select((a, index) => (a, index)),
+                usage: InputModelTypeUsage.ApiVersionEnum,
+                clientNamespace: "SampleNamespace");
+            await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var mockDeclaringType = new Mock<TypeProvider>();
+            mockDeclaringType.Protected().Setup<string>("BuildName").Returns("SampleNamespaceClientOptions");
+            mockDeclaringType.Protected().Setup<string>("BuildNamespace").Returns("SampleNamespace");
+            var enumType = EnumProvider.Create(input, mockDeclaringType.Object);
+            Assert.IsTrue(enumType is ApiVersionEnumProvider);
+
+            var provider = (ApiVersionEnumProvider)enumType;
+            Assert.IsNotNull(provider);
+            Assert.That(provider.Name, Is.EqualTo("ServiceVersion"));
+            Assert.That(provider.EnumValues.Count, Is.EqualTo(3));
+            Assert.AreEqual("V2023_10_01_Preview_1", provider.EnumValues[0].Name);
+            Assert.AreEqual(new LiteralExpression(0), provider.EnumValues[0].Value);
+            Assert.AreEqual("V2023_11_01", provider.EnumValues[1].Name);
+            Assert.AreEqual(new LiteralExpression(1), provider.EnumValues[1].Value);
+            Assert.AreEqual("V2024_01_01", provider.EnumValues[2].Name);
+            Assert.AreEqual(new LiteralExpression(2), provider.EnumValues[2].Value);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/TestData/ApiVersionEnumProviderTests/CustomEnumMembers/CustomEnumMembers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/TestData/ApiVersionEnumProviderTests/CustomEnumMembers/CustomEnumMembers.cs
@@ -1,0 +1,17 @@
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+
+namespace SampleNamespace
+{
+    public partial class SampleNamespaceClientOptions : ClientPipelineOptions
+    {
+        public enum ServiceVersion
+        {
+            V2023_10_01_Preview_1 = 0,
+            V2023_11_01 = 1,
+            V2024_01_01 = 2
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator.Expressions;
@@ -413,6 +412,44 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
             Assert.AreEqual("Foo", memberExpression!.MemberName);
         }
 
+        [Test]
+        public void ValidateEnumFieldsWithExplicitValues()
+        {
+            var enumProvider = new TestEnumWithValuesProvider();
+            var compilation = CompilationHelper.LoadCompilation([enumProvider]);
+            var iNamedSymbol = CompilationHelper.GetSymbol(compilation.Assembly.Modules.First().GlobalNamespace, "ServiceVersion");
+
+            var provider = new NamedTypeSymbolProvider(iNamedSymbol!, compilation);
+
+            // Validate that the enum has the expected fields
+            var fields = provider.Fields.ToDictionary(f => f.Name);
+            Assert.AreEqual(3, fields.Count);
+
+            // Validate V7_2 = 1
+            Assert.IsTrue(fields.ContainsKey("V7_2"));
+            var v72Field = fields["V7_2"];
+            Assert.IsNotNull(v72Field.InitializationValue);
+            Assert.IsInstanceOf<LiteralExpression>(v72Field.InitializationValue);
+            var v72Literal = v72Field.InitializationValue as LiteralExpression;
+            Assert.AreEqual(1, v72Literal!.Literal);
+
+            // Validate V7_3 = 2
+            Assert.IsTrue(fields.ContainsKey("V7_3"));
+            var v73Field = fields["V7_3"];
+            Assert.IsNotNull(v73Field.InitializationValue);
+            Assert.IsInstanceOf<LiteralExpression>(v73Field.InitializationValue);
+            var v73Literal = v73Field.InitializationValue as LiteralExpression;
+            Assert.AreEqual(2, v73Literal!.Literal);
+
+            // Validate V7_4 = 3
+            Assert.IsTrue(fields.ContainsKey("V7_4"));
+            var v74Field = fields["V7_4"];
+            Assert.IsNotNull(v74Field.InitializationValue);
+            Assert.IsInstanceOf<LiteralExpression>(v74Field.InitializationValue);
+            var v74Literal = v74Field.InitializationValue as LiteralExpression;
+            Assert.AreEqual(3, v74Literal!.Literal);
+        }
+
         public enum SomeEnum
         {
             Foo,
@@ -430,6 +467,24 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
                 return
                 [
                     new FieldProvider(FieldModifiers.Public | FieldModifiers.Static, typeof(int), "Foo", this, $"Foo"),
+                ];
+            }
+        }
+
+        private class TestEnumWithValuesProvider : TypeProvider
+        {
+            protected override string BuildRelativeFilePath() => ".";
+            protected override string BuildName() => "ServiceVersion";
+            protected override string BuildNamespace() => "Sample.Models";
+            protected override TypeSignatureModifiers BuildDeclarationModifiers() => TypeSignatureModifiers.Public | TypeSignatureModifiers.Enum;
+
+            protected override FieldProvider[] BuildFields()
+            {
+                return
+                [
+                    new FieldProvider(FieldModifiers.Public | FieldModifiers.Static, typeof(int), "V7_2", this, $"The Key Vault API version 7.2", initializationValue: Literal(1)),
+                    new FieldProvider(FieldModifiers.Public | FieldModifiers.Static, typeof(int), "V7_3", this, $"The Key Vault API version 7.3", initializationValue: Literal(2)),
+                    new FieldProvider(FieldModifiers.Public | FieldModifiers.Static, typeof(int), "V7_4", this, $"The Key Vault API version 7.4", initializationValue: Literal(3)),
                 ];
             }
         }


### PR DESCRIPTION
Fixes an edge case where we were not honoring the enum members and their values in the custom implementation of the service version enum. Since an enum can't be partial, this PR fixes the issue by using the custom implementation of the service version enum if it exists.

fixes: https://github.com/microsoft/typespec/issues/8614