### PR TITLE
build: bump to .net 9.0.306

### DIFF
--- a/packages/http-client-csharp/global.json
+++ b/packages/http-client-csharp/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.102",
+    "version": "9.0.306",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
Bumps the .net sdk version to `9.0.306`.