### PR TITLE
Removed circular dependency on self for http-client-java

### DIFF
--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.1",
-        "@typespec/http-client-java": "file:",
         "js-yaml": "~4.1.0",
         "lodash": "~4.17.21"
       },
@@ -2396,10 +2395,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@typespec/http-client-java": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/@typespec/openapi": {
       "version": "1.5.0",

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "@autorest/codemodel": "~4.20.1",
-    "@typespec/http-client-java": "file:",
     "js-yaml": "~4.1.0",
     "lodash": "~4.17.21"
   },


### PR DESCRIPTION
Removed circular dependency on self causing issues with the emitter. 

Related issues: https://github.com/microsoft/openai-openapi-pr/issues/184
