### PR TITLE
bump version for typespec-vs patch release

### DIFF
--- a/.chronus/changes/fix-vs-vulnerability-build-2025-9-16-15-5-57.md
+++ b/.chronus/changes/fix-vs-vulnerability-build-2025-9-16-15-5-57.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - typespec-vs
----
-
-Upgrade VS dependencies to fix vulnerability 

--- a/packages/typespec-vs/CHANGELOG.md
+++ b/packages/typespec-vs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - typespec-vs
 
+## 1.5.1
+
+### Bug Fixes
+
+- [#8745](https://github.com/microsoft/typespec/pull/8745) Upgrade VS dependencies to fix vulnerability 
+
 ## 1.5.0
 
 No changes, version bump only.

--- a/packages/typespec-vs/package.json
+++ b/packages/typespec-vs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typespec-vs",
   "author": "Microsoft Corporation",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "TypeSpec Language Support for Visual Studio",
   "homepage": "https://typespec.io",
   "readme": "https://github.com/microsoft/typespec/blob/main/README.md",


### PR DESCRIPTION
- To unblock https://github.com/Azure/typespec-azure/issues/3423
- Take vulnerability fix from https://github.com/microsoft/typespec/pull/8745