### PR TITLE
build: update createPr pipeline to auth

### DIFF
--- a/packages/http-client-csharp/eng/pipeline/publish.yml
+++ b/packages/http-client-csharp/eng/pipeline/publish.yml
@@ -95,6 +95,8 @@ extends:
                 inputs:
                   version: "22.x"
 
+              - task: NuGetAuthenticate@1
+
               - download: current
                 displayName: Download pipeline artifacts
 


### PR DESCRIPTION
Addresses a warning that is happening in the create PR step for the sdk-for-net repo on the generator upgrade pipeline:
<img width="820" height="12" alt="image" src="https://github.com/user-attachments/assets/bd1195e3-fe80-4ed7-bac2-5cb13b668366" />

fixes: https://github.com/microsoft/typespec/issues/8803
