### PR TITLE
Added long path support to prerequisite

### DIFF
--- a/packages/http-client-csharp/CONTRIBUTING.md
+++ b/packages/http-client-csharp/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Before you begin, ensure you have the following installed:
 - [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - [Git](https://git-scm.com/)
 - [PowerShell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell) (version 7.0 or higher, for advanced testing and code generation scenarios)
+- [Long Path Support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell#registry-setting-to-enable-long-paths) (Windows only required to avoid path length limitations during development)
 
 ## Getting Started
 


### PR DESCRIPTION
While setting up the repository for contribution. I faced the error:
`Microsoft.TypeSpec.Generator.Tests failed with 1 error(s) (0.4s)
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator\test\PostProcessing\TestData\PostProcessorTests\RemovesInvalidAttributesAndKeepsValidAttributesNoDocs\RemovesInvalidAttributesAndKeepsValidAttributesNoDocs.cs" because it was not found.
  Versioning.RenamedFrom.V1 succeeded (0.2s) → generator\artifacts\bin\Versioning.RenamedFrom.V1\Debug\net8.0\Versioning.RenamedFrom.V1.dll
  Client.Structure.Service.TwoOperationGroup succeeded (1.1s) → generator\artifacts\bin\Client.Structure.Service.TwoOperationGroup\Debug\net8.0\Client.Structure.Service.TwoOperationGroup.dll
  Microsoft.TypeSpec.Generator.ClientModel.Tests failed with 8 error(s) (0.3s)
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\ClientProviders\TestData\ClientProviderCustomizationTests\CanChangeClientOptionsAccessibility\CanChangeClientOptionsAccessibility.cs" because it was not found.
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\Definitions\TestData\ModelReaderWriterContextDefinitionTests\CustomizedExperimentalModelsHaveAttributeSuppressions\CustomizedExperimentalModel.cs" because it was not found.
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\Definitions\TestData\ModelReaderWriterContextDefinitionTests\ValidateCustomObsoleteTypeHasAttributeSuppression\CustomizedObsoleteModel.cs" because it was not found.
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\MrwSerializationTypeDefinitions\TestData\SerializationCustomizationTests\CanChangePropertyNameAndRedefineOriginal\MockInputModel.cs" because it was not found.
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\MrwSerializationTypeDefinitions\TestData\SerializationCustomizationTests\CanCustomizeLiteralExtensibleEnum(int32,1)\MockInputModel.cs" because it was not found.
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\MrwSerializationTypeDefinitions\TestData\SerializationCustomizationTests\CanCustomizeLiteralExtensibleEnum(string,foo)\MockInputModel.cs" because it was not found.
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\MrwSerializationTypeDefinitions\TestData\SerializationCustomizationTests\CanCustomizeSerializationMethodForPropertyInBase\BaseModel.cs" because it was not found.
    C:\Program Files\dotnet\sdk\9.0.205\Microsoft.Common.CurrentVersion.targets(5364,5): error MSB3030: Could not copy the file "C:\Users\radhgupta\Desktop\typespec\packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator.ClientModel\test\Providers\MrwSerializationTypeDefinitions\TestData\SerializationCustomizationTests\CanCustomizeSerializationMethodForRenamedProperty\MockInputModel.cs" because it was not foun`


Adding long path support helped me fix the error. Thought maybe adding this to contributed.md would be helpful as suggested by @jorgerangel-msft 