### PR TITLE
fix: use correct init value for custom apiversion enum

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientOptionsProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientOptionsProviderTests.cs
@@ -293,5 +293,47 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             Assert.AreEqual("ServiceVersion", serviceVersionType.Name);
             Assert.AreEqual("SomeOtherNamespace", serviceVersionType.Type.Namespace);
         }
+
+        [Test]
+        public async Task CustomEnumMembersGenerateSwitchCorrectly()
+        {
+            string[] apiVersions = ["2023-10-01-preview-1", "2023-11-01", "2024-01-01"];
+            var enumValues = apiVersions.Select((a, index) => (a, a));
+            var inputEnum = InputFactory.StringEnum(
+                "ServiceVersion",
+                enumValues,
+                usage: InputModelTypeUsage.ApiVersionEnum,
+                clientNamespace: "SampleNamespace");
+
+            await MockHelpers.LoadMockGeneratorAsync(
+                apiVersions: () => apiVersions,
+                inputEnums: () => [inputEnum],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var inputClient = InputFactory.Client("TestClient", clientNamespace: "SampleNamespace");
+            var clientProvider = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(clientProvider);
+            var clientOptionsProvider = clientProvider!.ClientOptions;
+            Assert.IsNotNull(clientOptionsProvider);
+
+            // validate the latest version field uses the last custom enum member
+            var latestVersionField = clientOptionsProvider!.Fields.FirstOrDefault(f => f.Name == "LatestVersion");
+            Assert.IsNotNull(latestVersionField);
+            Assert.AreEqual(
+                "global::SampleNamespace.TestClientOptions.ServiceVersion.V2024_01_01",
+                latestVersionField?.InitializationValue?.ToDisplayString());
+
+            // validate the constructor has the switch statement with custom enum members
+            var constructor = clientOptionsProvider.Constructors.FirstOrDefault();
+            Assert.IsNotNull(constructor);
+
+            var body = constructor?.BodyStatements?.ToDisplayString();
+            Assert.IsNotNull(body);
+            
+            // Verify the switch statement contains custom enum members with their correct string values
+            Assert.IsTrue(body?.Contains("ServiceVersion.V2023_10_01_Preview_1 => \"2023-10-01-preview-1\""));
+            Assert.IsTrue(body?.Contains("ServiceVersion.V2023_11_01 => \"2023-11-01\""));
+            Assert.IsTrue(body?.Contains("ServiceVersion.V2024_01_01 => \"2024-01-01\""));
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientOptionsProviderTests/CustomEnumMembersGenerateSwitchCorrectly/SampleNamespaceClientOptions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientOptionsProviderTests/CustomEnumMembersGenerateSwitchCorrectly/SampleNamespaceClientOptions.cs
@@ -1,0 +1,17 @@
+#nullable disable
+
+using System;
+using System.ClientModel.Primitives;
+
+namespace SampleNamespace
+{
+    public partial class TestClientOptions : ClientPipelineOptions
+    {
+        public enum ServiceVersion
+        {
+            V2023_10_01_Preview_1 = 0,
+            V2023_11_01 = 1,
+            V2024_01_01 = 2
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
@@ -77,6 +77,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private List<EnumTypeMember> BuildCustomEnumMembers(IReadOnlyList<FieldProvider> customMembers)
         {
             List<EnumTypeMember> values = new(customMembers.Count);
+            Dictionary<string, InputEnumTypeValue> allowedValues = AllowedValues.ToDictionary(av => av.Name.ToApiVersionMemberName());
             for (int i = 0; i < customMembers.Count; i++)
             {
                 var member = customMembers[i];
@@ -88,8 +89,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     this,
                     $"",
                     member.InitializationValue);
-
-                values.Add(new EnumTypeMember(member.Name, field, member.InitializationValue!));
+                object? inputValue = allowedValues.TryGetValue(member.OriginalName ?? member.Name, out var enumValue)
+                    ? enumValue.Value
+                    : member.Name;
+                values.Add(new EnumTypeMember(member.Name, field, inputValue));
             }
 
             return values;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/ApiVersionEnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/ApiVersionEnumProviderTests.cs
@@ -114,10 +114,11 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.EnumProviders
         [Test]
         public async Task CustomEnumMembers()
         {
-            string[] apiVersions = ["2.0.0", "3.0.0"];
-            var input = InputFactory.Int32Enum(
+            string[] apiVersions = ["2023-10-01-preview-1", "2023-11-01", "2024-01-01"];
+            var enumValues = apiVersions.Select((a, index) => (a, a));
+            var input = InputFactory.StringEnum(
                 "mockInputEnum",
-                apiVersions.Select((a, index) => (a, index)),
+                enumValues,
                 usage: InputModelTypeUsage.ApiVersionEnum,
                 clientNamespace: "SampleNamespace");
             await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
@@ -133,11 +134,14 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.EnumProviders
             Assert.That(provider.Name, Is.EqualTo("ServiceVersion"));
             Assert.That(provider.EnumValues.Count, Is.EqualTo(3));
             Assert.AreEqual("V2023_10_01_Preview_1", provider.EnumValues[0].Name);
-            Assert.AreEqual(new LiteralExpression(0), provider.EnumValues[0].Value);
+            Assert.AreEqual(apiVersions[0], provider.EnumValues[0].Value);
+            Assert.AreEqual(new LiteralExpression(0), provider.EnumValues[0].Field.InitializationValue);
             Assert.AreEqual("V2023_11_01", provider.EnumValues[1].Name);
-            Assert.AreEqual(new LiteralExpression(1), provider.EnumValues[1].Value);
+            Assert.AreEqual(new LiteralExpression(1), provider.EnumValues[1].Field.InitializationValue);
+            Assert.AreEqual(apiVersions[1], provider.EnumValues[1].Value);
             Assert.AreEqual("V2024_01_01", provider.EnumValues[2].Name);
-            Assert.AreEqual(new LiteralExpression(2), provider.EnumValues[2].Value);
+            Assert.AreEqual(new LiteralExpression(2), provider.EnumValues[2].Field.InitializationValue);
+            Assert.AreEqual(apiVersions[2], provider.EnumValues[2].Value);
         }
     }
 }


### PR DESCRIPTION
Fixes an edge case where the custom service version enum was being constructed with an incorrect initialization value, leading to an issue when generating the client options ctor for a client.

follow up to: https://github.com/microsoft/typespec/pull/8771