### PR TITLE
feat: bump scm to 1.8.0

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/Abstractions/HttpRequestApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/Abstractions/HttpRequestApi.cs
@@ -20,6 +20,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         public abstract MethodBodyStatement SetHeaders(IReadOnlyList<ValueExpression> arguments);
 
         public abstract ValueExpression Content();
+        public abstract ValueExpression ClientRequestId();
         public abstract HttpRequestApi FromExpression(ValueExpression original);
         public abstract HttpRequestApi ToExpression();
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/PipelineRequestProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/PipelineRequestProvider.cs
@@ -23,6 +23,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         public override ValueExpression Content()
             => Original.Property(nameof(PipelineRequest.Content));
 
+        public override ValueExpression ClientRequestId()
+            => Original.Property(nameof(PipelineRequest.ClientRequestId));
+
         public override HttpRequestApi FromExpression(ValueExpression original)
             => new PipelineRequestProvider(original);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/NewProjectScaffolding.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/NewProjectScaffolding.cs
@@ -81,7 +81,7 @@ namespace Microsoft.TypeSpec.Generator.Primitives
 
         private static readonly IReadOnlyList<CSharpProjectWriter.CSProjDependencyPackage> _unbrandedDependencyPackages = new CSharpProjectWriter.CSProjDependencyPackage[]
         {
-            new("System.ClientModel", "1.7.0"),
+            new("System.ClientModel", "1.8.0"),
         };
 
         protected virtual string GetSolutionFileContent()

--- a/packages/http-client-csharp/generator/Packages.Data.props
+++ b/packages/http-client-csharp/generator/Packages.Data.props
@@ -14,7 +14,7 @@
     <PackageReference Update="NuGet.Versioning" Version="6.14.0" />
     <PackageReference Update="NuGet.Protocol" Version="6.14.0" />
     <PackageReference Update="System.ComponentModel.Composition" Version="8.0.0" />
-    <PackageReference Update="System.ClientModel" Version="1.7.0" />
+    <PackageReference Update="System.ClientModel" Version="1.8.0" />
     <PackageReference Update="System.Memory.Data" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/SampleTypeSpec.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/SampleTypeSpec.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/api-key/src/Authentication.ApiKey.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/api-key/src/Authentication.ApiKey.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/http/custom/src/Authentication.Http.Custom.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/http/custom/src/Authentication.Http.Custom.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/oauth2/src/Authentication.OAuth2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/oauth2/src/Authentication.OAuth2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/union/src/Authentication.Union.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/authentication/union/src/Authentication.Union.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/client-operation-group/src/Client.Structure.Service.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/client-operation-group/src/Client.Structure.Service.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/default/src/Client.Structure.Service.Default.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/default/src/Client.Structure.Service.Default.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/multi-client/src/Client.Structure.Service.Multi.Client.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/multi-client/src/Client.Structure.Service.Multi.Client.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/renamed-operation/src/Client.Structure.Service.Renamed.Operation.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/renamed-operation/src/Client.Structure.Service.Renamed.Operation.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/two-operation-group/src/Client.Structure.Service.TwoOperationGroup.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/client/structure/two-operation-group/src/Client.Structure.Service.TwoOperationGroup.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/bytes/src/Encode.Bytes.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/bytes/src/Encode.Bytes.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/datetime/src/Encode.Datetime.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/datetime/src/Encode.Datetime.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/duration/src/Encode.Duration.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/duration/src/Encode.Duration.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/numeric/src/Encode.Numeric.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/encode/numeric/src/Encode.Numeric.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/basic/src/Parameters.Basic.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/basic/src/Parameters.Basic.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/body-optionality/src/Parameters.BodyOptionality.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/body-optionality/src/Parameters.BodyOptionality.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/collection-format/src/Parameters.CollectionFormat.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/collection-format/src/Parameters.CollectionFormat.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/path/src/Parameters.Path.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/path/src/Parameters.Path.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/spread/src/Parameters.Spread.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/parameters/spread/src/Parameters.Spread.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/content-negotiation/src/Payload.ContentNegotiation.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/content-negotiation/src/Payload.ContentNegotiation.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/json-merge-patch/src/Payload.JsonMergePatch.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/json-merge-patch/src/Payload.JsonMergePatch.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/media-type/src/Payload.MediaType.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/media-type/src/Payload.MediaType.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/multipart/src/Payload.MultiPart.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/multipart/src/Payload.MultiPart.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/pageable/src/Payload.Pageable.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/payload/pageable/src/Payload.Pageable.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/resiliency/srv-driven/v1/src/Resiliency.SrvDriven.V1.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/resiliency/srv-driven/v1/src/Resiliency.SrvDriven.V1.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/resiliency/srv-driven/v2/src/Resiliency.SrvDriven.V2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/resiliency/srv-driven/v2/src/Resiliency.SrvDriven.V2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/response/status-code-range/src/Response.StatusCodeRange.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/response/status-code-range/src/Response.StatusCodeRange.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/routes/src/Routes.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/routes/src/Routes.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/serialization/encoded-name/json/src/Serialization.EncodedName.Json.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/serialization/encoded-name/json/src/Serialization.EncodedName.Json.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/server/endpoint/not-defined/src/Server.Endpoint.NotDefined.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/server/endpoint/not-defined/src/Server.Endpoint.NotDefined.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/multiple/src/Server.Path.Multiple.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/multiple/src/Server.Path.Multiple.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/single/src/Server.Path.Single.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/server/path/single/src/Server.Path.Single.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/not-versioned/src/Server.Versions.NotVersioned.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/not-versioned/src/Server.Versions.NotVersioned.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/versioned/src/Server.Versions.Versioned.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/server/versions/versioned/src/Server.Versions.Versioned.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/conditional-request/src/SpecialHeaders.ConditionalRequest.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/conditional-request/src/SpecialHeaders.ConditionalRequest.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/repeatability/src/SpecialHeaders.Repeatability.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/special-headers/repeatability/src/SpecialHeaders.Repeatability.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/special-words/src/SpecialWords.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/special-words/src/SpecialWords.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/array/src/Type.Array.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/array/src/Type.Array.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/dictionary/src/Type.Dictionary.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/dictionary/src/Type.Dictionary.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/extensible/src/Type.Enum.Extensible.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/extensible/src/Type.Enum.Extensible.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/fixed/src/Type.Enum.Fixed.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/enum/fixed/src/Type.Enum.Fixed.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/empty/src/Type.Model.Empty.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/empty/src/Type.Model.Empty.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/enum-discriminator/src/Type.Model.Inheritance.EnumDiscriminator.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/enum-discriminator/src/Type.Model.Inheritance.EnumDiscriminator.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/nested-discriminator/src/Type.Model.Inheritance.NestedDiscriminator.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/nested-discriminator/src/Type.Model.Inheritance.NestedDiscriminator.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/not-discriminated/src/Type.Model.Inheritance.NotDiscriminated.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/not-discriminated/src/Type.Model.Inheritance.NotDiscriminated.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/recursive/src/Type.Model.Inheritance.Recursive.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/recursive/src/Type.Model.Inheritance.Recursive.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/single-discriminator/src/Type.Model.Inheritance.SingleDiscriminator.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/inheritance/single-discriminator/src/Type.Model.Inheritance.SingleDiscriminator.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/usage/src/Type.Model.Usage.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/usage/src/Type.Model.Usage.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/visibility/src/Type.Model.Visibility.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/model/visibility/src/Type.Model.Visibility.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/additional-properties/src/Type.Property.AdditionalProperties.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/additional-properties/src/Type.Property.AdditionalProperties.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/nullable/src/Type.Property.Nullable.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/nullable/src/Type.Property.Nullable.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/optionality/src/Type.Property.Optional.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/optionality/src/Type.Property.Optional.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/value-types/src/Type.Property.ValueTypes.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/property/value-types/src/Type.Property.ValueTypes.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/scalar/src/Type.Scalar.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/scalar/src/Type.Scalar.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/union/discriminated/src/Type.Union.Discriminated.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/union/discriminated/src/Type.Union.Discriminated.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/type/union/src/Type.Union.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/type/union/src/Type.Union.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/added/v1/src/Versioning.Added.V1.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/added/v1/src/Versioning.Added.V1.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/added/v2/src/Versioning.Added.V2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/added/v2/src/Versioning.Added.V2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/madeOptional/v1/src/Versioning.MadeOptional.V1.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/madeOptional/v1/src/Versioning.MadeOptional.V1.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/madeOptional/v2/src/Versioning.MadeOptional.V2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/madeOptional/v2/src/Versioning.MadeOptional.V2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/removed/v1/src/Versioning.Removed.V1.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/removed/v1/src/Versioning.Removed.V1.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/removed/v2/src/Versioning.Removed.V2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/removed/v2/src/Versioning.Removed.V2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/removed/v2Preview/src/Versioning.Removed.V2Preview.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/removed/v2Preview/src/Versioning.Removed.V2Preview.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/renamedFrom/v1/src/Versioning.RenamedFrom.V1.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/renamedFrom/v1/src/Versioning.RenamedFrom.V1.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/renamedFrom/v2/src/Versioning.RenamedFrom.V2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/renamedFrom/v2/src/Versioning.RenamedFrom.V2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/returnTypeChangedFrom/v1/src/Versioning.ReturnTypeChangedFrom.V1.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/returnTypeChangedFrom/v1/src/Versioning.ReturnTypeChangedFrom.V1.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/returnTypeChangedFrom/v2/src/Versioning.ReturnTypeChangedFrom.V2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/returnTypeChangedFrom/v2/src/Versioning.ReturnTypeChangedFrom.V2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/typeChangedFrom/v1/src/Versioning.TypeChangedFrom.V1.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/typeChangedFrom/v1/src/Versioning.TypeChangedFrom.V1.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/typeChangedFrom/v2/src/Versioning.TypeChangedFrom.V2.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/versioning/typeChangedFrom/v2/src/Versioning.TypeChangedFrom.V2.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ClientModel" Version="1.7.0" />
+    <PackageReference Include="System.ClientModel" Version="1.8.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumps the SCM version to `1.8.0` and adds an api for the `ClientRequestId` property in the HttpRequestApi abstraction.

contributes to: https://github.com/microsoft/typespec/issues/8911