### PR TITLE
Change vitest configuration setting in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,6 +56,6 @@
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "git.ignoreLimitWarning": true,
-  "vitest.workspaceConfig": "./vitest.config.ts",
+  "vitest.rootConfig": "vitest.config.js",
   "typespec.tsp-server.path": "${workspaceFolder}/packages/compiler"
 }


### PR DESCRIPTION
The workspace configuration doesn't seem to work for me to use a single vitest instance, but this setting does.