### PR TITLE
Explicitly define transitive dependencies of Eclipse JDT Core

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/pom.xml
+++ b/packages/http-client-java/generator/http-client-generator-core/pom.xml
@@ -134,6 +134,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>
+      <!-- cSpell:ignore osgi -->
       <artifactId>org.eclipse.osgi</artifactId>
       <version>3.17.0</version>
     </dependency>
@@ -147,7 +148,6 @@
       <artifactId>org.eclipse.core.commands</artifactId>
       <version>3.10.100</version>
     </dependency>
-
 
     <dependency>
       <groupId>org.atteo</groupId>


### PR DESCRIPTION
Explicitly define the transitive dependencies of Eclipse JDT Core as they are defined using version ranges and within the version range the transitive dependencies change from baselining on Java 11 to Java 17 and we want to remain compatible with Java 11.