### PR TITLE
[Python] Add test case for flatten model initialization to check compatibility

### DIFF
--- a/packages/http-client-python/generator/test/azure/mock_api_tests/test_model_base_flatten_compatibility.py
+++ b/packages/http-client-python/generator/test/azure/mock_api_tests/test_model_base_flatten_compatibility.py
@@ -14,10 +14,6 @@ from specs.azure.clientgenerator.core.flattenproperty._utils.model_base import (
     rest_field,
 )
 
-from collections.abc import MutableMapping
-
-JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
-
 
 class ModelProperty(Model):
     """This is a test model."""

--- a/packages/http-client-python/generator/test/unittests/requirements.txt
+++ b/packages/http-client-python/generator/test/unittests/requirements.txt
@@ -1,4 +1,3 @@
 -r ../dev_requirements.txt
 -e ../../../generator
 -e ../unbranded/generated/special-words
--e ../azure/generated/azure-client-generator-core-flatten-property


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/8994

We already support SDK users to initialize model with flattened items directly to keep compatibility, this PR adds test cases to cover this scenario.