### PR TITLE
Allow for scope descriptions

### DIFF
--- a/.chronus/changes/fix-allow-scope-descriptions-2025-11-2-12-5-39.md
+++ b/.chronus/changes/fix-allow-scope-descriptions-2025-11-2-12-5-39.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http"
+---
+
+Allow for OAuth2 scopes to be properly specified with descriptions

--- a/packages/http/lib/auth.tsp
+++ b/packages/http/lib/auth.tsp
@@ -100,6 +100,16 @@ model ApiKeyAuth<Location extends ApiKeyLocation, Name extends string> {
   name: Name;
 }
 
+model OAuth2Scope {
+  @doc("The scope identifier")
+  value: string;
+
+  @doc("A description of the scope")
+  description?: string;
+}
+
+alias ScopeList = string[] | OAuth2Scope[];
+
 /**
  * OAuth 2.0 is an authorization protocol that gives an API client limited access to user data on a web server.
  *
@@ -111,7 +121,7 @@ model ApiKeyAuth<Location extends ApiKeyLocation, Name extends string> {
  * @template Scopes The list of OAuth2 scopes, which are common for every flow from `Flows`. This list is combined with the scopes defined in specific OAuth2 flows.
  */
 @doc("")
-model OAuth2Auth<Flows extends OAuth2Flow[], Scopes extends string[] = []> {
+model OAuth2Auth<Flows extends OAuth2Flow[], Scopes extends ScopeList = []> {
   @doc("OAuth2 authentication")
   type: AuthType.oauth2;
 
@@ -154,7 +164,7 @@ model AuthorizationCodeFlow {
   refreshUrl?: string;
 
   @doc("list of scopes for the credential")
-  scopes?: string[];
+  scopes?: ScopeList;
 }
 
 @doc("Implicit flow")
@@ -169,7 +179,7 @@ model ImplicitFlow {
   refreshUrl?: string;
 
   @doc("list of scopes for the credential")
-  scopes?: string[];
+  scopes?: ScopeList;
 }
 
 @doc("Resource Owner Password flow")
@@ -184,7 +194,7 @@ model PasswordFlow {
   refreshUrl?: string;
 
   @doc("list of scopes for the credential")
-  scopes?: string[];
+  scopes?: ScopeList;
 }
 
 @doc("Client credentials flow")
@@ -199,7 +209,7 @@ model ClientCredentialsFlow {
   refreshUrl?: string;
 
   @doc("list of scopes for the credential")
-  scopes?: string[];
+  scopes?: ScopeList;
 }
 
 /**


### PR DESCRIPTION
This makes a small change to the code introduced in https://github.com/microsoft/typespec/pull/849 to allow for models to be used as OAuth scopes. Without this check, an object like `{value: "foo", description: "bar"}` gets wrapped in an additional `value` key. When the OpenAPI3 emitter tries to print out the `securitySchemes`, it sees `{value: {...}}` and produces a scope with value `[object Object]` and no description.

This also introduces a base `SecurityScheme` model that allows for more specific type checking on the `@useAuth` decorator.

We need to remove an `openapi3` test that checks for an error when providing an unsupported auth type.
Now the compiler enforces that the auth type is `AuthType`, and `openapi3` supports all of the types in `AuthType`, it should not be possible to trigger this condition in TSP.