### PR TITLE
Add support for open discriminators in JSON Schema emitter

### DIFF
--- a/.chronus/changes/mictaylor-json-schema-open-discriminator-support-2025-11-2-20-20-32.md
+++ b/.chronus/changes/mictaylor-json-schema-open-discriminator-support-2025-11-2-20-20-32.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/json-schema"
+---
+
+add support for open discriminators


### PR DESCRIPTION
## Summary

Adds support for **open discriminators** in the JSON Schema emitter. When a discriminator type includes `string` (indicating it can accept values beyond the explicitly defined ones), the emitter now generates a catch-all variant that validates unknown discriminator values against the base model schema. This applies only when using the `polymorphic-models-strategy` option as it is intended for validating discriminated unions.

## Problem

When defining a discriminated union with an "open" discriminator like:

```typespec
union ToolType {
  string,
  file_search: "file_search",
  function: "function",
}

@discriminator("type")
model Tool {
  type: ToolType;
}

model FileSearchTool extends Tool {
  type: ToolType.file_search;
}

model FunctionTool extends Tool {
  type: ToolType.function;
}
```

The previous behavior would only generate oneOf variants for the known types (file_search, function), causing validation to fail for any unknown tool types - even though the string in the union indicates they should be allowed.

## Solution

When the discriminator type includes string, the emitter now generates a catch-all variant:

```typespec
{
  "type": "object",
  "properties": {
    "type": {
      "type": "string",
      "not": {
        "enum": ["file_search", "function"]
      }
    }
  },
  "required": ["type"]
}
```

The catch all:
- Matches any discriminator value not in the known set
- Validates against the base model schema only
- Preserves full type checking for known discriminator values

## Testing
Added 3 test cases:
- Open discriminator with type: string - expects catch-all variant
- Open discriminator with union containing string variant - expects catch-all variant
- Closed discriminator (no string in union) - expects no catch-all variant (negative test)