### PR TITLE
fix: add fallback for nuget downloader

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageDownloader.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageDownloader.cs
@@ -265,6 +265,16 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 }
             }
 
+            // Fallback to any of the preferred versions if none of the target frameworks matched.
+            foreach (var preferredDotNetFrameworkVersion in PreferredDotNetFrameworkVersions)
+            {
+                var dotNetFolder = Path.Combine(packageLibraryPath, preferredDotNetFrameworkVersion);
+                if (DirectoryExists(dotNetFolder))
+                {
+                    return dotNetFolder;
+                }
+            }
+
             return null;
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestNugetPackageDownloader.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/TestNugetPackageDownloader.cs
@@ -19,6 +19,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.TestHelpers
         private const string DefaultTargetFramework = "netstandard2.0";
         private readonly SourceRepository _mockPackageSourceRepo;
         private readonly bool _mockDirectoryExists;
+        private readonly HashSet<string>? _existingDirectories;
         private readonly bool _mockTryFindPackageInCache;
         private readonly bool _mockPackageExistsInSource;
         private readonly LocalPackageInfo? _mockLocalPackageInfo;
@@ -39,10 +40,12 @@ namespace Microsoft.TypeSpec.Generator.Tests.TestHelpers
             bool directoryExists,
             bool packageExistsInSource,
             IEnumerable<string>? targetFrameworks = null,
-            LocalPackageInfo? localPackageInfo = null) : base(packageName, version, targetFrameworks ?? [DefaultTargetFramework], settings)
+            LocalPackageInfo? localPackageInfo = null,
+            HashSet<string>? existingDirectories = null) : base(packageName, version, targetFrameworks ?? [DefaultTargetFramework], settings)
         {
             _mockPackageSourceRepo = sourceRepository;
             _mockDirectoryExists = directoryExists;
+            _existingDirectories = existingDirectories;
             _mockLocalPackageInfo = localPackageInfo;
             _mockTryFindPackageInCache = _mockLocalPackageInfo != null;
             _mockPackageExistsInSource = packageExistsInSource;
@@ -55,6 +58,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.TestHelpers
 
         protected override bool DirectoryExists(string path)
         {
+            if (_existingDirectories != null)
+            {
+                return _existingDirectories.Contains(path);
+            }
             return _mockDirectoryExists;
         }
 


### PR DESCRIPTION
This PR addresses an edge case where the nuget downloader was not parsing the last contract DLL path on disk as expected.

fixes: https://github.com/microsoft/typespec/issues/9130