### PR TITLE
Refactor enum creation

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
@@ -13,7 +13,7 @@ using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Microsoft.TypeSpec.Generator.Providers
 {
-    public class ApiVersionEnumProvider : FixedEnumProvider
+    internal sealed class ApiVersionEnumProvider : FixedEnumProvider
     {
         private const string ApiVersionEnumName = "ServiceVersion";
         private const string ApiVersionEnumDescription = "The version of the service to use.";

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
@@ -21,30 +21,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 ? new ApiVersionEnumProvider(input, declaringType)
                 : new FixedEnumProvider(input, declaringType);
             var extensibleEnumProvider = new ExtensibleEnumProvider(input, declaringType);
+            fixedEnumProvider.ExtensibleEnumView = extensibleEnumProvider;
+            extensibleEnumProvider.FixedEnumView = fixedEnumProvider;
 
-            return CreateConcreteType(input, fixedEnumProvider, extensibleEnumProvider);
-        }
-
-        protected internal static EnumProvider CreateConcreteType(
-            InputEnumType input,
-            FixedEnumProvider fixedEnumProvider,
-            ExtensibleEnumProvider extensibleEnumProvider)
-        {
-            // Check to see if there is custom code that customizes the enum.
-            var customCodeView = fixedEnumProvider.CustomCodeView ?? extensibleEnumProvider.CustomCodeView;
-            EnumProvider provider = customCodeView switch
-            {
-                { Type: { IsValueType: true, IsStruct: true } } => extensibleEnumProvider,
-                { Type: { IsValueType: true, IsStruct: false } } => fixedEnumProvider,
-                _ => input.IsExtensible ? extensibleEnumProvider : fixedEnumProvider
-            };
-
-            if (input.Access == "public")
-            {
-                CodeModelGenerator.Instance.AddTypeToKeep(provider);
-            }
-
-            return provider;
+            return input.IsExtensible ? extensibleEnumProvider : fixedEnumProvider;
         }
 
         protected EnumProvider(InputEnumType? input)
@@ -53,6 +33,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _deprecated = input?.Deprecation;
             IsExtensible = input?.IsExtensible ?? false;
         }
+
+        internal EnumProvider? FixedEnumView { get; set; }
+        internal EnumProvider? ExtensibleEnumView { get; set; }
 
         public bool IsExtensible { get; }
         private bool? _isIntValue;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ExtensibleEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ExtensibleEnumProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private readonly IReadOnlyList<InputEnumTypeValue> _allowedValues;
         private readonly TypeSignatureModifiers _modifiers;
         private readonly InputEnumType _inputType;
-        public ExtensibleEnumProvider(InputEnumType input, TypeProvider? declaringType) : base(input)
+        internal ExtensibleEnumProvider(InputEnumType input, TypeProvider? declaringType) : base(input)
         {
             _inputType = input;
             _allowedValues = input.Values;
@@ -36,6 +36,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
             _valueField = new FieldProvider(FieldModifiers.Private | FieldModifiers.ReadOnly, EnumUnderlyingType, "_value", this);
             _declaringType = declaringType;
+            ExtensibleEnumView = this;
         }
 
         private readonly FieldProvider _valueField;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FixedEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/FixedEnumProvider.cs
@@ -30,6 +30,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
             _declaringTypeProvider = declaringType;
             AllowedValues = input?.Values ?? [];
+            FixedEnumView = this;
         }
 
         internal IReadOnlyList<InputEnumTypeValue> AllowedValues { get; }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Statements;
+using Microsoft.TypeSpec.Generator.Utilities;
 
 namespace Microsoft.TypeSpec.Generator.Providers
 {
@@ -187,7 +189,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
             // mask & (mask - 1) gives us 0 if mask is a power of 2, it means we have exactly one flag of above when the mask is a power of 2
             if ((mask & (mask - 1)) != 0)
             {
-                throw new InvalidOperationException($"Invalid modifier {modifiers} on TypeProvider {Name}");
+                CodeModelGenerator.Instance.Emitter.ReportDiagnostic(
+                   DiagnosticCodes.InvalidAccessModifier,
+                   $"Invalid modifiers {modifiers} detected.",
+                   severity: EmitterDiagnosticSeverity.Warning);
             }
 
             // we always add partial when possible

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/DiagnosticCodes.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/DiagnosticCodes.cs
@@ -6,5 +6,6 @@ namespace Microsoft.TypeSpec.Generator.Utilities
     internal static class DiagnosticCodes
     {
         public const string BaselineContractMissing = "baseline-contract-missing";
+        public const string InvalidAccessModifier = "invalid-access-modifier";
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/InputLibraryVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/InputLibraryVisitorTests.cs
@@ -57,7 +57,8 @@ namespace Microsoft.TypeSpec.Generator.Tests
 
             _mockVisitor.Object.VisitLibrary(_mockGenerator.Object.OutputLibrary);
 
-            _mockVisitor.Protected().Verify<TypeProvider>("PreVisitEnum", Times.Once(), inputEnum, ItExpr.Is<EnumProvider>(m => m.Name == EnumProvider.Create(inputEnum, null).Name));
+            // enum is visited twice, one additional time for the variant created for extensible enums
+            _mockVisitor.Protected().Verify<TypeProvider>("PreVisitEnum", Times.Exactly(2), inputEnum, ItExpr.Is<EnumProvider>(m => m.Name == EnumProvider.Create(inputEnum, null).Name));
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -621,9 +621,11 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                 [("val1", 1), ("val2", 2), ("val3", 3)],
                 isExtensible: false
             );
-            var enumProvider = EnumProvider.Create(inputEnum);
+            var enumProvider = CodeModelGenerator.Instance.TypeFactory.CreateEnum(inputEnum);
 
-            Assert.IsTrue(enumProvider.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public | TypeSignatureModifiers.Partial | TypeSignatureModifiers.Struct | TypeSignatureModifiers.ReadOnly));
+            Assert.IsNotNull(enumProvider);
+            Assert.IsTrue(enumProvider is ExtensibleEnumProvider);
+            Assert.IsTrue(enumProvider!.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public | TypeSignatureModifiers.Partial | TypeSignatureModifiers.Struct | TypeSignatureModifiers.ReadOnly));
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestData/TypeFactoryTests/CreateEnum_WithCustomCodeAsExtensible_ReturnsExtensibleEnum/CustomizedEnum.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestData/TypeFactoryTests/CreateEnum_WithCustomCodeAsExtensible_ReturnsExtensibleEnum/CustomizedEnum.cs
@@ -1,0 +1,8 @@
+#nullable disable
+
+namespace Sample.SomeOtherNamespace
+{
+    public readonly partial struct CustomizedEnum
+    {
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/MethodProviderHelpersTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/MethodProviderHelpersTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -12,6 +12,13 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
 {
     public class MethodProviderHelpersTests
     {
+
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator();
+        }
+
         [Test]
         public void BuildXmlDocsAddsCorrectExceptions()
         {


### PR DESCRIPTION
This PR refactors the enum creation to allow visitors to mutate an enum's namespace and the generator to load any custom code in the new namespace for said visitor, before the final enum type is added to the output library.

fixes: https://github.com/Azure/azure-sdk-for-net/issues/54368