### PR TITLE
fix: ensure dictionaries are instantiated in spread model building

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -261,6 +261,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         expressions.Add(new AsExpression(convenienceParam.NullConditional().ToList(), interfaceType)
                             .NullCoalesce(New.Instance(convenienceParam.Type.PropertyInitializationType, [])));
                     }
+                    else if (convenienceParam.Type.IsDictionary)
+                    {
+                        expressions.Add(convenienceParam.NullCoalesce(New.Instance(convenienceParam.Type.PropertyInitializationType)));
+                    }
                     else
                     {
                         expressions.Add(convenienceParam);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/SpreadModelWithOptionalDictionaryIsNotNull.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/SpreadModelWithOptionalDictionaryIsNotNull.cs
@@ -1,0 +1,4 @@
+global::Sample.Argument.AssertNotNullOrEmpty(requiredParam, nameof(requiredParam));
+
+global::Sample.Models.SpreadModelWithDict spreadModel = new global::Sample.Models.SpreadModelWithDict((query ?? new global::Sample.ChangeTrackingDictionary<string, string>()), (filter ?? new global::Sample.ChangeTrackingDictionary<string, string>()), requiredParam, default);
+return await this.CreateMessageAsync(spreadModel, cancellationToken.ToRequestOptions()).ConfigureAwait(false);


### PR DESCRIPTION
Fixes a corner case where optional dictionary props/parameters in a spread model were not being instantiated to an empty collection, which could lead to an issue during the request serialization as their value would be null.

fixes: https://github.com/Azure/azure-sdk-for-net/issues/54657