### PR TITLE
Fix discriminator inheritance in C# generator for intermediate hierarchyBuilding types

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -527,6 +527,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var unknownVariant = _model.DerivedModels.First(m => m.IsUnknownDiscriminatorModel);
             bool onlyContainsUnknownDerivedModel = _model.DerivedModels.Count == 1;
             var discriminator = _model.CanonicalView.Properties.Where(p => p.IsDiscriminator).FirstOrDefault();
+            if (discriminator == null && _model.BaseModelProvider != null)
+            {
+                // Look for discriminator property in the base model
+                discriminator = _model.BaseModelProvider.CanonicalView.Properties.Where(p => p.IsDiscriminator).FirstOrDefault();
+            }
+
             var deserializeDiscriminatedModelsConditions = BuildDiscriminatedModelsCondition(
                 discriminator,
                 GetDiscriminatorSwitchCases(unknownVariant),
@@ -568,7 +574,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 var model = _model.DerivedModels[i];
                 if (ReferenceEquals(model, unknownVariant))
+                {
                     continue;
+                }
                 cases[index++] = new SwitchCaseStatement(
                     Literal(model.DiscriminatorValue!),
                     Return(GetDeserializationMethodInvocationForType(model, _jsonElementParameterSnippet, _dataParameter, _serializationOptionsParameter)));

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/Pet.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/Pet.Serialization.cs
@@ -68,6 +68,14 @@ namespace SampleTypeSpec
             {
                 return null;
             }
+            if (element.TryGetProperty("kind"u8, out JsonElement discriminator))
+            {
+                switch (discriminator.GetString())
+                {
+                    case "dog":
+                        return Dog.DeserializeDog(element, options);
+                }
+            }
             return UnknownPet.DeserializeUnknownPet(element, options);
         }
 


### PR DESCRIPTION
This pull request improves the handling of discriminator properties in model deserialization The changes ensure that the deserialization logic can correctly locate discriminator properties even if they are defined in base models, and unify the cross-language IDs for server URL templates in the test project.

Updated `BuildDiscriminatedModelDeserializationMethodBody()` in `MrwSerializationTypeDefinition.cs` to search for the discriminator property in the base model if it is not present in the derived model, improving robustness for polymorphic deserialization.
