### PR TITLE
eng, require changelog for java client emitter

### DIFF
--- a/.chronus/config.yaml
+++ b/.chronus/config.yaml
@@ -66,11 +66,13 @@ versionPolicies:
     type: independent
     packages:
       - "@typespec/http-client-python"
+      - "@typespec/http-client-java"
 
 changelog: ["@chronus/github/changelog", { repo: "microsoft/typespec" }]
 
 additionalPackages:
   - packages/http-client-python
+  - packages/http-client-java
 
 changedFiles:
   - "!**/*.md"


### PR DESCRIPTION
Java client emitter would use the chronus to organize changelog.