### PR TITLE
http-client-java, bug fix for array encoding on enum

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/StreamSerializationModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/StreamSerializationModelTemplate.java
@@ -1658,7 +1658,7 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
                                 deserializationBlock.line("String %1$s = nonNullReader.getString();",
                                     propertyStringVariableName);
                                 deserializationBlock.line(
-                                    "%1$s.isEmpty() ? new LinkedList<>() : new LinkedList<>(Arrays.stream(%1$s.split(\"%2$s\", -1)).map(valueAsString -> %3$s).collect(Collectors.toList()));",
+                                    "return %1$s.isEmpty() ? new LinkedList<>() : new LinkedList<>(Arrays.stream(%1$s.split(\"%2$s\", -1)).map(valueAsString -> %3$s).collect(Collectors.toList()));",
                                     propertyStringVariableName, property.getArrayEncoding().getEscapedDelimiter(),
                                     conversionExpress);
                             });


### PR DESCRIPTION
missed one `return` in PR https://github.com/microsoft/typespec/pull/9413 commit https://github.com/microsoft/typespec/pull/9413/commits/d12f548c96b4aace025a3fdff9e41b186b5b95e4

tested in https://github.com/Azure/autorest.java/pull/3271 https://dev.azure.com/azure-sdk/public/_build/results?buildId=5777927&view=results