### PR TITLE
fix: date time offset formatting was culture variant for doc comments

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/PropertyDescriptionBuilder.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/PropertyDescriptionBuilder.cs
@@ -52,6 +52,12 @@ namespace Microsoft.TypeSpec.Generator.Primitives
                     {
                         description = new XmlDocStatement("description", [$"{literalValue:L}"]);
                     }
+                    else if (literalUnderlyingType == typeof(DateTimeOffset) && literalValue is DateTimeOffset dto)
+                    {
+                        //windows and linux us different default dto ToString so we need to be explicit here
+                        //using 02/03/0001 04:05:06 +00:00
+                        description = new XmlDocStatement("description", [$"{dto.ToString("MM/dd/yyyy HH:mm:ss zzz", System.Globalization.CultureInfo.InvariantCulture)}"]);
+                    }
                     else
                     {
                         description = new XmlDocStatement("description", [$"{literalValue}"]);


### PR DESCRIPTION
while onboarding to the project, I noticed a failing unit test on windows (en-CA) locale. This is due to a variant behaviour on how dates are represented