### PR TITLE
Fix JSON key formatting in formatter.md

### DIFF
--- a/website/src/content/docs/docs/handbook/formatter.md
+++ b/website/src/content/docs/docs/handbook/formatter.md
@@ -47,7 +47,7 @@ For VS Code to respect the TypeSpec standard style set the following options sty
   "[typespec]": {
     "editor.detectIndentation": false,
     "editor.insertSpaces": true,
-    "editor.tabSize": 2,
+    "editor.tabSize": 2
   }
 }
 ```


### PR DESCRIPTION
Quotation marks and square brackets were swapped in the example configuration.