### PR TITLE
Fix tsconfig.ws.json

### DIFF
--- a/tsconfig.ws.json
+++ b/tsconfig.ws.json
@@ -23,12 +23,11 @@
     { "path": "packages/monarch/tsconfig.build.json" },
     { "path": "packages/bundler/tsconfig.build.json" },
     { "path": "packages/pack/tsconfig.build.json" },
-    { "path": "packages/tspd/tsconfig.build.json" },
     { "path": "packages/samples/tsconfig.build.json" },
     { "path": "packages/json-schema/tsconfig.build.json" },
     { "path": "packages/best-practices/tsconfig.build.json" },
     { "path": "packages/xml/tsconfig.build.json" },
-    { "path": "packages/http-server-js/tsconfig.build.json" },
+    { "path": "packages/http-server-js/tsconfig.json" },
     { "path": "packages/http-server-csharp/tsconfig.build.json" },
     { "path": "packages/astro-utils/tsconfig.build.json" }
   ],


### PR DESCRIPTION
1. tspd shouldn't part of it anymore as it needs alloy to build
2. http-server-js wasn't migrated to tsconfig.build.json so this was incorrect(we can do that when we start using alloy there too)