### PR TITLE
refactor: add json serialization options

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Primitives/JsonSerialization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Primitives/JsonSerialization.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.Input;
+
+namespace Microsoft.TypeSpec.Generator.ClientModel.Primitives
+{
+    /// <summary>
+    /// Represents JSON serialization options for a property or model.
+    /// </summary>
+    public class JsonSerialization
+    {
+        public JsonSerialization(InputJsonSerializationOptions options)
+        {
+            Name = options.Name;
+        }
+
+        /// <summary>
+        /// Gets or sets the serialized name for JSON format.
+        /// </summary>
+        public string Name { get; internal set; }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Primitives/ScmSerializationOptions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Primitives/ScmSerializationOptions.cs
@@ -10,13 +10,16 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Primitives
     {
         public ScmSerializationOptions(InputSerializationOptions inputSerializationOptions) : base()
         {
+            Json = inputSerializationOptions.Json != null
+                ? new(inputSerializationOptions.Json)
+                : null;
             Xml = inputSerializationOptions.Xml != null
                 ? new(inputSerializationOptions.Xml)
                 : null;
         }
 
-        public XmlSerialization? Xml { get; }
+        public JsonSerialization? Json { get; }
 
-        // TO-DO: Add remaining SCM serialization options https://github.com/microsoft/typespec/issues/5861.
+        public XmlSerialization? Xml { get; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Primitives/XmlSerialization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Primitives/XmlSerialization.cs
@@ -5,6 +5,9 @@ using Microsoft.TypeSpec.Generator.Input;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Primitives
 {
+    /// <summary>
+    /// Represents XML serialization options for a property or model.
+    /// </summary>
     public class XmlSerialization
     {
         public XmlSerialization(InputXmlSerializationOptions xmlOptions)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmModelProvider.cs
@@ -308,7 +308,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         {
             var propertiesWithWireInfo = CanonicalView.Properties;
             if (propertiesWithWireInfo.Any(p =>
-                    p.WireInfo?.SerializedName != null &&
+                    p.WireInfo != null &&
                     ScmCodeModelGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(p.Type, out var provider) &&
                     provider is ScmModelProvider { IsDynamicModel: true }))
             {
@@ -316,7 +316,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             return propertiesWithWireInfo
-                .Where(p => p.Type.IsCollection && p.WireInfo?.SerializedName != null)
+                .Where(p => p.Type.IsCollection && p.WireInfo != null)
                 .Any(p => ScmCodeModelGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(
                               p.Type.GetNestedElementType(),
                               out var provider) &&

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DynamicModelSerializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DynamicModelSerializationTests.cs
@@ -962,14 +962,17 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
         [Test]
         public void DeserializeMultiplePrimitiveProperties()
         {
+            var fooSerializationOptions = InputFactory.Serialization.Json("foo");
+            var catSerializationOptions = InputFactory.Serialization.Json("x-cat");
+            var barSerializationOptions = InputFactory.Serialization.Json("bar");
             var inputModel = InputFactory.Model(
                "dynamicModel",
                isDynamicModel: true,
                properties:
                [
-                    InputFactory.Property("foo", InputPrimitiveType.String, isRequired: true),
-                    InputFactory.Property("cat", InputPrimitiveType.String, serializedName: "x-cat", isRequired: true),
-                    InputFactory.Property("bar", InputPrimitiveType.Int32, isRequired: false)
+                    InputFactory.Property("foo", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(fooSerializationOptions)),
+                    InputFactory.Property("cat", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(catSerializationOptions)),
+                    InputFactory.Property("bar", InputPrimitiveType.Int32, isRequired: false, serializationOptions: InputFactory.Serialization.Options(barSerializationOptions))
                ]);
 
             MockHelpers.LoadMockGenerator(inputModels: () => [inputModel]);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/XmlDeserializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/XmlDeserializationTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             var inputModel = InputFactory.Model(
                 "TestXmlModel",
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
-                properties: [InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("name"))]);
+                properties: [InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel]);
 
@@ -88,11 +88,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             var innerModel = InputFactory.Model(
                 "InnerModel",
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
-                properties: [InputFactory.Property("value", InputPrimitiveType.String, xmlSerializationOptions: new("value"))]);
+                properties: [InputFactory.Property("value", InputPrimitiveType.String, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("value")))]);
             var outerModel = InputFactory.Model(
                 "OuterModel",
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
-                properties: [InputFactory.Property("inner", innerModel, xmlSerializationOptions: new("inner"))]);
+                properties: [InputFactory.Property("inner", innerModel, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("inner")))]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [innerModel, outerModel]);
 
@@ -115,7 +115,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                     "colors",
                     InputFactory.Array(InputPrimitiveType.String),
                     isRequired: true,
-                    xmlSerializationOptions: new("colors", unwrapped: true))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("colors", unwrapped: true)))]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel]);
 
@@ -138,7 +138,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                     "counts",
                     InputFactory.Array(InputPrimitiveType.Int32),
                     isRequired: true,
-                    xmlSerializationOptions: new("counts", unwrapped: false, itemsName: "int32"))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("counts", unwrapped: false, itemsName: "int32")))]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel]);
 
@@ -160,7 +160,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 properties: [InputFactory.Property(
                     "timestamp",
                     new InputDateTimeType(DateTimeKnownEncoding.Rfc3339, "utcDateTime", "TypeSpec.utcDateTime", InputPrimitiveType.String),
-                    xmlSerializationOptions: new("timestamp"))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("timestamp")))]);
 
             var modelProvider = new ModelProvider(inputModel);
             var mrwProvider = modelProvider.SerializationProviders.FirstOrDefault() as MrwSerializationTypeDefinition;
@@ -184,7 +184,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 properties: [InputFactory.Property(
                     "duration",
                     new InputDurationType(DurationKnownEncoding.Iso8601, "duration", "TypeSpec.duration", InputPrimitiveType.String, null),
-                    xmlSerializationOptions: new("duration"))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("duration")))]);
 
             var modelProvider = new ModelProvider(inputModel);
             var mrwProvider = modelProvider.SerializationProviders.FirstOrDefault() as MrwSerializationTypeDefinition;
@@ -208,7 +208,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 properties: [InputFactory.Property(
                     "data",
                     InputPrimitiveType.Base64,
-                    xmlSerializationOptions: new("data"))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("data")))]);
 
             var modelProvider = new ModelProvider(inputModel);
             var mrwProvider = modelProvider.SerializationProviders.FirstOrDefault() as MrwSerializationTypeDefinition;
@@ -232,7 +232,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 properties: [InputFactory.Property(
                     "content",
                     InputPrimitiveType.Any,
-                    xmlSerializationOptions: new("content"))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("content")))]);
 
             var modelProvider = new ModelProvider(inputModel);
             var mrwProvider = modelProvider.SerializationProviders.FirstOrDefault() as MrwSerializationTypeDefinition;
@@ -261,7 +261,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 properties: [InputFactory.Property(
                     "status",
                     enumType,
-                    xmlSerializationOptions: new("status"))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("status")))]);
 
             MockHelpers.LoadMockGenerator(
                 inputEnums: () => [enumType],
@@ -295,7 +295,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 properties: [InputFactory.Property(
                     "status",
                     enumType,
-                    xmlSerializationOptions: new("status"))]);
+                    serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("status")))]);
 
             MockHelpers.LoadMockGenerator(
                 inputEnums: () => [enumType],
@@ -324,15 +324,15 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 discriminatedKind: "cat",
                 properties:
                 [
-                    InputFactory.Property("meows", InputPrimitiveType.Boolean, isRequired: true, xmlSerializationOptions: new("meows"))
+                    InputFactory.Property("meows", InputPrimitiveType.Boolean, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("meows")))
                 ]);
             var baseModel = InputFactory.Model(
                 "pet",
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true, xmlSerializationOptions: new("kind")),
-                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("name"))
+                    InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("kind"))),
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))
                 ],
                 discriminatedModels: new Dictionary<string, InputModelType>() { { "cat", catModel } });
 
@@ -365,15 +365,15 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 discriminatedKind: "cat",
                 properties:
                 [
-                    InputFactory.Property("meows", InputPrimitiveType.Boolean, isRequired: true, xmlSerializationOptions: new("meows"))
+                    InputFactory.Property("meows", InputPrimitiveType.Boolean, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("meows")))
                 ]);
             var baseModel = InputFactory.Model(
                 "pet",
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true, xmlSerializationOptions: new("kind")),
-                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("name"))
+                    InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("kind"))),
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))
                 ],
                 discriminatedModels: new Dictionary<string, InputModelType>() { { "cat", catModel } });
 
@@ -401,8 +401,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("id", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("id", attribute: true)),
-                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("name"))
+                    InputFactory.Property("id", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("id", attribute: true))),
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))
                 ]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel]);
@@ -427,9 +427,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("id", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("id", attribute: true)),
-                    InputFactory.Property("label", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("label", attribute: true, @namespace: new("https://example.com/ns1", "ns1"))),
-                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("name"))
+                    InputFactory.Property("id", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("id", attribute: true))),
+                    InputFactory.Property("label", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("label", attribute: true, @namespace: InputFactory.Serialization.XmlNamespace("https://example.com/ns1", "ns1")))),
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))
                 ]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel]);
@@ -454,8 +454,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("id", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("id")),
-                    InputFactory.Property("category", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("category", @namespace: new("https://example.com/ns1", "ns1")))
+                    InputFactory.Property("id", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("id"))),
+                    InputFactory.Property("category", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("category", @namespace: InputFactory.Serialization.XmlNamespace("https://example.com/ns1", "ns1"))))
                 ]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel]);
@@ -480,7 +480,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Output | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, xmlSerializationOptions: new("name"))
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))
                 ]);
 
             var (_, serialization) = MrwSerializationTypeDefinitionTests.CreateModelAndSerialization(inputModel);
@@ -503,7 +503,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Output | InputModelTypeUsage.Json | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, wireName: "name", xmlSerializationOptions: new("name"))
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, wireName: "name", serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))
                 ]);
 
             var (_, serialization) = MrwSerializationTypeDefinitionTests.CreateModelAndSerialization(inputModel);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/XmlSerializationCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/XmlSerializationCustomizationTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("Prop1", InputPrimitiveType.String, xmlSerializationOptions: new("prop1")),
-                    InputFactory.Property("Prop2", new InputNullableType(InputPrimitiveType.String), xmlSerializationOptions: new("prop2"))
+                    InputFactory.Property("Prop1", InputPrimitiveType.String, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("prop1"))),
+                    InputFactory.Property("Prop2", new InputNullableType(InputPrimitiveType.String), serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("prop2")))
                 ]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel],
@@ -62,7 +62,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("Prop1", InputPrimitiveType.String, xmlSerializationOptions: new("prop1"))
+                    InputFactory.Property("Prop1", InputPrimitiveType.String, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("prop1")))
                 ]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel],
@@ -98,8 +98,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("Prop1", InputPrimitiveType.String, xmlSerializationOptions: new("prop1")),
-                    InputFactory.Property("Prop2", new InputNullableType(InputPrimitiveType.String), xmlSerializationOptions: new("prop2"))
+                    InputFactory.Property("Prop1", InputPrimitiveType.String, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("prop1"))),
+                    InputFactory.Property("Prop2", new InputNullableType(InputPrimitiveType.String), serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("prop2")))
                 ]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel],
@@ -126,8 +126,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 usage: InputModelTypeUsage.Input | InputModelTypeUsage.Xml,
                 properties:
                 [
-                    InputFactory.Property("Id", InputPrimitiveType.String, xmlSerializationOptions: new("id", attribute: true)),
-                    InputFactory.Property("Name", InputPrimitiveType.String, xmlSerializationOptions: new("name"))
+                    InputFactory.Property("Id", InputPrimitiveType.String, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("id", attribute: true))),
+                    InputFactory.Property("Name", InputPrimitiveType.String, serializationOptions: InputFactory.Serialization.Options(xml: InputFactory.Serialization.Xml("name")))
                 ]);
             var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
                 inputModels: () => [inputModel],

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/InputFactory.cs
@@ -66,6 +66,37 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
             }
         }
 
+        public static class Serialization
+        {
+            public static InputSerializationOptions Options(
+                InputJsonSerializationOptions? json = null,
+                InputXmlSerializationOptions? xml = null)
+            {
+                return new InputSerializationOptions(json, xml);
+            }
+
+            public static InputJsonSerializationOptions Json(string name)
+            {
+                return new InputJsonSerializationOptions(name);
+            }
+
+            public static InputXmlSerializationOptions Xml(
+                string name,
+                bool? attribute = null,
+                InputXmlNamespaceOptions? @namespace = null,
+                bool? unwrapped = null,
+                string? itemsName = null,
+                InputXmlNamespaceOptions? itemsNamespace = null)
+            {
+                return new InputXmlSerializationOptions(name, attribute, @namespace, unwrapped, itemsName, itemsNamespace);
+            }
+
+            public static InputXmlNamespaceOptions XmlNamespace(string ns, string prefix)
+            {
+                return new InputXmlNamespaceOptions(ns, prefix);
+            }
+        }
+
         public static InputHeaderParameter ContentTypeParameter(string contentType)
             => HeaderParameter(
                 "contentType",
@@ -247,12 +278,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
             string? summary = null,
             string? serializedName = null,
             string? doc = null,
-            InputXmlSerializationOptions? xmlSerializationOptions = null)
+            InputSerializationOptions? serializationOptions = null)
         {
-            var serializationOptions = new InputSerializationOptions(
-                json: new(wireName ?? name.ToVariableName()),
-                xml: xmlSerializationOptions);
-
+            serializationOptions ??= new InputSerializationOptions();
             return new InputModelProperty(
                 name: name,
                 summary: summary,


### PR DESCRIPTION
Adds json serialization options to PropertyWireInformation and updates references to SerializedName to use the serialization options instead.

fixes: https://github.com/microsoft/typespec/issues/5861