### PR TITLE
[skill] Improve http-client-python bump-and-release skill

### DIFF
--- a/.github/skills/http-client-python-bump-and-release/SKILL.md
+++ b/.github/skills/http-client-python-bump-and-release/SKILL.md
@@ -60,7 +60,9 @@ npm install -g npm-check-updates
 
    Example:
    - Original: `@typespec/http-specs: 0.1.0-alpha.12-dev.5`, updated by step 4 to `0.1.0-alpha.11` → keep `0.1.0-alpha.12-dev.5`.
+   - Original: `@typespec/http-specs: 0.1.0-alpha.12-dev.5`, updated by step 4 to `0.1.0-alpha.12` → keep `0.1.0-alpha.12` (step 4 works as expected).
    - Original: `@azure-tools/azure-http-specs: 0.1.0-alpha.12-dev.2`, updated to `0.1.0-alpha.11` → keep `0.1.0-alpha.12-dev.2`.
+   - Original: `@azure-tools/azure-http-specs: 0.1.0-alpha.12-dev.2`, updated to `0.1.0-alpha.12` → keep `0.1.0-alpha.12` (step 4 works as expected).
 
 7. Run version change script:
 


### PR DESCRIPTION
Updates the http-client-python bump-and-release SKILL.md with:

- Clarified description text
- Added step 6: Verify devDependencies versions for specs (@typespec/http-specs and @azure-tools/azure-http-specs) to prevent npm-check-updates from downgrading dev versions
- Renumbered subsequent steps accordingly