### PR TITLE
[compiler] Identifier interpolation

### DIFF
--- a/.chronus/changes/witemple-msft-interpolation-2026-1-24-10-1-6.md
+++ b/.chronus/changes/witemple-msft-interpolation-2026-1-24-10-1-6.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Added the ability to interpolate identifiers in most positions (model, property, enum, union, scalar, operation names, etc.). To compute an identifier, use backticks as if creating a templated string type (e.g. `const v = "Model"; model \`My${v}` { ... }`).

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -695,6 +695,12 @@ const diagnostics = {
         "Interpolated identifier must evaluate to a string value. Interpolation in identifier names cannot produce non-string values.",
     },
   },
+  "invalid-interpolated-identifier-context": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Interpolated identifiers are not supported for ${"kind"} declarations yet.`,
+    },
+  },
 
   /**
    * Binder

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -688,6 +688,13 @@ const diagnostics = {
         "Value interpolated in this string template cannot be converted to a string. Only literal types can be automatically interpolated.",
     },
   },
+  "invalid-interpolated-identifier": {
+    severity: "error",
+    messages: {
+      default:
+        "Interpolated identifier must evaluate to a string value. Interpolation in identifier names cannot produce non-string values.",
+    },
+  },
 
   /**
    * Binder

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -1314,6 +1314,11 @@ export interface ImportStatementNode extends BaseNode {
 export interface IdentifierNode extends BaseNode {
   readonly kind: SyntaxKind.Identifier;
   readonly sv: string;
+  /**
+   * Present when this identifier was declared using backticked interpolation syntax
+   * (e.g. `My${name}`).
+   */
+  readonly interpolation?: StringTemplateExpressionNode;
 }
 
 export interface DecoratorExpressionNode extends BaseNode {

--- a/packages/compiler/test/checker/alias.test.ts
+++ b/packages/compiler/test/checker/alias.test.ts
@@ -194,6 +194,18 @@ describe("compiler: aliases", () => {
     strictEqual(Baz.properties.get("x")!.type, Bar);
   });
 
+  it("disallows interpolated alias declaration names", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      alias \`Alias\${"A"}\` = string;
+      `,
+    );
+
+    const diagnostics = await testHost.diagnose("./");
+    expectDiagnostics(diagnostics, [{ code: "invalid-interpolated-identifier-context" }]);
+  });
+
   it("model expression defined in alias use containing namespace", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",

--- a/packages/compiler/test/checker/enum.test.ts
+++ b/packages/compiler/test/checker/enum.test.ts
@@ -31,6 +31,24 @@ describe("compiler: enums", () => {
     ok(!E.members.get("C")!.value);
   });
 
+  it("supports interpolated enum and enum member names", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      const suffix = "A";
+      @test enum \`E\${suffix}\` {
+        \`M\${suffix}\`
+      }
+      `,
+    );
+
+    const { EA } = (await testHost.compile("./")) as {
+      EA: Enum;
+    };
+
+    ok(EA.members.get("MA"));
+  });
+
   it("can have values", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",

--- a/packages/compiler/test/checker/interface.test.ts
+++ b/packages/compiler/test/checker/interface.test.ts
@@ -53,6 +53,21 @@ describe("compiler: interfaces", () => {
     ok(blues.has(Foo));
   });
 
+  it("supports interpolated interface declaration names", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      const suffix = "A";
+      @test interface \`Interface\${suffix}\` {}
+      `,
+    );
+
+    const { InterfaceA } = (await testHost.compile("./")) as {
+      InterfaceA: Interface;
+    };
+    strictEqual(InterfaceA.name, "InterfaceA");
+  });
+
   it("throws diagnostics for duplicate properties", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",

--- a/packages/compiler/test/checker/model.test.ts
+++ b/packages/compiler/test/checker/model.test.ts
@@ -149,7 +149,6 @@ describe("compiler: models", () => {
       const diagnostics = await testHost.diagnose("main.tsp");
       expectDiagnostics(diagnostics, [{ code: "invalid-ref" }, { code: "expect-value" }]);
     });
-
   });
 
   describe("property defaults", () => {

--- a/packages/compiler/test/checker/model.test.ts
+++ b/packages/compiler/test/checker/model.test.ts
@@ -178,6 +178,24 @@ describe("compiler: models", () => {
       ok(S.constructors.get("fromA"));
       strictEqual(S.constructors.get("fromA")!.parameters[0].name, "valueA");
     });
+
+    it("disallows interpolated names for const/alias/namespace declarations", async () => {
+      testHost.addTypeSpecFile(
+        "main.tsp",
+        `
+        const \`Const\${"A"}\` = "ok";
+        alias \`Alias\${"A"}\` = string;
+        namespace \`Ns\${"A"}\` {}
+        `,
+      );
+
+      const diagnostics = await testHost.diagnose("main.tsp");
+      expectDiagnostics(diagnostics, [
+        { code: "invalid-interpolated-identifier-context" },
+        { code: "invalid-interpolated-identifier-context" },
+        { code: "invalid-interpolated-identifier-context" },
+      ]);
+    });
   });
 
   describe("property defaults", () => {

--- a/packages/compiler/test/checker/namespaces.test.ts
+++ b/packages/compiler/test/checker/namespaces.test.ts
@@ -64,6 +64,18 @@ describe("compiler: namespaces with blocks", () => {
     strictEqual(Test.kind, "Namespace" as const);
   });
 
+  it("disallows interpolated namespace declaration names", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      namespace \`Ns\${"A"}\` {}
+      `,
+    );
+
+    const diagnostics = await testHost.diagnose("./");
+    expectDiagnostics(diagnostics, [{ code: "invalid-interpolated-identifier-context" }]);
+  });
+
   it("merges like namespaces", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",

--- a/packages/compiler/test/checker/operations.test.ts
+++ b/packages/compiler/test/checker/operations.test.ts
@@ -25,6 +25,18 @@ describe("compiler: operations", () => {
     strictEqual((foo.returnType as IntrinsicType).name, "void");
   });
 
+  it("supports interpolated operation declaration names", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      const suffix = "A";
+      @test op \`op\${suffix}\`(): void;
+      `,
+    );
+    const { opA } = (await testHost.compile("./main.tsp")) as { opA: Operation };
+    strictEqual(opA.name, "opA");
+  });
+
   it("keeps reference to source operation", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",

--- a/packages/compiler/test/checker/scalar.test.ts
+++ b/packages/compiler/test/checker/scalar.test.ts
@@ -50,6 +50,19 @@ describe("compiler: scalars", () => {
     strictEqual(A.name, "A");
   });
 
+  it("supports interpolated scalar, constructor, and parameter names", async () => {
+    const { SA } = await runner.compile(`
+      const suffix = "A";
+      @test scalar \`S\${suffix}\` {
+        init \`from\${suffix}\`(\`value\${suffix}\`: string);
+      }
+    `);
+
+    strictEqual(SA.kind, "Scalar");
+    ok(SA.constructors.get("fromA"));
+    strictEqual(SA.constructors.get("fromA")!.parameters[0].name, "valueA");
+  });
+
   // Test for https://github.com/microsoft/typespec/issues/1764
   it("template parameter are scoped to the scalar", async () => {
     const { A, B } = await runner.compile(`

--- a/packages/compiler/test/checker/union.test.ts
+++ b/packages/compiler/test/checker/union.test.ts
@@ -70,6 +70,14 @@ describe("declarations", () => {
     strictEqual(varXType.kind, "Scalar");
     strictEqual(varXType.name, "int32");
   });
+
+  it("supports interpolated union declaration names", async () => {
+    const { UnionA } = await Tester.compile(t.code`
+      const suffix = "A";
+      @test union ${t.union("UnionA")} { variant: string };
+    `);
+    strictEqual(UnionA.kind, "Union");
+  });
 });
 
 describe("expressions", () => {

--- a/packages/compiler/test/checker/values/const.test.ts
+++ b/packages/compiler/test/checker/values/const.test.ts
@@ -34,6 +34,11 @@ it("declare const in namespace", async () => {
   strictEqual(value.value.asNumber(), 123);
 });
 
+it("disallows interpolated const declaration names", async () => {
+  const diagnostics = await diagnoseUsage(`┆const \`Const\${"A"}\` = "ok";┆`);
+  expectDiagnostics(diagnostics.diagnostics, [{ code: "invalid-interpolated-identifier-context" }]);
+});
+
 describe("invalid assignment", () => {
   async function expectInvalidAssignment(code: string) {
     const { diagnostics, pos, end } = await diagnoseUsage(code);

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -160,6 +160,33 @@ describe("compiler: parser", () => {
     ]);
   });
 
+  describe("interpolated identifiers", () => {
+    parseEach([
+      'const v = "A"; model `Model${v}` { `${v}`: string; }',
+      'const v = "A"; scalar `Scalar${v}`;',
+      'const v = "A"; enum `Enum${v}` { value }',
+      'const v = "A"; union `Union${v}` { value: string }',
+      'const v = "A"; interface `Interface${v}` {}',
+      'const v = "A"; op `op${v}`(): void;',
+      [
+        'const v = "A"; model `Model${v}` { `${v}`: string; }',
+        (script: TypeSpecScriptNode) => {
+          const model = script.statements.find((x) => x.kind === SyntaxKind.ModelStatement);
+          ok(model && model.kind === SyntaxKind.ModelStatement);
+          ok(model.id.interpolation);
+          strictEqual(model.id.interpolation.head.value, "Model");
+          strictEqual(model.id.interpolation.spans.length, 1);
+          strictEqual(model.id.interpolation.spans[0].literal.value, "");
+          const prop = model.properties[0];
+          ok(prop && prop.kind === SyntaxKind.ModelProperty);
+          ok(prop.id.interpolation);
+          strictEqual(prop.id.interpolation.head.value, "");
+          strictEqual(prop.id.interpolation.spans.length, 1);
+        },
+      ],
+    ]);
+  });
+
   describe("model extends statements", () => {
     parseEach([
       "model foo extends bar { }",


### PR DESCRIPTION
WIP

This PR enables interpolation of string values into identifiers in many cases, reusing the existing syntax for keyword escapes.

- `Type` declaration identifiers: model, union, enum, interface, etc. (with the limitation that these are not possible to reference by identifier, but they can still be declared. But NOT namespaces as this is just too fraught.
- Member identifiers: interface operations, model properties, enum members.

⚠️ This was 100% generated by the copilot CLI as an experiment.