### PR TITLE
[compiler] `name` metaproperty

### DIFF
--- a/.chronus/changes/witemple-msft-name-metaparam-2026-1-24-9-30-37.md
+++ b/.chronus/changes/witemple-msft-name-metaparam-2026-1-24-9-30-37.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Added a `name` metaproperty to most declarations that evaluates to the declared name of the type.

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3077,18 +3077,31 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
 
         if (base) {
           if (identifier.parent.selector === "::") {
-            if (base?.node === undefined && base?.declarations && base.declarations.length > 0) {
+            const baseNode = base?.node ?? base?.declarations?.[0];
+            if (baseNode?.kind === SyntaxKind.OperationStatement) {
               // Process meta properties separately, such as `::parameters`, `::returnType`
-              const nodeModels = base?.declarations[0];
-              if (nodeModels.kind === SyntaxKind.OperationStatement) {
-                const operation = nodeModels as OperationStatementNode;
-                addCompletion("parameters", operation.symbol);
-                addCompletion("returnType", operation.symbol);
-              }
-            } else if (base?.node?.kind === SyntaxKind.ModelProperty) {
+              const operation = baseNode as OperationStatementNode;
+              addCompletion("parameters", operation.symbol);
+              addCompletion("returnType", operation.symbol);
+              addCompletion("name", operation.symbol);
+            } else if (baseNode?.kind === SyntaxKind.ModelProperty) {
               // Process meta properties separately, such as `::type`
-              const metaProperty = base.node as ModelPropertyNode;
+              const metaProperty = baseNode as ModelPropertyNode;
               addCompletion("type", metaProperty.symbol);
+              addCompletion("name", metaProperty.symbol);
+            } else if (
+              baseNode?.kind === SyntaxKind.ModelStatement ||
+              baseNode?.kind === SyntaxKind.EnumStatement ||
+              baseNode?.kind === SyntaxKind.UnionStatement ||
+              baseNode?.kind === SyntaxKind.InterfaceStatement ||
+              baseNode?.kind === SyntaxKind.ScalarStatement ||
+              baseNode?.kind === SyntaxKind.EnumMember ||
+              baseNode?.kind === SyntaxKind.UnionVariant
+            ) {
+              const symbol = (baseNode as { symbol?: Sym }).symbol;
+              if (symbol) {
+                addCompletion("name", symbol);
+              }
             }
           } else {
             addCompletions(base.exports ?? base.members);

--- a/packages/compiler/test/checker/values/string-values.test.ts
+++ b/packages/compiler/test/checker/values/string-values.test.ts
@@ -97,6 +97,26 @@ describe("string templates", () => {
   });
 });
 
+describe("::name metaproperty", () => {
+  const cases: Array<[string, string, string]> = [
+    ["model", "M::name", `model M {}`],
+    ["model property", "M.p::name", `model M { p: string; }`],
+    ["enum", "E::name", `enum E { x }`],
+    ["enum member", "E.x::name", `enum E { x }`],
+    ["union", "U::name", `union U { a: string }`],
+    ["union variant", "U.a::name", `union U { a: string }`],
+    ["scalar", "S::name", `scalar S;`],
+    ["interface", "I::name", `interface I {}`],
+    ["operation", "o::name", `op o(): void;`],
+  ];
+
+  it.each(cases)("returns a string value for %s", async (_, expr, declaration) => {
+    const value = await compileValue(expr, declaration);
+    strictEqual(value.valueKind, "StringValue");
+    strictEqual(value.value, expr.split("::")[0].split(".").at(-1)!);
+  });
+});
+
 describe("validate literal are assignable", () => {
   const cases: Array<[string, Array<["✔" | "✘", string, string?]>]> = [
     [

--- a/packages/compiler/test/name-resolver.test.ts
+++ b/packages/compiler/test/name-resolver.test.ts
@@ -780,6 +780,54 @@ describe("operations", () => {
         ok(x.finalSymbol === Bar.finalSymbol, "Should resolve to Bar");
       });
     });
+
+    describe("resolves ::name meta property", () => {
+      it("on declaration symbols", () => {
+        const refs = getResolutions(
+          [
+            `
+            model M { p: string; }
+            enum E { x }
+            union U { a: string }
+            scalar S;
+            interface I {}
+            op O(): void;
+          `,
+          ],
+          "M::name",
+          "E::name",
+          "U::name",
+          "S::name",
+          "I::name",
+          "O::name",
+        );
+
+        for (const ref of Object.values(refs)) {
+          ok(ref.resolutionResult & ResolutionResultFlags.Resolved);
+          assertSymbol(ref.finalSymbol, { name: "name", flags: SymbolFlags.Const });
+        }
+      });
+
+      it("on member symbols", () => {
+        const refs = getResolutions(
+          [
+            `
+            model M { p: string; }
+            enum E { x }
+            union U { a: string }
+          `,
+          ],
+          "M.p::name",
+          "E.x::name",
+          "U.a::name",
+        );
+
+        for (const ref of Object.values(refs)) {
+          ok(ref.resolutionResult & ResolutionResultFlags.Resolved);
+          assertSymbol(ref.finalSymbol, { name: "name", flags: SymbolFlags.Const });
+        }
+      });
+    });
   });
 });
 

--- a/packages/compiler/test/server/completion.test.ts
+++ b/packages/compiler/test/server/completion.test.ts
@@ -503,10 +503,19 @@ describe("identifiers", () => {
           value: "(model property)\n```typespec\nB.a: A\n```",
         },
       },
+      {
+        label: "name",
+        insertText: "name",
+        kind: CompletionItemKind.Field,
+        documentation: {
+          kind: MarkupKind.Markdown,
+          value: "(model property)\n```typespec\nB.a: A\n```",
+        },
+      },
     ]);
   });
 
-  it("completes meta property '::parameters' and '::returnType' on operation", async () => {
+  it("completes meta property '::parameters', '::returnType' and '::name' on operation", async () => {
     const completions = await complete(
       `
       op base(one: string): void;    
@@ -527,6 +536,15 @@ describe("identifiers", () => {
       {
         label: "returnType",
         insertText: "returnType",
+        kind: CompletionItemKind.Method,
+        documentation: {
+          kind: MarkupKind.Markdown,
+          value: "```typespec\nop base(one: string): void\n```",
+        },
+      },
+      {
+        label: "name",
+        insertText: "name",
         kind: CompletionItemKind.Method,
         documentation: {
           kind: MarkupKind.Markdown,
@@ -562,6 +580,27 @@ describe("identifiers", () => {
         documentation: {
           kind: MarkupKind.Markdown,
           value: "```typespec\nop b(one: string): void\n```",
+        },
+      },
+    ]);
+  });
+
+  it("completes meta property '::name' on model", async () => {
+    const completions = await complete(
+      `
+      model A {}
+      @@doc(A::┆, "docs");
+      `,
+    );
+
+    check(completions, [
+      {
+        label: "name",
+        insertText: "name",
+        kind: CompletionItemKind.Class,
+        documentation: {
+          kind: MarkupKind.Markdown,
+          value: "```typespec\nmodel A\n```",
         },
       },
     ]);


### PR DESCRIPTION
WIP

This PR adds a `name` metaproperty to declarations. This applies to model, enum, union, interface, and scalar declarations, as well as member declarations of the same.

⚠️ This PR was 100% generated automatically by the copilot CLI.