### PR TITLE
Content type header shouldn't be dropped when returned from @head operation

### DIFF
--- a/packages/http/src/http-property.ts
+++ b/packages/http/src/http-property.ts
@@ -99,6 +99,10 @@ export interface GetHttpPropertyOptions {
   implicitParameter?: (
     param: ModelProperty,
   ) => PathParameterOptions | QueryParameterOptions | undefined;
+  /**
+   * When true, treat `Content-Type` headers as regular headers.
+   */
+  treatContentTypeAsHeader?: boolean;
 }
 /**
  * Find the type of a property in a model
@@ -196,11 +200,13 @@ function getHttpProperty(
   }
 
   if (annotations.header) {
-    if (annotations.header.name.toLowerCase() === "content-type") {
+    if (
+      annotations.header.name.toLowerCase() === "content-type" &&
+      !options.treatContentTypeAsHeader
+    ) {
       return createResult({ kind: "contentType" });
-    } else {
-      return createResult({ kind: "header", options: annotations.header });
     }
+    return createResult({ kind: "header", options: annotations.header });
   } else if (annotations.cookie) {
     return createResult({ kind: "cookie", options: annotations.cookie });
   } else if (annotations.query) {

--- a/packages/http/src/responses.ts
+++ b/packages/http/src/responses.ts
@@ -15,7 +15,11 @@ import {
   Type,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
-import { getStatusCodeDescription, getStatusCodesWithDiagnostics } from "./decorators.js";
+import {
+  getOperationVerb,
+  getStatusCodeDescription,
+  getStatusCodesWithDiagnostics,
+} from "./decorators.js";
 import { HttpProperty } from "./http-property.js";
 import { HttpStateKeys, reportDiagnostic } from "./lib.js";
 import { Visibility } from "./metadata.js";
@@ -118,8 +122,11 @@ function processResponseType(
   }
 
   // Get body
+  const verb = getOperationVerb(program, operation);
   let { body: resolvedBody, metadata } = diagnostics.pipe(
-    resolveHttpPayload(program, responseType, Visibility.Read, HttpPayloadDisposition.Response),
+    resolveHttpPayload(program, responseType, Visibility.Read, HttpPayloadDisposition.Response, {
+      treatContentTypeAsHeader: verb === "head",
+    }),
   );
   // Get explicity defined status codes
   const statusCodes: HttpStatusCodes = diagnostics.pipe(

--- a/packages/http/test/responses.test.ts
+++ b/packages/http/test/responses.test.ts
@@ -140,6 +140,22 @@ it("supports any casing for string literal 'Content-Type' header properties.", a
   deepStrictEqual(routes[2].responses[0].responses[0].body?.contentTypes, ["application/json"]);
 });
 
+it("treats content-type as a header for HEAD responses", async () => {
+  const [routes, diagnostics] = await getOperationsWithServiceNamespace(
+    `
+      @head
+      op head(): { @header "content-type": "text/plain" };
+    `,
+  );
+
+  expectDiagnosticEmpty(diagnostics);
+  strictEqual(routes.length, 1);
+  const response = routes[0].responses[0].responses[0];
+  strictEqual(response.body, undefined);
+  ok(response.headers);
+  deepStrictEqual(Object.keys(response.headers), ["content-type"]);
+});
+
 // Regression test for https://github.com/microsoft/typespec/issues/328
 it("empty response model becomes body if it has children", async () => {
   const [routes, diagnostics] = await getOperationsWithServiceNamespace(


### PR DESCRIPTION
fix #9809