### PR TITLE
fix: handle duplicate method signatures in BuildCurrentMethodSignatures

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -973,7 +973,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 ? originalMethods.Concat(CustomCodeView.Methods)
                 : originalMethods;
 
-            return allMethods.ToDictionary(m => m.Signature, m => m, MethodSignature.MethodSignatureComparer);
+            var result = new Dictionary<MethodSignature, MethodProvider>(MethodSignature.MethodSignatureComparer);
+            foreach (var method in allMethods)
+            {
+                result.TryAdd(method.Signature, method);
+            }
+            return result;
         }
 
         private static bool ShouldProcessMethodForBackCompat(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
@@ -2863,6 +2863,46 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         }
 
         [Test]
+        public async Task BackCompatibility_DuplicateMethodSignatureDoesNotThrow()
+        {
+            var bodyParam1 = InputFactory.BodyParameter("param1", InputPrimitiveType.String, isRequired: true);
+            var bodyParam2 = InputFactory.BodyParameter("param1", InputPrimitiveType.Int32, isRequired: true);
+
+            var operation1 = InputFactory.Operation(
+                "TestMethod",
+                parameters: [bodyParam1]);
+            var operation2 = InputFactory.Operation(
+                "TestMethod",
+                parameters: [bodyParam2]);
+
+            List<InputMethodParameter> methodParameters1 =
+            [
+                InputFactory.MethodParameter("param1", InputPrimitiveType.String, location: InputRequestLocation.Body, isRequired: true),
+            ];
+            List<InputMethodParameter> methodParameters2 =
+            [
+                InputFactory.MethodParameter("param1", InputPrimitiveType.Int32, location: InputRequestLocation.Body, isRequired: true),
+            ];
+
+            var method1 = InputFactory.BasicServiceMethod("TestMethod", operation1, parameters: methodParameters1);
+            var method2 = InputFactory.BasicServiceMethod("TestMethod", operation2, parameters: methodParameters2);
+            var client = InputFactory.Client(TestClientName, methods: [method1, method2]);
+
+            var generator = await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [client],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var clientProvider = generator.Object.OutputLibrary.TypeProviders.OfType<ClientProvider>().FirstOrDefault();
+            Assert.IsNotNull(clientProvider);
+            Assert.IsNotNull(clientProvider!.LastContractView);
+
+            // Use reflection to invoke internal ProcessTypeForBackCompatibility method
+            // This should not throw even when there are duplicate method signatures
+            var processMethod = typeof(ClientProvider).GetMethod("ProcessTypeForBackCompatibility", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.DoesNotThrow(() => processMethod?.Invoke(clientProvider, null));
+        }
+
+        [Test]
         public void ServerTemplateWithBasePathOnly_DoesNotDuplicateBasePath()
         {
             // This tests a scenario where the server template includes a base path:

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/BackCompatibility_DuplicateMethodSignatureDoesNotThrow/TestClient.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/BackCompatibility_DuplicateMethodSignatureDoesNotThrow/TestClient.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Threading.Tasks;
+
+namespace Sample
+{
+    public partial class TestClient
+    {
+        public virtual ClientResult TestMethod(BinaryContent content, RequestOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Task<ClientResult> TestMethodAsync(BinaryContent content, RequestOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Replace ToDictionary with TryAdd loop in ClientProvider.BuildCurrentMethodSignatures to gracefully handle duplicate method signatures. This prevents an ArgumentException when multiple methods share the same signature (e.g. overloaded operations with different body types producing identical protocol method signatures).