### PR TITLE
Fix tpm build order

### DIFF
--- a/eng/tsp-core/tpm/packages.ts
+++ b/eng/tsp-core/tpm/packages.ts
@@ -15,6 +15,18 @@ const EXCLUDED_PACKAGES = [
   "packages/http-client-java", // Too large for pkg-pr-new
 ];
 
+/**
+ * Critical packages that must be built before other packages.
+ * When using many pnpm --filter flags, pnpm may not correctly resolve the build
+ * order. These packages and their dependencies (via the "..." suffix) are placed
+ * first in the filter list to ensure they are built in the correct order.
+ *
+ * The key chain is: compiler → prettier-plugin-typespec → tspd
+ * Many packages run `tspd gen-extern-signature` during their build and need tspd
+ * (and its dependency prettier-plugin-typespec) to already be available.
+ */
+export const CRITICAL_PACKAGES = ["@typespec/prettier-plugin-typespec", "@typespec/tspd"];
+
 export interface PackageInfo {
   name: string;
   path: string;


### PR DESCRIPTION
Recent pr adding tpm to build all packages including standalone ones seems to not work well into building the upstream dependencies. This should fix it.