### PR TITLE
Docs: Fix useAuth example highlighted line

### DIFF
--- a/website/src/content/docs/docs/getting-started/getting-started-rest/05-authentication.md
+++ b/website/src/content/docs/docs/getting-started/getting-started-rest/05-authentication.md
@@ -18,7 +18,7 @@ Bearer authentication uses tokens for access control. The server generates a tok
 
 Let's update our existing operations by enforcing authentication using the `@useAuth` decorator.We'll add authentication to the operations that modify pet data, such as creating, updating, and deleting pets. We'll also add a new error model for unauthorized access.
 
-```tsp title=main.tsp tryit="{"emit": ["@typespec/openapi3"]}" ins={59,72-75,79,90-92,104,107-109,126-130}
+```tsp title=main.tsp tryit="{"emit": ["@typespec/openapi3"]}" ins={59,72-75,79,90-92,103,107-109,126-130}
 import "@typespec/http";
 
 using Http;


### PR DESCRIPTION
## Switch highlight comment to correct line

**Problem:**
On [Example: Enforcing Authentication on Specific Operations](https://typespec.io/docs/getting-started/getting-started-rest/05-authentication/#example-enforcing-authentication-on-specific-operations), into the Authentication documentation, the `@useAuth(BearerAuth)` should be highlighted.
But, the delete route declaration is highlighted instead:
<img width="701" height="114" alt="image" src="https://github.com/user-attachments/assets/3241bfd4-ffdf-4aa1-ba29-ac7c025287b7" />


**Solution:**
Modified `ins={104}` to `ins={103}`