### PR TITLE
Fix: Handle empty namespace in CodeWriter to prevent 'global::.' output

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -658,8 +658,11 @@ namespace Microsoft.TypeSpec.Generator
                 UseNamespace(type.Namespace);
 
                 AppendRaw("global::");
-                AppendRaw(type.Namespace);
-                AppendRaw(".");
+                if (!string.IsNullOrEmpty(type.Namespace))
+                {
+                    AppendRaw(type.Namespace);
+                    AppendRaw(".");
+                }
                 if (type.DeclaringType is not null)
                     AppendRaw($"{type.DeclaringType.Name}.");
                 AppendRaw(type.Name);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/CodeWriterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/CodeWriterTests.cs
@@ -727,5 +727,54 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
             var result = codeWriter.ToString(false);
             Assert.AreEqual(expected, result);
         }
+
+        // Regression test for https://github.com/microsoft/typespec/issues/9880
+        // When a CSharpType has an empty namespace (can happen when Roslyn cannot resolve the type),
+        // the CodeWriter should not output "global::." (global prefix followed by empty namespace and dot).
+        [Test]
+        public void TypeWithEmptyNamespaceDoesNotOutputGlobalDot()
+        {
+            // Create a CSharpType with an empty namespace (simulating an unresolved error type)
+            var typeWithEmptyNamespace = new CSharpType(
+                "UnresolvedType",
+                "", // empty namespace
+                isValueType: false,
+                isNullable: false,
+                declaringType: null,
+                args: [],
+                isPublic: true,
+                isStruct: false);
+
+            using var writer = new CodeWriter();
+            writer.Append($"{typeWithEmptyNamespace}");
+            var result = writer.ToString(false);
+
+            // Should contain "global::UnresolvedType" (without extra dot after global::)
+            Assert.That(result, Does.Contain("global::UnresolvedType"),
+                "Type with empty namespace should be prefixed with 'global::' directly followed by the type name");
+        }
+
+        // Verifies that types with proper namespaces still work correctly
+        [Test]
+        public void TypeWithNamespaceOutputsCorrectly()
+        {
+            var typeWithNamespace = new CSharpType(
+                "ResolvedType",
+                "Sample.Models",
+                isValueType: false,
+                isNullable: false,
+                declaringType: null,
+                args: [],
+                isPublic: true,
+                isStruct: false);
+
+            using var writer = new CodeWriter();
+            writer.Append($"{typeWithNamespace}");
+            var result = writer.ToString(false);
+
+            // Should contain the full qualified name
+            Assert.That(result, Does.Contain("global::Sample.Models.ResolvedType"),
+                "Type with namespace should include the full namespace in output");
+        }
     }
 }


### PR DESCRIPTION
## Summary

When a CSharpType has an empty namespace (which can occur when Roslyn cannot resolve a type reference, such as in Custom code that inherits from generated types), the CodeWriter was outputting `global::.` followed by the type name, resulting in invalid C# syntax.

**Before:**
```csharp
public partial class PublisherResource : global::.HciClusterPublisherResource, IJsonModel<PublisherData>
```

**After:**
```csharp
public partial class PublisherResource : global::HciClusterPublisherResource, IJsonModel<PublisherData>
```

## Root Cause

The issue occurs when:
1. Custom code has a type alias class (e.g., `PublisherResource : HciClusterPublisherResource`)
2. The base type `HciClusterPublisherResource` is a generated type that exists in the `Generated/` folder
3. When compiling the Custom code folder, Roslyn cannot resolve `HciClusterPublisherResource` because generated files are excluded from the compilation
4. This causes Roslyn to mark the base type as an error type with no namespace
5. When the CodeWriter writes the base type, it outputs `global::{empty_namespace}.{name}` which becomes `global::.{name}`

## Fix

Added a check in `CodeWriter.AppendType` to only append the namespace and dot separator when the namespace is not empty.

## Tests

Added two unit tests:
- `TypeWithEmptyNamespaceDoesNotOutputGlobalDot`: Verifies the fix
- `TypeWithNamespaceOutputsCorrectly`: Regression test for normal case

All existing tests pass (1263 generator tests + 1171 ClientModel tests).

Fixes https://github.com/microsoft/typespec/issues/9880