### PR TITLE
Remove cache for Azure devops

### DIFF
--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -24,12 +24,6 @@ steps:
         inputs:
           version: 8.0.x
 
-  - task: Cache@2
-    inputs:
-      key: 'pnpm | "$(Agent.OS)" | pnpm-lock.yaml'
-      path: ${{ parameters.pnpmStorePath }}
-    displayName: Cache pnpm store
-
   - script: npm install -g pnpm # Pnpm manage-package-manager-versions will respect packageManager field
     displayName: Install pnpm
   - script: pnpm config set store-dir ${{ parameters.pnpmStorePath }}


### PR DESCRIPTION
Cache@2 has been unreliable and barely brings a performance gain so just removing it. 