### PR TITLE
[Python] Support patching polymorphic models

### DIFF
--- a/packages/http-client-python/generator/pygen/codegen/templates/model_base.py.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/model_base.py.jinja2
@@ -725,6 +725,10 @@ class Model(_MyMutableMapping):
     def __init_subclass__(cls, discriminator: typing.Optional[str] = None) -> None:
         for base in cls.__bases__:
             if hasattr(base, "__mapping__"):
+                if discriminator is None:
+                    # This could mean that a ploymorphic model has been patched without an explicit discriminator.
+                    # We will attempt to find and replace its parent in the mapping.
+                    discriminator = next((k for k, v in base.__mapping__.items() if v == base), None)
                 base.__mapping__[discriminator or cls.__name__] = cls  # type: ignore
 
     {% if code_model.has_padded_model_property %}


### PR DESCRIPTION
If a polymorphic model is patched - it wont be deserialized unless it has explicitly been declared with the same discriminator as its parent. This patch intends to automatically infer that discriminator, so that the patched model will replace the original in polymorphic deserialization.

Before:
```python
from ._models import PolyMorphicModel as GeneratedModel

# Unless the original discriminator was specified, this patched model would not be
# used for deserialization.
class ModifiedModel(GeneratedModel, discriminator="fooModel"):
    extra_property: str = "Foo"

```

After:
```python
from ._models import PolyMorphicModel as GeneratedModel

# The discriminator is now automatically inferred from the inherited model.
class ModifiedModel(GeneratedModel):
    extra_property: str = "Foo"

```