### PR TITLE
fix: set git user and email in Submit-AzureSdkForNetPr.ps1

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -130,6 +130,10 @@ try {
     }
     
     Push-Location $tempDir
+
+    # Configure git user for commits in this repository
+    git config user.name "azure-sdk"
+    git config user.email "azuresdk@microsoft.com"
     
     # Add the remote
     git remote add origin "https://github.com/$RepoOwner/$RepoName.git"


### PR DESCRIPTION
Configure git user.name and user.email on the freshly initialized repo so commits succeed in CI environments without a global git identity.