### PR TITLE
Fix TypeFactory.CreateCSharpType re-entrant crash on self-referencing models

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -51,7 +51,12 @@ namespace Microsoft.TypeSpec.Generator
             }
 
             type = CreateCSharpTypeCore(inputType);
-            TypeCache.Add(inputType, type);
+            // Use indexer instead of Add() to handle re-entrant calls.
+            // Self-referencing models (e.g. QueryFilter with "and: QueryFilter[]")
+            // cause CreateCSharpTypeCore to recursively call CreateCSharpType for the
+            // same InputType before the outer call completes. The inner call adds the
+            // key first; the outer call then overwrites with the same value harmlessly.
+            TypeCache[inputType] = type;
             return type;
         }
 


### PR DESCRIPTION
## Summary

Fixes #10031

Self-referencing models (e.g. `QueryFilter` with `and: QueryFilter[]`) cause `TypeFactory.CreateCSharpType` to crash with `System.ArgumentException: An item with the same key has already been added`. This is because recursive property resolution triggers re-entrant calls that `Dictionary.Add()` cannot handle.

## Change

**One-line fix** in `TypeFactory.cs`: replace `TypeCache.Add(inputType, type)` with `TypeCache[inputType] = type`.

The indexer assignment is idempotent — when the inner (re-entrant) call adds the cache entry first, the outer call simply overwrites with the identical value.

## Call Flow (before fix)

```
CreateCSharpType(QueryFilter)          // outer — cache miss
  → CreateCSharpTypeCore
    → CreateModel → BuildProperties
      → CreateCSharpType(QueryFilter[])
        → CreateCSharpType(QueryFilter)  // inner — cache miss (outer hasn't added yet)
          → resolves → TypeCache.Add(QueryFilter, ...) ✅
      → outer resumes → TypeCache.Add(QueryFilter, ...) 💥 duplicate key
```

## Regression Testing

All existing tests pass with zero regressions:

| Test Suite | Passed | Failed |
|---|---|---|
| Generator.Tests | 1,274 | 0 |
| ClientModel.Tests | 1,216 | 0 |
| Input.Tests | 88 | 0 |
| Local.Tests (Sample) | 37 | 0 |
| Spector.Tests | 15 (843 skipped by design) | 0 |
| **Regen check (63 specs)** | **63/63** | **0** |
| **Git diff after regen** | **Zero diff** | — |

---

> 🤖 This PR was authored by GitHub Copilot