### PR TITLE
fix: improve error message when createTester base lacks package.json

### DIFF
--- a/.chronus/changes/fix-create-tester-error-message-2026-03-15.md
+++ b/.chronus/changes/fix-create-tester-error-message-2026-03-15.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Improve error message when `createTester` base directory does not contain a package.json

--- a/packages/compiler/src/testing/tester.ts
+++ b/packages/compiler/src/testing/tester.ts
@@ -72,7 +72,16 @@ async function createTesterFs(base: string, options: TesterOptions) {
   };
 
   const sl = await createSourceLoader(host);
-  const selfName = JSON.parse((await host.readFile(resolvePath(base, "package.json"))).text).name;
+  const packageJsonPath = resolvePath(base, "package.json");
+  let packageJsonContent: string;
+  try {
+    packageJsonContent = (await host.readFile(packageJsonPath)).text;
+  } catch (e) {
+    throw new Error(
+      `createTester failed to read '${packageJsonPath}'. The first argument to createTester must be the library root directory containing a package.json. Got: '${base}'`,
+    );
+  }
+  const selfName = JSON.parse(packageJsonContent).name;
   const moduleHost: ResolveModuleHost = {
     realpath: async (x) => x,
     stat: host.stat,

--- a/packages/compiler/src/testing/tester.ts
+++ b/packages/compiler/src/testing/tester.ts
@@ -79,6 +79,7 @@ async function createTesterFs(base: string, options: TesterOptions) {
   } catch (e) {
     throw new Error(
       `createTester failed to read '${packageJsonPath}'. The first argument to createTester must be the library root directory containing a package.json. Got: '${base}'`,
+      { cause: e },
     );
   }
   const selfName = JSON.parse(packageJsonContent).name;

--- a/packages/compiler/test/testing/tester-library-discovery.test.ts
+++ b/packages/compiler/test/testing/tester-library-discovery.test.ts
@@ -1,4 +1,4 @@
-import { it } from "vitest";
+import { expect, it } from "vitest";
 import { CompilerHost } from "../../src/core/types.js";
 import { createTestFileSystem, mockFile } from "../../src/testing/fs.js";
 import { resolveVirtualPath } from "../../src/testing/test-utils.js";
@@ -49,4 +49,15 @@ it("subpath typespec export get added to the test host", async () => {
     libraries: ["mylib"],
   });
   await Tester.compile(`import "mylib/subpath";`);
+});
+
+it("throws a clear error when base does not contain a package.json", async () => {
+  const fs = mkFs({});
+  const Tester = createTester(resolveVirtualPath("not-a-library-root"), {
+    host: fs,
+    libraries: [],
+  });
+  await expect(Tester.compile(``)).rejects.toThrowError(
+    /createTester failed to read.*package\.json.*first argument to createTester must be the library root/,
+  );
 });


### PR DESCRIPTION
Fixes #9597

## Summary

- When `createTester` is called with a base directory that does not contain a `package.json`, the error was a generic file-not-found. This change catches the error and throws a clear, actionable message indicating the first argument must be the library root directory.
- Adds a corresponding test case.

## Test plan

- [x] Added unit test that verifies a descriptive error is thrown when `package.json` is missing from the base directory.