### PR TITLE
Fix typos in source comments and strings

### DIFF
--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -646,7 +646,7 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
     const loadedType = stdTypes[name];
     compilerAssert(
       loadedType,
-      `TypeSpec std type "${name}" should have been initalized before using array syntax.`,
+      `TypeSpec std type "${name}" should have been initialized before using array syntax.`,
     );
     return loadedType as any;
   }

--- a/packages/compiler/src/server/tspconfig/completion.ts
+++ b/packages/compiler/src/server/tspconfig/completion.ts
@@ -479,7 +479,7 @@ function resolveVariableInterpolationCompleteItems(
   } else if (/{[^}]*$/.test(curText)) {
     // parameters and built-in variables
     const result = [
-      ...getVariableCompletionItem(yamlDocNodes, "parameters", "Custom paramters variables"),
+      ...getVariableCompletionItem(yamlDocNodes, "parameters", "Custom parameters variables"),
       ...["cwd", "project-root"].map((value) => {
         const item: CompletionItem = {
           label: value,

--- a/packages/http-server-csharp/src/lib/scaffolding.ts
+++ b/packages/http-server-csharp/src/lib/scaffolding.ts
@@ -153,7 +153,7 @@ namespace ${mock.namespace}
     public class ${mock.className} : ${mock.interfaceName}
     {
         /// <summary>
-        /// The controller constructor, using the dependency injection container to satisfy the paramters.
+        /// The controller constructor, using the dependency injection container to satisfy the parameters.
         /// </summary>
         /// <param name="initializer">The initializer class, registered with dependency injection</param>
         /// <param name="accessor">The accessor for the HttpContext, allows your implementation to 

--- a/packages/http-server-js/src/util/differentiate.ts
+++ b/packages/http-server-js/src/util/differentiate.ts
@@ -604,7 +604,7 @@ function overlaps(range: IntegerRange, other: IntegerRange): boolean {
 }
 
 /**
- * Optional paramters for model differentiation.
+ * Optional parameters for model differentiation.
  */
 interface DifferentiateModelOptions {
   /**


### PR DESCRIPTION
Fixed a few misspellings I noticed while reading through the code:

- `paramters` → `parameters` in scaffolding.ts, differentiate.ts, and completion.ts
- `initalized` → `initialized` in checker.ts