### PR TITLE
fix: fix dictionary deserialization crash for specs with example values

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/Utf8JsonReaderExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/Utf8JsonReaderExtensions.cs
@@ -164,9 +164,15 @@ namespace Microsoft.TypeSpec.Generator.Input
                 throw new JsonException();
             }
             reader.Read();
+            string? id = null;
             var result = new Dictionary<string, T>();
             while (reader.TokenType != JsonTokenType.EndObject)
             {
+                // Skip $id metadata (reference tracking), just like TryReadReferenceId does
+                if (reader.TryReadReferenceId(ref id))
+                {
+                    continue;
+                }
                 var key = reader.GetString() ?? throw new JsonException("Dictionary key cannot be null");
                 reader.Read();
                 var item = reader.ReadWithConverter<T>(options);


### PR DESCRIPTION
The dictionary TryReadComplexType overload (added in #9983) manually iterated dictionary entries but treated \ metadata as regular dictionary keys. When a dictionary value object contains \ (for reference tracking), the manual iteration read it as a dictionary entry key and tried to parse the reference ID string as an InputExampleValue, corrupting the reader position.

Fix: skip \ metadata entries (via TryReadReferenceId) when iterating dictionary keys, consistent with how other converters handle reference tracking metadata. This preserves the manual iteration needed to handle \$-prefixed user keys (like \) while correctly ignoring serialization metadata.

Fixes regression from #9983.