### PR TITLE
Fix typos across codebase and improve build script logging

### DIFF
--- a/packages/compiler/src/core/parser.ts
+++ b/packages/compiler/src/core/parser.ts
@@ -2676,7 +2676,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
         // Error recovery: If a list *is* surrounded by punctuation, then
         // the list ends at statement keyword or end-of-file under the
         // assumption that the closing delimiter is missing. This check is
-        // duplicated from above to preempt the parseExpected(delimeter)
+        // duplicated from above to preempt the parseExpected(delimiter)
         // below.
         if (parseExpected(kind.close)) {
           mutate(r.range).end = previousTokenEnd;

--- a/packages/http-client-java/emitter/src/common/operation.ts
+++ b/packages/http-client-java/emitter/src/common/operation.ts
@@ -27,7 +27,7 @@ export interface Operation extends Aspect {
   signatureParameters?: Array<Parameter>;
 
   /**
-   * Mapping of all the content types available for this operation to the coresponding request.
+   * Mapping of all the content types available for this operation to the corresponding request.
    */
   requestMediaTypes?: Record<string, Request>;
 

--- a/packages/http-client-python/generator/pygen/__init__.py
+++ b/packages/http-client-python/generator/pygen/__init__.py
@@ -222,7 +222,7 @@ class ReaderAndWriter:
         kwargs["output-folder"] = str(self.output_folder)
         self.options = OptionsDict(kwargs)
         if python_json:
-            _LOGGER.warning("Loading python.json file. This behavior will be depreacted")
+            _LOGGER.warning("Loading python.json file. This behavior will be deprecated")
         self.options.update(python_json)
 
     def read_file(self, path: Union[str, Path]) -> str:

--- a/packages/http/src/content-types.ts
+++ b/packages/http/src/content-types.ts
@@ -4,7 +4,7 @@ import { createDiagnostic } from "./lib.js";
 /**
  * Resolve the content types from a model property by looking at the value.
  * @property property Model property
- * @returns List of contnet types and any diagnostics if there was an issue.
+ * @returns List of content types and any diagnostics if there was an issue.
  */
 export function getContentTypes(property: ModelProperty): [string[], readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();

--- a/packages/http/src/responses.ts
+++ b/packages/http/src/responses.ts
@@ -128,7 +128,7 @@ function processResponseType(
       treatContentTypeAsHeader: verb === "head",
     }),
   );
-  // Get explicity defined status codes
+  // Get explicitly defined status codes
   const statusCodes: HttpStatusCodes = diagnostics.pipe(
     getResponseStatusCodes(program, responseType, metadata),
   );
@@ -183,7 +183,7 @@ function processResponseType(
 }
 
 /**
- * Get explicity defined status codes from response type and metadata
+ * Get explicitly defined status codes from response type and metadata
  * Return is an array of strings, possibly empty, which indicates no explicitly defined status codes.
  * We do not check for duplicates here -- that will be done by the caller.
  */

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -617,7 +617,7 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, openApiFor, version }) => {
     });
   });
 
-  it("parmeter with default value and $ref wraps $ref in allOf in OpenAPI 3.0 only", async () => {
+  it("parameter with default value and $ref wraps $ref in allOf in OpenAPI 3.0 only", async () => {
     const res = await openApiFor(
       `
       enum Example { a, b}

--- a/packages/versioning/src/decorators.ts
+++ b/packages/versioning/src/decorators.ts
@@ -391,7 +391,7 @@ export function getUseDependencies(
     while (current) {
       const data = getNamespaceUseDependencyState(program, current);
       if (!data) {
-        // See if the namspace has a version enum
+        // See if the namespace has a version enum
         if (searchEnum) {
           const versions = getVersion(program, current)?.getVersions();
           if (versions?.length) {


### PR DESCRIPTION
Found a few typos scattered across different packages while    
  reading through the code. Also added a small logging improvement to the build scripts for better traceability.