### PR TITLE
fix: set GH_TOKEN early and re-enable publish trigger for eng/ changes

### DIFF
--- a/packages/http-client-csharp/eng/pipeline/publish.yml
+++ b/packages/http-client-csharp/eng/pipeline/publish.yml
@@ -5,8 +5,6 @@ trigger:
   paths:
     include:
       - packages/http-client-csharp/
-    exclude:
-      - packages/http-client-csharp/eng/
 
 pr: none
 

--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -131,6 +131,11 @@ try {
     
     Push-Location $tempDir
 
+    # Set the authentication token for gh CLI early so that scripts invoked
+    # during the build (e.g. Emitter_Version_Dashboard.ps1) can call the
+    # GitHub API to resolve commit hashes in shallow clones.
+    $env:GH_TOKEN = $AuthToken
+
     # Configure git user for commits in this repository
     git config user.name "azure-sdk"
     git config user.email "azuresdk@microsoft.com"
@@ -658,9 +663,6 @@ try {
 
     # Create PR using GitHub CLI
     Write-Host "Creating PR in $RepoOwner/$RepoName using gh CLI..."
-    
-    # Set the authentication token for gh CLI
-    $env:GH_TOKEN = $AuthToken
     
     # Create the PR using gh CLI
     $ghArgs = @("pr", "create", "--repo", "$RepoOwner/$RepoName", "--title", $PRTitle, "--body", $PRBody, "--base", $BaseBranch, "--head", $PRBranch)


### PR DESCRIPTION
Move GH_TOKEN assignment to the start of the script so that the Emitter_Version_Dashboard.ps1 can use gh CLI to resolve commit hashes via the GitHub API in shallow clones.

Also revert the eng/ exclusion from publish.yml triggers so that changes to eng/ scripts (like this one) trigger the publish pipeline.