### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - "packages/http-client-csharp"
+      - "packages/http-client-java"
+      - "packages/http-client-python"
     groups:
       alloy:
         patterns:


### PR DESCRIPTION
Do no include http client standalone packages as part of the same config