### PR TITLE
Dependabot no labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
       - "packages/http-client-csharp"
       - "packages/http-client-java"
       - "packages/http-client-python"
+    labels: [] # conflict with our labels in labels.ts
     groups:
       alloy:
         patterns:
@@ -126,6 +127,7 @@ updates:
       interval: "weekly"
     exclude-paths:
       - ".github/workflows/*.lock.{yaml,yml}"
+    labels: [] # conflict with our labels in labels.ts
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Those labels are not really valuable and are not in our label config which cause label script to fail 