### PR TITLE
chore: remove redundant double semicolons

### DIFF
--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SmartLocation.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/extension/model/SmartLocation.java
@@ -63,7 +63,7 @@ public class SmartLocation implements JsonSerializable<SourceLocation> {
                 if ("path".equals(fieldName)) {
                     smartLocation.path = reader.readArray(JsonReader::readUntyped);
                 } else {
-                    reader.skipChildren();;
+                    reader.skipChildren();
                 }
             }
 


### PR DESCRIPTION
```java
reader.skipChildren();;
```

remove redundant double semicolons in [SmartLocation.java]

```java
reader.skipChildren();
```