### PR TITLE
Skip internal/private custom constructors for settings and schema gen…

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ConfigurationSchemaGenerator.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ConfigurationSchemaGenerator.cs
@@ -117,7 +117,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
 
             // Add custom constructor parameters from custom code (e.g., hand-written constructors
             // added via partial classes) that are not already covered by generated parameters.
-            // Skip credential types, endpoint types (Uri), and options types as they are handled separately.
+            // Only consider public constructors — internal/private constructors contain infrastructure
+            // parameters (pipeline, key credentials, etc.) that are not suitable for configuration.
             var customConstructors = client.CustomCodeView?.Constructors;
             if (customConstructors != null)
             {
@@ -126,6 +127,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
                 knownProps.Add("Options");
                 foreach (var ctor in customConstructors)
                 {
+                    if (!ctor.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public))
+                    {
+                        continue;
+                    }
+
                     foreach (var param in ctor.Signature.Parameters)
                     {
                         var propName = param.Name.ToIdentifierName();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
@@ -107,7 +107,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             // Include custom constructor parameters from custom code (e.g., hand-written constructors
             // added via partial classes) that are not already covered by generated parameters.
-            // Skip credential types, endpoint types (Uri), and options types as they are handled separately.
+            // Only consider public constructors — internal/private constructors contain infrastructure
+            // parameters (pipeline, key credentials, etc.) that are not suitable for configuration binding.
             var customConstructors = _clientProvider.CustomCodeView?.Constructors;
             if (customConstructors != null)
             {
@@ -116,6 +117,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 knownProps.Add("Options");
                 foreach (var ctor in customConstructors)
                 {
+                    if (!ctor.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public))
+                    {
+                        continue;
+                    }
+
                     foreach (var param in ctor.Signature.Parameters)
                     {
                         var propName = param.Name.ToIdentifierName();
@@ -165,8 +171,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 AppendBindingForProperty(body, sectionParam, propName, param.Name.ToVariableName(), param.Type);
             }
 
-            // Bind custom constructor parameters from custom code
-            // Skip credential types, endpoint types (Uri), and options types as they are handled separately.
+            // Bind custom constructor parameters from custom code.
+            // Only consider public constructors — internal/private constructors contain infrastructure
+            // parameters (pipeline, key credentials, etc.) that are not suitable for configuration binding.
             var customConstructors = _clientProvider.CustomCodeView?.Constructors;
             if (customConstructors != null)
             {
@@ -183,6 +190,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 knownProps.Add("Options");
                 foreach (var ctor in customConstructors)
                 {
+                    if (!ctor.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public))
+                    {
+                        continue;
+                    }
+
                     foreach (var param in ctor.Signature.Parameters)
                     {
                         var propName = param.Name.ToIdentifierName();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ConfigurationSchemaGeneratorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ConfigurationSchemaGeneratorTests.cs
@@ -919,6 +919,49 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
             Assert.AreEqual("string", connectionStringProp!["type"]?.GetValue<string>());
         }
 
+        [Test]
+        public async Task Generate_ExcludesInternalConstructorParameters()
+        {
+            // Reset singleton before loading async mock
+            var singletonField = typeof(ClientOptionsProvider).GetField("_singletonInstance", BindingFlags.Static | BindingFlags.NonPublic);
+            singletonField?.SetValue(null, null);
+
+            // Load mock generator with a compilation that contains a custom partial class
+            // for TestService with a public constructor (connectionString) and an internal
+            // constructor (internalParam, anotherInternalParam).
+            await MockHelpers.LoadMockGeneratorAsync(
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var client = InputFactory.Client("TestService");
+            var clientProvider = new ClientProvider(client);
+
+            Assert.IsNotNull(clientProvider.CustomCodeView,
+                "CustomCodeView should be available from the compilation");
+
+            var output = new TestOutputLibrary([clientProvider]);
+            var result = ConfigurationSchemaGenerator.Generate(output);
+
+            Assert.IsNotNull(result);
+            var doc = JsonNode.Parse(result!)!;
+
+            var clientEntry = doc["properties"]?["Clients"]?["properties"]?["TestService"];
+            Assert.IsNotNull(clientEntry, "TestService client entry should exist");
+
+            // Public constructor param should be included
+            var connectionStringProp = clientEntry!["properties"]?["ConnectionString"];
+            Assert.IsNotNull(connectionStringProp,
+                "Public constructor parameter 'connectionString' should appear in schema");
+
+            // Internal constructor params should NOT be included
+            var internalParamProp = clientEntry["properties"]?["InternalParam"];
+            Assert.IsNull(internalParamProp,
+                "Internal constructor parameter 'internalParam' should NOT appear in schema");
+
+            var anotherInternalProp = clientEntry["properties"]?["AnotherInternalParam"];
+            Assert.IsNull(anotherInternalProp,
+                "Internal constructor parameter 'anotherInternalParam' should NOT appear in schema");
+        }
+
         /// <summary>
         /// Test output library that wraps provided TypeProviders.
         /// </summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestData/ConfigurationSchemaGeneratorTests/Generate_ExcludesInternalConstructorParameters/TestService.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/TestData/ConfigurationSchemaGeneratorTests/Generate_ExcludesInternalConstructorParameters/TestService.cs
@@ -1,0 +1,10 @@
+#nullable disable
+
+namespace Sample
+{
+    public partial class TestService
+    {
+        public TestService(string connectionString) { }
+        internal TestService(string internalParam, int anotherInternalParam) { }
+    }
+}


### PR DESCRIPTION
…eration

Only public custom constructors should be considered when discovering additional client parameters for settings properties, BindCore binding, and ConfigurationSchema.json generation. Internal/private constructors contain infrastructure parameters (HttpPipeline, AzureKeyCredential, sync tokens, etc.) that are not suitable for configuration binding.

Fixes build failures in Azure SDK caused by generating bindings for abstract types and internal infrastructure types.