### PR TITLE
fix: skip ConfigurationSchema.json generation for non-public clients

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ConfigurationSchemaGenerator.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ConfigurationSchemaGenerator.cs
@@ -38,7 +38,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
         {
             var clientsWithSettings = output.TypeProviders
                 .OfType<ClientProvider>()
-                .Where(c => c.ClientSettings != null)
+                .Where(c => c.ClientSettings != null && c.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public))
                 .ToList();
 
             if (clientsWithSettings.Count == 0)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ConfigurationSchemaGeneratorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ConfigurationSchemaGeneratorTests.cs
@@ -47,6 +47,25 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
         }
 
         [Test]
+        public void Generate_ReturnsNull_WhenClientMadeInternalAfterConstruction()
+        {
+            var client = InputFactory.Client("TestService");
+            var clientProvider = new ClientProvider(client);
+
+            Assert.IsNotNull(clientProvider.ClientSettings, "ClientSettings should not be null for individually-initialized client");
+
+            // Simulate a visitor changing the client from public to internal (e.g., management RestClientVisitor)
+            var modifiers = clientProvider.DeclarationModifiers;
+            modifiers &= ~TypeSignatureModifiers.Public;
+            modifiers |= TypeSignatureModifiers.Internal;
+            clientProvider.Update(modifiers: modifiers);
+
+            var output = new TestOutputLibrary([clientProvider]);
+            var result = ConfigurationSchemaGenerator.Generate(output);
+            Assert.IsNull(result, "Schema should not be generated for internal clients");
+        }
+
+        [Test]
         public void Generate_ReturnsSchema_ForClientWithSettings()
         {
             var client = InputFactory.Client("TestService");


### PR DESCRIPTION
ConfigurationSchemaGenerator was generating schemas for clients that had been made internal by visitors (e.g., management RestClientVisitor). ClientSettings was set during construction when DeclarationModifiers was still Public, and the generator only checked ClientSettings != null.

Added a DeclarationModifiers.HasFlag(Public) check so only clients that are still public after visitors have run are included in the schema.