### PR TITLE
[http-client-csharp] Use local file reference for plugin sample dependency

### DIFF
--- a/docs/samples/client/csharp/SampleService/package.json
+++ b/docs/samples/client/csharp/SampleService/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@typespec/http-client-csharp": "latest",
+    "@typespec/http-client-csharp": "file:../../../../packages/http-client-csharp",
     "logging-plugin": "file:../plugins/logging"
   }
 }


### PR DESCRIPTION
### Problem

Every time TypeSpec releases a new version, the C# plugin sample fails to build because docs/samples/client/csharp/SampleService/package.json pins @typespec/http-client-csharp to a specific alpha version. The stale version peer dependencies conflict with the newer transitive dependencies.

### Fix

Changed the dependency from a pinned npm version to a file: reference pointing to the local packages/http-client-csharp package. This ensures the sample is always in sync with the monorepo build and eliminates recurring peer dependency conflicts after each release.

Note: the logging-plugin dependency already uses a file: reference with this same pattern.