### PR TITLE
[python] fix incorrect padding of wire key name in splatted body method signature

### DIFF
--- a/.chronus/changes/python-incorrectWireNamePadding-2026-3-9-13-17-1.md
+++ b/.chronus/changes/python-incorrectWireNamePadding-2026-3-9-13-17-1.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix padding of keys in splatted body parameter method signature

--- a/packages/http-client-python/generator/pygen/preprocess/__init__.py
+++ b/packages/http-client-python/generator/pygen/preprocess/__init__.py
@@ -362,11 +362,9 @@ class PreProcessPlugin(YamlUpdatePlugin):
                 yaml_data["clientName"].lower(), PadType.PARAMETER, yaml_data
             )
         if yaml_data.get("propertyToParameterName"):
-            # need to create a new one with padded keys and values
+            # need to create a new one with padded values (but NOT keys, since keys are wire names)
             yaml_data["propertyToParameterName"] = {
-                self.pad_reserved_words(prop, PadType.PROPERTY, yaml_data): self.pad_reserved_words(
-                    param_name, PadType.PARAMETER, yaml_data
-                ).lower()
+                prop: self.pad_reserved_words(param_name, PadType.PARAMETER, yaml_data).lower()
                 for prop, param_name in yaml_data["propertyToParameterName"].items()
             }
         wire_name_lower = (yaml_data.get("wireName") or "").lower()


### PR DESCRIPTION
fixes #10247