### PR TITLE
[python] pass `headers` kwarg to next requests in paging calls

### DIFF
--- a/.chronus/changes/python-headersFix-2026-3-9-15-51-55.md
+++ b/.chronus/changes/python-headersFix-2026-3-9-15-51-55.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Pass `headers` kwarg through to next requests in paging calls

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -129,6 +129,7 @@ words:
   - jsyaml
   - keyer
   - killpg
+  - kwarg
   - kwargs
   - labelledby
   - libc

--- a/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
@@ -1353,7 +1353,8 @@ class _PagingOperationSerializer(_OperationSerializer[PagingOperationType]):
         except StopIteration:
             pass
 
-        retval.append(f'_request = HttpRequest("{builder.next_link_verb}", {next_link_str}{query_str})')
+        header_str = ", headers=_headers"
+        retval.append(f'_request = HttpRequest("{builder.next_link_verb}", {next_link_str}{header_str}{query_str})')
         retval.extend(self._postprocess_http_request(builder, "_request.url"))
 
         return retval


### PR DESCRIPTION
fixes #10313