### PR TITLE
Fix node sea build with newer node

### DIFF
--- a/packages/standalone/scripts/build.ts
+++ b/packages/standalone/scripts/build.ts
@@ -101,9 +101,9 @@ async function buildWithNodeSea() {
   });
   await action(`Injecting blob into ${exePath}`, async () => {
     if (process.platform === "darwin") {
-      await execa`npx postject ${exePath} NODE_SEA_BLOB ${blobPath}  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA`;
+      await execa`npx postject ${exePath} NODE_SEA_BLOB ${blobPath}  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA --overwrite`;
     } else {
-      await execa`npx postject ${exePath} NODE_SEA_BLOB ${blobPath}  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`;
+      await execa`npx postject ${exePath} NODE_SEA_BLOB ${blobPath}  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --overwrite`;
     }
   });
 


### PR DESCRIPTION
It seems like node now is able to bundle single excutable without an external tool but as part of this is broke the existing pipeline. This should fix it until we figure out what we want to do.

Either we only keep building the executable directly on latest node and skip on other or we keep that until node 22 is dropped