### PR TITLE
feat(playground): add compilation spinner, diff highlighting, and out…

### DIFF
--- a/.chronus/changes/feat-playground-ux-improvements-2026-3-13-10-19-30.md
+++ b/.chronus/changes/feat-playground-ux-improvements-2026-3-13-10-19-30.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/playground"
+---
+
+Add compilation spinner, diff highlighting, and output preservation

--- a/packages/playground-website/e2e/ui.e2e.ts
+++ b/packages/playground-website/e2e/ui.e2e.ts
@@ -25,7 +25,8 @@ test.describe("playground UI tests", () => {
     const typespecEditor = page.locator(".monaco-editor").first();
     await typespecEditor.click();
     await page.keyboard.type("invalid");
-    await expect(page.getByText(`No files emitted.`)).toBeVisible();
+    // When compilation errors occur, diagnostics are shown as error markers
+    await expect(page.locator(".squiggly-error")).toBeVisible();
   });
 
   test("shared link works", async ({ page }) => {

--- a/packages/playground/src/react/diff-utils.ts
+++ b/packages/playground/src/react/diff-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Computes which lines in the new text are changed or inserted compared to the old text.
+ * Uses a greedy forward-matching approach to handle insertions/deletions.
+ */
+export function getChangedLineNumbers(oldText: string, newText: string): number[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+
+  const matchedNewIndices = new Set<number>();
+
+  // Simple greedy match: walk both arrays with two pointers
+  let oi = 0;
+  for (let ni = 0; ni < newLines.length; ni++) {
+    for (let j = oi; j < oldLines.length; j++) {
+      if (newLines[ni] === oldLines[j]) {
+        matchedNewIndices.add(ni);
+        oi = j + 1;
+        break;
+      }
+    }
+  }
+
+  // Lines not matched are changed/inserted
+  const changed: number[] = [];
+  for (let ni = 0; ni < newLines.length; ni++) {
+    if (!matchedNewIndices.has(ni)) {
+      changed.push(ni + 1); // Monaco lines are 1-based
+    }
+  }
+  return changed;
+}

--- a/packages/playground/src/react/editor-decorations.css
+++ b/packages/playground/src/react/editor-decorations.css
@@ -1,5 +1,0 @@
-/* Global styles for Monaco editor decorations.
-   These cannot be CSS modules because Monaco applies them by class name. */
-.playground-changed-line {
-  background-color: rgba(0, 180, 0, 0.15);
-}

--- a/packages/playground/src/react/editor-decorations.css
+++ b/packages/playground/src/react/editor-decorations.css
@@ -1,0 +1,5 @@
+/* Global styles for Monaco editor decorations.
+   These cannot be CSS modules because Monaco applies them by class name. */
+.playground-changed-line {
+  background-color: rgba(0, 180, 0, 0.15);
+}

--- a/packages/playground/src/react/file-output/file-output.tsx
+++ b/packages/playground/src/react/file-output/file-output.tsx
@@ -23,21 +23,10 @@ export const FileOutput: FunctionComponent<FileOutputProps> = ({
 }) => {
   const resolvedViewers: Record<string, FileOutputViewer> = useMemo(
     () => ({
-      [RawFileViewer.key]: changedLineNumbers
-        ? {
-            ...RawFileViewer,
-            render: ({ filename, content }: { filename: string; content: string }) => (
-              <OutputEditor
-                filename={filename}
-                value={content}
-                changedLineNumbers={changedLineNumbers}
-              />
-            ),
-          }
-        : RawFileViewer,
+      [RawFileViewer.key]: RawFileViewer,
       ...viewers,
     }),
-    [viewers, changedLineNumbers],
+    [viewers],
   );
   const keys = Object.keys(resolvedViewers);
 
@@ -54,7 +43,7 @@ export const FileOutput: FunctionComponent<FileOutputProps> = ({
   if (keys.length === 0) {
     return <>No viewers</>;
   } else if (keys.length === 1) {
-    return resolvedViewers[keys[0]].render({ filename, content });
+    return resolvedViewers[keys[0]].render({ filename, content, changedLineNumbers });
   }
 
   return (
@@ -69,7 +58,7 @@ export const FileOutput: FunctionComponent<FileOutputProps> = ({
         </Select>
       </div>
 
-      {selectedRender && selectedRender({ filename, content })}
+      {selectedRender && selectedRender({ filename, content, changedLineNumbers })}
     </div>
   );
 };
@@ -77,5 +66,7 @@ export const FileOutput: FunctionComponent<FileOutputProps> = ({
 const RawFileViewer: FileOutputViewer = {
   key: "raw",
   label: "File",
-  render: ({ filename, content }) => <OutputEditor filename={filename} value={content} />,
+  render: ({ filename, content, changedLineNumbers }) => (
+    <OutputEditor filename={filename} value={content} changedLineNumbers={changedLineNumbers} />
+  ),
 };

--- a/packages/playground/src/react/file-output/file-output.tsx
+++ b/packages/playground/src/react/file-output/file-output.tsx
@@ -8,18 +8,36 @@ export interface FileOutputProps {
   readonly filename: string;
   readonly content: string;
   readonly viewers: Record<string, FileOutputViewer>;
+  /** Line numbers to highlight as changed (1-based). */
+  readonly changedLineNumbers?: number[];
 }
 
 /**
  * Display a file output using different viewers.
  */
-export const FileOutput: FunctionComponent<FileOutputProps> = ({ filename, content, viewers }) => {
+export const FileOutput: FunctionComponent<FileOutputProps> = ({
+  filename,
+  content,
+  viewers,
+  changedLineNumbers,
+}) => {
   const resolvedViewers: Record<string, FileOutputViewer> = useMemo(
     () => ({
-      [RawFileViewer.key]: RawFileViewer,
+      [RawFileViewer.key]: changedLineNumbers
+        ? {
+            ...RawFileViewer,
+            render: ({ filename, content }: { filename: string; content: string }) => (
+              <OutputEditor
+                filename={filename}
+                value={content}
+                changedLineNumbers={changedLineNumbers}
+              />
+            ),
+          }
+        : RawFileViewer,
       ...viewers,
     }),
-    [viewers],
+    [viewers, changedLineNumbers],
   );
   const keys = Object.keys(resolvedViewers);
 

--- a/packages/playground/src/react/file-tree/file-tree.tsx
+++ b/packages/playground/src/react/file-tree/file-tree.tsx
@@ -8,10 +8,12 @@ export interface FileTreeExplorerProps {
   readonly files: string[];
   readonly selected: string;
   readonly onSelect: (file: string) => void;
+  readonly changedFiles?: Set<string>;
 }
 
 interface FileTreeNode extends TreeNode {
   readonly isDirectory: boolean;
+  readonly changed?: boolean;
 }
 
 const FileNodeIcon: FC<{ node: FileTreeNode }> = ({ node }) => {
@@ -21,10 +23,18 @@ const FileNodeIcon: FC<{ node: FileTreeNode }> = ({ node }) => {
   return <DocumentRegular />;
 };
 
+const FileNodeLabel: FC<{ node: FileTreeNode }> = ({ node }) => {
+  return (
+    <span style={node.changed ? { fontWeight: 600, color: "var(--colorPaletteGreenForeground1)" } : undefined}>
+      {node.name}
+    </span>
+  );
+};
+
 /**
  * Builds a tree structure from a flat list of file paths.
  */
-function buildTree(files: string[]): FileTreeNode {
+function buildTree(files: string[], changedFiles?: Set<string>): FileTreeNode {
   const root: FileTreeNode = { id: "__root__", name: "root", isDirectory: true, children: [] };
   const dirMap = new Map<string, FileTreeNode>();
   dirMap.set("", root);
@@ -54,6 +64,7 @@ function buildTree(files: string[]): FileTreeNode {
         id: file,
         name: file,
         isDirectory: false,
+        changed: changedFiles?.has(file),
       });
     } else {
       const dirPath = file.substring(0, lastSlash);
@@ -63,6 +74,7 @@ function buildTree(files: string[]): FileTreeNode {
         id: file,
         name: fileName,
         isDirectory: false,
+        changed: changedFiles?.has(file),
       });
     }
   }
@@ -90,8 +102,9 @@ export const FileTreeExplorer: FunctionComponent<FileTreeExplorerProps> = ({
   files,
   selected,
   onSelect,
+  changedFiles,
 }) => {
-  const tree = useMemo(() => buildTree(files), [files]);
+  const tree = useMemo(() => buildTree(files, changedFiles), [files, changedFiles]);
 
   return (
     <div className={style["file-tree"]}>
@@ -101,6 +114,7 @@ export const FileTreeExplorer: FunctionComponent<FileTreeExplorerProps> = ({
         selected={selected}
         onSelect={onSelect}
         nodeIcon={FileNodeIcon}
+        nodeLabel={FileNodeLabel}
       />
     </div>
   );

--- a/packages/playground/src/react/file-tree/file-tree.tsx
+++ b/packages/playground/src/react/file-tree/file-tree.tsx
@@ -25,7 +25,11 @@ const FileNodeIcon: FC<{ node: FileTreeNode }> = ({ node }) => {
 
 const FileNodeLabel: FC<{ node: FileTreeNode }> = ({ node }) => {
   return (
-    <span style={node.changed ? { fontWeight: 600, color: "var(--colorPaletteGreenForeground1)" } : undefined}>
+    <span
+      style={
+        node.changed ? { fontWeight: 600, color: "var(--colorPaletteGreenForeground1)" } : undefined
+      }
+    >
       {node.name}
     </span>
   );

--- a/packages/playground/src/react/index.ts
+++ b/packages/playground/src/react/index.ts
@@ -14,7 +14,11 @@ export {
   type VersionSelectorVersion,
 } from "./footer/index.js";
 export { Playground } from "./playground.js";
-export type { PlaygroundProps, PlaygroundSaveData } from "./playground.js";
+export type {
+  PlaygroundEmitterOptions,
+  PlaygroundProps,
+  PlaygroundSaveData,
+} from "./playground.js";
 export {
   StandalonePlayground,
   createReactPlayground,

--- a/packages/playground/src/react/output-view/file-viewer.tsx
+++ b/packages/playground/src/react/output-view/file-viewer.tsx
@@ -64,7 +64,10 @@ const FileViewerComponent = ({
               changed.add(file);
               // New file: highlight all lines
               const lineCount = contents.text.split("\n").length;
-              lines.set(file, Array.from({ length: lineCount }, (_, i) => i + 1));
+              lines.set(
+                file,
+                Array.from({ length: lineCount }, (_, i) => i + 1),
+              );
               hasAnyChange = true;
             } else if (prev !== undefined && prev !== contents.text) {
               changed.add(file);

--- a/packages/playground/src/react/output-view/file-viewer.tsx
+++ b/packages/playground/src/react/output-view/file-viewer.tsx
@@ -1,12 +1,12 @@
 import { FolderListRegular } from "@fluentui/react-icons";
 import { Pane, SplitPane } from "@typespec/react-components";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FileBreadcrumb } from "../breadcrumb/index.js";
 import { FileOutput } from "../file-output/file-output.js";
 import { FileTreeExplorer } from "../file-tree/index.js";
 import { OutputTabs } from "../output-tabs/output-tabs.js";
 import type { FileOutputViewer, OutputViewerProps, ProgramViewer } from "../types.js";
-import { getChangedLineNumbers } from "../typespec-editor.js";
+import { useFileChanges } from "./use-file-changes.js";
 
 import style from "./output-view.module.css";
 
@@ -21,9 +21,7 @@ const FileViewerComponent = ({
 }) => {
   const [filename, setFilename] = useState<string>("");
   const [content, setContent] = useState<string>("");
-  const [changedFiles, setChangedFiles] = useState<Set<string>>(new Set());
-  const [changedLines, setChangedLines] = useState<Map<string, number[]>>(new Map());
-  const prevContentsRef = useRef<Map<string, string>>(new Map());
+  const { changedFiles, changedLines } = useFileChanges(program, outputFiles, highlightChanges);
 
   const showFileTree = useMemo(
     () => outputFiles.some((f) => f.includes("/")) || outputFiles.length >= 3,
@@ -37,66 +35,6 @@ const FileViewerComponent = ({
     },
     [program.host],
   );
-
-  // When output files change, diff all file contents against cached versions
-  useEffect(() => {
-    if (!highlightChanges) return;
-    let cancelled = false;
-    async function diffFiles() {
-      const changed = new Set<string>();
-      const lines = new Map<string, number[]>();
-      const newContents = new Map<string, string>();
-
-      // If no files from the new output exist in the cache, this is an emitter
-      // switch or initial load — populate the cache without highlighting.
-      const isEmitterSwitch =
-        prevContentsRef.current.size > 0 &&
-        !outputFiles.some((f) => prevContentsRef.current.has(f));
-
-      let hasAnyChange = false;
-      for (const file of outputFiles) {
-        try {
-          const contents = await program.host.readFile("./tsp-output/" + file);
-          newContents.set(file, contents.text);
-          if (!isEmitterSwitch) {
-            const prev = prevContentsRef.current.get(file);
-            if (prev === undefined && prevContentsRef.current.size > 0) {
-              changed.add(file);
-              // New file: highlight all lines
-              const lineCount = contents.text.split("\n").length;
-              lines.set(
-                file,
-                Array.from({ length: lineCount }, (_, i) => i + 1),
-              );
-              hasAnyChange = true;
-            } else if (prev !== undefined && prev !== contents.text) {
-              changed.add(file);
-              lines.set(file, getChangedLineNumbers(prev, contents.text));
-              hasAnyChange = true;
-            } else if (prev === undefined) {
-              hasAnyChange = true;
-            }
-          } else {
-            hasAnyChange = true;
-          }
-        } catch {
-          // file may not be readable
-        }
-      }
-      if (cancelled) return;
-      // Only update cache and changed state when something actually changed.
-      // This prevents spurious effect re-runs from clearing the highlights.
-      if (hasAnyChange || prevContentsRef.current.size === 0) {
-        prevContentsRef.current = newContents;
-        setChangedFiles(changed);
-        setChangedLines(lines);
-      }
-    }
-    void diffFiles();
-    return () => {
-      cancelled = true;
-    };
-  }, [program, outputFiles, highlightChanges]);
 
   useEffect(() => {
     if (outputFiles.length > 0) {

--- a/packages/playground/src/react/output-view/file-viewer.tsx
+++ b/packages/playground/src/react/output-view/file-viewer.tsx
@@ -1,11 +1,12 @@
 import { FolderListRegular } from "@fluentui/react-icons";
 import { Pane, SplitPane } from "@typespec/react-components";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FileBreadcrumb } from "../breadcrumb/index.js";
 import { FileOutput } from "../file-output/file-output.js";
 import { FileTreeExplorer } from "../file-tree/index.js";
 import { OutputTabs } from "../output-tabs/output-tabs.js";
 import type { FileOutputViewer, OutputViewerProps, ProgramViewer } from "../types.js";
+import { getChangedLineNumbers } from "../typespec-editor.js";
 
 import style from "./output-view.module.css";
 
@@ -13,14 +14,19 @@ const FileViewerComponent = ({
   program,
   outputFiles,
   fileViewers,
-}: OutputViewerProps & { fileViewers: Record<string, FileOutputViewer> }) => {
+  highlightChanges,
+}: OutputViewerProps & {
+  fileViewers: Record<string, FileOutputViewer>;
+  highlightChanges: boolean;
+}) => {
   const [filename, setFilename] = useState<string>("");
   const [content, setContent] = useState<string>("");
+  const [changedFiles, setChangedFiles] = useState<Set<string>>(new Set());
+  const [changedLines, setChangedLines] = useState<Map<string, number[]>>(new Map());
+  const prevContentsRef = useRef<Map<string, string>>(new Map());
 
   const showFileTree = useMemo(
-    () =>
-      outputFiles.length > 1 &&
-      (outputFiles.some((f) => f.includes("/")) || outputFiles.length >= 3),
+    () => outputFiles.some((f) => f.includes("/")) || outputFiles.length >= 3,
     [outputFiles],
   );
 
@@ -31,6 +37,63 @@ const FileViewerComponent = ({
     },
     [program.host],
   );
+
+  // When output files change, diff all file contents against cached versions
+  useEffect(() => {
+    if (!highlightChanges) return;
+    let cancelled = false;
+    async function diffFiles() {
+      const changed = new Set<string>();
+      const lines = new Map<string, number[]>();
+      const newContents = new Map<string, string>();
+
+      // If no files from the new output exist in the cache, this is an emitter
+      // switch or initial load — populate the cache without highlighting.
+      const isEmitterSwitch =
+        prevContentsRef.current.size > 0 &&
+        !outputFiles.some((f) => prevContentsRef.current.has(f));
+
+      let hasAnyChange = false;
+      for (const file of outputFiles) {
+        try {
+          const contents = await program.host.readFile("./tsp-output/" + file);
+          newContents.set(file, contents.text);
+          if (!isEmitterSwitch) {
+            const prev = prevContentsRef.current.get(file);
+            if (prev === undefined && prevContentsRef.current.size > 0) {
+              changed.add(file);
+              // New file: highlight all lines
+              const lineCount = contents.text.split("\n").length;
+              lines.set(file, Array.from({ length: lineCount }, (_, i) => i + 1));
+              hasAnyChange = true;
+            } else if (prev !== undefined && prev !== contents.text) {
+              changed.add(file);
+              lines.set(file, getChangedLineNumbers(prev, contents.text));
+              hasAnyChange = true;
+            } else if (prev === undefined) {
+              hasAnyChange = true;
+            }
+          } else {
+            hasAnyChange = true;
+          }
+        } catch {
+          // file may not be readable
+        }
+      }
+      if (cancelled) return;
+      // Only update cache and changed state when something actually changed.
+      // This prevents spurious effect re-runs from clearing the highlights.
+      if (hasAnyChange || prevContentsRef.current.size === 0) {
+        prevContentsRef.current = newContents;
+        setChangedFiles(changed);
+        setChangedLines(lines);
+      }
+    }
+    void diffFiles();
+    return () => {
+      cancelled = true;
+    };
+  }, [program, outputFiles, highlightChanges]);
 
   useEffect(() => {
     if (outputFiles.length > 0) {
@@ -67,13 +130,19 @@ const FileViewerComponent = ({
               files={outputFiles}
               selected={filename}
               onSelect={handleFileSelection}
+              changedFiles={highlightChanges ? changedFiles : undefined}
             />
           </Pane>
           <Pane>
             <div className={style["file-viewer-content-with-breadcrumb"]}>
               <FileBreadcrumb path={filename} />
               <div className={style["file-viewer-content"]}>
-                <FileOutput filename={filename} content={content} viewers={fileViewers} />
+                <FileOutput
+                  filename={filename}
+                  content={content}
+                  viewers={fileViewers}
+                  changedLineNumbers={highlightChanges ? changedLines.get(filename) : undefined}
+                />
               </div>
             </div>
           </Pane>
@@ -86,20 +155,40 @@ const FileViewerComponent = ({
     <div className={style["file-viewer"]}>
       <OutputTabs filenames={outputFiles} selected={filename} onSelect={handleFileSelection} />
       <div className={style["file-viewer-content"]}>
-        <FileOutput filename={filename} content={content} viewers={fileViewers} />
+        <FileOutput
+          filename={filename}
+          content={content}
+          viewers={fileViewers}
+          changedLineNumbers={highlightChanges ? changedLines.get(filename) : undefined}
+        />
       </div>
     </div>
   );
 };
 
-export function createFileViewer(fileViewers: FileOutputViewer[]): ProgramViewer {
+export interface FileViewerOptions {
+  /** When true, highlights changed files in the tree and changed lines in the editor after recompilation. */
+  highlightChanges?: boolean;
+}
+
+export function createFileViewer(
+  fileViewers: FileOutputViewer[],
+  options?: FileViewerOptions,
+): ProgramViewer {
   const viewerMap = Object.fromEntries(fileViewers.map((x) => [x.key, x]));
+  const highlightChanges = options?.highlightChanges ?? false;
   return {
     key: "file-output",
     label: "Output explorer",
     icon: <FolderListRegular />,
     render: (props) => {
-      return <FileViewerComponent {...props} fileViewers={viewerMap} />;
+      return (
+        <FileViewerComponent
+          {...props}
+          fileViewers={viewerMap}
+          highlightChanges={highlightChanges}
+        />
+      );
     },
   };
 }

--- a/packages/playground/src/react/output-view/output-view.module.css
+++ b/packages/playground/src/react/output-view/output-view.module.css
@@ -54,11 +54,11 @@
   height: 100%;
 }
 
-.output-status-bar {
-  padding: 4px 12px;
-  font-size: 12px;
-  text-align: center;
-  background-color: var(--colorNeutralBackground3);
+.output-compiling-overlay {
+  position: absolute;
+  top: 8px;
+  right: 48px;
+  z-index: 10;
 }
 
 .output-stale-banner {

--- a/packages/playground/src/react/output-view/output-view.module.css
+++ b/packages/playground/src/react/output-view/output-view.module.css
@@ -41,3 +41,17 @@
 .viewer-error {
   padding: 20px;
 }
+
+.output-compiling {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.output-compiling-overlay {
+  position: absolute;
+  top: 8px;
+  right: 40px;
+  z-index: 10;
+}

--- a/packages/playground/src/react/output-view/output-view.module.css
+++ b/packages/playground/src/react/output-view/output-view.module.css
@@ -54,11 +54,11 @@
   height: 100%;
 }
 
-.output-compiling-overlay {
-  position: absolute;
-  top: 8px;
-  right: 40px;
-  z-index: 10;
+.output-status-bar {
+  padding: 4px 12px;
+  font-size: 12px;
+  text-align: center;
+  background-color: var(--colorNeutralBackground3);
 }
 
 .output-stale-banner {

--- a/packages/playground/src/react/output-view/output-view.module.css
+++ b/packages/playground/src/react/output-view/output-view.module.css
@@ -60,3 +60,11 @@
   right: 40px;
   z-index: 10;
 }
+
+.output-stale-banner {
+  background-color: var(--colorPaletteYellowBackground2);
+  color: var(--colorNeutralForeground1);
+  padding: 4px 12px;
+  font-size: 12px;
+  text-align: center;
+}

--- a/packages/playground/src/react/output-view/output-view.module.css
+++ b/packages/playground/src/react/output-view/output-view.module.css
@@ -42,6 +42,11 @@
   padding: 20px;
 }
 
+.output-view-wrapper {
+  position: relative;
+  height: 100%;
+}
+
 .output-compiling {
   display: flex;
   align-items: center;

--- a/packages/playground/src/react/output-view/output-view.tsx
+++ b/packages/playground/src/react/output-view/output-view.tsx
@@ -1,4 +1,10 @@
-import { Button, Spinner, Tab, TabList, type SelectTabEventHandler } from "@fluentui/react-components";
+import {
+  Button,
+  Spinner,
+  Tab,
+  TabList,
+  type SelectTabEventHandler,
+} from "@fluentui/react-components";
 import { useCallback, useMemo, useState, type FunctionComponent } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import type { PlaygroundEditorsOptions } from "../playground.js";

--- a/packages/playground/src/react/output-view/output-view.tsx
+++ b/packages/playground/src/react/output-view/output-view.tsx
@@ -75,7 +75,7 @@ export const OutputView: FunctionComponent<OutputViewProps> = ({
     return <></>;
   }
   return (
-    <div style={{ position: "relative", height: "100%" }}>
+    <div className={style["output-view-wrapper"]}>
       {isCompiling && (
         <div className={style["output-compiling-overlay"]}>
           <Spinner size="tiny" label="Compiling..." />

--- a/packages/playground/src/react/output-view/output-view.tsx
+++ b/packages/playground/src/react/output-view/output-view.tsx
@@ -80,11 +80,11 @@ export const OutputView: FunctionComponent<OutputViewProps> = ({
   return (
     <div className={style["output-view-wrapper"]}>
       {isCompiling && (
-        <div className={style["output-compiling-overlay"]}>
+        <div className={style["output-status-bar"]}>
           <Spinner size="tiny" label="Compiling..." />
         </div>
       )}
-      {isOutputStale && (
+      {!isCompiling && isOutputStale && (
         <div className={style["output-stale-banner"]}>
           Output is from last successful compilation
         </div>

--- a/packages/playground/src/react/output-view/output-view.tsx
+++ b/packages/playground/src/react/output-view/output-view.tsx
@@ -1,4 +1,4 @@
-import { Button, Tab, TabList, type SelectTabEventHandler } from "@fluentui/react-components";
+import { Button, Spinner, Tab, TabList, type SelectTabEventHandler } from "@fluentui/react-components";
 import { useCallback, useMemo, useState, type FunctionComponent } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import type { PlaygroundEditorsOptions } from "../playground.js";
@@ -10,12 +10,17 @@ import style from "./output-view.module.css";
 
 export interface OutputViewProps {
   compilationState: CompilationState | undefined;
+  isCompiling?: boolean;
   editorOptions?: PlaygroundEditorsOptions;
   /**
    * List of custom viewers to display the output. It can be file viewers or program viewers.
    */
   viewers?: ProgramViewer[];
   fileViewers?: FileOutputViewer[];
+  /**
+   * When true, highlights changed files and lines after recompilation.
+   */
+  highlightChanges?: boolean;
   /**
    * The currently selected viewer key.
    */
@@ -36,41 +41,58 @@ export interface OutputViewProps {
 
 export const OutputView: FunctionComponent<OutputViewProps> = ({
   compilationState,
+  isCompiling,
   viewers,
   fileViewers,
+  highlightChanges,
   selectedViewer,
   onViewerChange,
   viewerState,
   onViewerStateChange,
 }) => {
   const resolvedViewers = useMemo(
-    () => resolveViewers(viewers, fileViewers),
-    [fileViewers, viewers],
+    () => resolveViewers(viewers, fileViewers, highlightChanges),
+    [fileViewers, viewers, highlightChanges],
   );
 
   if (compilationState === undefined) {
+    if (isCompiling) {
+      return (
+        <div className={style["output-compiling"]}>
+          <Spinner size="small" label="Compiling..." />
+        </div>
+      );
+    }
     return <></>;
   }
   if ("internalCompilerError" in compilationState) {
     return <></>;
   }
   return (
-    <OutputViewInternal
-      compilationResult={compilationState}
-      viewers={resolvedViewers}
-      selectedViewer={selectedViewer}
-      onViewerChange={onViewerChange}
-      viewerState={viewerState}
-      onViewerStateChange={onViewerStateChange}
-    />
+    <div style={{ position: "relative", height: "100%" }}>
+      {isCompiling && (
+        <div className={style["output-compiling-overlay"]}>
+          <Spinner size="tiny" label="Compiling..." />
+        </div>
+      )}
+      <OutputViewInternal
+        compilationResult={compilationState}
+        viewers={resolvedViewers}
+        selectedViewer={selectedViewer}
+        onViewerChange={onViewerChange}
+        viewerState={viewerState}
+        onViewerStateChange={onViewerStateChange}
+      />
+    </div>
   );
 };
 
 function resolveViewers(
   viewers: ProgramViewer[] | undefined,
   fileViewers: FileOutputViewer[] | undefined,
+  highlightChanges?: boolean,
 ): ResolvedViewers {
-  const fileViewer = createFileViewer(fileViewers ?? []);
+  const fileViewer = createFileViewer(fileViewers ?? [], { highlightChanges });
   const output: ResolvedViewers = {
     programViewers: {
       [fileViewer.key]: fileViewer,

--- a/packages/playground/src/react/output-view/output-view.tsx
+++ b/packages/playground/src/react/output-view/output-view.tsx
@@ -79,14 +79,14 @@ export const OutputView: FunctionComponent<OutputViewProps> = ({
   }
   return (
     <div className={style["output-view-wrapper"]}>
-      {isCompiling && (
-        <div className={style["output-status-bar"]}>
-          <Spinner size="tiny" label="Compiling..." />
-        </div>
-      )}
-      {!isCompiling && isOutputStale && (
+      {isOutputStale && (
         <div className={style["output-stale-banner"]}>
           Output is from last successful compilation
+        </div>
+      )}
+      {isCompiling && (
+        <div className={style["output-compiling-overlay"]}>
+          <Spinner size="tiny" label="Compiling..." />
         </div>
       )}
       <OutputViewInternal

--- a/packages/playground/src/react/output-view/output-view.tsx
+++ b/packages/playground/src/react/output-view/output-view.tsx
@@ -17,6 +17,8 @@ import style from "./output-view.module.css";
 export interface OutputViewProps {
   compilationState: CompilationState | undefined;
   isCompiling?: boolean;
+  /** When true, the displayed output is from a previous successful compilation. */
+  isOutputStale?: boolean;
   editorOptions?: PlaygroundEditorsOptions;
   /**
    * List of custom viewers to display the output. It can be file viewers or program viewers.
@@ -48,6 +50,7 @@ export interface OutputViewProps {
 export const OutputView: FunctionComponent<OutputViewProps> = ({
   compilationState,
   isCompiling,
+  isOutputStale,
   viewers,
   fileViewers,
   highlightChanges,
@@ -79,6 +82,11 @@ export const OutputView: FunctionComponent<OutputViewProps> = ({
       {isCompiling && (
         <div className={style["output-compiling-overlay"]}>
           <Spinner size="tiny" label="Compiling..." />
+        </div>
+      )}
+      {isOutputStale && (
+        <div className={style["output-stale-banner"]}>
+          Output is from last successful compilation
         </div>
       )}
       <OutputViewInternal

--- a/packages/playground/src/react/output-view/use-file-changes.ts
+++ b/packages/playground/src/react/output-view/use-file-changes.ts
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getChangedLineNumbers } from "../diff-utils.js";
+import type { CompileResult } from "../types.js";
+
+export interface FileChanges {
+  changedFiles: Set<string>;
+  changedLines: Map<string, number[]>;
+}
+
+/**
+ * Tracks which output files have changed between compilations.
+ * Returns the set of changed file paths and a map of changed line numbers per file.
+ */
+export function useFileChanges(
+  program: CompileResult["program"],
+  outputFiles: string[],
+  highlightChanges: boolean,
+): FileChanges {
+  const [changedFiles, setChangedFiles] = useState<Set<string>>(new Set());
+  const [changedLines, setChangedLines] = useState<Map<string, number[]>>(new Map());
+  const prevContentsRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    if (!highlightChanges) return;
+    let cancelled = false;
+    async function diffFiles() {
+      const changed = new Set<string>();
+      const lines = new Map<string, number[]>();
+      const newContents = new Map<string, string>();
+
+      // If no files from the new output exist in the cache, this is an emitter
+      // switch or initial load — populate the cache without highlighting.
+      const isEmitterSwitch =
+        prevContentsRef.current.size > 0 &&
+        !outputFiles.some((f) => prevContentsRef.current.has(f));
+
+      let hasAnyChange = false;
+      for (const file of outputFiles) {
+        try {
+          const contents = await program.host.readFile("./tsp-output/" + file);
+          newContents.set(file, contents.text);
+          if (!isEmitterSwitch) {
+            const prev = prevContentsRef.current.get(file);
+            if (prev === undefined && prevContentsRef.current.size > 0) {
+              changed.add(file);
+              const lineCount = contents.text.split("\n").length;
+              lines.set(
+                file,
+                Array.from({ length: lineCount }, (_, i) => i + 1),
+              );
+              hasAnyChange = true;
+            } else if (prev !== undefined && prev !== contents.text) {
+              changed.add(file);
+              lines.set(file, getChangedLineNumbers(prev, contents.text));
+              hasAnyChange = true;
+            } else if (prev === undefined) {
+              hasAnyChange = true;
+            }
+          } else {
+            hasAnyChange = true;
+          }
+        } catch {
+          // file may not be readable
+        }
+      }
+      if (cancelled) return;
+      if (hasAnyChange || prevContentsRef.current.size === 0) {
+        prevContentsRef.current = newContents;
+        setChangedFiles(changed);
+        setChangedLines(lines);
+      }
+    }
+    void diffFiles();
+    return () => {
+      cancelled = true;
+    };
+  }, [program, outputFiles, highlightChanges]);
+
+  return useMemo(() => ({ changedFiles, changedLines }), [changedFiles, changedLines]);
+}

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -71,6 +71,9 @@ export interface PlaygroundProps {
   /** Custom file viewers that enabled for certain emitters. Key of the map is emitter name */
   emitterViewers?: Record<string, FileOutputViewer[]>;
 
+  /** Set of emitter names that should highlight changed files/lines after recompilation. */
+  emittersWithChangeHighlighting?: Set<string>;
+
   onSave?: (value: PlaygroundSaveData) => void;
 
   editorOptions?: PlaygroundEditorsOptions;
@@ -154,6 +157,8 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
 
   const typespecModel = useMonacoModel("inmemory://test/main.tsp", "typespec");
   const [compilationState, setCompilationState] = useState<CompilationState | undefined>(undefined);
+  const lastSuccessfulOutputRef = useRef<string[]>([]);
+  const [isCompiling, setIsCompiling] = useState(false);
 
   // Use the playground state hook
   const state = usePlaygroundState({
@@ -205,12 +210,48 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
     return Boolean(selectedSampleName && content === props.samples?.[selectedSampleName]?.content);
   }, [content, selectedSampleName, props.samples]);
 
+  const compileIdRef = useRef(0);
+
   const doCompile = useCallback(async () => {
     const currentContent = typespecModel.getValue();
     const typespecCompiler = host.compiler;
+    const compileId = ++compileIdRef.current;
 
-    const state = await compile(host, currentContent, selectedEmitter, compilerOptions);
-    setCompilationState(state);
+    setIsCompiling(true);
+    let state: CompilationState;
+    try {
+      state = await compile(host, currentContent, selectedEmitter, compilerOptions);
+    } catch (error) {
+      setIsCompiling(false);
+      // eslint-disable-next-line no-console
+      console.error("Compilation failed", error);
+      return;
+    }
+
+    // Discard stale results from an older compilation
+    if (compileId !== compileIdRef.current) return;
+
+    setIsCompiling(false);
+
+    // When compilation has errors and produced no output files, preserve the
+    // previous successful output so the user doesn't lose their selected file
+    // while typing (transient syntax errors).
+    if (
+      "program" in state &&
+      state.program.hasError() &&
+      state.outputFiles.length === 0 &&
+      lastSuccessfulOutputRef.current.length > 0
+    ) {
+      setCompilationState({
+        ...state,
+        outputFiles: lastSuccessfulOutputRef.current,
+      });
+    } else {
+      if ("program" in state && state.outputFiles.length > 0) {
+        lastSuccessfulOutputRef.current = state.outputFiles;
+      }
+      setCompilationState(state);
+    }
     if ("program" in state) {
       const markers: editor.IMarkerData[] = state.program.diagnostics.map((diag) => ({
         ...getMonacoRange(typespecCompiler, diag.target),
@@ -370,9 +411,11 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
   const outputPanel = (
     <OutputView
       compilationState={compilationState}
+      isCompiling={isCompiling}
       editorOptions={props.editorOptions}
       viewers={props.viewers}
       fileViewers={selectedEmitter ? props.emitterViewers?.[selectedEmitter] : undefined}
+      highlightChanges={selectedEmitter ? props.emittersWithChangeHighlighting?.has(selectedEmitter) : false}
       selectedViewer={selectedViewer}
       onViewerChange={onSelectedViewerChange}
       viewerState={viewerState}

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -192,6 +192,12 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
     onContentChange,
   } = state;
 
+  // Clear preserved output when switching emitters
+  useEffect(() => {
+    lastSuccessfulOutputRef.current = [];
+    setIsOutputStale(false);
+  }, [selectedEmitter]);
+
   // Sync Monaco model with state content
   useEffect(() => {
     if (typespecModel.getValue() !== (content ?? "")) {
@@ -282,7 +288,7 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
   const isClientEmitter = selectedEmitter ? props.clientEmitters?.has(selectedEmitter) : false;
 
   useEffect(() => {
-    const delay = isClientEmitter ? 1000 : 200;
+    const delay = isClientEmitter ? 500 : 200;
     const debouncer = debounce(() => doCompile(), delay);
     const disposable = typespecModel.onDidChangeContent(debouncer);
     return () => {

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -71,8 +71,11 @@ export interface PlaygroundProps {
   /** Custom file viewers that enabled for certain emitters. Key of the map is emitter name */
   emitterViewers?: Record<string, FileOutputViewer[]>;
 
-  /** Set of emitter names that should highlight changed files/lines after recompilation. */
-  emittersWithChangeHighlighting?: Set<string>;
+  /**
+   * Set of emitter names that are client emitters (e.g. C#, Python, Java).
+   * These emitters get a longer compile debounce and change highlighting.
+   */
+  clientEmitters?: Set<string>;
 
   onSave?: (value: PlaygroundSaveData) => void;
 
@@ -276,14 +279,17 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
     }
   }, [host, selectedEmitter, compilerOptions, typespecModel]);
 
+  const isClientEmitter = selectedEmitter ? props.clientEmitters?.has(selectedEmitter) : false;
+
   useEffect(() => {
-    const debouncer = debounce(() => doCompile(), 200);
+    const delay = isClientEmitter ? 1000 : 200;
+    const debouncer = debounce(() => doCompile(), delay);
     const disposable = typespecModel.onDidChangeContent(debouncer);
     return () => {
       debouncer.clear();
       disposable.dispose();
     };
-  }, [typespecModel, doCompile]);
+  }, [typespecModel, doCompile, isClientEmitter]);
 
   useEffect(() => {
     void doCompile();
@@ -418,9 +424,7 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
       editorOptions={props.editorOptions}
       viewers={props.viewers}
       fileViewers={selectedEmitter ? props.emitterViewers?.[selectedEmitter] : undefined}
-      highlightChanges={
-        selectedEmitter ? props.emittersWithChangeHighlighting?.has(selectedEmitter) : false
-      }
+      highlightChanges={isClientEmitter}
       selectedViewer={selectedViewer}
       onViewerChange={onSelectedViewerChange}
       viewerState={viewerState}

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -35,6 +35,13 @@ import { ViewToggle, type ViewMode } from "./view-toggle.js";
 // Re-export the PlaygroundState type for convenience
 export type { PlaygroundState };
 
+export interface PlaygroundEmitterOptions {
+  /** Compile debounce delay in milliseconds. Default is 200. */
+  debounce?: number;
+  /** When true, highlights changed files and lines after recompilation. */
+  newChangeDiff?: boolean;
+}
+
 export interface PlaygroundProps {
   host: BrowserHost;
 
@@ -72,10 +79,9 @@ export interface PlaygroundProps {
   emitterViewers?: Record<string, FileOutputViewer[]>;
 
   /**
-   * Set of emitter names that are client emitters (e.g. C#, Python, Java).
-   * These emitters get a longer compile debounce and change highlighting.
+   * Per-emitter playground options. Key is the emitter name.
    */
-  clientEmitters?: Set<string>;
+  emitterOptions?: Record<string, PlaygroundEmitterOptions>;
 
   onSave?: (value: PlaygroundSaveData) => void;
 
@@ -285,17 +291,19 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
     }
   }, [host, selectedEmitter, compilerOptions, typespecModel]);
 
-  const isClientEmitter = selectedEmitter ? props.clientEmitters?.has(selectedEmitter) : false;
+  const currentEmitterOptions = selectedEmitter
+    ? props.emitterOptions?.[selectedEmitter]
+    : undefined;
 
   useEffect(() => {
-    const delay = isClientEmitter ? 500 : 200;
+    const delay = currentEmitterOptions?.debounce ?? 200;
     const debouncer = debounce(() => doCompile(), delay);
     const disposable = typespecModel.onDidChangeContent(debouncer);
     return () => {
       debouncer.clear();
       disposable.dispose();
     };
-  }, [typespecModel, doCompile, isClientEmitter]);
+  }, [typespecModel, doCompile, currentEmitterOptions?.debounce]);
 
   useEffect(() => {
     void doCompile();
@@ -430,7 +438,7 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
       editorOptions={props.editorOptions}
       viewers={props.viewers}
       fileViewers={selectedEmitter ? props.emitterViewers?.[selectedEmitter] : undefined}
-      highlightChanges={isClientEmitter}
+      highlightChanges={currentEmitterOptions?.newChangeDiff}
       selectedViewer={selectedViewer}
       onViewerChange={onSelectedViewerChange}
       viewerState={viewerState}

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -415,7 +415,9 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
       editorOptions={props.editorOptions}
       viewers={props.viewers}
       fileViewers={selectedEmitter ? props.emitterViewers?.[selectedEmitter] : undefined}
-      highlightChanges={selectedEmitter ? props.emittersWithChangeHighlighting?.has(selectedEmitter) : false}
+      highlightChanges={
+        selectedEmitter ? props.emittersWithChangeHighlighting?.has(selectedEmitter) : false
+      }
       selectedViewer={selectedViewer}
       onViewerChange={onSelectedViewerChange}
       viewerState={viewerState}

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -222,16 +222,15 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
     try {
       state = await compile(host, currentContent, selectedEmitter, compilerOptions);
     } catch (error) {
-      setIsCompiling(false);
       // eslint-disable-next-line no-console
       console.error("Compilation failed", error);
       return;
+    } finally {
+      setIsCompiling(false);
     }
 
     // Discard stale results from an older compilation
     if (compileId !== compileIdRef.current) return;
-
-    setIsCompiling(false);
 
     // When compilation has errors and produced no output files, preserve the
     // previous successful output so the user doesn't lose their selected file

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -159,6 +159,7 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
   const [compilationState, setCompilationState] = useState<CompilationState | undefined>(undefined);
   const lastSuccessfulOutputRef = useRef<string[]>([]);
   const [isCompiling, setIsCompiling] = useState(false);
+  const [isOutputStale, setIsOutputStale] = useState(false);
 
   // Use the playground state hook
   const state = usePlaygroundState({
@@ -241,11 +242,13 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
       state.outputFiles.length === 0 &&
       lastSuccessfulOutputRef.current.length > 0
     ) {
+      setIsOutputStale(true);
       setCompilationState({
         ...state,
         outputFiles: lastSuccessfulOutputRef.current,
       });
     } else {
+      setIsOutputStale(false);
       if ("program" in state && state.outputFiles.length > 0) {
         lastSuccessfulOutputRef.current = state.outputFiles;
       }
@@ -411,6 +414,7 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
     <OutputView
       compilationState={compilationState}
       isCompiling={isCompiling}
+      isOutputStale={isOutputStale}
       editorOptions={props.editorOptions}
       viewers={props.viewers}
       fileViewers={selectedEmitter ? props.emitterViewers?.[selectedEmitter] : undefined}

--- a/packages/playground/src/react/types.ts
+++ b/packages/playground/src/react/types.ts
@@ -39,4 +39,6 @@ export interface FileOutputViewer {
 export interface FileOutputViewerProps {
   readonly filename: string;
   readonly content: string;
+  /** Line numbers to highlight as changed (1-based). */
+  readonly changedLineNumbers?: number[];
 }

--- a/packages/playground/src/react/typespec-editor.module.css
+++ b/packages/playground/src/react/typespec-editor.module.css
@@ -1,0 +1,4 @@
+/* Monaco decorations require global class names */
+:global(.playground-changed-line) {
+  background-color: rgba(0, 180, 0, 0.15);
+}

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -37,7 +37,6 @@ export const OutputEditor: FunctionComponent<{
   const model = useMonacoModel(filename);
   const [editorInstance, setEditorInstance] = useState<editor.IStandaloneCodeEditor | null>(null);
   const decorationCollectionRef = useRef<editor.IEditorDecorationsCollection | null>(null);
-  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const onMount = useCallback(({ editor: ed }: { editor: editor.IStandaloneCodeEditor }) => {
     decorationCollectionRef.current = ed.createDecorationsCollection();
@@ -49,7 +48,7 @@ export const OutputEditor: FunctionComponent<{
     model.setValue(value);
   }, [filename, value, model]);
 
-  // Apply changed line decorations when provided
+  // Apply changed line decorations — they persist until the next compilation clears them
   useEffect(() => {
     if (!editorInstance || !decorationCollectionRef.current) return;
 
@@ -63,11 +62,6 @@ export const OutputEditor: FunctionComponent<{
           },
         })),
       );
-
-      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
-      fadeTimerRef.current = setTimeout(() => {
-        decorationCollectionRef.current?.clear();
-      }, 3000);
     } else {
       decorationCollectionRef.current.clear();
     }

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -33,19 +33,16 @@ export function getChangedLineNumbers(oldText: string, newText: string): number[
   const newLines = newText.split("\n");
 
   // Build a set of old lines that are "matched" via LCS
-  const oldSet = new Set<string>(oldLines);
   const matchedNewIndices = new Set<number>();
 
   // Simple greedy match: walk both arrays with two pointers
   let oi = 0;
   for (let ni = 0; ni < newLines.length; ni++) {
     // Try to find current new line in remaining old lines
-    let found = false;
     for (let j = oi; j < oldLines.length; j++) {
       if (newLines[ni] === oldLines[j]) {
         matchedNewIndices.add(ni);
         oi = j + 1;
-        found = true;
         break;
       }
     }

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -3,6 +3,9 @@ import { useCallback, useEffect, useRef, useState, type FunctionComponent } from
 import { Editor, useMonacoModel, type EditorProps } from "./editor.js";
 import type { PlaygroundEditorsOptions } from "./playground.js";
 
+// Re-export for backward compatibility
+export { getChangedLineNumbers } from "./diff-utils.js";
+
 export interface TypeSpecEditorProps extends Omit<EditorProps, "options"> {
   options?: editor.IStandaloneEditorConstructionOptions;
 }
@@ -23,42 +26,6 @@ export const TypeSpecEditor: FunctionComponent<TypeSpecEditorProps> = ({
   };
   return <Editor actions={actions} options={resolvedOptions} {...other}></Editor>;
 };
-
-/**
- * Computes which lines in the new text are changed or inserted compared to the old text.
- * Uses a longest common subsequence (LCS) approach to handle insertions/deletions properly.
- */
-export function getChangedLineNumbers(oldText: string, newText: string): number[] {
-  const oldLines = oldText.split("\n");
-  const newLines = newText.split("\n");
-
-  // Build a set of old lines that are "matched" via LCS
-  const matchedNewIndices = new Set<number>();
-
-  // Simple greedy match: walk both arrays with two pointers
-  let oi = 0;
-  for (let ni = 0; ni < newLines.length; ni++) {
-    // Try to find current new line in remaining old lines
-    for (let j = oi; j < oldLines.length; j++) {
-      if (newLines[ni] === oldLines[j]) {
-        matchedNewIndices.add(ni);
-        oi = j + 1;
-        break;
-      }
-    }
-    // If not found in forward scan, it might still match a later occurrence
-    // but for highlighting purposes, treating it as changed is acceptable
-  }
-
-  // Lines not matched are changed/inserted
-  const changed: number[] = [];
-  for (let ni = 0; ni < newLines.length; ni++) {
-    if (!matchedNewIndices.has(ni)) {
-      changed.push(ni + 1); // Monaco lines are 1-based
-    }
-  }
-  return changed;
-}
 
 export const OutputEditor: FunctionComponent<{
   filename: string;

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -1,5 +1,6 @@
 import { editor, Range } from "monaco-editor";
 import { useCallback, useEffect, useRef, useState, type FunctionComponent } from "react";
+import "./editor-decorations.css";
 import { Editor, useMonacoModel, type EditorProps } from "./editor.js";
 import type { PlaygroundEditorsOptions } from "./playground.js";
 

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -1,5 +1,5 @@
-import { editor } from "monaco-editor";
-import type { FunctionComponent } from "react";
+import { editor, Range } from "monaco-editor";
+import { useCallback, useEffect, useRef, useState, type FunctionComponent } from "react";
 import { Editor, useMonacoModel, type EditorProps } from "./editor.js";
 import type { PlaygroundEditorsOptions } from "./playground.js";
 
@@ -24,12 +24,90 @@ export const TypeSpecEditor: FunctionComponent<TypeSpecEditorProps> = ({
   return <Editor actions={actions} options={resolvedOptions} {...other}></Editor>;
 };
 
+/**
+ * Computes which lines in the new text are changed or inserted compared to the old text.
+ * Uses a longest common subsequence (LCS) approach to handle insertions/deletions properly.
+ */
+export function getChangedLineNumbers(oldText: string, newText: string): number[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+
+  // Build a set of old lines that are "matched" via LCS
+  const oldSet = new Set<string>(oldLines);
+  const matchedNewIndices = new Set<number>();
+
+  // Simple greedy match: walk both arrays with two pointers
+  let oi = 0;
+  for (let ni = 0; ni < newLines.length; ni++) {
+    // Try to find current new line in remaining old lines
+    let found = false;
+    for (let j = oi; j < oldLines.length; j++) {
+      if (newLines[ni] === oldLines[j]) {
+        matchedNewIndices.add(ni);
+        oi = j + 1;
+        found = true;
+        break;
+      }
+    }
+    // If not found in forward scan, it might still match a later occurrence
+    // but for highlighting purposes, treating it as changed is acceptable
+  }
+
+  // Lines not matched are changed/inserted
+  const changed: number[] = [];
+  for (let ni = 0; ni < newLines.length; ni++) {
+    if (!matchedNewIndices.has(ni)) {
+      changed.push(ni + 1); // Monaco lines are 1-based
+    }
+  }
+  return changed;
+}
+
 export const OutputEditor: FunctionComponent<{
   filename: string;
   value: string;
+  changedLineNumbers?: number[];
   editorOptions?: PlaygroundEditorsOptions;
-}> = ({ filename, value, editorOptions }) => {
+}> = ({ filename, value, changedLineNumbers, editorOptions }) => {
   const model = useMonacoModel(filename);
+  const [editorInstance, setEditorInstance] = useState<editor.IStandaloneCodeEditor | null>(null);
+  const decorationCollectionRef = useRef<editor.IEditorDecorationsCollection | null>(null);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const onMount = useCallback(({ editor: ed }: { editor: editor.IStandaloneCodeEditor }) => {
+    decorationCollectionRef.current = ed.createDecorationsCollection();
+    setEditorInstance(ed);
+  }, []);
+
+  useEffect(() => {
+    if (filename === "") return;
+    model.setValue(value);
+  }, [filename, value, model]);
+
+  // Apply changed line decorations when provided
+  useEffect(() => {
+    if (!editorInstance || !decorationCollectionRef.current) return;
+
+    if (changedLineNumbers && changedLineNumbers.length > 0 && changedLineNumbers.length < 500) {
+      decorationCollectionRef.current.set(
+        changedLineNumbers.map((line) => ({
+          range: new Range(line, 1, line, 1),
+          options: {
+            isWholeLine: true,
+            className: "playground-changed-line",
+          },
+        })),
+      );
+
+      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+      fadeTimerRef.current = setTimeout(() => {
+        decorationCollectionRef.current?.clear();
+      }, 3000);
+    } else {
+      decorationCollectionRef.current.clear();
+    }
+  }, [changedLineNumbers, editorInstance]);
+
   if (filename === "") {
     return null;
   }
@@ -41,6 +119,5 @@ export const OutputEditor: FunctionComponent<{
       enabled: false,
     },
   };
-  model.setValue(value);
-  return <Editor model={model} options={options}></Editor>;
+  return <Editor model={model} options={options} onMount={onMount}></Editor>;
 };

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -1,8 +1,8 @@
 import { editor, Range } from "monaco-editor";
 import { useCallback, useEffect, useRef, useState, type FunctionComponent } from "react";
-import "./editor-decorations.css";
 import { Editor, useMonacoModel, type EditorProps } from "./editor.js";
 import type { PlaygroundEditorsOptions } from "./playground.js";
+import "./typespec-editor.module.css";
 
 // Re-export for backward compatibility
 export { getChangedLineNumbers } from "./diff-utils.js";

--- a/packages/playground/test/get-changed-line-numbers.test.ts
+++ b/packages/playground/test/get-changed-line-numbers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getChangedLineNumbers } from "../src/react/typespec-editor.js";
+import { getChangedLineNumbers } from "../src/react/diff-utils.js";
 
 describe("getChangedLineNumbers", () => {
   it("returns empty array when texts are identical", () => {

--- a/packages/playground/test/get-changed-line-numbers.test.ts
+++ b/packages/playground/test/get-changed-line-numbers.test.ts
@@ -33,8 +33,8 @@ describe("getChangedLineNumbers", () => {
   });
 
   it("detects multiple changed lines", () => {
-    const oldText = "aaa\nbbb\nccc\nddd";
-    const newText = "aaa\nXXX\nccc\nYYY";
+    const oldText = "alpha\nbeta\ngamma\ndelta";
+    const newText = "alpha\nXXX\ngamma\nYYY";
     const result = getChangedLineNumbers(oldText, newText);
     expect(result).toEqual([2, 4]);
   });
@@ -47,8 +47,8 @@ describe("getChangedLineNumbers", () => {
   });
 
   it("handles completely different content", () => {
-    const oldText = "aaa\nbbb\nccc";
-    const newText = "xxx\nyyy\nzzz";
+    const oldText = "apple\nbanana\ncherry";
+    const newText = "mango\norange\npeach";
     const result = getChangedLineNumbers(oldText, newText);
     expect(result).toEqual([1, 2, 3]);
   });
@@ -69,9 +69,9 @@ describe("getChangedLineNumbers", () => {
   });
 
   it("handles reordered lines as changes", () => {
-    const oldText = "aaa\nbbb\nccc";
-    const newText = "ccc\nbbb\naaa";
-    // Greedy forward scan: ccc at index 0 matches old[2], then bbb/aaa can't match forward
+    const oldText = "apple\nbanana\ncherry";
+    const newText = "cherry\nbanana\napple";
+    // Greedy forward scan: cherry at index 0 matches old[2], then banana/apple can't match forward
     const result = getChangedLineNumbers(oldText, newText);
     expect(result).toEqual([2, 3]);
   });

--- a/packages/playground/test/get-changed-line-numbers.test.ts
+++ b/packages/playground/test/get-changed-line-numbers.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { getChangedLineNumbers } from "../src/react/typespec-editor.js";
+
+describe("getChangedLineNumbers", () => {
+  it("returns empty array when texts are identical", () => {
+    const text = "line1\nline2\nline3";
+    expect(getChangedLineNumbers(text, text)).toEqual([]);
+  });
+
+  it("returns all line numbers when old text is empty", () => {
+    const result = getChangedLineNumbers("", "line1\nline2\nline3");
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("returns empty array when new text is empty", () => {
+    const result = getChangedLineNumbers("line1\nline2", "");
+    // The empty string splits into [""], which is 1 line that doesn't match any old line
+    expect(result).toEqual([1]);
+  });
+
+  it("detects a single changed line", () => {
+    const oldText = "line1\nline2\nline3";
+    const newText = "line1\nmodified\nline3";
+    const result = getChangedLineNumbers(oldText, newText);
+    expect(result).toEqual([2]);
+  });
+
+  it("detects inserted lines", () => {
+    const oldText = "line1\nline3";
+    const newText = "line1\nline2\nline3";
+    const result = getChangedLineNumbers(oldText, newText);
+    expect(result).toEqual([2]);
+  });
+
+  it("detects multiple changed lines", () => {
+    const oldText = "aaa\nbbb\nccc\nddd";
+    const newText = "aaa\nXXX\nccc\nYYY";
+    const result = getChangedLineNumbers(oldText, newText);
+    expect(result).toEqual([2, 4]);
+  });
+
+  it("returns 1-based line numbers (Monaco convention)", () => {
+    const oldText = "unchanged";
+    const newText = "changed";
+    const result = getChangedLineNumbers(oldText, newText);
+    expect(result).toEqual([1]);
+  });
+
+  it("handles completely different content", () => {
+    const oldText = "aaa\nbbb\nccc";
+    const newText = "xxx\nyyy\nzzz";
+    const result = getChangedLineNumbers(oldText, newText);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("handles appended lines", () => {
+    const oldText = "line1\nline2";
+    const newText = "line1\nline2\nline3\nline4";
+    const result = getChangedLineNumbers(oldText, newText);
+    expect(result).toEqual([3, 4]);
+  });
+
+  it("handles deleted lines (only remaining lines counted)", () => {
+    const oldText = "line1\nline2\nline3\nline4";
+    const newText = "line1\nline4";
+    const result = getChangedLineNumbers(oldText, newText);
+    // line1 and line4 are matched, nothing is "changed" in the new text
+    expect(result).toEqual([]);
+  });
+
+  it("handles reordered lines as changes", () => {
+    const oldText = "aaa\nbbb\nccc";
+    const newText = "ccc\nbbb\naaa";
+    // Greedy forward scan: ccc at index 0 matches old[2], then bbb/aaa can't match forward
+    const result = getChangedLineNumbers(oldText, newText);
+    expect(result).toEqual([2, 3]);
+  });
+});

--- a/packages/react-components/src/tree/tree-row.tsx
+++ b/packages/react-components/src/tree/tree-row.tsx
@@ -18,7 +18,15 @@ export interface TreeViewRowProps {
   readonly activate: (row: TreeRow<any>) => void;
 }
 
-export function TreeViewRow({ id, row, active, focussed, activate, icon: Icon, label: Label }: TreeViewRowProps) {
+export function TreeViewRow({
+  id,
+  row,
+  active,
+  focussed,
+  activate,
+  icon: Icon,
+  label: Label,
+}: TreeViewRowProps) {
   const paddingLeft = row.depth * INDENT_SIZE;
 
   const onClick = useCallback(() => activate(row), [activate, row]);

--- a/packages/react-components/src/tree/tree-row.tsx
+++ b/packages/react-components/src/tree/tree-row.tsx
@@ -14,10 +14,11 @@ export interface TreeViewRowProps {
   readonly active: boolean;
   readonly columns?: Array<TreeRowColumn<any>>;
   readonly icon?: FC<{ node: TreeNode }>;
+  readonly label?: FC<{ node: TreeNode }>;
   readonly activate: (row: TreeRow<any>) => void;
 }
 
-export function TreeViewRow({ id, row, active, focussed, activate, icon: Icon }: TreeViewRowProps) {
+export function TreeViewRow({ id, row, active, focussed, activate, icon: Icon, label: Label }: TreeViewRowProps) {
   const paddingLeft = row.depth * INDENT_SIZE;
 
   const onClick = useCallback(() => activate(row), [activate, row]);
@@ -46,7 +47,7 @@ export function TreeViewRow({ id, row, active, focussed, activate, icon: Icon }:
         </span>
       )}
       <span className="label" title={row.item.name}>
-        {row.item.name}
+        {Label ? <Label node={row.item} /> : row.item.name}
       </span>
     </div>
   );

--- a/packages/react-components/src/tree/tree.tsx
+++ b/packages/react-components/src/tree/tree.tsx
@@ -21,6 +21,7 @@ export interface TreeProps<T extends TreeNode> {
   readonly selectionMode?: "none" | "single";
   readonly tree: T;
   readonly nodeIcon?: FC<{ node: T }>;
+  readonly nodeLabel?: FC<{ node: T }>;
   readonly selected?: string;
   readonly onSelect?: (id: string) => void;
   readonly expanded?: Set<string>;
@@ -33,6 +34,7 @@ export function Tree<T extends TreeNode>({
   onSelect,
   onSetExpanded,
   nodeIcon,
+  nodeLabel,
   selectionMode = "none",
 }: TreeProps<T>) {
   const id = useId();
@@ -130,6 +132,7 @@ export function Tree<T extends TreeNode>({
           <TreeViewRow
             id={`${id}-${row.index}`}
             icon={nodeIcon as any}
+            label={nodeLabel as any}
             focussed={focusedIndex === row.index}
             key={row.id}
             row={row}

--- a/website/src/components/playground-component/playground.tsx
+++ b/website/src/components/playground-component/playground.tsx
@@ -36,6 +36,9 @@ export const WebsitePlayground = ({ versionData }: WebsitePlaygroundProps) => {
       {...TypeSpecPlaygroundConfig}
       libraries={imports}
       emitterViewers={{ "@typespec/openapi3": [SwaggerUIViewer] }}
+      emittersWithChangeHighlighting={
+        new Set(["@typespec/openapi3", "@typespec/http-client-python"])
+      }
       importConfig={{ useShim: true }}
       editorOptions={editorOptions}
       footer={<PlaygroundFooter versionData={versionData} />}

--- a/website/src/components/playground-component/playground.tsx
+++ b/website/src/components/playground-component/playground.tsx
@@ -36,9 +36,7 @@ export const WebsitePlayground = ({ versionData }: WebsitePlaygroundProps) => {
       {...TypeSpecPlaygroundConfig}
       libraries={imports}
       emitterViewers={{ "@typespec/openapi3": [SwaggerUIViewer] }}
-      emittersWithChangeHighlighting={
-        new Set(["@typespec/http-client-python", "@typespec/http-client-csharp"])
-      }
+      clientEmitters={new Set(["@typespec/http-client-python", "@typespec/http-client-csharp"])}
       importConfig={{ useShim: true }}
       editorOptions={editorOptions}
       footer={<PlaygroundFooter versionData={versionData} />}

--- a/website/src/components/playground-component/playground.tsx
+++ b/website/src/components/playground-component/playground.tsx
@@ -36,7 +36,9 @@ export const WebsitePlayground = ({ versionData }: WebsitePlaygroundProps) => {
       {...TypeSpecPlaygroundConfig}
       libraries={imports}
       emitterViewers={{ "@typespec/openapi3": [SwaggerUIViewer] }}
-      emittersWithChangeHighlighting={new Set(["@typespec/http-client-python"])}
+      emittersWithChangeHighlighting={
+        new Set(["@typespec/http-client-python", "@typespec/http-client-csharp"])
+      }
       importConfig={{ useShim: true }}
       editorOptions={editorOptions}
       footer={<PlaygroundFooter versionData={versionData} />}

--- a/website/src/components/playground-component/playground.tsx
+++ b/website/src/components/playground-component/playground.tsx
@@ -36,7 +36,10 @@ export const WebsitePlayground = ({ versionData }: WebsitePlaygroundProps) => {
       {...TypeSpecPlaygroundConfig}
       libraries={imports}
       emitterViewers={{ "@typespec/openapi3": [SwaggerUIViewer] }}
-      clientEmitters={new Set(["@typespec/http-client-python", "@typespec/http-client-csharp"])}
+      emitterOptions={{
+        "@typespec/http-client-python": { debounce: 500, newChangeDiff: true },
+        "@typespec/http-client-csharp": { debounce: 500, newChangeDiff: true },
+      }}
       importConfig={{ useShim: true }}
       editorOptions={editorOptions}
       footer={<PlaygroundFooter versionData={versionData} />}

--- a/website/src/components/playground-component/playground.tsx
+++ b/website/src/components/playground-component/playground.tsx
@@ -36,9 +36,7 @@ export const WebsitePlayground = ({ versionData }: WebsitePlaygroundProps) => {
       {...TypeSpecPlaygroundConfig}
       libraries={imports}
       emitterViewers={{ "@typespec/openapi3": [SwaggerUIViewer] }}
-      emittersWithChangeHighlighting={
-        new Set(["@typespec/openapi3", "@typespec/http-client-python"])
-      }
+      emittersWithChangeHighlighting={new Set(["@typespec/http-client-python"])}
       importConfig={{ useShim: true }}
       editorOptions={editorOptions}
       footer={<PlaygroundFooter versionData={versionData} />}


### PR DESCRIPTION
…put preservation

- Add isCompiling state with Spinner overlay during compilation
- Preserve previous output files when compilation has transient errors
- Fix race condition: discard stale compilation results
- Highlight changed files in file tree with bold green text (opt-in per emitter)
- Add nodeLabel prop to Tree component for custom label rendering
- Add CSS for Monaco changed-line decorations