### PR TITLE
fix(compiler): preserve dangling comments in empty operation parameter list

### DIFF
--- a/.chronus/changes/fix-formatter-dangling-comment-empty-params-2026-04-13.md
+++ b/.chronus/changes/fix-formatter-dangling-comment-empty-params-2026-04-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix formatter crash when an operation's parameter list contains only a block comment (e.g. `op find(/* conditions */): unknown;`). Dangling comments in empty parameter lists are now preserved instead of being dropped.

--- a/packages/compiler/src/formatter/print/printer.ts
+++ b/packages/compiler/src/formatter/print/printer.ts
@@ -969,12 +969,16 @@ export function printModelExpression(
   if (inBlock) {
     return group(printModelPropertiesBlock(path, options, print));
   } else {
-    const properties =
-      node.properties.length === 0
-        ? ""
-        : indent(
-            joinMembersInBlock(path, "properties", options, print, ifBreak(",", ", "), softline),
-          );
+    const nodeHasComments = hasComments(node, CommentCheckFlags.Dangling);
+    if (node.properties.length === 0) {
+      if (nodeHasComments) {
+        return group([indent(printDanglingComments(path, options, { sameIndent: true })), softline]);
+      }
+      return group(["", softline]);
+    }
+    const properties = indent(
+      joinMembersInBlock(path, "properties", options, print, ifBreak(",", ", "), softline),
+    );
     return group([properties, softline]);
   }
 }

--- a/packages/compiler/src/formatter/print/printer.ts
+++ b/packages/compiler/src/formatter/print/printer.ts
@@ -972,7 +972,10 @@ export function printModelExpression(
     const nodeHasComments = hasComments(node, CommentCheckFlags.Dangling);
     if (node.properties.length === 0) {
       if (nodeHasComments) {
-        return group([indent(printDanglingComments(path, options, { sameIndent: true })), softline]);
+        return group([
+          indent(printDanglingComments(path, options, { sameIndent: true })),
+          softline,
+        ]);
       }
       return group(["", softline]);
     }

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -737,6 +737,21 @@ op foo(
         });
       });
 
+      it("keeps block comment in empty parameter list", async () => {
+        await assertFormat({
+          code: `
+namespace MyApp;
+
+op find( /* conditions */) : unknown;
+`,
+          expected: `
+namespace MyApp;
+
+op find(/* conditions */): unknown;
+`,
+        });
+      });
+
       it("wrap in new lines parameters with block comments", async () => {
         await assertFormat({
           code: `


### PR DESCRIPTION
## Summary

`tsp format` crashed on:

```tsp
namespace MyApp;

op find(/* conditions */): unknown;
```

with `TypeError: Cannot read properties of undefined (reading 'trim')`
from prettier's ensureAllCommentsPrinted.

### Root cause

printModelExpression (used for operation parameter lists) returned an
empty string when the property list was empty, dropping any dangling
comments. Prettier then detected an unprinted comment and threw.

### Fix

Print dangling comments in the empty-properties branch so the block
comment survives formatting.

## Test

Added keeps block comment in empty parameter list to
formatter.test.ts. All 199 formatter tests pass.
