### PR TITLE
Fix glob normalize

### DIFF
--- a/.chronus/changes/fix-glob-normalize-2026-3-14-12-2-56.md
+++ b/.chronus/changes/fix-glob-normalize-2026-3-14-12-2-56.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/spector"
+---
+

--- a/packages/spector/src/utils/file-utils.ts
+++ b/packages/spector/src/utils/file-utils.ts
@@ -1,9 +1,10 @@
 import { glob, mkdir } from "fs/promises";
+import { normalizePath } from "./path-utils.js";
 
 export async function findFilesFromPattern(pattern: string | string[]): Promise<string[]> {
   const results: string[] = [];
   for await (const file of glob(pattern)) {
-    results.push(file);
+    results.push(normalizePath(file));
   }
   return results;
 }


### PR DESCRIPTION
Node built glob in doesn't normalize the path automatically to unix style unlike globby which cause some failure of http specs in typespec-azure