### PR TITLE
[http-client-python] Fix grouped parameter attribute access for reserved words

### DIFF
--- a/.chronus/changes/fix-black-linesep-windows-2026-3-15-13-52-35.md
+++ b/.chronus/changes/fix-black-linesep-windows-2026-3-15-13-52-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix mixed line endings in black plugin on Windows by using literal newlines instead of os.linesep

--- a/.chronus/changes/fix-black-linesep-windows-2026-3-15-13-52-35.md
+++ b/.chronus/changes/fix-black-linesep-windows-2026-3-15-13-52-35.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/http-client-python"
 ---
 
-Fix mixed line endings in black plugin on Windows by using literal newlines instead of os.linesep
+Fix grouped parameter attribute access for reserved words in code generation

--- a/packages/http-client-python/generator/pygen/black.py
+++ b/packages/http-client-python/generator/pygen/black.py
@@ -69,9 +69,9 @@ class BlackScriptPlugin(Plugin):
                 pylint_disables.append("too-many-lines")
             if pylint_disables:
                 file_content = (
-                    "\n".join([lines[0] + ",".join([""] + pylint_disables)] + lines[1:]) + "\n"
+                    os.linesep.join([lines[0] + ",".join([""] + pylint_disables)] + lines[1:])
                     if "pylint: disable=" in lines[0]
-                    else f"# pylint: disable={','.join(pylint_disables)}\n" + file_content
+                    else f"# pylint: disable={','.join(pylint_disables)}{os.linesep}" + file_content
                 )
         self.write_file(file, file_content)
 

--- a/packages/http-client-python/generator/pygen/black.py
+++ b/packages/http-client-python/generator/pygen/black.py
@@ -69,9 +69,9 @@ class BlackScriptPlugin(Plugin):
                 pylint_disables.append("too-many-lines")
             if pylint_disables:
                 file_content = (
-                    os.linesep.join([lines[0] + ",".join([""] + pylint_disables)] + lines[1:])
+                    "\n".join([lines[0] + ",".join([""] + pylint_disables)] + lines[1:]) + "\n"
                     if "pylint: disable=" in lines[0]
-                    else f"# pylint: disable={','.join(pylint_disables)}{os.linesep}" + file_content
+                    else f"# pylint: disable={','.join(pylint_disables)}\n" + file_content
                 )
         self.write_file(file, file_content)
 

--- a/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
@@ -107,7 +107,7 @@ def _serialize_grouped_body(builder: BuilderType) -> list[str]:
     groupers = [p for p in builder.parameters if p.grouper]
     for grouper in groupers:
         retval.append(f"if {grouper.client_name} is not None:")
-        # Keys in property_to_parameter_name are unpadded client names (e.g. "from", "custom_header").
+        # Keys in property_to_parameter_name are original client names (e.g. "from", "custom_header").
         # Attribute access needs the padded client_name from the model property (e.g. "from_property").
         # Build lookup from both wire_name and client_name to handle all cases.
         grouper_model = cast(ModelType, grouper.type)

--- a/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
@@ -107,10 +107,18 @@ def _serialize_grouped_body(builder: BuilderType) -> list[str]:
     groupers = [p for p in builder.parameters if p.grouper]
     for grouper in groupers:
         retval.append(f"if {grouper.client_name} is not None:")
+        # Keys in property_to_parameter_name are unpadded client names (e.g. "from", "custom_header").
+        # Attribute access needs the padded client_name from the model property (e.g. "from_property").
+        # Build lookup from both wire_name and client_name to handle all cases.
+        grouper_model = cast(ModelType, grouper.type)
+        prop_name_to_client = {}
+        for prop in grouper_model.properties:
+            prop_name_to_client[prop.wire_name] = prop.client_name
+            prop_name_to_client[prop.client_name] = prop.client_name
         retval.extend(
             [
-                f"    {parameter} = {grouper.client_name}.{property}"
-                for property, parameter in grouper.property_to_parameter_name.items()
+                f"    {parameter} = {grouper.client_name}.{prop_name_to_client[prop_name]}"
+                for prop_name, parameter in grouper.property_to_parameter_name.items()
             ]
         )
     return retval


### PR DESCRIPTION
## Problem

PR #10326 correctly stopped padding keys in `propertyToParameterName` for flattened body paths (where keys are used as constructor kwargs or dict keys). However, `_serialize_grouped_body` in `builder_serializer.py` uses those same keys as Python attribute access (`.{property}`), which generates invalid code for reserved words like `from`:

```python
# Generated invalid code:
_from_parameter = params.from  # SyntaxError! 'from' is a Python reserved word
```

## Fix

In `_serialize_grouped_body`, look up the padded `client_name` from the grouper model's properties instead of using the raw `propertyToParameterName` key directly for attribute access. A lookup dict is built from both `wire_name` and `client_name` to handle all key formats.

## Validation

- Regenerated `AzureParameterGrouping` test: reserved word `from` correctly generates `.from_property`
- Operations file is identical to the committed version after regeneration