### PR TITLE
Publish @typespec/http-client-java@0.8.1

### DIFF
--- a/.chronus/changes/add-test-withRelativeNextLink-2026-4-14.md
+++ b/.chronus/changes/add-test-withRelativeNextLink-2026-4-14.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: internal
-packages:
-  - "@typespec/http-client-java"
----
-
-Add test case for `withRelativeNextLink`, `FlattenUnknownModel`, `FlattenReadOnlyModel` scenario.

--- a/.chronus/changes/client-required-false-error-2026-4-14.md
+++ b/.chronus/changes/client-required-false-error-2026-4-14.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@typespec/http-client-java"
----
-
-Report an error when `clientRequired` is set to `false` on a property.

--- a/.chronus/changes/http-client-java_update-tcgc-2026-3-15-10-28-44.md
+++ b/.chronus/changes/http-client-java_update-tcgc-2026-3-15-10-28-44.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@typespec/http-client-java"
----
-
-Update dependencies: typespec-azure-resource-manager 0.67.1, typespec-client-generator-core 0.67.2, vitest 4.1.4

--- a/packages/http-client-java/CHANGELOG.md
+++ b/packages/http-client-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - @typespec/http-client-java
 
+## 0.8.1
+
+### Bug Fixes
+
+- [#10365](https://github.com/microsoft/typespec/pull/10365) Report an error when `clientRequired` is set to `false` on a property.
+
+
 ## 0.8.0
 
 ### Features

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/package.json
@@ -16,7 +16,7 @@
     "@typespec/spec-api": "0.1.0-alpha.14",
     "@typespec/http-specs": "0.1.0-alpha.36",
     "@typespec/json-schema": "1.11.0",
-    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.8.0.tgz",
+    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.8.1.tgz",
     "@typespec/http-client-java-tests": "file:"
   },
   "overrides": {

--- a/packages/http-client-java/generator/http-client-generator-test/package.json
+++ b/packages/http-client-java/generator/http-client-generator-test/package.json
@@ -16,7 +16,7 @@
     "@typespec/spec-api": "0.1.0-alpha.14",
     "@typespec/http-specs": "0.1.0-alpha.36",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.39",
-    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.8.0.tgz",
+    "@typespec/http-client-java": "file:../../typespec-http-client-java-0.8.1.tgz",
     "@typespec/http-client-java-tests": "file:"
   },
   "overrides": {

--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typespec/http-client-java",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typespec/http-client-java",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@autorest/codemodel": "~4.20.1",

--- a/packages/http-client-java/package.json
+++ b/packages/http-client-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-java",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
Patch release for `@typespec/http-client-java` v0.8.1.

Changes:
- Update dependencies: typespec-azure-resource-manager 0.67.1, typespec-client-generator-core 0.67.2, vitest 4.1.4