### PR TITLE
http-client-java, support responseAsBool

### DIFF
--- a/.chronus/changes/http-client-java_responseAsBool-2026-3-15-18-5-31.md
+++ b/.chronus/changes/http-client-java_responseAsBool-2026-3-15-18-5-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-java"
+---
+
+Support TCGC decorator responseAsBool

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -2273,7 +2273,12 @@ export class CodeModelBuilder {
       }
     }
 
-    const bodyType: SdkType | undefined = sdkResponse.type;
+    let bodyType: SdkType | undefined = sdkResponse.type;
+    if ((op.requests?.[0]?.protocol.http?.method as string).toUpperCase() === "HEAD") {
+      // for HEAD method, the response body should be empty
+      // currently TCGC would return constent boolean value in responses, for "@responseAsBool" decorator, erase the body type
+      bodyType = undefined;
+    }
     let trackConvenienceApi: boolean = Boolean(op.convenienceApi);
 
     let responseBodyIsFile: boolean = false;


### PR DESCRIPTION
Locally tested.

Formal test should be in azure-http-specs.

We won't need this PR if this can be fixed at tcgc https://github.com/Azure/typespec-azure/issues/4272