### PR TITLE
[playground] fix: don't show compilation spinner when toggling dark mode

### DIFF
--- a/website/src/components/playground-component/playground.tsx
+++ b/website/src/components/playground-component/playground.tsx
@@ -28,9 +28,14 @@ export const WebsitePlayground = ({ versionData }: WebsitePlaygroundProps) => {
   }, [theme]);
 
   const importItem = useImportCommandBarItem();
-  const imports = Object.keys(versionData.importMap.imports).filter(
-    (x) => (x.match(/\//g) || []).length < 2, // Don't include sub imports as libraries.
+  const imports = useMemo(
+    () =>
+      Object.keys(versionData.importMap.imports).filter(
+        (x) => (x.match(/\//g) || []).length < 2, // Don't include sub imports as libraries.
+      ),
+    [versionData.importMap.imports],
   );
+  const importConfig = useMemo(() => ({ useShim: true }), []);
   return (
     <StandalonePlayground
       {...TypeSpecPlaygroundConfig}
@@ -40,7 +45,7 @@ export const WebsitePlayground = ({ versionData }: WebsitePlaygroundProps) => {
         "@typespec/http-client-python": { debounce: 500, newChangeDiff: true },
         "@typespec/http-client-csharp": { debounce: 500, newChangeDiff: true },
       }}
-      importConfig={{ useShim: true }}
+      importConfig={importConfig}
       editorOptions={editorOptions}
       footer={<PlaygroundFooter versionData={versionData} />}
       fallback={<LoadingSpinner message="Loading libraries..." />}

--- a/website/src/layouts/base-layout.astro
+++ b/website/src/layouts/base-layout.astro
@@ -23,12 +23,17 @@ const initJsIntegrity = computeSriHash("1ds-init.js");
     <title>typespec.io</title>
     <script is:inline>
       (function () {
-        var theme =
+        var raw =
           localStorage.getItem("theme") ||
           (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+        var theme = raw === "dark" ? "dark" : "light";
         document.documentElement.setAttribute("data-theme", theme);
         if (theme === "dark") {
+          document.documentElement.classList.remove("light");
           document.documentElement.classList.add("dark");
+        } else {
+          document.documentElement.classList.remove("dark");
+          document.documentElement.classList.add("light");
         }
       })();
     </script>

--- a/website/src/layouts/base-layout.astro
+++ b/website/src/layouts/base-layout.astro
@@ -21,6 +21,17 @@ const initJsIntegrity = computeSriHash("1ds-init.js");
     <link rel="og:image" type="image/svg+xml" href={baseUrl("/img/social.svg")} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>typespec.io</title>
+    <script is:inline>
+      (function () {
+        var theme =
+          localStorage.getItem("theme") ||
+          (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+        document.documentElement.setAttribute("data-theme", theme);
+        if (theme === "dark") {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
     <script
       src="https://consentdeliveryfd.azurefd.net/mscc/lib/v2/wcp-consent.js"
       crossorigin="anonymous"


### PR DESCRIPTION
I noticed the playground compilation spinner appears when the dark mode toggle is clicked, which doesn't seem desirable

- When the dark mode toggle fires, WebsitePlayground re-renders and recreates imports (from .filter()) and importConfig ({ useShim: true }) as new object references
- These are dependencies of the useEffect in useStandalonePlaygroundContext in `standalone.tsx`, which re-runs the entire host creation and triggers the compile effect. So memoizing these to avoid that

- change to base-layout is because I noticed if I have dark mode, when switching pages, it briefly flashes to light mode before switching back to dark mode