### PR TITLE
feat: support UseTypeSpecNext for Azure emitter in azure-sdk-for-net

### DIFF
--- a/packages/http-client-csharp/eng/pipeline/publish.yml
+++ b/packages/http-client-csharp/eng/pipeline/publish.yml
@@ -214,6 +214,7 @@ extends:
                     ${{ replace(replace('True', eq(parameters.RegenerateAzureLibraries, false), ''), 'True', '-RegenerateAzureLibraries') }}
                     ${{ replace(replace('True', eq(parameters.RegenerateMgmtLibraries, false), ''), 'True', '-RegenerateMgmtLibraries') }}
                     -BuildArtifactsPath '$(Pipeline.Workspace)/build_artifacts_csharp/packages'
+                    ${{ replace(replace('True', eq(parameters.UseTypeSpecNext, false), ''), 'True', '-UseTypeSpecNext') }}
 
               - pwsh: |
                   $npmrcPath = "$(Build.SourcesDirectory)/packages/http-client-csharp/.npmrc"

--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -47,7 +47,10 @@ param(
   [switch]$RegenerateMgmtLibraries,
 
   [Parameter(Mandatory = $false)]
-  [string]$BuildArtifactsPath
+  [string]$BuildArtifactsPath,
+
+  [Parameter(Mandatory = $false)]
+  [switch]$UseTypeSpecNext
 )
 
 # Import the Generation module to use the Invoke helper function
@@ -241,6 +244,18 @@ try {
         # Run npm install in the http-client-csharp directory
         Write-Host "##[section]Running npm install in eng/packages/http-client-csharp..."
         $httpClientDir = Join-Path $tempDir "eng/packages/http-client-csharp"
+
+        # Update TypeSpec dependencies to @next versions in the Azure emitter package.json
+        if ($UseTypeSpecNext) {
+            Write-Host "##[section]Updating Azure emitter TypeSpec dependencies to @next versions..."
+            $azurePackageJsonPath = Join-Path $httpClientDir "package.json"
+            Invoke "npx -y @azure-tools/typespec-bump-deps@latest --use-peer-ranges `"$azurePackageJsonPath`"" $httpClientDir
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "typespec-bump-deps failed with exit code $LASTEXITCODE"
+            } else {
+                Write-Host "Azure emitter TypeSpec dependencies updated to @next versions"
+            }
+        }
         
         # Copy .npmrc file from source directory if it exists (for internal builds)
         $sourceNpmrcPath = Join-Path $PSScriptRoot "../../.npmrc"


### PR DESCRIPTION
When UseTypeSpecNext is enabled, run typespec-bump-deps on the Azure emitter package.json in the cloned azure-sdk-for-net repo before npm install. This bumps the TypeSpec dependencies in
eng/packages/http-client-csharp/package.json to @next versions so the regenerated Azure SDK libraries use the latest TypeSpec preview.