### PR TITLE
Fix optional properties dropped from generic base models

### DIFF
--- a/packages/http-server-csharp/src/lib/utils.ts
+++ b/packages/http-server-csharp/src/lib/utils.ts
@@ -731,7 +731,7 @@ export class ModelInfo {
     for (const prop of model.properties.values()) props.push(prop);
     if (model.baseModel) {
       const additional = this.getAllProperties(program, model.baseModel);
-      if (additional !== undefined) props.concat(additional);
+      if (additional !== undefined) props.push(...additional);
     }
 
     return props;

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -3422,3 +3422,35 @@ it("emits class for model extending another model with no additional properties"
     ],
   );
 });
+
+it("includes optional properties from generic base model when using 'is'", async () => {
+  await compileAndValidateSingleModel(
+    tester,
+    `
+      model Message<TData> {
+        source: string;
+        msgType: string;
+        reference?: string;
+        timestamp?: offsetDateTime;
+        data: TData;
+      }
+
+      model Report {
+        value: string;
+      }
+
+      model ReportMessage is Message<Report>;
+
+      @route("/report") @get op getReport(): ReportMessage;
+      `,
+    "ReportMessage.cs",
+    [
+      "public partial class ReportMessage",
+      "public string Source { get; set; }",
+      "public string MsgType { get; set; }",
+      "public string Reference { get; set; }",
+      "public DateTimeOffset? Timestamp { get; set; }",
+      "public Report Data { get; set; }",
+    ],
+  );
+});


### PR DESCRIPTION
Base model properties were getting dropped from the generated classes because concat() doesn't mutate in place. Switched to push() and added a test case to verify. Fixes #10400