### PR TITLE
fix: free disk space in CreateAzureSdkForNetPR pipeline stage

### DIFF
--- a/packages/http-client-csharp/eng/pipeline/publish.yml
+++ b/packages/http-client-csharp/eng/pipeline/publish.yml
@@ -106,6 +106,12 @@ extends:
         jobs:
           - job: CreatePR
             timeoutInMinutes: 90
+            variables:
+              # Redirect temp and cache directories to Agent.TempDirectory (a separate, larger partition)
+              # to avoid running out of disk space on the root partition during generation
+              TMPDIR: $(Agent.TempDirectory)
+              NUGET_PACKAGES: $(Agent.TempDirectory)/nuget
+              npm_config_cache: $(Agent.TempDirectory)/npm-cache
             steps:
               - checkout: self
               - pwsh: |
@@ -150,6 +156,7 @@ extends:
                   workingFile: $(Build.SourcesDirectory)/packages/http-client-csharp/.npmrc
 
               - download: current
+                artifact: build_artifacts_csharp
                 displayName: Download pipeline artifacts
 
               - pwsh: |


### PR DESCRIPTION
The SubmitPr stage was hitting 95% disk usage. Three changes to reduce it:

- Download only build_artifacts_csharp instead of all pipeline artifacts
- Add disk cleanup step to remove Docker data, ghc, and Boost from runner
- Clean up node_modules and npm cache after build, before sdk checkout