### PR TITLE
Implement UseTypeSpecNext in Initialize-Repository scripts

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Initialize-Repository.ps1
+++ b/packages/http-client-csharp/eng/scripts/Initialize-Repository.ps1
@@ -29,7 +29,13 @@ try {
         Invoke-LoggedCommand "npm ci"
     }
     elseif ($UseTypeSpecNext) {
-        # TODO: add use typespec next to template later
+        if (Test-Path "./package-lock.json") {
+            Remove-Item -Force "./package-lock.json"
+        }
+
+        Write-Host "Using TypeSpec.Next"
+        Invoke-LoggedCommand "npx -y @azure-tools/typespec-bump-deps@latest --add-npm-overrides package.json"
+        Invoke-LoggedCommand "npm install"
     }
     else {
         Invoke-LoggedCommand "npm ci"

--- a/packages/http-client-java/eng/scripts/Initialize-Repository.ps1
+++ b/packages/http-client-java/eng/scripts/Initialize-Repository.ps1
@@ -80,7 +80,13 @@ try {
         Invoke-LoggedCommand "npm ci"
     }
     elseif ($UseTypeSpecNext) {
-        # TODO: add use typespec next to template later
+        if (Test-Path "./package-lock.json") {
+            Remove-Item -Force "./package-lock.json"
+        }
+
+        Write-Host "Using TypeSpec.Next"
+        Invoke-LoggedCommand "npx -y @azure-tools/typespec-bump-deps@latest --add-npm-overrides package.json"
+        Invoke-LoggedCommand "npm install"
     }
     else {
         Invoke-LoggedCommand "npm ci"

--- a/packages/http-client-python/eng/scripts/Initialize-Repository.ps1
+++ b/packages/http-client-python/eng/scripts/Initialize-Repository.ps1
@@ -11,7 +11,7 @@
     Optional path to build artifacts (used in CI for caching lock files).
 
 .PARAMETER UseTypeSpecNext
-    Optional switch for using TypeSpec next version (not currently used).
+    Switch to install TypeSpec next version using typespec-bump-deps.
 
 .EXAMPLE
     ./Initialize-Repository.ps1
@@ -39,7 +39,26 @@ try {
     }
 
     Write-Host "Installing npm dependencies..."
-    Invoke-LoggedCommand "npm ci"
+    if ($BuildArtifactsPath) {
+        $lockFilesPath = Resolve-Path "$BuildArtifactsPath/lock-files"
+        Write-Host "Using emitter/package.json and emitter/package-lock.json from $lockFilesPath"
+        Copy-Item "$lockFilesPath/emitter/package.json" './package.json' -Force
+        Copy-Item "$lockFilesPath/emitter/package-lock.json" './package-lock.json' -Force
+
+        Invoke-LoggedCommand "npm ci"
+    }
+    elseif ($UseTypeSpecNext) {
+        if (Test-Path "./package-lock.json") {
+            Remove-Item -Force "./package-lock.json"
+        }
+
+        Write-Host "Using TypeSpec.Next"
+        Invoke-LoggedCommand "npx -y @azure-tools/typespec-bump-deps@latest --add-npm-overrides package.json"
+        Invoke-LoggedCommand "npm install"
+    }
+    else {
+        Invoke-LoggedCommand "npm ci"
+    }
     Invoke-LoggedCommand "npm ls -a" -GroupOutput
 
     # Copy lock files to artifacts for CI caching (if running in Azure DevOps)


### PR DESCRIPTION
The UseTypeSpecNext flag was accepted but not implemented in the Initialize-Repository.ps1 scripts for http-client-csharp, http-client-java, and http-client-python.

**Problem:**
- **http-client-csharp** and **http-client-java**: Had a TODO placeholder that skipped `npm ci` entirely when the flag was set, resulting in no packages being installed
- **http-client-python**: Completely ignored the flag, always ran `npm ci`

**Fix:**
Implement the flag in all three scripts following the pattern from azure-sdk-for-net:
1. Remove `package-lock.json`
2. Run `npx -y @azure-tools/typespec-bump-deps@latest --add-npm-overrides package.json`
3. Run `npm install`