### PR TITLE
fix(http): use @bodyRoot in HttpStream to eliminate spurious metadata-ignored warnings

### DIFF
--- a/.chronus/changes/fix-httpstream-bodyroot-2026-4-18.md
+++ b/.chronus/changes/fix-httpstream-bodyroot-2026-4-18.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http"
+---
+
+Fix `HttpStream` to use `@bodyRoot` instead of `@body` so that the `@header contentType` property is not silently ignored, eliminating spurious `@typespec/http/metadata-ignored` warnings on every `SSEStream` instantiation.

--- a/packages/http/lib/streams/main.tsp
+++ b/packages/http/lib/streams/main.tsp
@@ -20,7 +20,7 @@ namespace TypeSpec.Http.Streams;
 model HttpStream<Type, ContentType extends valueof string, BodyType extends bytes | string = string>
   is Stream<Type> {
   @header contentType: typeof ContentType;
-  @body body: BodyType;
+  @bodyRoot body: BodyType;
 }
 
 /**


### PR DESCRIPTION
Thanks for creating such a lovely thing, that's something I was looking for for a while.

## Problem

`HttpStream` defines `@header contentType` alongside `@body body` in the same model. This triggers the `@typespec/http/metadata-ignored` warning on **every instantiation** of `HttpStream` — including `SSEStream` from `@typespec/sse`:

```
node_modules/@typespec/http/lib/streams/main.tsp:22:11 - warning @typespec/http/metadata-ignored:
header property will be ignored as it is inside of a @body property. Use @bodyRoot instead if wanting to mix.
  occurred while instantiating template SSEStream<...>
```

This warning fires from library code that users cannot modify, making it impossible to use `--warn-as-error` without suppressing a warning they didn't cause.

## Fix

Change `@body body` to `@bodyRoot body` in `HttpStream`. This is exactly what the warning message recommends, and it allows `@header` and body to coexist correctly.

## Test plan

- [ ] Existing HTTP stream tests pass
- [ ] No `@typespec/http/metadata-ignored` warning when instantiating `SSEStream`