### PR TITLE
fix: add namespace override for azure/client-generator-core/client-doc spec

### DIFF
--- a/.chronus/changes/fix-python-client-doc-package-name-2026-4-20-10-15-50.md
+++ b/.chronus/changes/fix-python-client-doc-package-name-2026-4-20-10-15-50.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-python"
+---
+
+Add namespace override for new `azure/client-generator-core/client-doc` spec to fix nightly build failure

--- a/packages/http-client-python/eng/scripts/ci/regenerate-common.ts
+++ b/packages/http-client-python/eng/scripts/ci/regenerate-common.ts
@@ -48,6 +48,9 @@ export const BASE_AZURE_EMITTER_OPTIONS: Record<
   "azure/client-generator-core/usage": {
     namespace: "specs.azure.clientgenerator.core.usage",
   },
+  "azure/client-generator-core/client-doc": {
+    namespace: "specs.azure.clientgenerator.core.clientdoc",
+  },
   "azure/client-generator-core/override": {
     namespace: "specs.azure.clientgenerator.core.override",
   },


### PR DESCRIPTION
The new client-doc spec in azure-http-specs@next has namespace _Specs_.Azure.ClientGenerator.Core.ClientDoc which produces an invalid Python package name starting with underscore. Add explicit namespace override in regenerate-common.ts to fix nightly build failure.