### PR TITLE
fix: use identifier name for positional args

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/PositionalParameterReferenceExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/PositionalParameterReferenceExpression.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 
         internal override void Write(CodeWriter writer)
         {
-            writer.Append($"{ParameterName}: ");
+            writer.Append($"{ParameterName:I}: ");
             ParameterValue.Write(writer);
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Expressions/PositionalParameterReferenceExpressionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Expressions/PositionalParameterReferenceExpressionTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Expressions
+{
+    public class PositionalParameterReferenceExpressionTests
+    {
+        [Test]
+        public void NonKeywordParameterName()
+        {
+            var expression = new PositionalParameterReferenceExpression("myParam", ValueExpression.Empty);
+            using CodeWriter writer = new CodeWriter();
+            expression.Write(writer);
+
+            Assert.AreEqual("myParam: ", writer.ToString(false));
+        }
+
+        [Test]
+        public void KeywordParameterNameFromPropertyIsEscaped()
+        {
+            // Simulates the realistic flow: a property named "Object" becomes
+            // parameter name "object" via ToIdentifierName, which is a C# keyword.
+            var paramName = "Object".ToIdentifierName(useCamelCase: true);
+            Assert.AreEqual("object", paramName);
+
+            var expression = new PositionalParameterReferenceExpression(paramName, ValueExpression.Empty);
+            using CodeWriter writer = new CodeWriter();
+            expression.Write(writer);
+
+            Assert.AreEqual("@object: ", writer.ToString(false));
+        }
+
+        // Validates that all C# keywords and contextual keywords are properly escaped
+        // with the '@' prefix when used as named argument identifiers.
+        [TestCase("abstract")]
+        [TestCase("add")]
+        [TestCase("alias")]
+        [TestCase("as")]
+        [TestCase("ascending")]
+        [TestCase("async")]
+        [TestCase("await")]
+        [TestCase("base")]
+        [TestCase("bool")]
+        [TestCase("break")]
+        [TestCase("by")]
+        [TestCase("byte")]
+        [TestCase("case")]
+        [TestCase("catch")]
+        [TestCase("char")]
+        [TestCase("checked")]
+        [TestCase("class")]
+        [TestCase("const")]
+        [TestCase("continue")]
+        [TestCase("decimal")]
+        [TestCase("default")]
+        [TestCase("delegate")]
+        [TestCase("descending")]
+        [TestCase("do")]
+        [TestCase("double")]
+        [TestCase("else")]
+        [TestCase("enum")]
+        [TestCase("equals")]
+        [TestCase("event")]
+        [TestCase("explicit")]
+        [TestCase("extern")]
+        [TestCase("false")]
+        [TestCase("finally")]
+        [TestCase("fixed")]
+        [TestCase("float")]
+        [TestCase("for")]
+        [TestCase("foreach")]
+        [TestCase("from")]
+        [TestCase("get")]
+        [TestCase("global")]
+        [TestCase("goto")]
+        [TestCase("if")]
+        [TestCase("implicit")]
+        [TestCase("in")]
+        [TestCase("int")]
+        [TestCase("interface")]
+        [TestCase("internal")]
+        [TestCase("into")]
+        [TestCase("is")]
+        [TestCase("join")]
+        [TestCase("let")]
+        [TestCase("lock")]
+        [TestCase("long")]
+        [TestCase("nameof")]
+        [TestCase("namespace")]
+        [TestCase("new")]
+        [TestCase("null")]
+        [TestCase("object")]
+        [TestCase("on")]
+        [TestCase("operator")]
+        [TestCase("out")]
+        [TestCase("override")]
+        [TestCase("params")]
+        [TestCase("partial")]
+        [TestCase("private")]
+        [TestCase("protected")]
+        [TestCase("public")]
+        [TestCase("readonly")]
+        [TestCase("ref")]
+        [TestCase("remove")]
+        [TestCase("return")]
+        [TestCase("sbyte")]
+        [TestCase("sealed")]
+        [TestCase("set")]
+        [TestCase("short")]
+        [TestCase("sizeof")]
+        [TestCase("stackalloc")]
+        [TestCase("static")]
+        [TestCase("string")]
+        [TestCase("struct")]
+        [TestCase("switch")]
+        [TestCase("this")]
+        [TestCase("throw")]
+        [TestCase("true")]
+        [TestCase("try")]
+        [TestCase("typeof")]
+        [TestCase("uint")]
+        [TestCase("ulong")]
+        [TestCase("unchecked")]
+        [TestCase("unmanaged")]
+        [TestCase("unsafe")]
+        [TestCase("ushort")]
+        [TestCase("using")]
+        [TestCase("var")]
+        [TestCase("virtual")]
+        [TestCase("void")]
+        [TestCase("volatile")]
+        [TestCase("when")]
+        [TestCase("where")]
+        [TestCase("while")]
+        [TestCase("yield")]
+        public void CSharpKeywordParameterNameIsEscaped(string keyword)
+        {
+            var expression = new PositionalParameterReferenceExpression(keyword, ValueExpression.Empty);
+            using CodeWriter writer = new CodeWriter();
+            expression.Write(writer);
+
+            Assert.AreEqual($"@{keyword}: ", writer.ToString(false));
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -488,6 +488,60 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
                 childMethod!.BodyStatements!.ToDisplayString());
         }
 
+        // This test validates that when a model has a property whose name is a C# keyword (e.g. "Object"),
+        // the backward-compat overload correctly escapes the named argument identifier with '@'.
+        [Test]
+        public async Task BackCompatibility_NewPropertyAddedWithKeywordPropertyName()
+        {
+            InputModelProperty[] keywordProperties =
+            [
+                InputFactory.Property("StringProp", InputPrimitiveType.String),
+                InputFactory.Property("Object", InputPrimitiveType.String),
+                InputFactory.Property("ListProp", InputFactory.Array(InputPrimitiveType.String)),
+                InputFactory.Property("DictProp", InputFactory.Dictionary(InputPrimitiveType.String, InputPrimitiveType.String)),
+            ];
+            var keywordModelList = new[]
+            {
+                InputFactory.Model("PublicModel1", properties: keywordProperties),
+            };
+
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: keywordModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            Assert.AreEqual("SampleNamespaceModelFactory", modelFactory.Name);
+
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            var methods = modelFactory.Methods;
+            // There should be an additional method for backward compatibility
+            Assert.AreEqual(2, methods.Count);
+
+            var currentOverloadMethod = methods
+                .FirstOrDefault(m => m.Signature.Name == "PublicModel1" && m.Signature.Parameters.Any(p => p.Name == "dictProp"));
+            var backwardCompatibilityMethod = methods
+                .FirstOrDefault(m => m.Signature.Name == "PublicModel1" && m.Signature.Parameters.All(p => p.Name != "dictProp"));
+            Assert.IsNotNull(currentOverloadMethod);
+            Assert.IsNotNull(backwardCompatibilityMethod);
+
+            // validate the signature of the backward compatibility method
+            var parameters = backwardCompatibilityMethod!.Signature.Parameters;
+            Assert.AreEqual(3, parameters.Count);
+            Assert.AreEqual("stringProp", parameters[0].Name);
+            Assert.AreEqual("object", parameters[1].Name);
+            Assert.AreEqual("listProp", parameters[2].Name);
+
+            // validate the previous method body uses @object for the named argument
+            var body = backwardCompatibilityMethod!.BodyStatements;
+            Assert.IsNotNull(body);
+            var result = body!.ToDisplayString();
+            Assert.AreEqual(
+                "return PublicModel1(stringProp: stringProp, @object: @object, listProp: listProp, dictProp: default);\n",
+                result);
+        }
+
         [Test]
         public void RequiredConstantPropertiesAreNotExposedAsParameters()
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_NewPropertyAddedWithKeywordPropertyName/SampleNamespaceModelFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_NewPropertyAddedWithKeywordPropertyName/SampleNamespaceModelFactory.cs
@@ -1,0 +1,23 @@
+using SampleTypeSpec;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Sample.Models;
+
+namespace Sample.Namespace
+{
+    public static partial class SampleNamespaceModelFactory
+    {
+        public static PublicModel1 PublicModel1(
+            string stringProp = default,
+            string @object = default,
+            IEnumerable<string> listProp = default)
+        { }
+    }
+}
+
+namespace Sample.Models
+{
+    public partial class PublicModel1
+    { }
+}


### PR DESCRIPTION
fixes a corner case where a model has properties that collide with identifier names:

``/mnt/vss/_work/1/s/sdk/voicelive/Azure.AI.VoiceLive/src/Generated/VoiceLiveModelFactory.cs(2135,44): error CS1525: Invalid expression term 'object' [/mnt/vss/_work/1/s/sdk/voicelive/Azure.AI.VoiceLive/src/Azure.AI.VoiceLive.csproj::TargetFramework=net10.0]``