### PR TITLE
fix(playground): line-level diff highlighting and reduce typing freezes

### DIFF
--- a/.chronus/changes/fix-playground-line-diff-2026-4-21.md
+++ b/.chronus/changes/fix-playground-line-diff-2026-4-21.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/playground"
+---
+
+Fix line-level diff highlighting not appearing in the playground output editor, and reduce typing freezes by coalescing recompiles triggered while a compile is already running.

--- a/.chronus/changes/fix-playground-line-diff-2026-4-21.md
+++ b/.chronus/changes/fix-playground-line-diff-2026-4-21.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/playground"
 ---
 
-Fix line-level diff highlighting not appearing in the playground output editor, and reduce typing freezes by coalescing recompiles triggered while a compile is already running.
+Fix line-level diff highlighting not appearing in the playground output editor, and reduce typing freezes by coalescing recompilations triggered while a compile is already running.

--- a/packages/playground/src/react/playground.tsx
+++ b/packages/playground/src/react/playground.tsx
@@ -227,12 +227,23 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
   }, [content, selectedSampleName, props.samples]);
 
   const compileIdRef = useRef(0);
+  const isCompilingRef = useRef(false);
+  const pendingRecompileRef = useRef(false);
+  const doCompileRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
   const doCompile = useCallback(async () => {
+    // If a compile is already in progress, mark that a recompile is needed and
+    // bail out. The in-flight compile will re-trigger on completion. This avoids
+    // stacking up synchronous compiles that block the UI thread during typing.
+    if (isCompilingRef.current) {
+      pendingRecompileRef.current = true;
+      return;
+    }
     const currentContent = typespecModel.getValue();
     const typespecCompiler = host.compiler;
     const compileId = ++compileIdRef.current;
 
+    isCompilingRef.current = true;
     setIsCompiling(true);
     let state: CompilationState;
     try {
@@ -240,10 +251,16 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error("Compilation failed", error);
-      return;
-    } finally {
+      isCompilingRef.current = false;
       setIsCompiling(false);
+      if (pendingRecompileRef.current) {
+        pendingRecompileRef.current = false;
+        void doCompileRef.current();
+      }
+      return;
     }
+    isCompilingRef.current = false;
+    setIsCompiling(false);
 
     // Discard stale results from an older compilation
     if (compileId !== compileIdRef.current) return;
@@ -289,7 +306,18 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
       updateDiagnosticsForCodeFixes(typespecCompiler, []);
       editor.setModelMarkers(typespecModel, "owner", []);
     }
+
+    // If typing happened while this compile was running, trigger a trailing
+    // compile so the output stays in sync with the latest content.
+    if (pendingRecompileRef.current) {
+      pendingRecompileRef.current = false;
+      void doCompileRef.current();
+    }
   }, [host, selectedEmitter, compilerOptions, typespecModel]);
+
+  useEffect(() => {
+    doCompileRef.current = doCompile;
+  }, [doCompile]);
 
   const currentEmitterOptions = selectedEmitter
     ? props.emitterOptions?.[selectedEmitter]
@@ -438,7 +466,7 @@ export const Playground: FunctionComponent<PlaygroundProps> = (props) => {
       editorOptions={props.editorOptions}
       viewers={props.viewers}
       fileViewers={selectedEmitter ? props.emitterViewers?.[selectedEmitter] : undefined}
-      highlightChanges={currentEmitterOptions?.newChangeDiff}
+      highlightChanges={currentEmitterOptions?.newChangeDiff ?? true}
       selectedViewer={selectedViewer}
       onViewerChange={onSelectedViewerChange}
       viewerState={viewerState}

--- a/packages/playground/src/react/typespec-editor.css
+++ b/packages/playground/src/react/typespec-editor.css
@@ -1,0 +1,5 @@
+/* Monaco decoration class (must be a plain global selector) */
+.playground-changed-line {
+  background-color: rgba(0, 180, 0, 0.15);
+}
+

--- a/packages/playground/src/react/typespec-editor.css
+++ b/packages/playground/src/react/typespec-editor.css
@@ -2,4 +2,3 @@
 .playground-changed-line {
   background-color: rgba(0, 180, 0, 0.15);
 }
-

--- a/packages/playground/src/react/typespec-editor.module.css
+++ b/packages/playground/src/react/typespec-editor.module.css
@@ -1,4 +1,0 @@
-/* Monaco decorations require global class names */
-:global(.playground-changed-line) {
-  background-color: rgba(0, 180, 0, 0.15);
-}

--- a/packages/playground/src/react/typespec-editor.tsx
+++ b/packages/playground/src/react/typespec-editor.tsx
@@ -2,7 +2,7 @@ import { editor, Range } from "monaco-editor";
 import { useCallback, useEffect, useRef, useState, type FunctionComponent } from "react";
 import { Editor, useMonacoModel, type EditorProps } from "./editor.js";
 import type { PlaygroundEditorsOptions } from "./playground.js";
-import "./typespec-editor.module.css";
+import "./typespec-editor.css";
 
 // Re-export for backward compatibility
 export { getChangedLineNumbers } from "./diff-utils.js";


### PR DESCRIPTION
Bug 1: The CSS rule for '.playground-changed-line' was defined inside a .module.css file and imported as a side-effect. Vite/CSS Modules does not emit :global() rules from a side-effect import, so the class was never in the built stylesheet and Monaco decorations were invisible. Renamed to a plain .css file and removed the :global() wrapper.

Additionally, 'highlightChanges' was gated by 'emitterOptions.newChangeDiff' which the shipping website never sets. Default it to true so the feature is live out of the box (callers can still opt out).

Bug 2: While a compile is in progress, any additional onDidChangeContent-triggered recompile now marks a pending recompile flag and bails out instead of stacking work. When the current compile completes we run a single trailing recompile. This doesn't fix the fundamental main-thread block from synchronous compilation, but prevents queuing redundant blocking compiles while the user is typing.