### PR TITLE
ci: trigger azure-sdk-for-python regeneration after http-client-python publish

### DIFF
--- a/.chronus/changes/python-publish-dispatch-2026-04-21-17-01-13.md
+++ b/.chronus/changes/python-publish-dispatch-2026-04-21-17-01-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-python"
+---
+
+Add repository_dispatch to publish pipeline to trigger azure-sdk-for-python regeneration

--- a/packages/http-client-python/eng/pipeline/publish.yml
+++ b/packages/http-client-python/eng/pipeline/publish.yml
@@ -32,3 +32,24 @@ extends:
           EnableCadlRanchReport: false
           PythonVersion: "3.11"
           UploadPlaygroundBundle: true
+
+      - stage: Python_Notify
+        displayName: Python - Notify downstream
+        dependsOn: Python_Publish
+        condition: succeeded()
+        pool:
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
+        jobs:
+          - job: DispatchRegeneration
+            displayName: Trigger azure-sdk-for-python regeneration
+            steps:
+              - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+              - script: |
+                  curl -f -X POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer $(GH_TOKEN)" \
+                    https://api.github.com/repos/Azure/azure-sdk-for-python/dispatches \
+                    -d '{"event_type":"typespec-python-regenerate","client_payload":{"sha":"$(Build.SourceVersion)"}}'
+                displayName: Dispatch typespec-python-regenerate


### PR DESCRIPTION
After http-client-python is published to npm, dispatch a `typespec-python-regenerate` event to Azure/azure-sdk-for-python to trigger test regeneration.

Uses the existing `login-to-github.yml` template to mint a GitHub App token via Azure Key Vault (no PAT needed).

**Changes:**
- `eng/emitters/pipelines/templates/stages/emitter-stages.yml`: Add dispatch step after publish, gated to `python` language only