### PR TITLE
[http-client-csharp] Preserve previously-published parameter names across back-compat

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -1112,16 +1112,21 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 if (_backCompatProvider != backCompatProvider)
                 {
                     _backCompatProvider = backCompatProvider;
-                    // reset cache so methods are rebuilt with the new backcompat provider
-                    Reset();
+                    // Only reset the cached methods (and the underlying RestClient methods)
+                    // so they are rebuilt with the new backcompat provider. Do NOT call full
+                    // Reset() — that would discard properties/constructors/fields applied by
+                    // visitors that may have already run (e.g., Azure DistributedTracingVisitor's
+                    // ClientDiagnostics property).
+                    ResetMethods();
+                    _restClient?.ResetMethods();
                     _methodCache = null;
                 }
             }
             else if (_backCompatProvider != null)
             {
-                // backcompat provider was previously set but not requested now — reset to default
                 _backCompatProvider = null;
-                Reset();
+                ResetMethods();
+                _restClient?.ResetMethods();
                 _methodCache = null;
             }
             _ = Methods; // Ensure methods are built

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -926,10 +926,24 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 : null;
         }
 
-        private static void UpdateParameterNameWithBackCompat(InputParameter inputParameter, string proposedName, TypeProvider backCompatProvider)
+        private static void UpdateParameterNameWithBackCompat(InputParameter inputParameter, string proposedName, TypeProvider backCompatProvider, InputServiceMethod? serviceMethod = null)
         {
+            // Look up the parameter's original (spec) name in the previous contract.
+            // When a service method is supplied, scope the search to methods whose name matches
+            // the current service method (allowing for sync/async pairing) so that a common
+            // parameter name (e.g. "id") on multiple methods can't cross-match.
+            var lastContractMethods = backCompatProvider.LastContractView?.Methods;
+            IEnumerable<MethodProvider>? scopedMethods = lastContractMethods;
+            if (lastContractMethods != null && serviceMethod != null)
+            {
+                var serviceMethodName = serviceMethod.Name;
+                scopedMethods = lastContractMethods.Where(m =>
+                    string.Equals(m.Signature.Name, serviceMethodName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(m.Signature.Name, serviceMethodName + "Async", StringComparison.OrdinalIgnoreCase));
+            }
+
             // Check if the original wire name exists in LastContractView for backward compatibility.
-            var existingParam = backCompatProvider.LastContractView?.Methods
+            var existingParam = scopedMethods
                 ?.SelectMany(method => method.Signature.Parameters)
                 .FirstOrDefault(p => string.Equals(p.Name, inputParameter.OriginalName, StringComparison.OrdinalIgnoreCase))
                 ?.Name;
@@ -1064,12 +1078,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 // For paging operations, handle parameter name corrections with backward compatibility
                 if (serviceMethod is InputPagingServiceMethod)
                 {
-                    var backCompatProvider = client.BackCompatProvider;
+                    var pagingBackCompatProvider = client.BackCompatProvider;
 
                     // Rename "top" parameter to "maxCount" (with backward compatibility).
                     if (string.Equals(inputParam.OriginalName, TopParameterName, StringComparison.OrdinalIgnoreCase))
                     {
-                        UpdateParameterNameWithBackCompat(inputParam, MaxCountParameterName, backCompatProvider);
+                        UpdateParameterNameWithBackCompat(inputParam, MaxCountParameterName, pagingBackCompatProvider, serviceMethod);
                     }
 
                     // Ensure page size parameter uses the correct casing (with backward compatibility)
@@ -1080,9 +1094,16 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                             : pageSizeParameterName;
                         // For page size parameters, normalize badly-cased "maxpagesize" variants to proper camelCase, but always
                         // respect backcompat.
-                        UpdateParameterNameWithBackCompat(inputParam, updatedPageSizeParameterName, backCompatProvider);
+                        UpdateParameterNameWithBackCompat(inputParam, updatedPageSizeParameterName, pagingBackCompatProvider, serviceMethod);
                     }
                 }
+
+                // For every parameter, preserve a previously-published parameter name when the
+                // last contract has a matching parameter (matched by spec/original name). This
+                // generalizes back-compat name preservation beyond the paging-specific renames
+                // above so that any rename emitted by the generator falls back to the prior name
+                // when one was already published.
+                UpdateParameterNameWithBackCompat(inputParam, inputParam.Name, client.BackCompatProvider, serviceMethod);
 
                 ParameterProvider? parameter = ScmCodeModelGenerator.Instance.TypeFactory.CreateParameter(inputParam)?.ToPublicInputParameter();
                 if (parameter is null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -1078,12 +1078,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 // For paging operations, handle parameter name corrections with backward compatibility
                 if (serviceMethod is InputPagingServiceMethod)
                 {
-                    var pagingBackCompatProvider = client.BackCompatProvider;
-
                     // Rename "top" parameter to "maxCount" (with backward compatibility).
                     if (string.Equals(inputParam.OriginalName, TopParameterName, StringComparison.OrdinalIgnoreCase))
                     {
-                        UpdateParameterNameWithBackCompat(inputParam, MaxCountParameterName, pagingBackCompatProvider, serviceMethod);
+                        UpdateParameterNameWithBackCompat(inputParam, MaxCountParameterName, client.BackCompatProvider, serviceMethod);
                     }
 
                     // Ensure page size parameter uses the correct casing (with backward compatibility)
@@ -1094,7 +1092,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                             : pageSizeParameterName;
                         // For page size parameters, normalize badly-cased "maxpagesize" variants to proper camelCase, but always
                         // respect backcompat.
-                        UpdateParameterNameWithBackCompat(inputParam, updatedPageSizeParameterName, pagingBackCompatProvider, serviceMethod);
+                        UpdateParameterNameWithBackCompat(inputParam, updatedPageSizeParameterName, client.BackCompatProvider, serviceMethod);
                     }
                 }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
@@ -362,6 +362,39 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientPro
             Assert.AreEqual("contentType", methodParameters[2].Name); // contentType after body
         }
 
+        [Test]
+        public async Task ParameterNamePreservedFromLastContractView()
+        {
+            // A non-paging, non-special parameter that the generator renames from "oldParam" to
+            // "newParam". The previously-published contract (TestData/.../TestClient.cs) declares
+            // the parameter as "oldParam", so backcompat should restore that name.
+            var queryParam = InputFactory.QueryParameter("oldParam", InputPrimitiveType.String, isRequired: true);
+            queryParam.Update(name: "newParam");
+            Assert.AreEqual("newParam", queryParam.Name);
+            Assert.AreEqual("oldParam", queryParam.OriginalName);
+
+            var operation = InputFactory.Operation("GetSomething", parameters: [queryParam]);
+            var serviceMethod = InputFactory.BasicServiceMethod("GetSomething", operation);
+            var client = InputFactory.Client("TestClient", methods: [serviceMethod]);
+
+            var generator = await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [client],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var clientProvider = generator.Object.OutputLibrary.TypeProviders.OfType<ClientProvider>().FirstOrDefault();
+            Assert.IsNotNull(clientProvider);
+            Assert.IsNotNull(clientProvider!.LastContractView);
+
+            var protocolParams = RestClientProvider.GetMethodParameters(serviceMethod, ScmMethodKind.Protocol, clientProvider!);
+
+            Assert.IsNotNull(
+                protocolParams.FirstOrDefault(p => string.Equals(p.Name, "oldParam", StringComparison.Ordinal)),
+                "Protocol parameter should be restored to the previously-published 'oldParam' name.");
+            Assert.IsNull(
+                protocolParams.FirstOrDefault(p => string.Equals(p.Name, "newParam", StringComparison.Ordinal)),
+                "When 'oldParam' is preserved, the renamed 'newParam' must not appear.");
+        }
+
         [TestCase(true, true)]
         [TestCase(true, false)]
         [TestCase(false, true)]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/TestData/RestClientProviderTests/ParameterNamePreservedFromLastContractView/TestClient.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/TestData/RestClientProviderTests/ParameterNamePreservedFromLastContractView/TestClient.cs
@@ -1,0 +1,15 @@
+#nullable disable
+
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Threading.Tasks;
+
+namespace Sample
+{
+    public partial class TestClient
+    {
+        // Represents the previously published contract: parameter is named "oldParam".
+        public virtual Task<ClientResult> GetSomethingAsync(string oldParam, RequestOptions options = null) { return null; }
+        public virtual ClientResult GetSomething(string oldParam, RequestOptions options = null) { return null; }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -247,6 +247,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
                         continue;
                     }
 
+                    CodeModelGenerator.Instance.Emitter.Debug(
+                        $"Preserved parameter name '{previousName}' on '{Name}.{matchingCurrent.Signature.Name}' from last contract (instead of '{currentParam.Name}').",
+                        BackCompatibilityChangeCategory.ParameterNamePreserved);
+
                     currentParam.Update(name: previousName);
                 }
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -97,7 +97,14 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             List<MethodProvider> factoryMethods = [.. originalMethods];
-            HashSet<MethodSignature> currentMethodSignatures = new List<MethodProvider>([.. originalMethods, .. CustomCodeView?.Methods ?? []])
+
+            // Preserve the original parameter names on current factory methods when the only
+            // change between the previous and current contract is a parameter rename. This
+            // avoids source-breaking changes for callers using named arguments (e.g. when a
+            // property is renamed via @@clientName, spec rename, or naming-rule change).
+            PreservePreviousParameterNames(factoryMethods);
+
+            HashSet<MethodSignature> currentMethodSignatures = new List<MethodProvider>([.. factoryMethods, .. CustomCodeView?.Methods ?? []])
                .Select(m => m.Signature)
                .ToHashSet(MethodSignature.MethodSignatureComparer);
 
@@ -175,6 +182,56 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             return [.. factoryMethods];
+        }
+
+        // Preserve original parameter names from the previous contract when a current factory
+        // method matches a previous one by name + parameter types/order but differs only in
+        // parameter names. The rename is applied in-place via ParameterProvider.Update which
+        // also updates the cached variable/argument expressions used by the method body and
+        // XML docs, so the body and docs serialize with the preserved names automatically.
+        private void PreservePreviousParameterNames(List<MethodProvider> currentFactoryMethods)
+        {
+            if (LastContractView?.Methods == null)
+            {
+                return;
+            }
+
+            foreach (var previousMethod in LastContractView.Methods)
+            {
+                MethodProvider? matchingCurrent = null;
+                foreach (var current in currentFactoryMethods)
+                {
+                    if (MethodSignature.MethodSignatureComparer.Equals(current.Signature, previousMethod.Signature))
+                    {
+                        matchingCurrent = current;
+                        break;
+                    }
+                }
+
+                if (matchingCurrent is null)
+                {
+                    continue;
+                }
+
+                var previousParameters = previousMethod.Signature.Parameters;
+                var currentParameters = matchingCurrent.Signature.Parameters;
+                if (previousParameters.Count != currentParameters.Count)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < previousParameters.Count; i++)
+                {
+                    var previousName = previousParameters[i].Name;
+                    var currentParam = currentParameters[i];
+                    if (string.IsNullOrEmpty(previousName) || currentParam.Name == previousName)
+                    {
+                        continue;
+                    }
+
+                    currentParam.Update(name: previousName);
+                }
+            }
         }
 
         private bool TryBuildCompatibleMethodForPreviousContract(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -201,6 +201,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 MethodProvider? matchingCurrent = null;
                 foreach (var current in currentFactoryMethods)
                 {
+                    // MethodSignatureComparer matches on method name + parameter count + parameter
+                    // types (positional); it does not consider parameter names. So a previous
+                    // method whose only difference from a current method is parameter names will
+                    // still match here.
                     if (MethodSignature.MethodSignatureComparer.Equals(current.Signature, previousMethod.Signature))
                     {
                         matchingCurrent = current;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -403,6 +403,17 @@ namespace Microsoft.TypeSpec.Generator.Providers
         protected abstract string BuildName();
 
         /// <summary>
+        /// Resets only the cached methods so they are rebuilt on next access.
+        /// Use this instead of <see cref="Reset"/> when you need to force a method
+        /// rebuild without discarding visitor-applied state on properties, fields,
+        /// constructors, or canonical/last-contract views.
+        /// </summary>
+        public void ResetMethods()
+        {
+            _methods = null;
+        }
+
+        /// <summary>
         /// Resets the type provider to its initial state, clearing all cached properties and fields.
         /// This allows for the type provider to rebuild its state on subsequent calls to its properties.
         /// </summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -488,6 +488,57 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             Assert.AreEqual("oldModelProp", docParams[1].Parameter.Name);
         }
 
+        // Validates that when ALL parameters in a factory method are renamed in the previous
+        // contract, every preserved name is propagated to the current method. This complements
+        // BackCompatibility_OnlyParamNameChanged which exercises a partial rename.
+        [Test]
+        public async Task BackCompatibility_MultipleParamNamesChanged()
+        {
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: ModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            var methods = modelFactory.Methods;
+            // No additional overload should be added — the renames are absorbed into the current method.
+            Assert.AreEqual(ModelList.Length - ModelList.Where(m => m.Access == "internal").Count(), methods.Count);
+
+            var publicModel1Methods = methods.Where(m => m.Signature.Name == "PublicModel1").ToList();
+            Assert.AreEqual(1, publicModel1Methods.Count);
+            var publicModel1Method = publicModel1Methods[0];
+
+            var parameters = publicModel1Method.Signature.Parameters;
+            Assert.AreEqual(4, parameters.Count);
+            Assert.AreEqual("previousStringProp", parameters[0].Name);
+            Assert.AreEqual("previousModelProp", parameters[1].Name);
+            Assert.AreEqual("previousListProp", parameters[2].Name);
+            Assert.AreEqual("previousDictProp", parameters[3].Name);
+
+            // No EditorBrowsable hidden overload — there's a single visible method.
+            Assert.AreEqual(0, publicModel1Method.Signature.Attributes.Count);
+
+            // The body should reference the renamed parameters when constructing the model.
+            var body = publicModel1Method.BodyStatements;
+            Assert.IsNotNull(body);
+            var result = body!.ToDisplayString();
+            Assert.AreEqual(
+                "previousListProp ??= new global::Sample.Namespace.ChangeTrackingList<string>();\n" +
+                "previousDictProp ??= new global::Sample.Namespace.ChangeTrackingDictionary<string, string>();\n\n" +
+                "return new global::Sample.Models.PublicModel1(previousStringProp, previousModelProp, previousListProp.ToList(), previousDictProp, additionalBinaryDataProperties: null);\n",
+                result);
+
+            // The XML doc <param> entries should also use the preserved names.
+            var docParams = publicModel1Method.XmlDocs!.Parameters;
+            Assert.AreEqual(parameters.Count, docParams.Count);
+            Assert.AreEqual("previousStringProp", docParams[0].Parameter.Name);
+            Assert.AreEqual("previousModelProp", docParams[1].Parameter.Name);
+            Assert.AreEqual("previousListProp", docParams[2].Parameter.Name);
+            Assert.AreEqual("previousDictProp", docParams[3].Parameter.Name);
+        }
+
         [Test]
         public void ModelWithNestedDiscriminators()
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -539,6 +539,69 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             Assert.AreEqual("previousDictProp", docParams[3].Parameter.Name);
         }
 
+        // Validates that when a new property is added AND the previous contract used different
+        // names for some of the surviving parameters, the rename-only fast path does NOT apply
+        // (parameter counts differ). Instead the standard "new property added" backcompat overload
+        // is generated using the previously-published parameter names.
+        [Test]
+        public async Task BackCompatibility_NewPropertyAddedWithRenamedParam()
+        {
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: ModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            var methods = modelFactory.Methods;
+            // There should be an additional method for backward compatibility.
+            Assert.AreEqual(ModelList.Length - ModelList.Where(m => m.Access == "internal").Count() + 1, methods.Count);
+
+            var currentOverloadMethod = methods
+                .FirstOrDefault(m => m.Signature.Name == "PublicModel1" && m.Signature.Parameters.Any(p => p.Name == "dictProp"));
+            var backwardCompatibilityMethod = methods
+                .FirstOrDefault(m => m.Signature.Name == "PublicModel1" && m.Signature.Parameters.All(p => p.Name != "dictProp"));
+            Assert.IsNotNull(currentOverloadMethod);
+            Assert.IsNotNull(backwardCompatibilityMethod);
+
+            // The current method keeps the new property-derived names (no rename absorbed) since
+            // the parameter count differs between the current and previous methods.
+            var currentParameters = currentOverloadMethod!.Signature.Parameters;
+            Assert.AreEqual(4, currentParameters.Count);
+            Assert.AreEqual("stringProp", currentParameters[0].Name);
+            Assert.AreEqual("modelProp", currentParameters[1].Name);
+            Assert.AreEqual("listProp", currentParameters[2].Name);
+            Assert.AreEqual("dictProp", currentParameters[3].Name);
+
+            // The backcompat overload preserves the previously-published parameter names.
+            var attributes = backwardCompatibilityMethod!.Signature.Attributes;
+            Assert.AreEqual(1, attributes.Count);
+            Assert.AreEqual(
+                "[global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]\n",
+                attributes[0].ToDisplayString());
+
+            var parameters = backwardCompatibilityMethod.Signature.Parameters;
+            Assert.AreEqual(3, parameters.Count);
+            Assert.AreEqual("oldStringProp", parameters[0].Name);
+            Assert.AreEqual("oldModelProp", parameters[1].Name);
+            Assert.AreEqual("listProp", parameters[2].Name);
+            foreach (var param in parameters)
+            {
+                Assert.IsNull(param.DefaultValue);
+            }
+
+            // The backcompat overload's body instantiates the model directly because the previous
+            // parameter names (oldStringProp, oldModelProp) do not match any current property name.
+            // For unmatched parameters the generator falls back to passing `default` to the
+            // constructor; matched names (listProp) are threaded through.
+            var body = backwardCompatibilityMethod.BodyStatements;
+            Assert.IsNotNull(body);
+            var bodyString = body!.ToDisplayString();
+            StringAssert.Contains("listProp ??= new global::Sample.Namespace.ChangeTrackingList<string>();", bodyString);
+            StringAssert.Contains("return new global::Sample.Models.PublicModel1(default, default, listProp.ToList(), default, additionalBinaryDataProperties: null);", bodyString);
+        }
+
         [Test]
         public void ModelWithNestedDiscriminators()
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -440,6 +440,55 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         }
 
         [Test]
+        public async Task BackCompatibility_OnlyParamNameChanged()
+        {
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: ModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            Assert.AreEqual("SampleNamespaceModelFactory", modelFactory.Name);
+
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            var methods = modelFactory.Methods;
+            // No additional overload should be added — the rename is absorbed into the current method.
+            Assert.AreEqual(ModelList.Length - ModelList.Where(m => m.Access == "internal").Count(), methods.Count);
+
+            var publicModel1Methods = methods.Where(m => m.Signature.Name == "PublicModel1").ToList();
+            Assert.AreEqual(1, publicModel1Methods.Count);
+
+            var publicModel1Method = publicModel1Methods[0];
+            // Previous parameter names should be preserved on the current method.
+            var parameters = publicModel1Method.Signature.Parameters;
+            Assert.AreEqual(4, parameters.Count);
+            Assert.AreEqual("oldStringProp", parameters[0].Name);
+            Assert.AreEqual("oldModelProp", parameters[1].Name);
+            Assert.AreEqual("listProp", parameters[2].Name);
+            Assert.AreEqual("dictProp", parameters[3].Name);
+
+            // No EditorBrowsable hidden overload — there's a single visible method.
+            Assert.AreEqual(0, publicModel1Method.Signature.Attributes.Count);
+
+            // The body should reference the renamed parameters when constructing the model.
+            var body = publicModel1Method.BodyStatements;
+            Assert.IsNotNull(body);
+            var result = body!.ToDisplayString();
+            Assert.AreEqual(
+                "listProp ??= new global::Sample.Namespace.ChangeTrackingList<string>();\n" +
+                "dictProp ??= new global::Sample.Namespace.ChangeTrackingDictionary<string, string>();\n\n" +
+                "return new global::Sample.Models.PublicModel1(oldStringProp, oldModelProp, listProp.ToList(), dictProp, additionalBinaryDataProperties: null);\n",
+                result);
+
+            // The XML doc <param> entries should also use the preserved names.
+            var docParams = publicModel1Method.XmlDocs!.Parameters;
+            Assert.AreEqual(parameters.Count, docParams.Count);
+            Assert.AreEqual("oldStringProp", docParams[0].Parameter.Name);
+            Assert.AreEqual("oldModelProp", docParams[1].Parameter.Name);
+        }
+
+        [Test]
         public void ModelWithNestedDiscriminators()
         {
             var discriminatorProperty =

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_MultipleParamNamesChanged/SampleNamespaceModelFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_MultipleParamNamesChanged/SampleNamespaceModelFactory.cs
@@ -1,0 +1,26 @@
+using SampleTypeSpec;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Sample.Models;
+
+namespace Sample.Namespace
+{
+    public static partial class SampleNamespaceModelFactory
+    {
+        // Previous contract renamed ALL parameters of the factory method. The current
+        // method should preserve every previous parameter name.
+        public static PublicModel1 PublicModel1(
+            string previousStringProp = default,
+            Thing previousModelProp = default,
+            IEnumerable<string> previousListProp = default,
+            IDictionary<string, string> previousDictProp = default)
+        { }
+    }
+}
+
+namespace Sample.Models
+{
+    public partial class Thing
+    { }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_NewPropertyAddedWithRenamedParam/SampleNamespaceModelFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_NewPropertyAddedWithRenamedParam/SampleNamespaceModelFactory.cs
@@ -1,0 +1,30 @@
+using SampleTypeSpec;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Sample.Models;
+
+namespace Sample.Namespace
+{
+    public static partial class SampleNamespaceModelFactory
+    {
+        // Previous contract had only three of the four current properties AND the first two were
+        // exposed under different parameter names. Because the parameter count differs from the
+        // current method, the rename-only fast path does not apply; the standard "new property
+        // added" overload is generated using the previously-published names.
+        public static PublicModel1 PublicModel1(
+            string oldStringProp = default,
+            Thing oldModelProp = default,
+            IEnumerable<string> listProp = default)
+        { }
+    }
+}
+
+namespace Sample.Models
+{
+    public partial class PublicModel1
+    { }
+
+    public partial class Thing
+    { }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_OnlyParamNameChanged/SampleNamespaceModelFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_OnlyParamNameChanged/SampleNamespaceModelFactory.cs
@@ -1,0 +1,27 @@
+using SampleTypeSpec;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Sample.Models;
+
+namespace Sample.Namespace
+{
+    public static partial class SampleNamespaceModelFactory
+    {
+        // Previous contract used different parameter names for two of the parameters.
+        // The current method should preserve the previous names rather than renaming them
+        // to the new property-derived names.
+        public static PublicModel1 PublicModel1(
+            string oldStringProp = default,
+            Thing oldModelProp = default,
+            IEnumerable<string> listProp = default,
+            IDictionary<string, string> dictProp = default)
+        { }
+    }
+}
+
+namespace Sample.Models
+{
+    public partial class Thing
+    { }
+}

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -6,6 +6,9 @@
 - [How It Works](#how-it-works)
 - [Supported Scenarios](#supported-scenarios)
   - [Model Factory Methods](#model-factory-methods)
+    - [New Model Property Added](#scenario-new-model-property-added)
+    - [Parameter Ordering Changed](#scenario-parameter-ordering-changed)
+    - [Property Renamed](#scenario-property-renamed)
   - [Model Properties](#model-properties)
   - [AdditionalProperties Type Preservation](#additionalproperties-type-preservation)
   - [API Version Enum](#api-version-enum)
@@ -109,6 +112,55 @@ public static PublicModel1 PublicModel1(
 ```
 
 **Result:** The generator keeps the previous parameter ordering to maintain compatibility.
+
+#### Scenario: Property Renamed
+
+**Description:** When a model property is renamed (via `@@clientName`, a spec rename, a generator naming-rule change, etc.), the generated factory parameter would normally change name to follow the new property name. Renaming a parameter is source-breaking for callers using named arguments and is not flagged by ApiCompat / binary-compat tooling. To avoid this, the generator preserves the previous parameter name on the current factory method whenever the only difference between the previous and current method is one or more parameter names (same method name, same parameter types in the same order, same parameter count).
+
+**Example:**
+
+Previous version exposed `stringProp` and `modelProp`:
+
+```csharp
+public static PublicModel1 PublicModel1(
+    string stringProp = default,
+    Thing modelProp = default,
+    IEnumerable<string> listProp = default,
+    IDictionary<string, string> dictProp = default)
+```
+
+Current TypeSpec renames the underlying properties to `CertificateStringProp` and `CertificateModelProp`, which would normally produce:
+
+```csharp
+public static PublicModel1 PublicModel1(
+    string certificateStringProp = default,
+    Thing certificateModelProp = default,
+    IEnumerable<string> listProp = default,
+    IDictionary<string, string> dictProp = default)
+```
+
+**Generated Compatibility Result:**
+
+The generator detects that previous and current methods differ only in parameter names and preserves the previous names on the current method:
+
+```csharp
+public static PublicModel1 PublicModel1(
+    string stringProp = default,
+    Thing modelProp = default,
+    IEnumerable<string> listProp = default,
+    IDictionary<string, string> dictProp = default)
+{
+    // body uses the preserved names when constructing the model
+    return new PublicModel1(stringProp, modelProp, listProp.ToList(), dictProp, additionalBinaryDataProperties: null);
+}
+```
+
+**Key Points:**
+
+- Only one method is generated — no additional `[EditorBrowsable(EditorBrowsableState.Never)]` overload is needed
+- Existing source code using named arguments (e.g. `PublicModel1(stringProp: "x")`) continues to compile
+- The matching is by method name plus parameter types in the same order; the parameter count must also match. If a parameter is added or removed in addition to a rename, the standard "new property added" overload is generated instead
+- The XML doc `<param>` entries on the method are updated to reference the preserved names
 
 ### Model Properties
 

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -9,6 +9,7 @@
     - [New Model Property Added](#scenario-new-model-property-added)
     - [Parameter Ordering Changed](#scenario-parameter-ordering-changed)
     - [Property Renamed](#scenario-property-renamed)
+    - [New Property Added Together with a Rename](#scenario-new-property-added-together-with-a-rename)
   - [Model Properties](#model-properties)
   - [AdditionalProperties Type Preservation](#additionalproperties-type-preservation)
   - [API Version Enum](#api-version-enum)
@@ -17,6 +18,7 @@
   - [Parameter Naming](#parameter-naming)
     - [Page Size Parameter Casing Correction](#scenario-page-size-parameter-casing-correction)
     - [Top Parameter Conversion to MaxCount](#scenario-top-parameter-conversion-to-maxcount)
+    - [Method Parameter Name Preserved from Last Contract](#scenario-method-parameter-name-preserved-from-last-contract)
   - [Content-Type Parameter Ordering](#content-type-parameter-ordering)
     - [Content-Type Before Body Preserved from Last Contract](#scenario-content-type-before-body-preserved-from-last-contract)
 
@@ -159,8 +161,58 @@ public static PublicModel1 PublicModel1(
 
 - Only one method is generated — no additional `[EditorBrowsable(EditorBrowsableState.Never)]` overload is needed
 - Existing source code using named arguments (e.g. `PublicModel1(stringProp: "x")`) continues to compile
-- The matching is by method name plus parameter types in the same order; the parameter count must also match. If a parameter is added or removed in addition to a rename, the standard "new property added" overload is generated instead
+- The matching is by method name plus parameter types in the same order; the parameter count must also match. If a parameter is added or removed in addition to a rename, the standard "new property added" overload is generated instead (see scenario below)
 - The XML doc `<param>` entries on the method are updated to reference the preserved names
+
+#### Scenario: New Property Added Together with a Rename
+
+**Description:** When a new property is added to a model AND a previously-published property has been renamed at the same time, the parameter counts of the previous and current factory methods differ, so the rename-only fast path above does not apply. The generator falls back to the standard "new property added" flow and emits an `[EditorBrowsable(EditorBrowsableState.Never)]` backcompat overload using the previously-published parameter names.
+
+> [!NOTE]
+> The body of the backcompat overload constructs the model directly. Renamed parameters whose names no longer match a current property are passed as `default` to the constructor, since the body can no longer thread them through the renamed properties. This keeps existing source compiling, but callers who depended on the old parameter being forwarded should migrate to the current method.
+
+**Example:**
+
+Previous version exposed three properties, with the first two under different names:
+
+```csharp
+public static PublicModel1 PublicModel1(
+    string oldStringProp = default,
+    Thing oldModelProp = default,
+    IEnumerable<string> listProp = default)
+```
+
+Current TypeSpec renames the first two properties (now `stringProp` / `modelProp`) and adds a new property (`dictProp`):
+
+```csharp
+public static PublicModel1 PublicModel1(
+    string stringProp = default,
+    Thing modelProp = default,
+    IEnumerable<string> listProp = default,
+    IDictionary<string, string> dictProp = default)
+```
+
+**Generated Compatibility Method:**
+
+```csharp
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static PublicModel1 PublicModel1(
+    string oldStringProp,
+    Thing oldModelProp,
+    IEnumerable<string> listProp)
+{
+    listProp ??= new ChangeTrackingList<string>();
+
+    return new PublicModel1(default, default, listProp.ToList(), default, additionalBinaryDataProperties: null);
+}
+```
+
+**Key Points:**
+
+- The previous (renamed) signature is preserved so existing source code continues to compile
+- Parameters whose names matched a current property (`listProp`) are threaded through; renamed parameters are passed as `default`
+- The new property is also passed as `default`
+- A separate visible method exposes the current signature with the new property and the renamed parameters
 
 ### Model Properties
 
@@ -644,6 +696,50 @@ public virtual AsyncPageable<Item> GetItemsAsync(int? maxCount = null, Cancellat
 - This conversion is specific to paging operations only
 - Existing client code with `top` continues to compile without changes
 - New code benefits from the standardized `maxCount` naming convention
+
+#### Scenario: Method Parameter Name Preserved from Last Contract
+
+**Description:** When a service method parameter is renamed by the spec or by the generator (e.g., a `@@clientName`, a TypeSpec property rename, or a generator naming-rule change), the new name would normally appear on the generated convenience and protocol methods. Renaming a parameter is source-breaking for callers using named arguments and is not flagged by ApiCompat / binary-compat tooling. To avoid this, the generator looks up the parameter's original (spec) name in `LastContractView` and, when a previously-published parameter with that name exists on the matching method (matched by method name, allowing for the sync/async pair), restores the previously-published parameter name on the current method.
+
+This generalizes the paging-specific `top → maxCount` and page-size casing scenarios above so that any renamed parameter on any operation falls back to the prior published name.
+
+**Example:**
+
+Previous version exposed `oldParam` on `GetSomething`:
+
+```csharp
+public virtual ClientResult GetSomething(string oldParam, RequestOptions options = null)
+{
+    // ...
+}
+```
+
+Current TypeSpec renames the parameter to `newParam` (e.g., via `@@clientName` or a property rename), which would normally produce:
+
+```csharp
+public virtual ClientResult GetSomething(string newParam, RequestOptions options = null)
+{
+    // ...
+}
+```
+
+**Generated Compatibility Result:**
+
+The generator detects `oldParam` on the matching method in `LastContractView` and restores that name on the current method:
+
+```csharp
+public virtual ClientResult GetSomething(string oldParam, RequestOptions options = null)
+{
+    // body and HTTP request still use the spec's serialized name; only the public parameter name is preserved
+}
+```
+
+**Key Points:**
+
+- Lookup is scoped to the matching service method (allowing for the sync/async pair) so a parameter name shared across multiple methods cannot false-match another method's parameter
+- The HTTP query/path/header/body serialized name continues to use the spec's wire name — only the C# parameter identifier is restored
+- Existing source code using named arguments (e.g., `client.GetSomething(oldParam: "x")`) continues to compile
+- If no matching parameter is found in `LastContractView`, the generator uses the current (renamed) name
 
 ### Content-Type Parameter Ordering
 

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -117,7 +117,7 @@ public static PublicModel1 PublicModel1(
 
 #### Scenario: Property Renamed
 
-**Description:** When a model property is renamed (via `@@clientName`, a spec rename, a generator naming-rule change, etc.), the generated factory parameter would normally change name to follow the new property name. Renaming a parameter is source-breaking for callers using named arguments and is not flagged by ApiCompat / binary-compat tooling. To avoid this, the generator preserves the previous parameter name on the current factory method whenever the only difference between the previous and current method is one or more parameter names (same method name, same parameter types in the same order, same parameter count).
+**Description:** When a model property is renamed (via `@@clientName`, a spec rename, a generator naming-rule change, etc.), the generated factory parameter would normally change its name to follow the new property name. Renaming a parameter is source-breaking for callers using named arguments and is not flagged by ApiCompat / binary-compat tooling. To avoid this, the generator preserves the previous parameter name on the current factory method whenever the only difference between the previous and current method is one or more parameter names (same method name, same parameter types in the same order, same parameter count).
 
 **Example:**
 


### PR DESCRIPTION
Generalizes parameter-name preservation across the back-compat feature so that renamed parameters in both **model factory methods** and **service method signatures** continue to use their previously-published names.

Combines and supersedes #10465.

Fixes #10463

### Model factory methods (`ModelFactoryProvider`)

When the only difference between a previous and current factory method is one or more parameter names (same method name, same parameter types in the same order, same count), the previous names are mutated in place on the current `ParameterProvider` so that the body and XML docs serialize with the preserved names. This avoids source-breaking changes for callers using named arguments when properties are renamed.

When a new property is added at the same time as a rename (parameter counts differ), the standard `[EditorBrowsable(EditorBrowsableState.Never)]` overload is generated using the previously-published parameter names; renamed parameters that no longer match a current property are passed as `default` to the constructor.

### Service method signatures (`RestClientProvider`)

The back-compat lookup against `LastContractView` previously only ran for the paging-specific `top -> maxCount` rename and the page-size casing normalization. This PR extends it so every parameter participates: when a service method's parameter has been renamed by the generator and the previous contract published a parameter with the original spec name, restore that name. The search is scoped to methods whose name matches the current service method (allowing for the sync/async pair) so that a common parameter name shared across multiple methods can't false-match.

### Tests

- `ModelFactoryProviderTests.BackCompatibility_OnlyParamNameChanged` (partial rename)
- `ModelFactoryProviderTests.BackCompatibility_MultipleParamNamesChanged` (all params renamed)
- `ModelFactoryProviderTests.BackCompatibility_NewPropertyAddedWithRenamedParam` (new property + rename)
- `RestClientProviderTests.ParameterNamePreservedFromLastContractView` (non-paging service method rename)
- Full ClientModel + Generator suites green (1312 + 1427 tests).

### Docs

Updated `backward-compatibility.md` with two new scenarios:
- *Property Renamed* / *New Property Added Together with a Rename* (model factory)
- *Method Parameter Name Preserved from Last Contract* (service method signatures)