### PR TITLE
perf(http-client-python): precompute model class state to speed up list operations

### DIFF
--- a/.chronus/changes/perf-model-base-easy-wins-2026-3-20-0-0-0.md
+++ b/.chronus/changes/perf-model-base-easy-wins-2026-3-20-0-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Speed up model deserialization for list-style operations by precomputing per-class defaults and rest-name metadata once in `__new__`, turning `_RestField._rest_name` and `Model._calculated_done` into plain attribute reads instead of a `@property` and a string-keyed set lookup. Also narrows a broad `except Exception` in `_deserialize_default` to `except DeserializationError` so real coding bugs are no longer silently swallowed.

--- a/packages/http-client-python/generator/pygen/codegen/templates/model_base.py.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/model_base.py.jinja2
@@ -609,19 +609,17 @@ def _create_value(rf: typing.Optional["_RestField"], value: typing.Any) -> typin
 
 class Model(_MyMutableMapping):
     _is_model = True
-    # label whether current class's _attr_to_rest_field has been calculated
-    # could not see _attr_to_rest_field directly because subclass inherits it from parent class
-    _calculated: set[str] = set()
+    # _attr_to_rest_field, _defaults, and the per-class "calculation done" marker are
+    # populated by __new__ on first instantiation; declared here so subclasses inherit
+    # the descriptor protocol contract.
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         class_name = self.__class__.__name__
         if len(args) > 1:
             raise TypeError(f"{class_name}.__init__() takes 2 positional arguments but {len(args) + 1} were given")
-        dict_to_pass = {
-            rest_field._rest_name: rest_field._default
-            for rest_field in self._attr_to_rest_field.values()
-            if rest_field._default is not _UNSET
-        }
+        # _defaults is precomputed once per class in __new__; copy per instance so callers
+        # can mutate the resulting dict freely.
+        dict_to_pass = dict(self._defaults)
         if args:
             if isinstance(args[0], ET.Element):
                 dict_to_pass.update(self._init_from_xml(args[0]))
@@ -710,7 +708,10 @@ class Model(_MyMutableMapping):
         return Model(self.__dict__)
 
     def __new__(cls, *args: typing.Any, **kwargs: typing.Any) -> Self:
-        if f"{cls.__module__}.{cls.__qualname__}" not in cls._calculated:
+        # Use a per-class boolean marker stored in cls.__dict__ to avoid the cost of
+        # formatting and looking up a qualname string on every instantiation. __dict__
+        # access ensures we re-run for each subclass (the marker is not inherited).
+        if not cls.__dict__.get("_calculated_done", False):
             # we know the last nine classes in mro are going to be 'Model', '_MyMutableMapping', 'MutableMapping',
             # 'Mapping', 'Collection', 'Sized', 'Iterable', 'Container' and 'object'
             mros = cls.__mro__[:-9][::-1]  # ignore parents, and reverse the mro order
@@ -727,16 +728,23 @@ class Model(_MyMutableMapping):
                 rf._module = cls.__module__
                 if not rf._type:
                     rf._type = rf._get_deserialize_callable_from_annotation(annotations.get(attr, None))
-                if not rf._rest_name_input:
-                    rf._rest_name_input = attr
+                if not rf._rest_name:
+                    rf._rest_name = attr
             cls._attr_to_rest_field: dict[str, _RestField] = dict(attr_to_rest_field.items())
+            # Precompute the default-value dict once per class. Model.__init__ copies this
+            # per instance instead of rebuilding it from _attr_to_rest_field every call.
+            cls._defaults: dict[str, typing.Any] = {
+                rf._rest_name: rf._default
+                for rf in cls._attr_to_rest_field.values()
+                if rf._default is not _UNSET
+            }
             {% if code_model.has_padded_model_property %}
             cls._backcompat_attr_to_rest_field: dict[str, _RestField] = {
                 Model._get_backcompat_attribute_name(cls._attr_to_rest_field, attr): rf for attr, rf in cls
                 ._attr_to_rest_field.items()
             }
             {% endif %}
-            cls._calculated.add(f"{cls.__module__}.{cls.__qualname__}")
+            cls._calculated_done = True
 
         return super().__new__(cls)
 
@@ -1016,7 +1024,10 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=too-many-retur
             return obj
         try:
             return _deserialize_with_callable(deserializer, obj)
-        except Exception:
+        except DeserializationError:
+            # _deserialize_with_callable wraps any inner failure as DeserializationError;
+            # narrowing the except keeps real bugs (like AttributeError on a malformed
+            # template binding) visible instead of silently returning the raw value.
             pass
         return obj
 
@@ -1128,7 +1139,10 @@ class _RestField:
         {% endif %}
     ):
         self._type = type
-        self._rest_name_input = name
+        # _rest_name was previously a @property reading _rest_name_input; collapsed to
+        # a plain attribute since it is read on every field deserialize (146 times per
+        # blob in storage list-blobs profiles) and the property dispatch was a hot spot.
+        self._rest_name: typing.Optional[str] = name
         self._module: typing.Optional[str] = None
         self._is_discriminator = is_discriminator
         self._visibility = visibility
@@ -1149,12 +1163,6 @@ class _RestField:
         if isinstance(result, functools.partial):
             return getattr(result, "args", [None])[0]
         return result
-
-    @property
-    def _rest_name(self) -> str:
-        if self._rest_name_input is None:
-            raise ValueError("Rest name was never set")
-        return self._rest_name_input
 
     def __get__(self, obj: Model, type=None):  # pylint: disable=redefined-builtin
         # by this point, type and rest_name will have a value bc we default


### PR DESCRIPTION
## Summary

Profiling `azure-storage-blob`'s `list_blobs` against a 500-blob container on the in-progress TypeSpec migration (Azure/azure-sdk-for-python#45133) identified the generated `_utils/model_base.py` deserializer as the dominant hot path – roughly half the wall time was spent there, causing a **~-48% throughput regression vs. the current msrest-generated package**. Download/upload were unaffected because they deserialize exactly one model per HTTP call regardless of payload size; `list_blobs` is the only operation where one response produces *N* model instances, so per-instance overhead is what matters.

This PR addresses the most mechanical of those hot spots in the shared `model_base.py.jinja2` template so every TypeSpec-emitted Python SDK benefits.

## Changes

1. **Precompute `cls._defaults` once in `Model.__new__`** – `Model.__init__` no longer walks `_attr_to_rest_field` on every instance build; it just copies the pre-built mapping.
2. **Promote `_RestField._rest_name` from `@property` to plain attribute** – set once in `__new__`; removes a descriptor lookup that was hit once per field per model (~73k calls for a 500-blob list).
3. **Replace the string-keyed `_calculated` set with a `_calculated_done: bool` flag** – checked via `cls.__dict__.get("_calculated_done", False)` so subclasses re-run the per-class setup correctly without inheriting the flag.
4. **Narrow `_deserialize_default`'s `except Exception` to `except DeserializationError`** – the caller `_deserialize_with_callable` already wraps everything into `DeserializationError`, so this is semantically equivalent for the success-and-expected-failure paths while surfacing real coding bugs (`AttributeError`/`TypeError`) instead of masking them as deserialization failures.

No public API change; no generated-code change for consumers beyond the `_utils/model_base.py` body itself.

## Validation

- `npm run build` – clean.
- `npm run regenerate` – unbranded fixtures regenerate successfully. Regenerated `_utils/model_base.py` contains the new code paths (`_calculated_done`, `_defaults =`, `except DeserializationError`).
- Unit tests: `tests/unit/test_model_base_serialization.py` + `test_model_base_xml_serialization.py` – **156/157 pass**. The one failure (`test_null_serialization`) is a pre-existing cross-package `isinstance` mismatch (`azure.core.serialization._Null` vs. `corehttp.serialization._Null`) in the unchanged `_deserialize_with_callable` dispatcher and is unrelated to this change – it reproduces on `main` when both `azure.core` and `corehttp` are importable simultaneously in the test env.

## Follow-ups (not in this PR)

There are larger wins still on the table that I'd like to address in a second PR if this one is well-received:
- Cache per-class XML metadata (xml_name, wrapped, attribute) so `_init_from_xml` stops recomputing it once per field per instance.
- Cache the `typing.get_args` / annotation analysis in `_deserialize` that currently re-runs for every instance.
- Flatten the 13-branch `_deserialize_with_callable` dispatcher into a precomputed callable per field.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
