### PR TITLE
Bump http-client-python pyrightconfig pythonVersion to 3.10

### DIFF
--- a/.chronus/changes/bump-pyright-python-version-2026-4-24-11-28-0.md
+++ b/.chronus/changes/bump-pyright-python-version-2026-4-24-11-28-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/http-client-python"
+---
+
+Bump pyright-configured `pythonVersion` from 3.9 to 3.10 for CI type checking.

--- a/packages/http-client-python/eng/scripts/ci/config/pyrightconfig.json
+++ b/packages/http-client-python/eng/scripts/ci/config/pyrightconfig.json
@@ -2,5 +2,5 @@
   "reportUnnecessaryCast": "warning",
   "reportTypeCommentUsage": true,
   "reportMissingImports": false,
-  "pythonVersion": "3.9"
+  "pythonVersion": "3.10"
 }


### PR DESCRIPTION
Bumps the pyright-configured Python version for the http-client-python package CI from 3.9 to 3.10