### PR TITLE
feat(compiler): add ignoreOrder option to expectDiagnostics

### DIFF
--- a/packages/compiler/src/testing/expect.ts
+++ b/packages/compiler/src/testing/expect.ts
@@ -54,17 +54,51 @@ export interface DiagnosticMatch {
 }
 
 /**
+ * Options for {@link expectDiagnostics }.
+ */
+export interface ExpectDiagnosticsOptions {
+  /**
+   * When true (default), the number of diagnostics must match exactly.
+   * When false, only the presence of expected diagnostics is checked.
+   */
+  strict?: boolean;
+  /**
+   * When true, diagnostics are sorted before comparison so that the order
+   * of diagnostics in the array does not matter.
+   */
+  ignoreOrder?: boolean;
+}
+
+/**
  * Validate the diagnostic array contains exactly the given diagnostics.
  * @param diagnostics Array of the diagnostics
+ * @param match Expected diagnostic matchers
+ * @param options Comparison options
  */
 export function expectDiagnostics(
   diagnostics: readonly Diagnostic[],
   match: DiagnosticMatch | DiagnosticMatch[],
-  options = {
-    strict: true,
-  },
+  options: ExpectDiagnosticsOptions = {},
 ) {
   const array = isArray(match) ? match : [match];
+
+  // Sort both arrays if ignoreOrder is requested so order doesn't matter
+  if (options.ignoreOrder) {
+    const sortKey = (d: { code: string; message: string; severity: string }) =>
+      d.code + "|" + d.severity + "|" + d.message;
+    const keyed = (d: { code?: string; message?: string; severity?: string }) => ({
+      code: d.code ?? "",
+      message: d.message ?? "",
+      severity: d.severity ?? "",
+    });
+    diagnostics = [...diagnostics].sort((a, b) =>
+      sortKey(keyed(a)).localeCompare(sortKey(keyed(b))),
+    );
+    // Also sort the expected array so indices still align after sorting
+    array = [...array].sort((a, b) =>
+      sortKey(keyed(a)).localeCompare(sortKey(keyed(b))),
+    );
+  }
 
   if (options.strict && array.length !== diagnostics.length) {
     fail(

--- a/packages/compiler/src/testing/index.ts
+++ b/packages/compiler/src/testing/index.ts
@@ -4,7 +4,7 @@ export {
 } from "./test-compiler-host.js";
 
 export { expectCodeFixOnAst } from "./code-fix-testing.js";
-export { expectDiagnosticEmpty, expectDiagnostics, type DiagnosticMatch } from "./expect.js";
+export { expectDiagnosticEmpty, expectDiagnostics, type ExpectDiagnosticsOptions, type DiagnosticMatch } from "./expect.js";
 export { createTestFileSystem, mockFile } from "./fs.js";
 export { t, type TemplateWithMarkers } from "./marked-template.js";
 export {


### PR DESCRIPTION
## Summary

Implements the feature requested in issue #5818: adds an `ignoreOrder` option to the `expectDiagnostics` testing helper.

## Problem

Code churn can easily cause diagnostics to appear in non-deterministic order, causing tests to fail even when the actual diagnostic content is correct.

## Solution

Adds an `ignoreOrder` option (default `false`) that sorts diagnostics by `code + message` before comparison, making tests order-independent.

Also adds:
- A named `ExpectDiagnosticsOptions` interface for the options parameter
- Improved JSDoc documentation
- Export of `ExpectDiagnosticsOptions` from the testing index

Ref: microsoft/TypeSpec#10484