### PR TITLE
http-client-java, validate java runtime

### DIFF
--- a/.chronus/changes/main-2026-3-28-11-19-44.md
+++ b/.chronus/changes/main-2026-3-28-11-19-44.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-java"
+---
+
+Validate Java runtime version in dependency check

--- a/packages/http-client-java/emitter/src/lib.ts
+++ b/packages/http-client-java/emitter/src/lib.ts
@@ -23,6 +23,8 @@ export const $lib = createTypeSpecLibrary({
         default:
           "Java Development Kit (JDK) is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download",
         jdkVersion: paramMessage`Java Development Kit (JDK) in PATH is version '${"javaVersion"}'. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download`,
+        java: "Java Runtime is not found in PATH. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download",
+        javaVersion: paramMessage`Java Runtime in PATH is version '${"javaVersion"}'. Please install JDK 17 or above. Microsoft Build of OpenJDK can be downloaded from https://learn.microsoft.com/java/openjdk/download`,
         maven:
           "Apache Maven is not found in PATH. Apache Maven can be downloaded from https://maven.apache.org/download.cgi",
       },

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -51,6 +51,47 @@ export async function validateDependencies(
     }
   }
 
+  // Check Java Runtime and version
+  try {
+    const result = await spawnAsync("java", ["-version"], { stdio: "pipe" });
+    const javaRuntimeVersion =
+      findJavaRuntimeVersion(result.stdout) ?? findJavaRuntimeVersion(result.stderr);
+    if (javaRuntimeVersion) {
+      if (program && logDiagnostic) {
+        trace(program, `Java Runtime in PATH is version ${javaRuntimeVersion}.`);
+      }
+      const javaMajorVersion = getJavaMajorVersion(javaRuntimeVersion);
+      if (javaMajorVersion < 11) {
+        if (program && logDiagnostic) {
+          reportDiagnostic(program, {
+            code: "invalid-java-sdk-dependency",
+            messageId: "javaVersion",
+            format: { javaVersion: javaRuntimeVersion },
+            target: NoTarget,
+          });
+        }
+      }
+    }
+  } catch (error: any) {
+    if (error && "code" in error && error["code"] === "ENOENT") {
+      if (program && logDiagnostic) {
+        reportDiagnostic(program, {
+          code: "invalid-java-sdk-dependency",
+          messageId: "java",
+          target: NoTarget,
+        });
+      }
+    } else {
+      if (program && logDiagnostic) {
+        reportDiagnostic(program, {
+          code: "unknown-error",
+          format: { errorMessage: error.message },
+          target: NoTarget,
+        });
+      }
+    }
+  }
+
   // Check Maven
   // nodejs does not allow spawn of .cmd on win32
   const shell = process.platform === "win32";
@@ -111,6 +152,15 @@ export function getJavaMajorVersion(version: string): number {
     }
   }
   return 0;
+}
+
+export function findJavaRuntimeVersion(output: string): string | undefined {
+  // "java version "21.0.3"" or "openjdk version "17.0.11""
+  const matches = output.match(/version "?([\d.]+)"?.*/);
+  if (matches && matches.length > 1) {
+    return matches[1];
+  }
+  return undefined;
 }
 
 function findMavenVersion(output: string): string | undefined {

--- a/packages/http-client-java/emitter/test/validate.test.ts
+++ b/packages/http-client-java/emitter/test/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { findJavaVersion, getJavaMajorVersion } from "../src/validate.js";
+import { findJavaRuntimeVersion, findJavaVersion, getJavaMajorVersion } from "../src/validate.js";
 
 describe("validate", () => {
   it("findJavaVersion", () => {
@@ -12,5 +12,11 @@ describe("validate", () => {
     expect(getJavaMajorVersion("1.8.0")).toBe(8);
     expect(getJavaMajorVersion("21.0.3")).toBe(21);
     expect(getJavaMajorVersion("24")).toBe(24);
+  });
+
+  it("findJavaRuntimeVersion", () => {
+    expect(findJavaRuntimeVersion('java version "1.8.0_422"')).toBe("1.8.0");
+    expect(findJavaRuntimeVersion('openjdk version "21.0.3" 2024-04-16')).toBe("21.0.3");
+    expect(findJavaRuntimeVersion('openjdk version "17.0.11" 2024-04-16')).toBe("17.0.11");
   });
 });


### PR DESCRIPTION
Validate JDK is not enough. We got case that seems javac is good, but java is on 8.

Better to verify both.