### PR TITLE
fix(typespec-vscode): ensure operation telemetry result is never undefined

### DIFF
--- a/.chronus/changes/fix-vscode-telemetry-result-undefined-2026-4-28-13-0-0.md
+++ b/.chronus/changes/fix-vscode-telemetry-result-undefined-2026-4-28-13-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "typespec-vscode"
+---
+
+Ensure operation telemetry events always carry a valid `result` value. Previously the `start-extension` event (and any other operation whose callback returned `void`) was sent with `result="undefined"` and classified as an error event. The `doOperationWithTelemetry` callback is now constrained to return `ResultCode | Result<...>`, so the result is always derived from the operation's return value.

--- a/packages/typespec-vscode/src/extension.ts
+++ b/packages/typespec-vscode/src/extension.ts
@@ -48,7 +48,7 @@ logger.registerLogListener("extension-log", new ExtensionLogListener(outputChann
 export async function activate(context: ExtensionContext) {
   await telemetryClient.doOperationWithTelemetry(
     TelemetryEventName.StartExtension,
-    async (tel: OperationTelemetryEvent) => {
+    async (tel: OperationTelemetryEvent): Promise<ResultCode> => {
       const stateManager = new ExtensionStateManager(context);
       telemetryClient.Initialize(stateManager);
       /**
@@ -324,6 +324,7 @@ export async function activate(context: ExtensionContext) {
       }
       showStartUpMessages(stateManager);
       telemetryClient.sendDelayedTelemetryEvents();
+      return ResultCode.Success;
     },
   );
 

--- a/packages/typespec-vscode/src/telemetry/telemetry-client.ts
+++ b/packages/typespec-vscode/src/telemetry/telemetry-client.ts
@@ -4,7 +4,7 @@ import pkgJson from "../../package.json" with { type: "json" };
 import { EmptyGuid } from "../const.js";
 import { ExtensionStateManager } from "../extension-state-manager.js";
 import logger from "../log/logger.js";
-import { ResultCode } from "../types.js";
+import { Result, ResultCode } from "../types.js";
 import { isWhitespaceStringOrUndefined } from "../utils.js";
 import {
   emptyActivityId,
@@ -108,11 +108,11 @@ export class TelemetryClient {
     }
   }
 
-  public async doOperationWithTelemetry<T>(
+  public async doOperationWithTelemetry<T extends ResultCode | Result<unknown>>(
     eventName: TelemetryEventName,
     /**
-     * The result will be set automatically if the return type is ResultCode or Result<T>
-     * Otherwise, you can set the result manually by setting the opTelemetryEvent.result
+     * The operation must return either a {@link ResultCode} or a {@link Result}, and the
+     * telemetry event's result will be set from it automatically.
      */
     operation: (
       opTelemetryEvent: OperationTelemetryEvent,
@@ -137,13 +137,11 @@ export class TelemetryClient {
       const result = await operation(opTelemetryEvent, (result, delay) =>
         sendTelemetryEvent(result, delay),
       );
-      if (result) {
-        const isResultCode = (v: any) => Object.values(ResultCode).includes(v as ResultCode);
-        if (isResultCode(result)) {
-          opTelemetryEvent.result ??= result as ResultCode;
-        } else if (typeof result === "object" && "code" in result && isResultCode(result.code)) {
-          opTelemetryEvent.result ??= result.code as ResultCode;
-        }
+      const isResultCode = (v: any) => Object.values(ResultCode).includes(v as ResultCode);
+      if (isResultCode(result)) {
+        opTelemetryEvent.result ??= result as ResultCode;
+      } else if (typeof result === "object" && "code" in result && isResultCode(result.code)) {
+        opTelemetryEvent.result ??= result.code as ResultCode;
       }
       return result;
     } catch (e) {


### PR DESCRIPTION
﻿## Problem

The `start-extension` telemetry event (and any other operation whose callback returned `void`) was always being sent with `result="undefined"` and routed through `sendTelemetryErrorEvent`, so it was incorrectly classified as an error event in App Insights.

Root cause: the generic type parameter `T` on `doOperationWithTelemetry` was unconstrained, so the auto-detect block (`if (result) ...`) could not derive a `ResultCode` from a callback returning `void` or `undefined`. The `activate` callback in `extension.ts` returned `Promise<void>`, hitting this case on every successful activation.

## Fix

- Constrain the generic in `doOperationWithTelemetry` to `T extends ResultCode | Result<unknown>`. Now callers must return one of those, and the result is always derivable.
- Update `activate` to return `ResultCode.Success` so it conforms to the new contract.
- Drop the `if (result)` guard around the auto-detect block. If a future caller manages to bypass the type system and return a falsy value, the event will still be sent with `result="undefined"` so the bug is visible rather than silent.

## Verification

Walked through all 9 `doOperationWithTelemetry` callsites against their callback return types - every one now returns a `ResultCode` or `Result<...>`. TypeScript build is clean.
