### PR TITLE
feat(http-specs): add test for operation body params with reserved names

### DIFF
--- a/.chronus/changes/specs-addReservedWordsOperation-2026-3-28-12-30-56.md
+++ b/.chronus/changes/specs-addReservedWordsOperation-2026-3-28-12-30-56.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-specs"
+---
+
+Add test scenario for operation body parameters with reserved names (e.g., `items`) to verify wire name is not mangled.

--- a/packages/http-specs/spec-summary.md
+++ b/packages/http-specs/spec-summary.md
@@ -5166,6 +5166,19 @@ Verify that the name "with" works. Send this parameter to pass with value `ok`.
 
 Verify that the name "yield" works. Send this parameter to pass with value `ok`.
 
+### SpecialWords_ReservedOperationBodyParams_withItems
+
+- Endpoint: `post /special-words/operations/body-param-reserved`
+
+Verify that an operation parameter named "items" is sent with the key "items" on the wire,
+not mangled to "items_property" or similar.
+
+Send
+
+```json
+{ "items": ["item"] }
+```
+
 ### Streaming_Jsonl_Basic_receive
 
 - Endpoint: `get /streaming/jsonl/basic/receive`

--- a/packages/http-specs/specs/special-words/main.tsp
+++ b/packages/http-specs/specs/special-words/main.tsp
@@ -291,6 +291,28 @@ namespace ModelProperties {
 }
 
 /**
+ * Verify that operation parameters whose names match Python Mapping protocol methods
+ * (e.g., items, keys, values) are sent with the original name on the wire, not mangled.
+ */
+@route("/operations")
+namespace ReservedOperationBodyParams {
+  @scenario
+  @scenarioDoc("""
+    Verify that an operation parameter named "items" is sent with the key "items" on the wire,
+    not mangled to "items_property" or similar.
+    
+    Send
+    
+    ```json
+    {"items": ["item"]}
+    ```
+    """)
+  @post
+  @route("/body-param-reserved")
+  op withItems(items: string[]): void;
+}
+
+/**
  * Verify enum member names that are special words.
  */
 @route("/extensible-strings")

--- a/packages/http-specs/specs/special-words/mockapi.ts
+++ b/packages/http-specs/specs/special-words/mockapi.ts
@@ -420,6 +420,20 @@ Scenarios.SpecialWords_Parameters_cancellationToken = createParametersTests(
   "cancellationToken",
 );
 
+Scenarios.SpecialWords_ReservedOperationBodyParams_withItems = passOnSuccess({
+  uri: "/special-words/operations/body-param-reserved",
+  method: "post",
+  request: {
+    body: json({
+      items: ["item"],
+    }),
+  },
+  response: {
+    status: 204,
+  },
+  kind: "MockApiDefinition",
+});
+
 Scenarios.SpecialWords_ExtensibleStrings_putExtensibleStringValue = passOnSuccess({
   uri: `/special-words/extensible-strings/string`,
   method: "put",


### PR DESCRIPTION
## Summary

Add a Spector scenario to verify that operation parameters whose names match Python Mapping protocol methods (e.g., `items`) are sent with the original name on the wire, not mangled (e.g., to `items_property`).

Fixes #10247

## Changes

- **`main.tsp`**: Added `ReservedOperationBodyParams` namespace with `withItems(items: string[]): void` operation
- **`mockapi.ts`**: Mock expects `POST /special-words/operations/body-param-reserved` with body `{"items": ["item"]}`
- **`spec-summary.md`**: Auto-regenerated

## Labels
`lib:http-specs`