### PR TITLE
feat(http-client-csharp): add ParameterProvider.Invoke overload accepting extensionType

### DIFF
--- a/.chronus/changes/add-invoke-extensiontype-overload-2026-4-28-17-45-0.md
+++ b/.chronus/changes/add-invoke-extensiontype-overload-2026-4-28-17-45-0.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: feature
-packages:
-  - "@typespec/http-client-csharp"
----
-
-Add `Invoke(this ParameterProvider, string, IReadOnlyList<ValueExpression>, IReadOnlyList<CSharpType>, CSharpType?)` overload so the extension type can be set at construction time without a follow-up `Update` call.

--- a/.chronus/changes/add-invoke-extensiontype-overload-2026-4-28-17-45-0.md
+++ b/.chronus/changes/add-invoke-extensiontype-overload-2026-4-28-17-45-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Add `Invoke(this ParameterProvider, string, IReadOnlyList<ValueExpression>, IReadOnlyList<CSharpType>, CSharpType?)` overload so the extension type can be set at construction time without a follow-up `Update` call.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/Snippet.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/Snippet.cs
@@ -125,6 +125,13 @@ namespace Microsoft.TypeSpec.Generator.Snippets
             IReadOnlyList<CSharpType> typeArgs)
             => new InvokeMethodExpression(parameter, methodName, args) { TypeArguments = typeArgs };
 
+        public static InvokeMethodExpression Invoke(this ParameterProvider parameter,
+            string methodName,
+            IReadOnlyList<ValueExpression> args,
+            IReadOnlyList<CSharpType> typeArgs,
+            CSharpType? extensionType)
+            => new InvokeMethodExpression(parameter, methodName, args) { TypeArguments = typeArgs, ExtensionType = extensionType };
+
         public static InvokeMethodExpression Invoke(this ParameterProvider parameter, string methodName, params ValueExpression[] args)
             => new InvokeMethodExpression(parameter, methodName, args);
 


### PR DESCRIPTION
Adds an overload of `Invoke(this ParameterProvider, string, IReadOnlyList<ValueExpression>, IReadOnlyList<CSharpType>, CSharpType?)` to `Microsoft.TypeSpec.Generator.Snippets.Snippet` so downstream emitters can construct an `InvokeMethodExpression` with `ExtensionType` set in a single expression instead of constructing it and then calling `Update(extensionType: …)`.

Motivated by [Azure/azure-sdk-for-net#58615 (review)](https://github.com/Azure/azure-sdk-for-net/pull/58615#discussion_r3138663776), where `ClientHostExtensionsDefinition` currently has to do:

```csharp
var invoke = hostParam.Invoke(targetMethodName, args, typeArgs);
invoke.Update(extensionType: ConfigurationExtensionsType);
```

After this change it can be:

```csharp
var invoke = hostParam.Invoke(targetMethodName, args, typeArgs, ConfigurationExtensionsType);
```

The existing 4-arg overload is preserved as-is for source compatibility.