### PR TITLE
feat(http-client-csharp): support partial method customization

### DIFF
--- a/packages/http-client-csharp/.tspd/docs/customization.md
+++ b/packages/http-client-csharp/.tspd/docs/customization.md
@@ -1273,9 +1273,11 @@ namespace Azure.Service.Operations
 
 </details>
 
-## Customize a generated method's signature
+## Customize a generated client method's signature
 
-Declare a `partial` method (without a body) on the generated client (or any other generated `TypeProvider`) with the same name and parameter types as the generated method. The generator emits a matching partial implementation, taking the modifiers and parameter names from your declaration while keeping its generated body. This works for protocol methods, convenience methods, and other methods on `TypeProvider`s such as model factories.
+Declare a `partial` method (without a body) on the generated client class with the same name and parameter types as a generated protocol or convenience method. The generator emits a matching partial implementation, taking the modifiers and parameter names from your declaration while keeping its generated body.
+
+This applies specifically to **client methods** (protocol and convenience methods on the generated `*Client` class). Other generated members (model constructors, model serialization methods, model factories, etc.) should be customized using `[CodeGenSuppress]` + a hand-written replacement, or one of the other techniques in this document.
 
 Use this when you want to keep the generated body but tweak the surface — typically:
 
@@ -1289,12 +1291,14 @@ This is preferred over `[CodeGenSuppress]` + a hand-written replacement when the
 
 - **Modifier changes** (access modifier, `virtual`, `override`, `new`, `unsafe`).
 - **Parameter renames.** The generator clones each parameter with the customer-chosen name while preserving all internal metadata (parameter location, wire info, spread source, validation, …) so the generated body keeps compiling.
+- Both protocol method overloads and convenience method overloads (sync and async) on the generated client. Each overload must be customized independently.
 
 ### What is NOT supported
 
 - **Renaming the method itself.** Matching is by `(method name, ordered parameter type list)`. To rename, use `[CodeGenSuppress]` + a hand-written method that delegates to the underlying request/pipeline machinery.
 - **Adding/removing/reordering parameters.** The parameter type list must match the generated signature exactly. To restructure, use `[CodeGenSuppress]`.
 - **Default values on the partial implementation.** C# requires partial method implementations to have all parameters required, so any default values on your partial declaration are stripped on the generated impl. Callers still see the defaults from your declaration in custom code.
+- **Non-client members** (models, serialization methods, model factories). Use `[CodeGenSuppress]` for these.
 
 <details>
 

--- a/packages/http-client-csharp/.tspd/docs/customization.md
+++ b/packages/http-client-csharp/.tspd/docs/customization.md
@@ -1296,6 +1296,7 @@ This is preferred over `[CodeGenSuppress]` + a hand-written replacement when the
 ### What is NOT supported
 
 - **Renaming the method itself.** Matching is by `(method name, ordered parameter type list)`. To rename, use `[CodeGenSuppress]` + a hand-written method that delegates to the underlying request/pipeline machinery.
+- **Changing parameter types.** The parameter type list must match the generated signature exactly (matched by type name). Replacing a parameter type with a different type — even an implicitly convertible one — will simply fail to match and the partial decl will be ignored. To project a different type, use `[CodeGenSuppress]` + a hand-written wrapper that converts and forwards.
 - **Adding/removing/reordering parameters.** The parameter type list must match the generated signature exactly. To restructure, use `[CodeGenSuppress]`.
 - **Default values on the partial implementation.** C# requires partial method implementations to have all parameters required, so any default values on your partial declaration are stripped on the generated impl. Callers still see the defaults from your declaration in custom code.
 - **Non-client members** (models, serialization methods, model factories). Use `[CodeGenSuppress]` for these.

--- a/packages/http-client-csharp/.tspd/docs/customization.md
+++ b/packages/http-client-csharp/.tspd/docs/customization.md
@@ -1273,6 +1273,83 @@ namespace Azure.Service.Operations
 
 </details>
 
+## Customize a generated method's signature
+
+Declare a `partial` method (without a body) on the generated client (or any other generated `TypeProvider`) with the same name and parameter types as the generated method. The generator emits a matching partial implementation, taking the modifiers and parameter names from your declaration while keeping its generated body. This works for protocol methods, convenience methods, and other methods on `TypeProvider`s such as model factories.
+
+Use this when you want to keep the generated body but tweak the surface — typically:
+
+- Tighten the access modifier (`public` → `internal`).
+- Add `virtual` / `override` / `new` modifiers.
+- Rename a parameter to something more idiomatic.
+
+This is preferred over `[CodeGenSuppress]` + a hand-written replacement when the only thing you want to change is the signature, because you stay in lock-step with the generated body — future regenerations automatically pick up changes (new optional parameters, body changes from spec edits, etc.).
+
+### What is supported
+
+- **Modifier changes** (access modifier, `virtual`, `override`, `new`, `unsafe`).
+- **Parameter renames.** The generator clones each parameter with the customer-chosen name while preserving all internal metadata (parameter location, wire info, spread source, validation, …) so the generated body keeps compiling.
+
+### What is NOT supported
+
+- **Renaming the method itself.** Matching is by `(method name, ordered parameter type list)`. To rename, use `[CodeGenSuppress]` + a hand-written method that delegates to the underlying request/pipeline machinery.
+- **Adding/removing/reordering parameters.** The parameter type list must match the generated signature exactly. To restructure, use `[CodeGenSuppress]`.
+- **Default values on the partial implementation.** C# requires partial method implementations to have all parameters required, so any default values on your partial declaration are stripped on the generated impl. Callers still see the defaults from your declaration in custom code.
+
+<details>
+
+**Generated code before (Generated/TestClient.cs):**
+
+```C#
+namespace Azure.Service
+{
+    public partial class TestClient
+    {
+        public virtual ClientResult HelloAgain(BinaryContent p1, RequestOptions options = null)
+        {
+            Argument.AssertNotNull(p1, nameof(p1));
+            using PipelineMessage message = CreateRequest(p1, options);
+            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
+        }
+    }
+}
+```
+
+**Add customized client (TestClient.cs):**
+
+```C#
+namespace Azure.Service
+{
+    public partial class TestClient
+    {
+        // Renames `p1` to `content` and changes accessibility from public to internal.
+        internal partial ClientResult HelloAgain(BinaryContent content, RequestOptions options);
+    }
+}
+```
+
+**Generated code after (Generated/TestClient.cs):**
+
+```diff
+namespace Azure.Service
+{
+    public partial class TestClient
+    {
+-        public virtual ClientResult HelloAgain(BinaryContent p1, RequestOptions options = null)
++        internal partial ClientResult HelloAgain(BinaryContent content, RequestOptions options)
+        {
+-            Argument.AssertNotNull(p1, nameof(p1));
+-            using PipelineMessage message = CreateRequest(p1, options);
++            Argument.AssertNotNull(content, nameof(content));
++            using PipelineMessage message = CreateRequest(content, options);
+            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
+        }
+    }
+}
+```
+
+</details>
+
 ## Replace any generated member
 
 Works for model and client properties, methods, constructors etc.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -110,31 +110,81 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         private ScmMethodProvider BuildConvenienceMethod(MethodProvider protocolMethod, bool isAsync)
         {
-            if (EnclosingType is not ClientProvider)
+            if (EnclosingType is not ClientProvider client)
             {
                 throw new InvalidOperationException("Protocol methods can only be built for client types.");
             }
 
-            var methodSignature = new MethodSignature(
-                isAsync ? ServiceMethod.Name + "Async" : ServiceMethod.Name,
-                DocHelpers.GetFormattableDescription(ServiceMethod.Operation.Summary, ServiceMethod.Operation.Doc) ?? FormattableStringHelpers.FromString(ServiceMethod.Operation.Name),
-                protocolMethod.Signature.Modifiers,
-                GetResponseType(ServiceMethod.Operation.Responses, true, isAsync, out var responseBodyType),
-                null,
-                [.. ConvenienceMethodParameters, ScmKnownParameters.CancellationToken]);
+            var methodName = isAsync ? ServiceMethod.Name + "Async" : ServiceMethod.Name;
+            ParameterProvider[] signatureParameters = [.. ConvenienceMethodParameters, ScmKnownParameters.CancellationToken];
+
+            // Detect a partial method declaration in the client's custom code matching this convenience method.
+            var customSignature = FindPartialMethodSignature(client, methodName, signatureParameters);
+            bool isPartialMethod = false;
+
+            // Parameters used to construct the method body. When customizing, we clone the generator's
+            // parameter providers with the customer's names but keep all generator metadata so that the
+            // body construction (param conversions, request invocation, etc.) still works.
+            ParameterProvider[] convenienceBodyParameters = [.. ConvenienceMethodParameters];
+
+            MethodSignature methodSignature;
+
+            if (customSignature != null)
+            {
+                isPartialMethod = true;
+
+                var renamedSignatureParameters = new ParameterProvider[signatureParameters.Length];
+                for (int i = 0; i < signatureParameters.Length; i++)
+                {
+                    renamedSignatureParameters[i] = CloneParameterWithName(signatureParameters[i], customSignature.Parameters[i].Name, removeDefault: true);
+                }
+
+                // The generator-controlled body params are the leading parameters (everything except the trailing CancellationToken).
+                convenienceBodyParameters = new ParameterProvider[ConvenienceMethodParameters.Count];
+                for (int i = 0; i < ConvenienceMethodParameters.Count; i++)
+                {
+                    convenienceBodyParameters[i] = renamedSignatureParameters[i];
+                }
+
+                methodSignature = new MethodSignature(
+                    customSignature.Name,
+                    customSignature.Description,
+                    customSignature.Modifiers | MethodSignatureModifiers.Partial,
+                    customSignature.ReturnType,
+                    customSignature.ReturnDescription,
+                    renamedSignatureParameters,
+                    customSignature.Attributes,
+                    customSignature.GenericArguments,
+                    customSignature.GenericParameterConstraints,
+                    customSignature.ExplicitInterface,
+                    customSignature.NonDocumentComment);
+            }
+            else
+            {
+                methodSignature = new MethodSignature(
+                    methodName,
+                    DocHelpers.GetFormattableDescription(ServiceMethod.Operation.Summary, ServiceMethod.Operation.Doc) ?? FormattableStringHelpers.FromString(ServiceMethod.Operation.Name),
+                    protocolMethod.Signature.Modifiers,
+                    GetResponseType(ServiceMethod.Operation.Responses, true, isAsync, out _),
+                    null,
+                    signatureParameters);
+            }
+
+            // Recompute the response body type so we can branch the body accordingly.
+            GetResponseType(ServiceMethod.Operation.Responses, true, isAsync, out var responseBodyType);
 
             MethodBodyStatement[] methodBody;
             TypeProvider? collection = null;
             if (_pagingServiceMethod != null)
             {
                 collection = ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.CreateClientCollectionResultDefinition(Client, _pagingServiceMethod, responseBodyType, isAsync);
-                methodBody = [.. GetPagingMethodBody(collection, ConvenienceMethodParameters, true)];
+                methodBody = [.. GetPagingMethodBody(collection, convenienceBodyParameters, true)];
             }
             else if (responseBodyType is null)
             {
                 methodBody =
                 [
-                    .. GetStackVariablesForProtocolParamConversion(ConvenienceMethodParameters, out var declarations),
+                    .. GetStackVariablesForProtocolParamConversion(convenienceBodyParameters, out var declarations),
                     Return(This.Invoke(protocolMethod.Signature, [.. GetProtocolMethodArguments(declarations)], isAsync))
                 ];
             }
@@ -142,7 +192,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 methodBody =
                 [
-                    .. GetStackVariablesForProtocolParamConversion(ConvenienceMethodParameters, out var paramDeclarations),
+                    .. GetStackVariablesForProtocolParamConversion(convenienceBodyParameters, out var paramDeclarations),
                     Declare("result", This.Invoke(protocolMethod.Signature, [.. GetProtocolMethodArguments(paramDeclarations)], isAsync).ToApi<ClientResponseApi>(), out ClientResponseApi result),
                     .. GetStackVariablesForReturnValueConversion(result, responseBodyType, isAsync, out var resultDeclarations),
                     IsConvertibleFromBinaryData(responseBodyType)
@@ -167,6 +217,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             var convenienceMethod = new ScmMethodProvider(methodSignature, methodBody, EnclosingType, ScmMethodKind.Convenience, collectionDefinition: collection, serviceMethod: ServiceMethod);
 
+            if (isPartialMethod)
+            {
+                convenienceMethod.IsPartialMethod = true;
+            }
+
             if (convenienceMethod.XmlDocs != null)
             {
                 var exceptions = new List<XmlDocExceptionStatement>(convenienceMethod.XmlDocs.Exceptions);
@@ -175,6 +230,39 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             return convenienceMethod;
+        }
+
+        // Clones a ParameterProvider with a new name while preserving all generator metadata
+        // (Location, WireInfo, SpreadSource, InputParameter, etc.). Used when applying a user's
+        // partial method declaration so that body construction (which references the parameters
+        // by their providers) emits code referring to the customer-chosen names.
+        private static ParameterProvider CloneParameterWithName(ParameterProvider source, string newName, bool removeDefault)
+        {
+            if (source.Name == newName && !(removeDefault && source.DefaultValue != null))
+            {
+                return source;
+            }
+
+            return new ParameterProvider(
+                newName,
+                source.Description,
+                source.Type,
+                defaultValue: removeDefault ? null : source.DefaultValue,
+                isRef: source.IsRef,
+                isOut: source.IsOut,
+                isIn: source.IsIn,
+                isParams: source.IsParams,
+                attributes: source.Attributes,
+                property: source.Property,
+                field: source.Field,
+                initializationValue: source.InitializationValue,
+                location: source.Location,
+                wireInfo: source.WireInfo,
+                validation: source.Validation,
+                inputParameter: source.InputParameter)
+            {
+                SpreadSource = source.SpreadSource,
+            };
         }
 
         private IEnumerable<MethodBodyStatement> GetStackVariablesForProtocolParamConversion(IReadOnlyList<ParameterProvider> convenienceMethodParameters, out Dictionary<string, ValueExpression> declarations)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -121,35 +121,34 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Detect a partial method declaration in the client's custom code matching this convenience method.
             MethodSignature? customSignature = null;
             PartialMethodCustomization.TryFindCustomSignature(client, methodName, signatureParameters, out customSignature);
-            bool isPartialMethod = false;
 
             // Parameters used to construct the method body. When customizing, we clone the generator's
             // parameter providers with the customer's names but keep all generator metadata so that the
             // body construction (param conversions, request invocation, etc.) still works.
-            ParameterProvider[] convenienceBodyParameters = [.. ConvenienceMethodParameters];
+            IReadOnlyList<ParameterProvider> convenienceBodyParameters;
 
             MethodSignature methodSignature;
 
             if (customSignature != null)
             {
-                isPartialMethod = true;
-
                 var renamedSignatureParameters = PartialMethodCustomization.RenameAndCloneParameters(
                     signatureParameters,
                     customSignature.Parameters,
                     removeDefaults: true);
 
                 // The generator-controlled body params are the leading parameters (everything except the trailing CancellationToken).
-                convenienceBodyParameters = new ParameterProvider[ConvenienceMethodParameters.Count];
+                var bodyParams = new ParameterProvider[ConvenienceMethodParameters.Count];
                 for (int i = 0; i < ConvenienceMethodParameters.Count; i++)
                 {
-                    convenienceBodyParameters[i] = renamedSignatureParameters[i];
+                    bodyParams[i] = renamedSignatureParameters[i];
                 }
+                convenienceBodyParameters = bodyParams;
 
                 methodSignature = PartialMethodCustomization.BuildPartialSignature(customSignature, renamedSignatureParameters);
             }
             else
             {
+                convenienceBodyParameters = ConvenienceMethodParameters;
                 methodSignature = new MethodSignature(
                     methodName,
                     DocHelpers.GetFormattableDescription(ServiceMethod.Operation.Summary, ServiceMethod.Operation.Doc) ?? FormattableStringHelpers.FromString(ServiceMethod.Operation.Name),
@@ -205,11 +204,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             var convenienceMethod = new ScmMethodProvider(methodSignature, methodBody, EnclosingType, ScmMethodKind.Convenience, collectionDefinition: collection, serviceMethod: ServiceMethod);
-
-            if (isPartialMethod)
-            {
-                convenienceMethod.IsPartialMethod = true;
-            }
 
             if (convenienceMethod.XmlDocs != null)
             {
@@ -984,15 +978,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // generated body using the customized parameter references.
             MethodSignature? customSignature = null;
             PartialMethodCustomization.TryFindCustomSignature(client, methodName, parameters, out customSignature);
-            bool isPartialMethod = false;
 
             MethodSignature methodSignature;
             ParameterProvider[] bodyParameters;
 
             if (customSignature != null)
             {
-                isPartialMethod = true;
-
                 // Partial methods cannot have optional parameters in the implementation.
                 var requiredCustomParameters = PartialMethodCustomization.RenameAndCloneParameters(
                     customSignature.Parameters,
@@ -1040,11 +1031,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             var protocolMethod =
                 new ScmMethodProvider(methodSignature, methodBody, EnclosingType, ScmMethodKind.Protocol, collectionDefinition: collection, serviceMethod: ServiceMethod);
-
-            if (isPartialMethod)
-            {
-                protocolMethod.IsPartialMethod = true;
-            }
 
             if (protocolMethod.XmlDocs != null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -119,7 +119,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             ParameterProvider[] signatureParameters = [.. ConvenienceMethodParameters, ScmKnownParameters.CancellationToken];
 
             // Detect a partial method declaration in the client's custom code matching this convenience method.
-            var customSignature = FindPartialMethodSignature(client, methodName, signatureParameters);
+            MethodSignature? customSignature = null;
+            PartialMethodCustomization.TryFindCustomSignature(client, methodName, signatureParameters, out customSignature);
             bool isPartialMethod = false;
 
             // Parameters used to construct the method body. When customizing, we clone the generator's
@@ -133,11 +134,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 isPartialMethod = true;
 
-                var renamedSignatureParameters = new ParameterProvider[signatureParameters.Length];
-                for (int i = 0; i < signatureParameters.Length; i++)
-                {
-                    renamedSignatureParameters[i] = CloneParameterWithName(signatureParameters[i], customSignature.Parameters[i].Name, removeDefault: true);
-                }
+                var renamedSignatureParameters = PartialMethodCustomization.RenameAndCloneParameters(
+                    signatureParameters,
+                    customSignature.Parameters,
+                    removeDefaults: true);
 
                 // The generator-controlled body params are the leading parameters (everything except the trailing CancellationToken).
                 convenienceBodyParameters = new ParameterProvider[ConvenienceMethodParameters.Count];
@@ -146,18 +146,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     convenienceBodyParameters[i] = renamedSignatureParameters[i];
                 }
 
-                methodSignature = new MethodSignature(
-                    customSignature.Name,
-                    customSignature.Description,
-                    customSignature.Modifiers | MethodSignatureModifiers.Partial,
-                    customSignature.ReturnType,
-                    customSignature.ReturnDescription,
-                    renamedSignatureParameters,
-                    customSignature.Attributes,
-                    customSignature.GenericArguments,
-                    customSignature.GenericParameterConstraints,
-                    customSignature.ExplicitInterface,
-                    customSignature.NonDocumentComment);
+                methodSignature = PartialMethodCustomization.BuildPartialSignature(customSignature, renamedSignatureParameters);
             }
             else
             {
@@ -230,39 +219,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             return convenienceMethod;
-        }
-
-        // Clones a ParameterProvider with a new name while preserving all generator metadata
-        // (Location, WireInfo, SpreadSource, InputParameter, etc.). Used when applying a user's
-        // partial method declaration so that body construction (which references the parameters
-        // by their providers) emits code referring to the customer-chosen names.
-        private static ParameterProvider CloneParameterWithName(ParameterProvider source, string newName, bool removeDefault)
-        {
-            if (source.Name == newName && !(removeDefault && source.DefaultValue != null))
-            {
-                return source;
-            }
-
-            return new ParameterProvider(
-                newName,
-                source.Description,
-                source.Type,
-                defaultValue: removeDefault ? null : source.DefaultValue,
-                isRef: source.IsRef,
-                isOut: source.IsOut,
-                isIn: source.IsIn,
-                isParams: source.IsParams,
-                attributes: source.Attributes,
-                property: source.Property,
-                field: source.Field,
-                initializationValue: source.InitializationValue,
-                location: source.Location,
-                wireInfo: source.WireInfo,
-                validation: source.Validation,
-                inputParameter: source.InputParameter)
-            {
-                SpreadSource = source.SpreadSource,
-            };
         }
 
         private IEnumerable<MethodBodyStatement> GetStackVariablesForProtocolParamConversion(IReadOnlyList<ParameterProvider> convenienceMethodParameters, out Dictionary<string, ValueExpression> declarations)
@@ -1026,7 +982,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Detect a partial method declaration in the client's custom code matching this protocol method.
             // When found, we use the customized signature (modifiers, name, parameter names) and emit the
             // generated body using the customized parameter references.
-            var customSignature = FindPartialMethodSignature(client, methodName, parameters);
+            MethodSignature? customSignature = null;
+            PartialMethodCustomization.TryFindCustomSignature(client, methodName, parameters, out customSignature);
             bool isPartialMethod = false;
 
             MethodSignature methodSignature;
@@ -1037,30 +994,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 isPartialMethod = true;
 
                 // Partial methods cannot have optional parameters in the implementation.
-                var requiredCustomParameters = customSignature.Parameters
-                    .Select(p => p.DefaultValue != null
-                        ? new ParameterProvider(p.Name, p.Description, p.Type, defaultValue: null,
-                            isRef: p.IsRef, isOut: p.IsOut, isIn: p.IsIn, isParams: p.IsParams,
-                            attributes: p.Attributes, property: p.Property)
-                        {
-                            Validation = p.Validation,
-                            Field = p.Field,
-                        }
-                        : p)
-                    .ToArray();
+                var requiredCustomParameters = PartialMethodCustomization.RenameAndCloneParameters(
+                    customSignature.Parameters,
+                    customSignature.Parameters,
+                    removeDefaults: true).ToArray();
 
-                methodSignature = new MethodSignature(
-                    customSignature.Name,
-                    customSignature.Description,
-                    customSignature.Modifiers | MethodSignatureModifiers.Partial,
-                    customSignature.ReturnType,
-                    customSignature.ReturnDescription,
-                    requiredCustomParameters,
-                    customSignature.Attributes,
-                    customSignature.GenericArguments,
-                    customSignature.GenericParameterConstraints,
-                    customSignature.ExplicitInterface,
-                    customSignature.NonDocumentComment);
+                methodSignature = PartialMethodCustomization.BuildPartialSignature(customSignature, requiredCustomParameters);
 
                 bodyParameters = requiredCustomParameters;
                 // Re-resolve the request options parameter from the customized parameter list so the
@@ -1122,59 +1061,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 protocolMethod.XmlDocs.Update(summary: summary, exceptions: exceptions);
             }
             return protocolMethod;
-        }
-
-        private MethodSignature? FindPartialMethodSignature(ClientProvider client, string methodName, IReadOnlyList<ParameterProvider> parameters)
-        {
-            var customMethods = client.CustomCodeView?.Methods;
-            if (customMethods == null || customMethods.Count == 0)
-            {
-                return null;
-            }
-
-            foreach (var customMethod in customMethods)
-            {
-                if (!customMethod.IsPartialMethod)
-                {
-                    continue;
-                }
-
-                var customSignature = customMethod.Signature;
-                if (customSignature.Name != methodName || customSignature.Parameters.Count != parameters.Count)
-                {
-                    continue;
-                }
-
-                bool match = true;
-                for (int i = 0; i < parameters.Count; i++)
-                {
-                    if (!IsTypeNameMatch(customSignature.Parameters[i].Type, parameters[i].Type))
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-
-                if (match)
-                {
-                    return customSignature;
-                }
-            }
-
-            return null;
-        }
-
-        private static bool IsTypeNameMatch(CSharpType typeFromCustomization, CSharpType generatedType)
-        {
-            // The namespace may not be available for generated types referenced from customization as they
-            // are not yet generated, so Roslyn will not have the namespace information.
-            if (string.IsNullOrEmpty(typeFromCustomization.Namespace))
-            {
-                return typeFromCustomization.Name == generatedType.Name;
-            }
-
-            return typeFromCustomization.Namespace == generatedType.Namespace
-                && typeFromCustomization.Name == generatedType.Name;
         }
 
         private ParameterProvider ProcessOptionalParameters(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -933,21 +933,70 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             ParameterProvider[] parameters = [.. requiredParameters, .. optionalParameters, requestOptionsParameter];
+            var methodName = isAsync ? ServiceMethod.Name + "Async" : ServiceMethod.Name;
 
-            var methodSignature = new MethodSignature(
-                isAsync ? ServiceMethod.Name + "Async" : ServiceMethod.Name,
-                DocHelpers.GetFormattableDescription(ServiceMethod.Operation.Summary, ServiceMethod.Operation.Doc) ?? FormattableStringHelpers.FromString(ServiceMethod.Operation.Name),
-                methodModifiers,
-                GetResponseType(ServiceMethod.Operation.Responses, false, isAsync, out _),
-                $"The response returned from the service.",
-                parameters);
+            // Detect a partial method declaration in the client's custom code matching this protocol method.
+            // When found, we use the customized signature (modifiers, name, parameter names) and emit the
+            // generated body using the customized parameter references.
+            var customSignature = FindPartialMethodSignature(client, methodName, parameters);
+            bool isPartialMethod = false;
+
+            MethodSignature methodSignature;
+            ParameterProvider[] bodyParameters;
+
+            if (customSignature != null)
+            {
+                isPartialMethod = true;
+
+                // Partial methods cannot have optional parameters in the implementation.
+                var requiredCustomParameters = customSignature.Parameters
+                    .Select(p => p.DefaultValue != null
+                        ? new ParameterProvider(p.Name, p.Description, p.Type, defaultValue: null,
+                            isRef: p.IsRef, isOut: p.IsOut, isIn: p.IsIn, isParams: p.IsParams,
+                            attributes: p.Attributes, property: p.Property)
+                        {
+                            Validation = p.Validation,
+                            Field = p.Field,
+                        }
+                        : p)
+                    .ToArray();
+
+                methodSignature = new MethodSignature(
+                    customSignature.Name,
+                    customSignature.Description,
+                    customSignature.Modifiers | MethodSignatureModifiers.Partial,
+                    customSignature.ReturnType,
+                    customSignature.ReturnDescription,
+                    requiredCustomParameters,
+                    customSignature.Attributes,
+                    customSignature.GenericArguments,
+                    customSignature.GenericParameterConstraints,
+                    customSignature.ExplicitInterface,
+                    customSignature.NonDocumentComment);
+
+                bodyParameters = requiredCustomParameters;
+                // Re-resolve the request options parameter from the customized parameter list so the
+                // generated body references the user-named options parameter (typically the last param).
+                requestOptionsParameter = requiredCustomParameters[requiredCustomParameters.Length - 1];
+            }
+            else
+            {
+                methodSignature = new MethodSignature(
+                    methodName,
+                    DocHelpers.GetFormattableDescription(ServiceMethod.Operation.Summary, ServiceMethod.Operation.Doc) ?? FormattableStringHelpers.FromString(ServiceMethod.Operation.Name),
+                    methodModifiers,
+                    GetResponseType(ServiceMethod.Operation.Responses, false, isAsync, out _),
+                    $"The response returned from the service.",
+                    parameters);
+                bodyParameters = parameters;
+            }
 
             TypeProvider? collection = null;
             MethodBodyStatement[] methodBody;
             if (_pagingServiceMethod != null)
             {
                 collection = ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.CreateClientCollectionResultDefinition(Client, _pagingServiceMethod, null, isAsync);
-                methodBody = [.. GetPagingMethodBody(collection, parameters, false)];
+                methodBody = [.. GetPagingMethodBody(collection, bodyParameters, false)];
             }
             else
             {
@@ -956,7 +1005,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 [
                     UsingDeclare("message", ScmCodeModelGenerator.Instance.TypeFactory.HttpMessageApi.HttpMessageType,
                         This.Invoke(createRequestMethod.Signature,
-                            [.. parameters.Select(p => (ValueExpression)p)]), out var message),
+                            [.. bodyParameters.Select(p => (ValueExpression)p)]), out var message),
                     Return(ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ToExpression().FromResponse(client
                         .PipelineProperty.Invoke(processMessageName, [message, requestOptionsParameter], isAsync, true, extensionType: _clientPipelineExtensionsDefinition.Type)))
                 ];
@@ -964,6 +1013,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             var protocolMethod =
                 new ScmMethodProvider(methodSignature, methodBody, EnclosingType, ScmMethodKind.Protocol, collectionDefinition: collection, serviceMethod: ServiceMethod);
+
+            if (isPartialMethod)
+            {
+                protocolMethod.IsPartialMethod = true;
+            }
 
             if (protocolMethod.XmlDocs != null)
             {
@@ -980,6 +1034,59 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 protocolMethod.XmlDocs.Update(summary: summary, exceptions: exceptions);
             }
             return protocolMethod;
+        }
+
+        private MethodSignature? FindPartialMethodSignature(ClientProvider client, string methodName, IReadOnlyList<ParameterProvider> parameters)
+        {
+            var customMethods = client.CustomCodeView?.Methods;
+            if (customMethods == null || customMethods.Count == 0)
+            {
+                return null;
+            }
+
+            foreach (var customMethod in customMethods)
+            {
+                if (!customMethod.IsPartialMethod)
+                {
+                    continue;
+                }
+
+                var customSignature = customMethod.Signature;
+                if (customSignature.Name != methodName || customSignature.Parameters.Count != parameters.Count)
+                {
+                    continue;
+                }
+
+                bool match = true;
+                for (int i = 0; i < parameters.Count; i++)
+                {
+                    if (!IsTypeNameMatch(customSignature.Parameters[i].Type, parameters[i].Type))
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match)
+                {
+                    return customSignature;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsTypeNameMatch(CSharpType typeFromCustomization, CSharpType generatedType)
+        {
+            // The namespace may not be available for generated types referenced from customization as they
+            // are not yet generated, so Roslyn will not have the namespace information.
+            if (string.IsNullOrEmpty(typeFromCustomization.Namespace))
+            {
+                return typeFromCustomization.Name == generatedType.Name;
+            }
+
+            return typeFromCustomization.Namespace == generatedType.Namespace
+                && typeFromCustomization.Name == generatedType.Name;
         }
 
         private ParameterProvider ProcessOptionalParameters(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
@@ -334,5 +334,46 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
             var cachingField = fields.SingleOrDefault(f => f.Name == "_cachedDog");
             Assert.IsNull(cachingField);
         }
+
+        // Validates that a generated protocol method can be customized via a partial method declaration in custom code.
+        [Test]
+        public async Task CanCustomizeMethodSignature()
+        {
+            var inputOperation = InputFactory.Operation("HelloAgain", parameters:
+            [
+                InputFactory.BodyParameter("p1", InputFactory.Array(InputPrimitiveType.String))
+            ]);
+            var inputServiceMethod = InputFactory.BasicServiceMethod("test", inputOperation);
+            var inputClient = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+            var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [inputClient],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var clientProvider = mockGenerator.Object.OutputLibrary.TypeProviders.SingleOrDefault(t => t is ClientProvider);
+            Assert.IsNotNull(clientProvider);
+
+            // Find the protocol method that should now be partial.
+            var partialMethod = clientProvider!.Methods.FirstOrDefault(m =>
+                m.Signature.Name == "HelloAgain"
+                && m.IsPartialMethod
+                && m.Signature.Parameters.Any(p => p.Type.Name == "BinaryContent"));
+            Assert.IsNotNull(partialMethod, "HelloAgain protocol method should be generated as partial");
+            Assert.IsTrue(partialMethod!.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Partial));
+
+            // Custom signature changes should be applied (parameter renamed to "content").
+            Assert.AreEqual(2, partialMethod.Signature.Parameters.Count);
+            Assert.AreEqual("content", partialMethod.Signature.Parameters[0].Name);
+            Assert.AreEqual("options", partialMethod.Signature.Parameters[1].Name);
+
+            // All parameters in the partial implementation must be required (no default values).
+            Assert.IsTrue(partialMethod.Signature.Parameters.All(p => p.DefaultValue == null));
+
+            // The original generated (non-partial) HelloAgain protocol method should not also be present.
+            var nonPartialDuplicates = clientProvider.Methods.Where(m =>
+                m.Signature.Name == "HelloAgain"
+                && !m.IsPartialMethod
+                && m.Signature.Parameters.Any(p => p.Type.Name == "BinaryContent")).ToList();
+            Assert.AreEqual(0, nonPartialDuplicates.Count);
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderCustomizationTests.cs
@@ -375,5 +375,94 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
                 && m.Signature.Parameters.Any(p => p.Type.Name == "BinaryContent")).ToList();
             Assert.AreEqual(0, nonPartialDuplicates.Count);
         }
+
+        [Test]
+        public async Task CanCustomizeMethodModifierOnly()
+        {
+            // Verifies that a partial method declaration that changes only the access modifier
+            // (without renaming any parameters) still produces a partial implementation with
+            // the customer's modifier and the generator's parameter names.
+            var inputOperation = InputFactory.Operation("HelloAgain", parameters:
+            [
+                InputFactory.BodyParameter("p1", InputFactory.Array(InputPrimitiveType.String))
+            ]);
+            var inputServiceMethod = InputFactory.BasicServiceMethod("test", inputOperation);
+            var inputClient = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+            var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [inputClient],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var clientProvider = mockGenerator.Object.OutputLibrary.TypeProviders.SingleOrDefault(t => t is ClientProvider);
+            Assert.IsNotNull(clientProvider);
+
+            var partialMethod = clientProvider!.Methods.FirstOrDefault(m =>
+                m.Signature.Name == "HelloAgain"
+                && m.IsPartialMethod
+                && m.Signature.Parameters.Any(p => p.Type.Name == "BinaryContent"));
+            Assert.IsNotNull(partialMethod, "HelloAgain protocol method should be generated as partial");
+            Assert.IsTrue(partialMethod!.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Partial));
+
+            // Modifier comes from the partial declaration -> should be internal.
+            Assert.IsTrue(partialMethod.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal));
+            Assert.IsFalse(partialMethod.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+
+            // Parameter names are unchanged (generator-chosen).
+            Assert.AreEqual(2, partialMethod.Signature.Parameters.Count);
+            Assert.AreEqual("p1", partialMethod.Signature.Parameters[0].Name);
+            Assert.AreEqual("options", partialMethod.Signature.Parameters[1].Name);
+
+            // Defaults stripped on the implementation.
+            Assert.IsTrue(partialMethod.Signature.Parameters.All(p => p.DefaultValue == null));
+        }
+
+        [Test]
+        public async Task CanCustomizeConvenienceMethodSignature()
+        {
+            // Verifies the matching/cloning logic in BuildConvenienceMethod: a partial method
+            // declaration on the convenience overload renames parameters and the generator
+            // emits a partial implementation that references the customer-chosen names.
+            List<InputMethodParameter> methodParameters =
+            [
+                InputFactory.MethodParameter("p1", InputFactory.Array(InputPrimitiveType.String))
+            ];
+            List<InputBodyParameter> operationParameters =
+            [
+                InputFactory.BodyParameter("p1", InputFactory.Array(InputPrimitiveType.String))
+            ];
+            var inputOperation = InputFactory.Operation("HelloAgain", parameters: operationParameters);
+            var inputServiceMethod = InputFactory.BasicServiceMethod("HelloAgain", inputOperation, parameters: methodParameters);
+            var inputClient = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+            var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [inputClient],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var clientProvider = mockGenerator.Object.OutputLibrary.TypeProviders.SingleOrDefault(t => t is ClientProvider);
+            Assert.IsNotNull(clientProvider);
+
+            // Find the convenience overload (the one whose first parameter is IEnumerable<string>,
+            // not BinaryContent).
+            var convenienceMethod = clientProvider!.Methods.FirstOrDefault(m =>
+                m.Signature.Name == "HelloAgain"
+                && m.IsPartialMethod
+                && m.Signature.Parameters.Any(p => p.Type.IsList));
+            Assert.IsNotNull(convenienceMethod, "HelloAgain convenience method should be generated as partial");
+            Assert.IsTrue(convenienceMethod!.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Partial));
+
+            // Parameters take their names from the partial declaration.
+            Assert.AreEqual(2, convenienceMethod.Signature.Parameters.Count);
+            Assert.AreEqual("body", convenienceMethod.Signature.Parameters[0].Name);
+            Assert.AreEqual("ct", convenienceMethod.Signature.Parameters[1].Name);
+
+            // The cloned parameters preserve generator-side metadata: the body parameter
+            // still reports its original Location so the body construction works.
+            Assert.AreEqual("CancellationToken", convenienceMethod.Signature.Parameters[1].Type.Name);
+
+            // No duplicate non-partial convenience method.
+            var nonPartialDuplicates = clientProvider.Methods.Where(m =>
+                m.Signature.Name == "HelloAgain"
+                && !m.IsPartialMethod
+                && m.Signature.Parameters.Any(p => p.Type.IsList)).ToList();
+            Assert.AreEqual(0, nonPartialDuplicates.Count);
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanCustomizeConvenienceMethodSignature/CanCustomizeConvenienceMethodSignature.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanCustomizeConvenienceMethodSignature/CanCustomizeConvenienceMethodSignature.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.ClientModel;
+
+namespace Sample
+{
+    public partial class TestClient
+    {
+        // Customizes the convenience method's signature: renames `p1` to `body` and
+        // `cancellationToken` to `ct`. The generator emits a partial implementation
+        // using these names while keeping the generated body.
+        public partial ClientResult HelloAgain(IEnumerable<string> body, CancellationToken ct);
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanCustomizeMethodModifierOnly/CanCustomizeMethodModifierOnly.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanCustomizeMethodModifierOnly/CanCustomizeMethodModifierOnly.cs
@@ -1,0 +1,12 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+
+namespace Sample
+{
+    public partial class TestClient
+    {
+        // Modifier-only customization: changes accessibility from public to internal,
+        // keeps the generator-chosen parameter names (`p1`, `options`).
+        internal partial ClientResult HelloAgain(BinaryContent p1, RequestOptions options);
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanCustomizeMethodSignature/CanCustomizeMethodSignature.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderCustomizationTests/CanCustomizeMethodSignature/CanCustomizeMethodSignature.cs
@@ -1,0 +1,12 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+
+namespace Sample
+{
+    public partial class TestClient
+    {
+        // Partial method declaration that customizes the generated protocol method's
+        // signature (renames parameters). The generator emits the partial implementation.
+        public partial ClientResult HelloAgain(BinaryContent content, RequestOptions options);
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
@@ -23,6 +23,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         public IReadOnlyList<SuppressionStatement> Suppressions { get; internal set; }
 
+        /// <summary>
+        /// Indicates whether this method should be generated as a partial method.
+        /// When true, custom code provides the signature declaration and the generator
+        /// emits a matching partial implementation.
+        /// </summary>
+        public bool IsPartialMethod { get; set; }
+
         // for mocking
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         protected MethodProvider()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/MethodProvider.cs
@@ -24,11 +24,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
         public IReadOnlyList<SuppressionStatement> Suppressions { get; internal set; }
 
         /// <summary>
-        /// Indicates whether this method should be generated as a partial method.
-        /// When true, custom code provides the signature declaration and the generator
-        /// emits a matching partial implementation.
+        /// Indicates whether this method is declared as a <c>partial</c> method.
+        /// Derived from the <see cref="MethodSignatureModifiers.Partial"/> modifier on the signature.
         /// </summary>
-        public bool IsPartialMethod { get; set; }
+        public bool IsPartialMethod => Signature?.Modifiers.HasFlag(MethodSignatureModifiers.Partial) ?? false;
 
         // for mocking
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -263,6 +263,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     kindOptions: SymbolDisplayKindOptions.None);
 
                 AddAdditionalModifiers(methodSymbol, ref modifiers);
+
+                bool isPartialDeclaration = IsPartialMethodDeclaration(methodSymbol);
+                if (isPartialDeclaration)
+                {
+                    modifiers |= MethodSignatureModifiers.Partial;
+                }
+
                 var explicitInterface = methodSymbol.ExplicitInterfaceImplementations.FirstOrDefault();
 
                 // For conversion operators, use the target type name as the method name to match generated code
@@ -287,9 +294,27 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     [.. methodSymbol.Parameters.Select(p => ConvertToParameterProvider(methodSymbol, p))],
                     ExplicitInterface: explicitInterface?.ContainingType?.GetCSharpType());
 
-                methods.Add(new MethodProvider(signature, MethodBodyStatement.Empty, this));
+                methods.Add(new MethodProvider(signature, MethodBodyStatement.Empty, this) { IsPartialMethod = isPartialDeclaration });
             }
             return [.. methods];
+        }
+
+        private static bool IsPartialMethodDeclaration(IMethodSymbol methodSymbol)
+        {
+            foreach (var syntaxReference in methodSymbol.DeclaringSyntaxReferences)
+            {
+                if (syntaxReference.GetSyntax() is MethodDeclarationSyntax methodSyntax)
+                {
+                    bool hasPartialModifier = methodSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword));
+                    bool hasNoBody = methodSyntax.Body == null && methodSyntax.ExpressionBody == null;
+                    if (hasPartialModifier && hasNoBody)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         protected override bool GetIsEnum() => _namedTypeSymbol.TypeKind == TypeKind.Enum;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -294,7 +294,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     [.. methodSymbol.Parameters.Select(p => ConvertToParameterProvider(methodSymbol, p))],
                     ExplicitInterface: explicitInterface?.ContainingType?.GetCSharpType());
 
-                methods.Add(new MethodProvider(signature, MethodBodyStatement.Empty, this) { IsPartialMethod = isPartialDeclaration });
+                methods.Add(new MethodProvider(signature, MethodBodyStatement.Empty, this));
             }
             return [.. methods];
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PartialMethodCustomization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PartialMethodCustomization.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.TypeSpec.Generator.Primitives;
+
+namespace Microsoft.TypeSpec.Generator.Providers
+{
+    /// <summary>
+    /// Helpers used to honor C# <c>partial</c> method declarations supplied in customer code
+    /// when emitting generated method signatures and bodies.
+    /// </summary>
+    /// <remarks>
+    /// A library author can declare an unimplemented <c>partial</c> method on a generated
+    /// <see cref="TypeProvider"/> to customize the method's signature (modifiers, name, parameter
+    /// names) while keeping the generator-emitted body. The generator detects the partial
+    /// declaration on <see cref="TypeProvider.CustomCodeView"/> and uses the helpers in this class
+    /// to:
+    /// <list type="number">
+    /// <item>find a matching custom partial signature for a generated method,</item>
+    /// <item>clone the generator's <see cref="ParameterProvider"/>s with the customer-chosen names
+    /// while preserving generator metadata (so the body keeps compiling), and</item>
+    /// <item>build a final <see cref="MethodSignature"/> with <c>partial</c> applied and all
+    /// parameters required (a C# constraint on partial method implementations).</item>
+    /// </list>
+    /// These helpers are exposed publicly so that downstream emitters (for example the management
+    /// emitter, which wraps <c>ClientProvider</c>s in its own public-surface providers) can reuse
+    /// the same matching and parameter-cloning behavior in their own method builders.
+    /// </remarks>
+    public static class PartialMethodCustomization
+    {
+        /// <summary>
+        /// Attempts to find a customer-declared <c>partial</c> method on <paramref name="enclosingType"/>'s
+        /// <see cref="TypeProvider.CustomCodeView"/> matching the given method name and parameter list
+        /// (matched by parameter type names, position-sensitive).
+        /// </summary>
+        /// <param name="enclosingType">The generated type whose custom code view should be searched.</param>
+        /// <param name="methodName">The generated method's name.</param>
+        /// <param name="parameters">The generated method's parameter list (in declaration order).</param>
+        /// <param name="customSignature">When the method returns <c>true</c>, set to the matching partial signature from custom code.</param>
+        /// <returns><c>true</c> when a matching partial declaration was found; <c>false</c> otherwise.</returns>
+        public static bool TryFindCustomSignature(
+            TypeProvider enclosingType,
+            string methodName,
+            IReadOnlyList<ParameterProvider> parameters,
+            out MethodSignature? customSignature)
+        {
+            customSignature = null;
+
+            if (enclosingType is null)
+            {
+                return false;
+            }
+
+            var customMethods = enclosingType.CustomCodeView?.Methods;
+            if (customMethods == null || customMethods.Count == 0)
+            {
+                return false;
+            }
+
+            MethodSignature? firstMatch = null;
+            foreach (var customMethod in customMethods)
+            {
+                if (!customMethod.IsPartialMethod)
+                {
+                    continue;
+                }
+
+                var candidate = customMethod.Signature;
+                if (candidate.Name != methodName || candidate.Parameters.Count != parameters.Count)
+                {
+                    continue;
+                }
+
+                bool match = true;
+                for (int i = 0; i < parameters.Count; i++)
+                {
+                    if (!IsTypeNameMatch(candidate.Parameters[i].Type, parameters[i].Type))
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (!match)
+                {
+                    continue;
+                }
+
+                if (firstMatch != null)
+                {
+                    // C# itself disallows duplicate signatures in the same type, so this should be
+                    // unreachable in well-formed custom code. Surface it as a clear build-time error
+                    // rather than silently picking one declaration over another.
+                    throw new InvalidOperationException(
+                        $"Multiple partial method declarations on '{enclosingType.Type.Name}' match the generated method '{methodName}' " +
+                        $"with {parameters.Count} parameter(s). Each generated method may be customized by at most one partial declaration.");
+                }
+
+                firstMatch = candidate;
+            }
+
+            customSignature = firstMatch;
+            return firstMatch != null;
+        }
+
+        /// <summary>
+        /// Produces a new parameter list whose entries take their names (and modifier flags such
+        /// as default value, ref/out/in/params) from <paramref name="customParameters"/> while
+        /// preserving every other piece of generator metadata from <paramref name="generatorParameters"/>
+        /// (such as <see cref="ParameterProvider.Location"/>, <see cref="ParameterProvider.WireInfo"/>,
+        /// <see cref="ParameterProvider.SpreadSource"/>, <see cref="ParameterProvider.InputParameter"/>,
+        /// validation, property/field references, and so on).
+        /// </summary>
+        /// <param name="generatorParameters">The parameters originally produced by the generator.
+        /// Body construction depends on the metadata carried by these instances.</param>
+        /// <param name="customParameters">The parameters from the customer's partial signature.
+        /// Must have the same count as <paramref name="generatorParameters"/>.</param>
+        /// <param name="removeDefaults">When <c>true</c>, drop default values on the cloned
+        /// parameters. Required for partial method implementations.</param>
+        public static IReadOnlyList<ParameterProvider> RenameAndCloneParameters(
+            IReadOnlyList<ParameterProvider> generatorParameters,
+            IReadOnlyList<ParameterProvider> customParameters,
+            bool removeDefaults)
+        {
+            if (generatorParameters is null) throw new ArgumentNullException(nameof(generatorParameters));
+            if (customParameters is null) throw new ArgumentNullException(nameof(customParameters));
+            if (generatorParameters.Count != customParameters.Count)
+            {
+                throw new ArgumentException(
+                    $"Parameter counts differ ({generatorParameters.Count} vs {customParameters.Count}).",
+                    nameof(customParameters));
+            }
+
+            var renamed = new ParameterProvider[generatorParameters.Count];
+            for (int i = 0; i < generatorParameters.Count; i++)
+            {
+                renamed[i] = CloneParameterWithName(
+                    generatorParameters[i],
+                    customParameters[i].Name,
+                    removeDefaults);
+            }
+
+            return renamed;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="MethodSignature"/> for a partial method implementation using
+        /// <paramref name="customSignature"/> (modifiers, name, return type, attributes, and
+        /// other signature metadata) and the supplied <paramref name="implementationParameters"/>.
+        /// The result has <see cref="MethodSignatureModifiers.Partial"/> applied.
+        /// </summary>
+        /// <param name="customSignature">The customer's partial declaration signature.</param>
+        /// <param name="implementationParameters">The parameters to use for the implementation.
+        /// Must all be required (no default values) per the C# partial method rules.</param>
+        public static MethodSignature BuildPartialSignature(
+            MethodSignature customSignature,
+            IReadOnlyList<ParameterProvider> implementationParameters)
+        {
+            if (customSignature is null) throw new ArgumentNullException(nameof(customSignature));
+            if (implementationParameters is null) throw new ArgumentNullException(nameof(implementationParameters));
+
+            return new MethodSignature(
+                customSignature.Name,
+                customSignature.Description,
+                customSignature.Modifiers | MethodSignatureModifiers.Partial,
+                customSignature.ReturnType,
+                customSignature.ReturnDescription,
+                implementationParameters,
+                customSignature.Attributes,
+                customSignature.GenericArguments,
+                customSignature.GenericParameterConstraints,
+                customSignature.ExplicitInterface,
+                customSignature.NonDocumentComment);
+        }
+
+        // Clones a ParameterProvider with a new name (and optionally without its default value)
+        // while preserving all generator metadata. Returns the source unchanged when no change is
+        // needed.
+        private static ParameterProvider CloneParameterWithName(
+            ParameterProvider source,
+            string newName,
+            bool removeDefault)
+        {
+            if (source.Name == newName && !(removeDefault && source.DefaultValue != null))
+            {
+                return source;
+            }
+
+            return new ParameterProvider(
+                newName,
+                source.Description,
+                source.Type,
+                defaultValue: removeDefault ? null : source.DefaultValue,
+                isRef: source.IsRef,
+                isOut: source.IsOut,
+                isIn: source.IsIn,
+                isParams: source.IsParams,
+                attributes: source.Attributes,
+                property: source.Property,
+                field: source.Field,
+                initializationValue: source.InitializationValue,
+                location: source.Location,
+                wireInfo: source.WireInfo,
+                validation: source.Validation,
+                inputParameter: source.InputParameter)
+            {
+                SpreadSource = source.SpreadSource,
+            };
+        }
+
+        // Compares parameter types by name. The namespace may not be available for generated types
+        // referenced from customization since they aren't yet generated, so Roslyn won't have the
+        // namespace information; in that case we fall back to a name-only comparison.
+        private static bool IsTypeNameMatch(CSharpType typeFromCustomization, CSharpType generatedType)
+        {
+            if (string.IsNullOrEmpty(typeFromCustomization.Namespace))
+            {
+                return typeFromCustomization.Name == generatedType.Name;
+            }
+
+            return typeFromCustomization.Namespace == generatedType.Namespace
+                && typeFromCustomization.Name == generatedType.Name;
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PartialMethodCustomization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PartialMethodCustomization.cs
@@ -76,7 +76,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 bool match = true;
                 for (int i = 0; i < parameters.Count; i++)
                 {
-                    if (!IsTypeNameMatch(candidate.Parameters[i].Type, parameters[i].Type))
+                    // The customer's CSharpType may not carry a namespace (when referencing a
+                    // not-yet-generated type, Roslyn returns an empty namespace). AreNamesEqual
+                    // handles that by falling back to name-only comparison and also recurses into
+                    // generic type arguments.
+                    if (!candidate.Parameters[i].Type.AreNamesEqual(parameters[i].Type))
                     {
                         match = false;
                         break;
@@ -208,20 +212,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 SpreadSource = source.SpreadSource,
             };
-        }
-
-        // Compares parameter types by name. The namespace may not be available for generated types
-        // referenced from customization since they aren't yet generated, so Roslyn won't have the
-        // namespace information; in that case we fall back to a name-only comparison.
-        private static bool IsTypeNameMatch(CSharpType typeFromCustomization, CSharpType generatedType)
-        {
-            if (string.IsNullOrEmpty(typeFromCustomization.Namespace))
-            {
-                return typeFromCustomization.Name == generatedType.Name;
-            }
-
-            return typeFromCustomization.Namespace == generatedType.Namespace
-                && typeFromCustomization.Name == generatedType.Name;
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -398,7 +398,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 ? new MethodProvider(partialSignature, generatedMethod.BodyExpression, generatedMethod.EnclosingType, generatedMethod.XmlDocs, generatedMethod.Suppressions)
                 : new MethodProvider(partialSignature, generatedMethod.BodyStatements ?? MethodBodyStatement.Empty, generatedMethod.EnclosingType, generatedMethod.XmlDocs, generatedMethod.Suppressions);
 
-            partialMethod.IsPartialMethod = true;
             return partialMethod;
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -331,8 +331,27 @@ namespace Microsoft.TypeSpec.Generator.Providers
         internal MethodProvider[] FilterCustomizedMethods(IEnumerable<MethodProvider> specMethods)
         {
             var methods = new List<MethodProvider>();
+            var customMethods = CustomCodeView?.Methods ?? [];
+            var partialDeclarations = customMethods.Where(m => m.IsPartialMethod).ToList();
+
             foreach (var method in specMethods)
             {
+                // If a generated method is already marked as partial (e.g., by
+                // ScmMethodProviderCollection's early detection), keep it as-is.
+                if (method.IsPartialMethod)
+                {
+                    methods.Add(method);
+                    continue;
+                }
+
+                var matchingPartial = partialDeclarations
+                    .FirstOrDefault(p => MethodSignatureBase.SignatureComparer.Equals(p.Signature, method.Signature));
+                if (matchingPartial != null)
+                {
+                    methods.Add(CreatePartialMethodFromCustomSignature(matchingPartial.Signature, method));
+                    continue;
+                }
+
                 if (ShouldGenerate(method))
                 {
                     methods.Add(method);
@@ -340,6 +359,42 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             return [.. methods];
+        }
+
+        private static MethodProvider CreatePartialMethodFromCustomSignature(MethodSignature customSignature, MethodProvider generatedMethod)
+        {
+            // Partial method implementations require all parameters to be required (no default values).
+            var requiredParameters = customSignature.Parameters
+                .Select(p => p.DefaultValue != null
+                    ? new ParameterProvider(p.Name, p.Description, p.Type, defaultValue: null,
+                        isRef: p.IsRef, isOut: p.IsOut, isIn: p.IsIn, isParams: p.IsParams,
+                        attributes: p.Attributes, property: p.Property)
+                    {
+                        Validation = p.Validation,
+                        Field = p.Field,
+                    }
+                    : p)
+                .ToList();
+
+            var partialSignature = new MethodSignature(
+                customSignature.Name,
+                customSignature.Description,
+                customSignature.Modifiers | MethodSignatureModifiers.Partial,
+                customSignature.ReturnType,
+                customSignature.ReturnDescription,
+                requiredParameters,
+                customSignature.Attributes,
+                customSignature.GenericArguments,
+                customSignature.GenericParameterConstraints,
+                customSignature.ExplicitInterface,
+                customSignature.NonDocumentComment);
+
+            MethodProvider partialMethod = generatedMethod.BodyExpression != null
+                ? new MethodProvider(partialSignature, generatedMethod.BodyExpression, generatedMethod.EnclosingType, generatedMethod.XmlDocs, generatedMethod.Suppressions)
+                : new MethodProvider(partialSignature, generatedMethod.BodyStatements ?? MethodBodyStatement.Empty, generatedMethod.EnclosingType, generatedMethod.XmlDocs, generatedMethod.Suppressions);
+
+            partialMethod.IsPartialMethod = true;
+            return partialMethod;
         }
 
         internal ConstructorProvider[] FilterCustomizedConstructors(IEnumerable<ConstructorProvider> specConstructors)
@@ -671,6 +726,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var customMethods = method.EnclosingType.CustomCodeView?.Methods ?? [];
             foreach (var customMethod in customMethods)
             {
+                // Partial method declarations are handled in FilterCustomizedMethods and
+                // should not suppress the generated method.
+                if (customMethod.IsPartialMethod)
+                {
+                    continue;
+                }
+
                 if (MethodSignatureBase.SignatureComparer.Equals(customMethod.Signature, method.Signature))
                 {
                     return false;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -331,8 +331,20 @@ namespace Microsoft.TypeSpec.Generator.Providers
         internal MethodProvider[] FilterCustomizedMethods(IEnumerable<MethodProvider> specMethods)
         {
             var methods = new List<MethodProvider>();
-            var customMethods = CustomCodeView?.Methods ?? [];
-            var partialDeclarations = customMethods.Where(m => m.IsPartialMethod).ToList();
+            var customMethods = CustomCodeView?.Methods;
+            // Only build the partial-declarations list when there are custom methods to inspect.
+            // The vast majority of TypeProviders have no custom code; skip the allocation in that case.
+            List<MethodProvider>? partialDeclarations = null;
+            if (customMethods != null && customMethods.Count > 0)
+            {
+                foreach (var customMethod in customMethods)
+                {
+                    if (customMethod.IsPartialMethod)
+                    {
+                        (partialDeclarations ??= new List<MethodProvider>()).Add(customMethod);
+                    }
+                }
+            }
 
             foreach (var method in specMethods)
             {
@@ -344,8 +356,19 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     continue;
                 }
 
-                var matchingPartial = partialDeclarations
-                    .FirstOrDefault(p => MethodSignatureBase.SignatureComparer.Equals(p.Signature, method.Signature));
+                MethodProvider? matchingPartial = null;
+                if (partialDeclarations != null)
+                {
+                    foreach (var partial in partialDeclarations)
+                    {
+                        if (MethodSignatureBase.SignatureComparer.Equals(partial.Signature, method.Signature))
+                        {
+                            matchingPartial = partial;
+                            break;
+                        }
+                    }
+                }
+
                 if (matchingPartial != null)
                 {
                     methods.Add(CreatePartialMethodFromCustomSignature(matchingPartial.Signature, method));

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -364,30 +364,12 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private static MethodProvider CreatePartialMethodFromCustomSignature(MethodSignature customSignature, MethodProvider generatedMethod)
         {
             // Partial method implementations require all parameters to be required (no default values).
-            var requiredParameters = customSignature.Parameters
-                .Select(p => p.DefaultValue != null
-                    ? new ParameterProvider(p.Name, p.Description, p.Type, defaultValue: null,
-                        isRef: p.IsRef, isOut: p.IsOut, isIn: p.IsIn, isParams: p.IsParams,
-                        attributes: p.Attributes, property: p.Property)
-                    {
-                        Validation = p.Validation,
-                        Field = p.Field,
-                    }
-                    : p)
-                .ToList();
+            var requiredParameters = PartialMethodCustomization.RenameAndCloneParameters(
+                customSignature.Parameters,
+                customSignature.Parameters,
+                removeDefaults: true);
 
-            var partialSignature = new MethodSignature(
-                customSignature.Name,
-                customSignature.Description,
-                customSignature.Modifiers | MethodSignatureModifiers.Partial,
-                customSignature.ReturnType,
-                customSignature.ReturnDescription,
-                requiredParameters,
-                customSignature.Attributes,
-                customSignature.GenericArguments,
-                customSignature.GenericParameterConstraints,
-                customSignature.ExplicitInterface,
-                customSignature.NonDocumentComment);
+            var partialSignature = PartialMethodCustomization.BuildPartialSignature(customSignature, requiredParameters);
 
             MethodProvider partialMethod = generatedMethod.BodyExpression != null
                 ? new MethodProvider(partialSignature, generatedMethod.BodyExpression, generatedMethod.EnclosingType, generatedMethod.XmlDocs, generatedMethod.Suppressions)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
@@ -335,25 +334,14 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
         }
 
         [Test]
-        public void ValidatePartialMethodIsDetected()
+        public async Task ValidatePartialMethodIsDetected()
         {
-            const string source = @"
-namespace Sample
-{
-    public partial class WithPartial
-    {
-        public partial void DoIt(int value);
-        public void NonPartial(int value) { }
-    }
-}";
-            var syntaxTree = CSharpSyntaxTree.ParseText(source);
-            var compilation = CSharpCompilation.Create(
-                assemblyName: "PartialTest",
-                syntaxTrees: [syntaxTree],
-                references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+            var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var compilation = mockGenerator.Object.SourceInputModel.Customization;
+            Assert.IsNotNull(compilation);
 
-            MockHelpers.LoadMockGenerator();
-            var symbol = CompilationHelper.GetSymbol(compilation.Assembly.Modules.First().GlobalNamespace, "WithPartial")!;
+            var symbol = CompilationHelper.GetSymbol(compilation!.Assembly.Modules.First().GlobalNamespace, "WithPartial")!;
             var provider = new NamedTypeSymbolProvider(symbol, compilation);
 
             var partial = provider.Methods.Single(m => m.Signature.Name == "DoIt");
@@ -366,26 +354,16 @@ namespace Sample
         }
 
         [Test]
-        public void ValidatePartialMethodWithBodyIsNotDetectedAsPartialDeclaration()
+        public async Task ValidatePartialMethodWithBodyIsNotDetectedAsPartialDeclaration()
         {
             // A partial method *with* a body is the implementation half - not the declaration we
             // want to treat as a customization signal.
-            const string source = @"
-namespace Sample
-{
-    public partial class WithPartial
-    {
-        public partial void DoIt(int value) { /* body */ }
-    }
-}";
-            var syntaxTree = CSharpSyntaxTree.ParseText(source);
-            var compilation = CSharpCompilation.Create(
-                assemblyName: "PartialImplTest",
-                syntaxTrees: [syntaxTree],
-                references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+            var mockGenerator = await MockHelpers.LoadMockGeneratorAsync(
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var compilation = mockGenerator.Object.SourceInputModel.Customization;
+            Assert.IsNotNull(compilation);
 
-            MockHelpers.LoadMockGenerator();
-            var symbol = CompilationHelper.GetSymbol(compilation.Assembly.Modules.First().GlobalNamespace, "WithPartial")!;
+            var symbol = CompilationHelper.GetSymbol(compilation!.Assembly.Modules.First().GlobalNamespace, "WithPartial")!;
             var provider = new NamedTypeSymbolProvider(symbol, compilation);
 
             var doIt = provider.Methods.Single(m => m.Signature.Name == "DoIt");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
@@ -331,6 +332,64 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
             var parameter = parameters[0];
 
             Assert.AreEqual(isRef, parameter.IsRef);
+        }
+
+        [Test]
+        public void ValidatePartialMethodIsDetected()
+        {
+            const string source = @"
+namespace Sample
+{
+    public partial class WithPartial
+    {
+        public partial void DoIt(int value);
+        public void NonPartial(int value) { }
+    }
+}";
+            var syntaxTree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CSharpCompilation.Create(
+                assemblyName: "PartialTest",
+                syntaxTrees: [syntaxTree],
+                references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+            MockHelpers.LoadMockGenerator();
+            var symbol = CompilationHelper.GetSymbol(compilation.Assembly.Modules.First().GlobalNamespace, "WithPartial")!;
+            var provider = new NamedTypeSymbolProvider(symbol, compilation);
+
+            var partial = provider.Methods.Single(m => m.Signature.Name == "DoIt");
+            Assert.IsTrue(partial.IsPartialMethod, "Expected DoIt to be detected as partial.");
+            Assert.IsTrue(partial.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Partial));
+
+            var nonPartial = provider.Methods.Single(m => m.Signature.Name == "NonPartial");
+            Assert.IsFalse(nonPartial.IsPartialMethod, "Expected NonPartial to not be detected as partial.");
+            Assert.IsFalse(nonPartial.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Partial));
+        }
+
+        [Test]
+        public void ValidatePartialMethodWithBodyIsNotDetectedAsPartialDeclaration()
+        {
+            // A partial method *with* a body is the implementation half - not the declaration we
+            // want to treat as a customization signal.
+            const string source = @"
+namespace Sample
+{
+    public partial class WithPartial
+    {
+        public partial void DoIt(int value) { /* body */ }
+    }
+}";
+            var syntaxTree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CSharpCompilation.Create(
+                assemblyName: "PartialImplTest",
+                syntaxTrees: [syntaxTree],
+                references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+            MockHelpers.LoadMockGenerator();
+            var symbol = CompilationHelper.GetSymbol(compilation.Assembly.Modules.First().GlobalNamespace, "WithPartial")!;
+            var provider = new NamedTypeSymbolProvider(symbol, compilation);
+
+            var doIt = provider.Methods.Single(m => m.Signature.Name == "DoIt");
+            Assert.IsFalse(doIt.IsPartialMethod, "Partial methods with bodies should not be treated as customization signals.");
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/TestData/NamedTypeSymbolProviderTests/ValidatePartialMethodIsDetected/WithPartial.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/TestData/NamedTypeSymbolProviderTests/ValidatePartialMethodIsDetected/WithPartial.cs
@@ -1,0 +1,9 @@
+namespace Sample
+{
+    public partial class WithPartial
+    {
+        public partial void DoIt(int value);
+
+        public void NonPartial(int value) { }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/TestData/NamedTypeSymbolProviderTests/ValidatePartialMethodWithBodyIsNotDetectedAsPartialDeclaration/WithPartial.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/TestData/NamedTypeSymbolProviderTests/ValidatePartialMethodWithBodyIsNotDetectedAsPartialDeclaration/WithPartial.cs
@@ -1,0 +1,7 @@
+namespace Sample
+{
+    public partial class WithPartial
+    {
+        public partial void DoIt(int value) { /* body */ }
+    }
+}


### PR DESCRIPTION
Adds support for customizing the signature of a generated client method (protocol or convenience) by declaring a `partial` method in custom code. The generator detects the partial declaration and emits a matching partial implementation, applying the user''s modifiers and parameter names while keeping the generated body.

Based on (and adapted from) #8627. Refs #10526.

### Example

**Custom code:**
```csharp
public partial class TestClient
{
    public partial ClientResult HelloAgain(BinaryContent content, RequestOptions options);
}
```

**Generated code:**
```csharp
public partial class TestClient
{
    public partial ClientResult HelloAgain(BinaryContent content, RequestOptions options)
    {
        Argument.AssertNotNull(content, nameof(content));
        using PipelineMessage message = CreateRequest(content, options);
        return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
    }
}
```

### Scope
This feature is targeted at **client methods** (protocol and convenience methods on the generated `*Client` class). For other generated members (models, serialization, model factories), use the existing `[CodeGenSuppress]` + hand-written replacement pattern.

### What is supported
- Changing modifiers (e.g., `public` → `internal`, adding `virtual`/`override`).
- Renaming parameters (e.g., `p1` → `content`). The generator clones the parameter providers with the customer-chosen names while preserving all metadata (`Location`, `WireInfo`, `SpreadSource`, `InputParameter`, …) so the generated body keeps compiling.
- Both protocol and convenience method overloads (sync and async). Each overload is matched independently.

### What is NOT supported
- **Renaming the method itself.** Matching is by `(method name, ordered parameter type list)`. A renamed partial decl will not match any generated method. Use `[CodeGenSuppress]` + a hand-written method to rename, or follow up with an attribute-based opt-in (e.g., `[CodeGenName("Get")]`) in a future PR.
- **Changing parameter types.** Matching requires identical parameter type names; substituting a different type (even an implicitly convertible one) will simply fail to match and the partial decl will be ignored.
- **Adding/removing/reordering parameters.** The parameter type list must match the generated signature exactly.
- **Default values on the partial implementation.** C# requires partial method impls to have all parameters required; defaults are stripped on the impl (callers still see the defaults from the partial decl in custom code).

### Changes
- `MethodProvider.IsPartialMethod` — tracks partial methods.
- `NamedTypeSymbolProvider` — detects `partial` method declarations (partial keyword + no body) via Roslyn syntax and sets the `Partial` modifier on the symbol-based `MethodProvider`.
- `TypeProvider.FilterCustomizedMethods` — when a generated method matches a custom partial declaration, emits a partial implementation using the custom signature + generated body, with all params forced to required. Skips its scan entirely when there are no custom methods (no extra allocations on the common path).
- `TypeProvider.ShouldGenerate(MethodProvider)` — partial declarations no longer suppress the generated method.
- `ScmMethodProviderCollection.BuildProtocolMethod` and `BuildConvenienceMethod` — perform the same matching *before* the body is built, so the body references the customer''s parameter names. Also fixes a gap in the original PR where the non-paging body still passed the generator''s parameters to `CreateRequest(...)`.
- New `PartialMethodCustomization` static helper class (in `Microsoft.TypeSpec.Generator`) exposing `TryFindCustomSignature`, `RenameAndCloneParameters`, and `BuildPartialSignature` so downstream emitters (e.g. the management emitter, which wraps `ClientProvider`s in its own public-surface providers) can reuse the same matching/cloning behavior in their own method builders. Throws on multiple partial decls matching the same generated method (defensive — C# itself disallows duplicate signatures).

### Documentation
- Adds a "Customize a generated client method''s signature" section to the customization guide (`packages/http-client-csharp/.tspd/docs/customization.md`).

### Tests
- `CanCustomizeMethodSignature` — protocol method parameter rename.
- `CanCustomizeMethodModifierOnly` — modifier-only customization with no parameter renames.
- `CanCustomizeConvenienceMethodSignature` — convenience method parameter rename (covers the `BuildConvenienceMethod` matching/cloning path).
- All existing generator (1434) and ClientModel (1316) tests continue to pass.