### PR TITLE
[python] add `CrossLanguageVersion` to `apiview-properties.json`

### DIFF
--- a/.chronus/changes/python-addCrossLanguageVersion-2026-4-4-13-18-58.md
+++ b/.chronus/changes/python-addCrossLanguageVersion-2026-4-4-13-18-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-python"
+---
+
+add `CrossLanguageVersion` to `apiview-properties.json`

--- a/packages/http-client-python/emitter/src/code-model.ts
+++ b/packages/http-client-python/emitter/src/code-model.ts
@@ -400,6 +400,7 @@ export function emitCodeModel(sdkContext: PythonSdkContext) {
     ...sdkContext.__simpleTypesMap.values(),
   ];
   codeModel["crossLanguagePackageId"] = ignoreDiagnostics(getCrossLanguagePackageId(sdkContext));
+  codeModel["crossLanguageVersion"] = sdkContext.sdkPackage.crossLanguageVersion;
   if ((sdkContext.emitContext.options as any).flavor === "azure") {
     const metadata = { ...sdkPackage.metadata } as any;
     if (metadata.apiVersions) {

--- a/packages/http-client-python/generator/pygen/codegen/models/code_model.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/code_model.py
@@ -95,6 +95,7 @@ class CodeModel:  # pylint: disable=too-many-public-methods, disable=too-many-in
             t for t in self.types_map.values() if isinstance(t, CombinedType) and t.name
         ]
         self.cross_language_package_id = self.yaml_data.get("crossLanguagePackageId")
+        self.cross_language_version = self.yaml_data.get("crossLanguageVersion")
         self.for_test: bool = False
         # key is typespec namespace, value is models/clients/opeartion_groups/enums cache in the namespace
         self._client_namespace_types: dict[str, ClientNamespaceType] = {}

--- a/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
@@ -329,6 +329,7 @@ class GeneralSerializer(BaseSerializer):
             {
                 "CrossLanguagePackageId": self.code_model.cross_language_package_id,
                 "CrossLanguageDefinitionId": cross_langauge_def_dict,
+                "CrossLanguageVersion": self.code_model.cross_language_version,
             },
             indent=4,
         )


### PR DESCRIPTION
Will emit something like

```json
{
    "CrossLanguagePackageId": "Client.Naming.EnumConflict",
    "CrossLanguageDefinitionId": {
        "client.naming.enumconflict.firstnamespace.models.FirstModel": "Client.Naming.EnumConflict.FirstNamespace.FirstModel",
        "client.naming.enumconflict.secondnamespace.models.SecondModel": "Client.Naming.EnumConflict.SecondNamespace.SecondModel",
        "client.naming.enumconflict.models.Status": "Client.Naming.EnumConflict.FirstNamespace.Status",
        "client.naming.enumconflict.models.SecondStatus": "Client.Naming.EnumConflict.SecondNamespace.Status",
        "client.naming.enumconflict.operations.FirstOperationsOperations.first": "Client.Naming.EnumConflict.FirstOperations.first",
        "client.naming.enumconflict.aio.operations.FirstOperationsOperations.first": "Client.Naming.EnumConflict.FirstOperations.first",
        "client.naming.enumconflict.operations.SecondOperationsOperations.second": "Client.Naming.EnumConflict.SecondOperations.second",
        "client.naming.enumconflict.aio.operations.SecondOperationsOperations.second": "Client.Naming.EnumConflict.SecondOperations.second"
    },
    "CrossLanguageVersion": "2eb972a19ec9"
}
```

`"CrossLanguageVersion"` is gotten from tcgc