### PR TITLE
Do not emit deprecated-implicit-optionality when in an `op is`

### DIFF
--- a/.chronus/changes/fix-implicit-optionality-no-op-is-warn-2026-4-5-13-43-12.md
+++ b/.chronus/changes/fix-implicit-optionality-no-op-is-warn-2026-4-5-13-43-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+
+Do not emit deprecated-implicit-optionality on op is

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -418,10 +418,18 @@ export const $patch: PatchDecorator = (
 
   if (options) {
     if (options.implicitOptionality === true) {
-      reportDiagnostic(context.program, {
-        code: "deprecated-implicit-optionality",
-        target: entity,
-      });
+      // Only emit the deprecation warning on the original use of the decorator,
+      // not when inherited via `op is`.
+      const decoratorNode = context.decoratorTarget as any;
+      if (
+        decoratorNode.kind !== SyntaxKind.DecoratorExpression ||
+        decoratorNode.parent === entity.node
+      ) {
+        reportDiagnostic(context.program, {
+          code: "deprecated-implicit-optionality",
+          target: entity,
+        });
+      }
     }
     setPatchOptions(context.program, entity, options);
   }

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -70,6 +70,16 @@ describe("http: decorators", () => {
 
       expectDiagnosticEmpty(diagnostics);
     });
+
+    it(`@patch does not emit deprecation warning when inherited via 'op is'`, async () => {
+      const diagnostics = await Tester.diagnose(`
+        #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
+        @patch(#{ implicitOptionality: true }) op base(): string;
+        op derived is base;
+        `);
+
+      expectDiagnosticEmpty(diagnostics);
+    });
   });
 
   describe("@header", () => {

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -73,9 +73,9 @@ describe("http: decorators", () => {
 
     it(`@patch does not emit deprecation warning when inherited via 'op is'`, async () => {
       const diagnostics = await Tester.diagnose(`
-        #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
+        @route("/base") #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
         @patch(#{ implicitOptionality: true }) op base(): string;
-        op derived is base;
+        @route("/derived") op derived is base;
         `);
 
       expectDiagnosticEmpty(diagnostics);


### PR DESCRIPTION
Makes this warning less aggressive