### PR TITLE
fix(http-server-js): send bytes body directly without JSON serialization

### DIFF
--- a/packages/http-server-js/src/http/server/index.ts
+++ b/packages/http-server-js/src/http/server/index.ts
@@ -641,24 +641,30 @@ function* emitResultProcessingForType(
 
   if (body) {
     const bodyCase = parseCase(body.name);
-    const serializationRequired = isSerializationRequired(
-      ctx,
-      module,
-      body.type,
-      "application/json",
-    );
-    requireSerialization(ctx, body.type, "application/json");
 
-    yield `${names.ctx}.response.setHeader("content-type", "application/json");`;
-
-    if (serializationRequired) {
-      const typeReference = emitTypeReference(ctx, body.type, body, module, {
-        altName: namer.getAltName("Body"),
-        requireDeclaration: true,
-      });
-      yield `${names.ctx}.response.end(globalThis.JSON.stringify(${typeReference}.toJsonObject(${names.result}.${bodyCase.camelCase})))`;
+    if (ctx.program.checker.isStdType(body.type, "bytes")) {
+      // Binary response: content-type already set by @header above, send bytes directly.
+      yield `${names.ctx}.response.end(${names.result}.${bodyCase.camelCase});`;
     } else {
-      yield `${names.ctx}.response.end(globalThis.JSON.stringify(${names.result}.${bodyCase.camelCase}));`;
+      const serializationRequired = isSerializationRequired(
+        ctx,
+        module,
+        body.type,
+        "application/json",
+      );
+      requireSerialization(ctx, body.type, "application/json");
+
+      yield `${names.ctx}.response.setHeader("content-type", "application/json");`;
+
+      if (serializationRequired) {
+        const typeReference = emitTypeReference(ctx, body.type, body, module, {
+          altName: namer.getAltName("Body"),
+          requireDeclaration: true,
+        });
+        yield `${names.ctx}.response.end(globalThis.JSON.stringify(${typeReference}.toJsonObject(${names.result}.${bodyCase.camelCase})))`;
+      } else {
+        yield `${names.ctx}.response.end(globalThis.JSON.stringify(${names.result}.${bodyCase.camelCase}));`;
+      }
     }
   } else if (isArrayModelType(target)) {
     const itemType = target.indexer.value;

--- a/packages/http-server-js/test/scalar.test.ts
+++ b/packages/http-server-js/test/scalar.test.ts
@@ -209,6 +209,27 @@ describe("scalar", () => {
     expect(serverRaw).toMatch(/response\.end\(globalThis\.JSON\.stringify\(__result_\d+\)\);/);
   });
 
+  it("emits direct bytes send for binary body with custom content-type", async () => {
+    const { outputs } = await HttpServerEmitterTester.compile(`
+      @service(#{ title: "Example" })
+      @route("/")
+      namespace Example {
+        @post op download(): {
+          @statusCode statusCode: 200;
+          @header contentType: "application/zip";
+          @body content: bytes;
+        };
+      }
+    `);
+
+    const serverRaw = outputs["src/generated/http/operations/server-raw.ts"];
+
+    expect(serverRaw).toBeDefined();
+    expect(serverRaw).not.toContain('"application/json"');
+    expect(serverRaw).not.toContain("Uint8Array.toJsonObject");
+    expect(serverRaw).toMatch(/response\.end\(__result_\d+\.content\);/);
+  });
+
   describe("date/time/duration types", () => {
     describe("mode: temporal", () => {
       const options: JsEmitterOptions = {


### PR DESCRIPTION
When an operation returns a `bytes` body with a custom `@header contentType`
(e.g. `"application/zip"`), the emitter was unconditionally overwriting the
content-type with `"application/json"` and calling the non-existent
`Uint8Array.toJsonObject()`, causing a runtime crash.

Add a `isStdType(body.type, "bytes")` check in `emitResultProcessingForType`
before the JSON serialization path — mirroring the equivalent check already
present on the request deserialization side (added in #6898) — so that binary
responses are written directly to the response stream with the content-type
already set by the `@header` property.



Fixes #10609 