### PR TITLE
Do not report implicit optionality deprecation when via interface extends

### DIFF
--- a/.chronus/changes/fix-implicit-optionality-no-interface-extends-2026-4-7-9-25-59.md
+++ b/.chronus/changes/fix-implicit-optionality-no-interface-extends-2026-4-7-9-25-59.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -409,6 +409,43 @@ const [_getPatchOptions, setPatchOptions] = useStateMap<Operation, PatchOptions 
   HttpStateKeys.patchOptions,
 );
 
+/**
+ * Determines whether a decorator is being applied as the original source-level application,
+ * as opposed to being inherited via `op is` or `interface extends`.
+ *
+ * @param context - The decorator context.
+ * @param entity - The operation the decorator is being applied to.
+ * @returns `true` if the decorator was directly written on this operation, `false` if inherited.
+ */
+function isOriginalDecoratorApplication(context: DecoratorContext, entity: Operation): boolean {
+  const decoratorNode = context.decoratorTarget as any;
+
+  // If inherited via `interface extends`, the cloned operation retains the original node,
+  // but its interface is different from the node's parent.
+  if (
+    entity.interface !== undefined &&
+    entity.node !== undefined &&
+    entity.node.parent !== entity.interface.node
+  ) {
+    return false;
+  }
+
+  // If inherited via `op is`, the operation has a sourceOperation set.
+  if (entity.sourceOperation !== undefined) {
+    return false;
+  }
+
+  // If inherited via `op is` (fallback for when sourceOperation isn't yet set),
+  // the decorator expression's parent won't match the entity's node.
+  if (decoratorNode?.kind === SyntaxKind.DecoratorExpression && decoratorNode.parent) {
+    if (decoratorNode.parent !== entity.node) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export const $patch: PatchDecorator = (
   context: DecoratorContext,
   entity: Operation,
@@ -419,12 +456,8 @@ export const $patch: PatchDecorator = (
   if (options) {
     if (options.implicitOptionality === true) {
       // Only emit the deprecation warning on the original use of the decorator,
-      // not when inherited via `op is`.
-      const decoratorNode = context.decoratorTarget as any;
-      if (
-        decoratorNode.kind !== SyntaxKind.DecoratorExpression ||
-        decoratorNode.parent === entity.node
-      ) {
+      // not when inherited via `op is` or `interface extends`.
+      if (isOriginalDecoratorApplication(context, entity)) {
         reportDiagnostic(context.program, {
           code: "deprecated-implicit-optionality",
           target: entity,

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -80,6 +80,19 @@ describe("http: decorators", () => {
 
       expectDiagnosticEmpty(diagnostics);
     });
+
+    it(`@patch does not emit deprecation warning when inherited via 'interface extends'`, async () => {
+      const diagnostics = await Tester.diagnose(`
+        #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
+        interface Base {
+          @route("/test") @patch(#{ implicitOptionality: true }) test(): string;
+        }
+        @route("/derived")
+        interface Derived extends Base {}
+        `);
+
+      expectDiagnosticEmpty(diagnostics);
+    });
   });
 
   describe("@header", () => {


### PR DESCRIPTION
Previous pr prevent it from being reported when run via op is, but we still did when op is cloned via interface extends