### PR TITLE
fix(http-client-csharp): support int64 enum/union base types

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeIntegerValue.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputEnumTypeIntegerValue.cs
@@ -5,12 +5,12 @@ namespace Microsoft.TypeSpec.Generator.Input
 {
     internal class InputEnumTypeIntegerValue : InputEnumTypeValue
     {
-        public InputEnumTypeIntegerValue(string name, int integerValue, InputPrimitiveType valueType, string? summary, string? doc, InputEnumType? enumType = default)
+        public InputEnumTypeIntegerValue(string name, long integerValue, InputPrimitiveType valueType, string? summary, string? doc, InputEnumType? enumType = default)
             : base(name, integerValue, valueType, summary, doc, enumType)
         {
             IntegerValue = integerValue;
         }
 
-        public int IntegerValue { get; }
+        public long IntegerValue { get; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputEnumTypeValueConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/InputEnumTypeValueConverter.cs
@@ -60,8 +60,9 @@ namespace Microsoft.TypeSpec.Generator.Input
             {
                 InputPrimitiveTypeKind.String => new InputEnumTypeStringValue(name, rawValue.Value.GetString() ?? throw new JsonException(), valueType, summary, doc, enumType) { Decorators = decorators ?? [] },
                 InputPrimitiveTypeKind.Int32 => new InputEnumTypeIntegerValue(name, rawValue.Value.GetInt32(), valueType, summary, doc, enumType) { Decorators = decorators ?? [] },
+                InputPrimitiveTypeKind.Int64 => new InputEnumTypeIntegerValue(name, rawValue.Value.GetInt64(), valueType, summary, doc, enumType) { Decorators = decorators ?? [] },
                 InputPrimitiveTypeKind.Float32 => new InputEnumTypeFloatValue(name, rawValue.Value.GetSingle(), valueType, summary, doc, enumType) { Decorators = decorators ?? [] },
-                _ => throw new JsonException()
+                _ => throw new JsonException($"Unsupported enum valueType kind '{valueType.Kind}' for enum '{enumType.Name}' value '{name}'.")
             };
             if (id != null)
             {


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-net#59168.

## Problem

The C# generator crashes during code generation when a TypeSpec `union`/`enum` declares its base type as `int64` (or any primitive other than `string`/`int32`/`float32`). The failure surfaces as a `TypeInitializationException` on `ModelReaderWriterContextDefinition` with the inner `JsonException` swallowed, making it hard to diagnose.

Root cause: `InputEnumTypeValueConverter.CreateEnumTypeValue` only handles `String`, `Int32`, and `Float32` in its `switch`. Anything else falls into a bare `throw new JsonException()` with no message.

## Fix

1. Add an `InputPrimitiveTypeKind.Int64` arm using `rawValue.Value.GetInt64()`.
2. Widen `InputEnumTypeIntegerValue.IntegerValue` (and its ctor parameter) from `int` to `long` so it can hold both Int32 and Int64 values. The class is `internal` and downstream `EnumProvider.IsIntValueType` already accepts `typeof(long)`, so no further changes are required.
3. Improve the default-arm `JsonException` message to include the offending kind, enum name, and value name so future unsupported kinds are diagnosable from build output.

Other kinds (`Int16`/`Int8`/`Float64`/`Decimal`/`Decimal128`/etc.) are intentionally out of scope for this change — `int64` is the kind blocking real specs today (see Azure/azure-rest-api-specs#43069). The improved error message makes any remaining unsupported kinds easy to identify.
