### PR TITLE
fix(openapi3): emit uniqueItems on operation parameter schemas

### DIFF
--- a/.chronus/changes/fix-openapi3-uniqueitems-parameter-2026-05-12.md
+++ b/.chronus/changes/fix-openapi3-uniqueitems-parameter-2026-05-12.md
@@ -1,0 +1,15 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Propagate `@JsonSchema.uniqueItems` to query, path and header parameter schemas. The decorator was only applied to body model property schemas; for HTTP parameter schemas (which go through `applyIntrinsicDecorators`) it was silently dropped, so arrays declared on operation parameters never emitted `uniqueItems: true` even when the decorator was present.
+
+```tsp
+op listUsers(
+  @query
+  @JsonSchema.uniqueItems
+  $select?: ("id" | "displayName")[],
+): User[];
+```

--- a/.chronus/changes/internal-json-schema-uniqueitems-type-2026-05-12.md
+++ b/.chronus/changes/internal-json-schema-uniqueitems-type-2026-05-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/json-schema"
+---
+
+Add the explicit `<Type, boolean>` generic to the `useStateMap` call backing `@uniqueItems`, matching the convention used by every other state-backed decorator in the compiler. This makes `getUniqueItems` return `boolean | undefined` rather than `unknown | undefined` and lets downstream emitters consume the value without a cast.

--- a/packages/json-schema/src/decorators.ts
+++ b/packages/json-schema/src/decorators.ts
@@ -207,7 +207,7 @@ export const [
   /** Check if the given array is annotated with `@uniqueItems` decorator */
   getUniqueItems,
   setUniqueItems,
-] = useStateMap(JsonSchemaStateKeys["JsonSchema.uniqueItems"]);
+] = useStateMap<Type, boolean>(JsonSchemaStateKeys["JsonSchema.uniqueItems"]);
 /** {@inheritdoc UniqueItemsDecorator} */
 export const $uniqueItems: UniqueItemsDecorator = (context: DecoratorContext, target: Type) =>
   setUniqueItems(context.program, target, true);

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -300,6 +300,7 @@ function createOAPIEmitter(
   let metadataInfo: MetadataInfo;
   let visibilityUsage: VisibilityUsageTracker;
   let sseModule: SSEModule | undefined;
+  let jsonSchemaModule: JsonSchemaModule | undefined;
 
   // Map model properties that represent shared parameters to their parameter
   // definition that will go in #/components/parameters. Inlined parameters do not go in
@@ -417,6 +418,7 @@ function createOAPIEmitter(
     diagnostics = createDiagnosticCollector();
     currentService = service;
     sseModule = optionalDependencies.sseModule;
+    jsonSchemaModule = optionalDependencies.jsonSchemaModule;
     metadataInfo = createMetadataInfo(program, {
       canonicalVisibility: Visibility.Read,
       canShareProperty: (p) => isReadonlyProperty(program, p),
@@ -1900,6 +1902,13 @@ function createOAPIEmitter(
     const maxItems = getMaxItems(program, typespecType);
     if (!target.maxItems && maxItems !== undefined) {
       newTarget.maxItems = maxItems;
+    }
+
+    if (jsonSchemaModule) {
+      const uniqueItems = jsonSchemaModule.getUniqueItems(program, typespecType);
+      if (uniqueItems !== undefined) {
+        newTarget.uniqueItems = uniqueItems;
+      }
     }
 
     if (isSecret(program, typespecType)) {

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -51,6 +51,17 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, openApiFor, version }) => {
       });
     });
 
+    it("propagates @JsonSchema.uniqueItems to a query parameter schema", async () => {
+      const param = await getQueryParam(
+        `op test(@query @JsonSchema.uniqueItems myParam: string[]): void;`,
+      );
+      expect(param.schema).toStrictEqual({
+        type: "array",
+        uniqueItems: true,
+        items: { type: "string" },
+      });
+    });
+
     describe("doesn't set explode if explode: true (Openapi3.0 inverse default)", () => {
       it("with option", async () => {
         const param = await getQueryParam(


### PR DESCRIPTION
`@JsonSchema.uniqueItems` is currently a no-op when applied to query, path or header parameters in `@typespec/openapi3`. The body schema-emitter applies it via `applyConstraint(jsonSchemaModule.getUniqueItems, ...)` in `schema-emitter.ts`, but parameter schemas go through `applyIntrinsicDecorators` in `openapi.ts`, which never consulted the optional `jsonSchemaModule`. Arrays declared inline on operation parameters therefore lost the constraint between source TypeSpec and the emitted OpenAPI.

```tsp
op listUsers(
  @query
  @JsonSchema.uniqueItems
  `$select`?: ("id" | "displayName")[],
): User[];
```

Before this PR the emitted schema for `$select` was `{ type: array, items: { ... } }`. After, it is `{ type: array, uniqueItems: true, items: { ... } }` — which matters in practice because the openapi-generator typescript-axios template renders that as `Set<EnumX>` instead of `Array<EnumX>`.

The same patch also tightens the `useStateMap` generic for `uniqueItems` in `@typespec/json-schema` from the implicit `unknown` to `boolean`, matching every other state-backed decorator in the compiler so the openapi3 emitter can consume `getUniqueItems` without a cast.
