### PR TITLE
feat(http-client-csharp): support dynamic loading of ExternalTypes from NuGet

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
@@ -28,13 +28,22 @@ namespace Microsoft.TypeSpec.Generator
             CodeModelGenerator.Instance.Emitter.Info("Starting code generation");
             CodeModelGenerator.Instance.Stopwatch.Start();
 
-            GeneratedCodeWorkspace.Initialize();
             var outputPath = CodeModelGenerator.Instance.Configuration.OutputDirectory;
             var generatedSourceOutputPath = CodeModelGenerator.Instance.Configuration.ProjectGeneratedDirectory;
 
             // Resolve PackageReference items from the .csproj so custom code referencing
             // external NuGet types (e.g., Azure.Storage.Common) compiles correctly.
             await GeneratedCodeWorkspace.AddPackageReferencesFromProject();
+
+            // Pre-walk the input library and resolve any external types that point at NuGet packages.
+            // This populates ExternalTypeReferenceResolver's cache and registers each resolved assembly
+            // as an additional metadata reference *before* the generated/custom code workspaces are
+            // constructed, so their cached Roslyn projects pick the references up.
+            await ExternalTypeReferenceResolver.ResolveAllAsync();
+
+            // Initialize the workspace project AFTER all metadata references have been added so the
+            // eagerly-cached project sees them.
+            GeneratedCodeWorkspace.Initialize();
 
             GeneratedCodeWorkspace customCodeWorkspace = await GeneratedCodeWorkspace.Create(isCustomCodeProject: true);
             // The generated attributes need to be added into the workspace before loading the custom code. Otherwise,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
@@ -18,8 +18,6 @@ using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Utilities;
 using NuGet.Configuration;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
 
 namespace Microsoft.TypeSpec.Generator
 {
@@ -327,14 +325,14 @@ namespace Microsoft.TypeSpec.Generator
                 }
 
                 // Search the NuGet global packages folder for any cached version of this package.
-                string? resolvedAssemblyPath = FindPackageAssembly(globalPackagesFolder, refPackageName);
+                string? resolvedAssemblyPath = NugetPackageResolver.FindPackageAssembly(globalPackagesFolder, refPackageName);
 
                 // If not found in cache, download the latest version from NuGet feeds
                 if (resolvedAssemblyPath == null)
                 {
                     try
                     {
-                        var latestVersion = await ResolveLatestPackageVersion(refPackageName, nugetSettings);
+                        var latestVersion = await NugetPackageResolver.ResolveLatestPackageVersion(refPackageName, nugetSettings);
                         if (latestVersion != null)
                         {
                             var downloader = new NugetPackageDownloader(refPackageName, latestVersion, null, nugetSettings);
@@ -361,67 +359,6 @@ namespace Microsoft.TypeSpec.Generator
                         $"Added metadata reference: {refPackageName} from {resolvedAssemblyPath}");
                 }
             }
-        }
-
-        /// <summary>
-        /// Searches the NuGet global packages folder for a package assembly across all cached versions.
-        /// Returns the first matching assembly found, preferring newer versions.
-        /// </summary>
-        private static string? FindPackageAssembly(string globalPackagesFolder, string packageName)
-        {
-            var packageDir = Path.Combine(globalPackagesFolder, packageName.ToLowerInvariant());
-
-            if (!Directory.Exists(packageDir))
-            {
-                return null;
-            }
-
-            foreach (var versionDir in Directory.GetDirectories(packageDir).OrderDescending())
-            {
-                foreach (var tfm in NugetPackageDownloader.PreferredDotNetFrameworkVersions)
-                {
-                    var assemblyPath = Path.Combine(versionDir, "lib", tfm, $"{packageName}.dll");
-                    if (File.Exists(assemblyPath))
-                    {
-                        return assemblyPath;
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Queries configured NuGet feeds to resolve the latest stable version of a package.
-        /// </summary>
-        private static async Task<string?> ResolveLatestPackageVersion(string packageName, ISettings nugetSettings)
-        {
-            var sources = SettingsUtility.GetEnabledSources(nugetSettings);
-            using var cacheContext = new SourceCacheContext();
-            foreach (var source in sources)
-            {
-                try
-                {
-                    var repository = Repository.Factory.GetCoreV3(source.Source);
-                    var resource = await repository.GetResourceAsync<FindPackageByIdResource>();
-                    var versions = await resource.GetAllVersionsAsync(
-                        packageName, cacheContext, NuGet.Common.NullLogger.Instance, CancellationToken.None);
-                    var latest = versions?
-                        .Where(v => !v.IsPrerelease)
-                        .OrderByDescending(v => v)
-                        .FirstOrDefault();
-                    if (latest != null)
-                    {
-                        return latest.ToString();
-                    }
-                }
-                catch
-                {
-                    // Skip sources that fail (auth, network, etc.)
-                }
-            }
-
-            return null;
         }
 
         internal static async Task<Compilation?> LoadBaselineContract()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -294,16 +294,17 @@ namespace Microsoft.TypeSpec.Generator
             }
 
             // 3. Neither path worked — emit a diagnostic that explains what was attempted.
-            var packageInfo = string.IsNullOrEmpty(externalProperties.Package)
+            // Each branch is a self-contained sentence so the final message reads naturally and
+            // doesn't repeat "could not be resolved".
+            var details = string.IsNullOrEmpty(externalProperties.Package)
                 ? "no package metadata was provided"
-                : $"package '{externalProperties.Package}'"
-                  + (string.IsNullOrEmpty(externalProperties.MinVersion)
-                      ? " could not be resolved"
-                      : $" (>= {externalProperties.MinVersion}) could not be resolved");
+                : string.IsNullOrEmpty(externalProperties.MinVersion)
+                    ? $"package '{externalProperties.Package}' was not found in the NuGet cache or any configured feed"
+                    : $"package '{externalProperties.Package}' (>= {externalProperties.MinVersion}) was not found in the NuGet cache or any configured feed";
 
             CodeModelGenerator.Instance.Emitter.ReportDiagnostic(
                 "unsupported-external-type",
-                $"External type '{externalProperties.Identity}' could not be resolved: {packageInfo}.");
+                $"External type '{externalProperties.Identity}' could not be resolved: {details}.");
 
             return null;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -11,6 +11,7 @@ using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Utilities;
 
 namespace Microsoft.TypeSpec.Generator
 {
@@ -272,18 +273,37 @@ namespace Microsoft.TypeSpec.Generator
         /// <returns>A <see cref="CSharpType"/> representing the external type, or null if the type cannot be resolved.</returns>
         private CSharpType? CreateExternalType(InputExternalTypeMetadata externalProperties)
         {
-            // Try to create a framework type from the fully qualified name
+            // 1. Try to create a framework type from the fully qualified name. This stays as the
+            // first attempt because it's free (no I/O) and is the source of truth for BCL types.
             var frameworkType = CreateFrameworkType(externalProperties.Identity);
             if (frameworkType != null)
             {
                 return new CSharpType(frameworkType);
             }
 
-            // External types that cannot be resolved as framework types are not supported
-            // Report a diagnostic to inform the user
+            // 2. Fallback: dynamically resolve the type from the NuGet package named in the metadata.
+            // ExternalTypeReferenceResolver consults a process-wide cache populated by the eager
+            // pre-walk in CSharpGen.ExecuteAsync; on a miss it resolves on-demand.
+            if (!string.IsNullOrEmpty(externalProperties.Package))
+            {
+                var resolvedType = ExternalTypeReferenceResolver.TryResolve(externalProperties);
+                if (resolvedType != null)
+                {
+                    return new CSharpType(resolvedType);
+                }
+            }
+
+            // 3. Neither path worked — emit a diagnostic that explains what was attempted.
+            var packageInfo = string.IsNullOrEmpty(externalProperties.Package)
+                ? "no package metadata was provided"
+                : $"package '{externalProperties.Package}'"
+                  + (string.IsNullOrEmpty(externalProperties.MinVersion)
+                      ? " could not be resolved"
+                      : $" (>= {externalProperties.MinVersion}) could not be resolved");
+
             CodeModelGenerator.Instance.Emitter.ReportDiagnostic(
                 "unsupported-external-type",
-                $"External type '{externalProperties.Identity}' is not currently supported.");
+                $"External type '{externalProperties.Identity}' could not be resolved: {packageInfo}.");
 
             return null;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
@@ -264,7 +264,10 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
         private static void CollectExternalTypes(InputLibrary library, IDictionary<string, InputExternalTypeMetadata> collected)
         {
-            var visited = new HashSet<InputType>(ReferenceEqualityComparer.Instance);
+            // InputType uses default reference equality (no Equals/GetHashCode overrides),
+            // so the default HashSet comparer is already reference-based and is what we want
+            // for cycle detection during the type-graph walk.
+            var visited = new HashSet<InputType>();
             var ns = library.InputNamespace;
             if (ns == null)
             {
@@ -371,13 +374,6 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                     VisitType(enumType.ValueType, visited, collected);
                     break;
             }
-        }
-
-        private sealed class ReferenceEqualityComparer : IEqualityComparer<InputType>
-        {
-            public static readonly ReferenceEqualityComparer Instance = new();
-            public bool Equals(InputType? x, InputType? y) => ReferenceEquals(x, y);
-            public int GetHashCode(InputType obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.TypeSpec.Generator.Input;
+using NuGet.Configuration;
+
+namespace Microsoft.TypeSpec.Generator.Utilities
+{
+    /// <summary>
+    /// Resolves <see cref="InputExternalTypeMetadata"/> entries to <see cref="Type"/> instances by
+    /// looking up the package in the NuGet global cache (or downloading it from configured feeds when
+    /// missing) and loading the assembly via reflection. Used by <c>TypeFactory.CreateExternalType</c>
+    /// as a fallback after <c>CreateFrameworkType</c> returns <c>null</c>.
+    /// </summary>
+    /// <remarks>
+    /// The cache is process-wide so that a single external type referenced from many input types only
+    /// triggers one NuGet probe and one assembly load. <see cref="ResolveAllAsync"/> performs an eager
+    /// pre-walk of the input library and registers each resolved assembly as a Roslyn metadata reference
+    /// before the generated/custom code workspaces are constructed; <see cref="TryResolve"/> serves as a
+    /// synchronous lookup (with on-demand resolution as a defensive fallback) from the type factory.
+    /// </remarks>
+    internal static class ExternalTypeReferenceResolver
+    {
+        // Cached resolution per (Package, Identity, MinVersion) key. Value is the loaded Type, or null
+        // if resolution was attempted and failed (so we don't keep re-trying).
+        private static readonly ConcurrentDictionary<string, Lazy<Type?>> _resolved = new(StringComparer.Ordinal);
+
+        // Tracks assembly file paths that we've already added as Roslyn metadata references, so the
+        // same dll isn't registered twice when it contains multiple referenced types.
+        private static readonly ConcurrentDictionary<string, byte> _addedAssemblyRefs = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Walks all <see cref="InputType"/> instances reachable from
+        /// <see cref="CodeModelGenerator.InputLibrary"/> and resolves any <see cref="InputExternalTypeMetadata"/>
+        /// that names a package. Results are cached for use by <see cref="TryResolve"/>; their assemblies
+        /// are added to <see cref="CodeModelGenerator.AdditionalMetadataReferences"/> so subsequent Roslyn
+        /// workspaces can compile generated code that references the external types.
+        /// </summary>
+        public static async Task ResolveAllAsync()
+        {
+            var generator = CodeModelGenerator.Instance;
+            if (generator?.InputLibrary == null)
+            {
+                return;
+            }
+
+            var collected = new Dictionary<string, InputExternalTypeMetadata>(StringComparer.Ordinal);
+            try
+            {
+                CollectExternalTypes(generator.InputLibrary, collected);
+            }
+            catch (Exception ex)
+            {
+                generator.Emitter?.Debug($"External-type pre-walk failed: {ex.Message}");
+                return;
+            }
+
+            if (collected.Count == 0)
+            {
+                return;
+            }
+
+            // Resolve each external metadata sequentially so that NuGet feed downloads do not all hit
+            // the network at once and so that the metadata reference list mutates predictably.
+            foreach (var external in collected.Values)
+            {
+                try
+                {
+                    await ResolveAsync(external);
+                }
+                catch (Exception ex)
+                {
+                    generator.Emitter?.Debug(
+                        $"Failed to pre-resolve external type '{external.Identity}' from package '{external.Package}': {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Synchronously returns the resolved <see cref="Type"/> for <paramref name="external"/>, or
+        /// <c>null</c> if the metadata is missing a package name or the assembly/type cannot be located.
+        /// On a cache miss, performs the NuGet resolution synchronously (a deadlock-free fall-through
+        /// for the rare case where <see cref="ResolveAllAsync"/> didn't see this metadata up front).
+        /// </summary>
+        public static Type? TryResolve(InputExternalTypeMetadata? external)
+        {
+            if (external == null
+                || string.IsNullOrEmpty(external.Identity)
+                || string.IsNullOrEmpty(external.Package))
+            {
+                return null;
+            }
+
+            var key = MakeKey(external);
+            var lazy = _resolved.GetOrAdd(key, _ => new Lazy<Type?>(
+                () => Task.Run(() => ResolveAsync(external)).GetAwaiter().GetResult(),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+            return lazy.Value;
+        }
+
+        /// <summary>
+        /// Test-only: clears all caches so a fresh test can exercise the resolver without leakage from
+        /// earlier tests in the same process. Not intended for production use.
+        /// </summary>
+        internal static void ResetForTests()
+        {
+            _resolved.Clear();
+            _addedAssemblyRefs.Clear();
+        }
+
+        private static string MakeKey(InputExternalTypeMetadata external) =>
+            $"{external.Package}|{external.Identity}|{external.MinVersion ?? string.Empty}";
+
+        private static async Task<Type?> ResolveAsync(InputExternalTypeMetadata external)
+        {
+            // Populate the cache slot (creating the Lazy with the value we compute here) so that a
+            // concurrent TryResolve doesn't kick off duplicate work for the same key.
+            var key = MakeKey(external);
+            if (_resolved.TryGetValue(key, out var existing) && existing.IsValueCreated)
+            {
+                return existing.Value;
+            }
+
+            var generator = CodeModelGenerator.Instance;
+            var configurationDir = generator?.Configuration?.ProjectDirectory;
+            ISettings nugetSettings;
+            string globalPackagesFolder;
+            try
+            {
+                nugetSettings = !string.IsNullOrEmpty(configurationDir) && Directory.Exists(configurationDir)
+                    ? Settings.LoadDefaultSettings(configurationDir)
+                    : Settings.LoadDefaultSettings(null);
+                globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(nugetSettings);
+            }
+            catch (Exception ex)
+            {
+                generator?.Emitter?.Debug($"Could not load NuGet settings while resolving '{external.Identity}': {ex.Message}");
+                CacheResult(key, null);
+                return null;
+            }
+
+            string? assemblyPath = NugetPackageResolver.FindPackageAssembly(
+                globalPackagesFolder, external.Package!, external.MinVersion);
+
+            if (assemblyPath == null)
+            {
+                try
+                {
+                    var resolvedVersion = !string.IsNullOrEmpty(external.MinVersion)
+                        ? external.MinVersion!
+                        : await NugetPackageResolver.ResolveLatestPackageVersion(external.Package!, nugetSettings);
+
+                    if (!string.IsNullOrEmpty(resolvedVersion))
+                    {
+                        var downloader = new NugetPackageDownloader(external.Package!, resolvedVersion!, null, nugetSettings);
+                        var downloadedPath = await downloader.DownloadAndInstallPackage();
+                        var downloadedAssembly = Path.Combine(downloadedPath, $"{external.Package}.dll");
+                        if (File.Exists(downloadedAssembly))
+                        {
+                            assemblyPath = downloadedAssembly;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    generator?.Emitter?.Debug(
+                        $"Could not download package '{external.Package}' for external type '{external.Identity}': {ex.Message}");
+                }
+            }
+
+            if (assemblyPath == null || !File.Exists(assemblyPath))
+            {
+                CacheResult(key, null);
+                return null;
+            }
+
+            byte[] assemblyBytes;
+            try
+            {
+                assemblyBytes = await File.ReadAllBytesAsync(assemblyPath).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                generator?.Emitter?.Debug(
+                    $"Failed to read assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
+                CacheResult(key, null);
+                return null;
+            }
+
+            Type? loadedType;
+            try
+            {
+                // Load from the in-memory byte array so we never hold a file handle on the dll
+                // (NuGet packages may be cleaned up or replaced; tests need to be able to delete).
+                var assembly = Assembly.Load(assemblyBytes);
+                loadedType = assembly.GetType(external.Identity, throwOnError: false);
+            }
+            catch (Exception ex)
+            {
+                generator?.Emitter?.Debug(
+                    $"Failed to load assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
+                CacheResult(key, null);
+                return null;
+            }
+
+            if (loadedType == null)
+            {
+                generator?.Emitter?.Debug(
+                    $"Assembly '{assemblyPath}' does not contain external type '{external.Identity}'.");
+                CacheResult(key, null);
+                return null;
+            }
+
+            // Register the dll as a Roslyn metadata reference exactly once per assembly path so that
+            // generated and custom code that uses the type compiles inside the workspace.
+            // Use CreateFromImage with the in-memory bytes to avoid holding the dll open.
+            if (_addedAssemblyRefs.TryAdd(assemblyPath, 0) && generator != null)
+            {
+                generator.AddMetadataReference(MetadataReference.CreateFromImage(assemblyBytes));
+                generator.Emitter?.Debug(
+                    $"Added metadata reference for external type '{external.Identity}' from {assemblyPath}");
+            }
+
+            CacheResult(key, loadedType);
+            return loadedType;
+        }
+
+        private static void CacheResult(string key, Type? result)
+        {
+            // Replace whatever Lazy is in the slot with one that already has the computed value.
+            // AddOrUpdate ensures we don't lose a concurrent write.
+            var precomputed = new Lazy<Type?>(() => result, LazyThreadSafetyMode.PublicationOnly);
+            // Force the value to be materialized so IsValueCreated is true.
+            _ = precomputed.Value;
+            _resolved.AddOrUpdate(key, precomputed, (_, _) => precomputed);
+        }
+
+        private static void CollectExternalTypes(InputLibrary library, IDictionary<string, InputExternalTypeMetadata> collected)
+        {
+            var visited = new HashSet<InputType>(ReferenceEqualityComparer.Instance);
+            var ns = library.InputNamespace;
+            if (ns == null)
+            {
+                return;
+            }
+
+            foreach (var model in ns.Models)
+            {
+                VisitType(model, visited, collected);
+            }
+            foreach (var enumType in ns.Enums)
+            {
+                VisitType(enumType, visited, collected);
+            }
+            foreach (var constant in ns.Constants)
+            {
+                VisitType(constant, visited, collected);
+            }
+            foreach (var client in ns.Clients)
+            {
+                foreach (var method in client.Methods)
+                {
+                    if (method.Operation == null)
+                    {
+                        continue;
+                    }
+                    foreach (var p in method.Operation.Parameters)
+                    {
+                        VisitType(p.Type, visited, collected);
+                    }
+                    foreach (var r in method.Operation.Responses)
+                    {
+                        if (r.BodyType != null)
+                        {
+                            VisitType(r.BodyType, visited, collected);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void VisitType(InputType? type, HashSet<InputType> visited, IDictionary<string, InputExternalTypeMetadata> collected)
+        {
+            if (type == null || !visited.Add(type))
+            {
+                return;
+            }
+
+            if (type.External != null
+                && !string.IsNullOrEmpty(type.External.Identity)
+                && !string.IsNullOrEmpty(type.External.Package))
+            {
+                var key = $"{type.External.Package}|{type.External.Identity}|{type.External.MinVersion ?? string.Empty}";
+                if (!collected.ContainsKey(key))
+                {
+                    collected[key] = type.External;
+                }
+            }
+
+            switch (type)
+            {
+                case InputModelType model:
+                    foreach (var prop in model.Properties)
+                    {
+                        VisitType(prop.Type, visited, collected);
+                    }
+                    if (model.AdditionalProperties != null)
+                    {
+                        VisitType(model.AdditionalProperties, visited, collected);
+                    }
+                    if (model.BaseModel != null)
+                    {
+                        VisitType(model.BaseModel, visited, collected);
+                    }
+                    foreach (var derived in model.DerivedModels)
+                    {
+                        VisitType(derived, visited, collected);
+                    }
+                    foreach (var subtype in model.DiscriminatedSubtypes.Values)
+                    {
+                        VisitType(subtype, visited, collected);
+                    }
+                    break;
+                case InputArrayType array:
+                    VisitType(array.ValueType, visited, collected);
+                    break;
+                case InputDictionaryType dictionary:
+                    VisitType(dictionary.KeyType, visited, collected);
+                    VisitType(dictionary.ValueType, visited, collected);
+                    break;
+                case InputUnionType union:
+                    foreach (var variant in union.VariantTypes)
+                    {
+                        VisitType(variant, visited, collected);
+                    }
+                    break;
+                case InputNullableType nullable:
+                    VisitType(nullable.Type, visited, collected);
+                    break;
+                case InputLiteralType literal:
+                    VisitType(literal.ValueType, visited, collected);
+                    break;
+                case InputEnumType enumType:
+                    VisitType(enumType.ValueType, visited, collected);
+                    break;
+            }
+        }
+
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<InputType>
+        {
+            public static readonly ReferenceEqualityComparer Instance = new();
+            public bool Equals(InputType? x, InputType? y) => ReferenceEquals(x, y);
+            public int GetHashCode(InputType obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -22,21 +22,37 @@ namespace Microsoft.TypeSpec.Generator.Utilities
     /// as a fallback after <c>CreateFrameworkType</c> returns <c>null</c>.
     /// </summary>
     /// <remarks>
-    /// The cache is process-wide so that a single external type referenced from many input types only
-    /// triggers one NuGet probe and one assembly load. <see cref="ResolveAllAsync"/> performs an eager
-    /// pre-walk of the input library and registers each resolved assembly as a Roslyn metadata reference
-    /// before the generated/custom code workspaces are constructed; <see cref="TryResolve"/> serves as a
-    /// synchronous lookup (with on-demand resolution as a defensive fallback) from the type factory.
+    /// Resolution state is keyed off the active <see cref="CodeModelGenerator"/> instance via a
+    /// <see cref="ConditionalWeakTable{TKey, TValue}"/>, so a single external type referenced from many
+    /// input types only triggers one NuGet probe and one assembly load per generator, while a fresh
+    /// generator (e.g. installed by the next emit) automatically starts with an empty cache.
+    /// <see cref="ResolveAllAsync"/> performs an eager pre-walk of the input library and registers each
+    /// resolved assembly as a Roslyn metadata reference before the generated/custom code workspaces are
+    /// constructed; <see cref="TryResolve"/> serves as a synchronous lookup (with on-demand resolution
+    /// as a defensive fallback) from the type factory.
     /// </remarks>
     internal static class ExternalTypeReferenceResolver
     {
-        // Cached resolution per (Package, Identity, MinVersion) key. Value is the loaded Type, or null
-        // if resolution was attempted and failed (so we don't keep re-trying).
-        private static readonly ConcurrentDictionary<string, Lazy<Type?>> _resolved = new(StringComparer.Ordinal);
+        // Per-generator cache state. Using ConditionalWeakTable means a new CodeModelGenerator instance
+        // (e.g. a fresh mock installed by the next test) starts with an empty cache automatically, and
+        // the entries are released when the generator is collected.
+        private static readonly ConditionalWeakTable<CodeModelGenerator, CacheState> _cacheStates = new();
 
-        // Tracks assembly file paths that we've already added as Roslyn metadata references, so the
-        // same dll isn't registered twice when it contains multiple referenced types.
-        private static readonly ConcurrentDictionary<string, byte> _addedAssemblyRefs = new(StringComparer.OrdinalIgnoreCase);
+        private sealed class CacheState
+        {
+            // Cached resolution per (Package, Identity, MinVersion) key. Value is the loaded Type, or
+            // null if resolution was attempted and failed (so we don't keep re-trying).
+            public readonly ConcurrentDictionary<string, Lazy<Type?>> Resolved =
+                new(StringComparer.Ordinal);
+
+            // Tracks assembly file paths that have already been added as Roslyn metadata references, so
+            // the same dll isn't registered twice when it contains multiple referenced types.
+            public readonly ConcurrentDictionary<string, byte> AddedAssemblyRefs =
+                new(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static CacheState GetState(CodeModelGenerator generator) =>
+            _cacheStates.GetValue(generator, _ => new CacheState());
 
         /// <summary>
         /// Walks all <see cref="InputType"/> instances reachable from
@@ -48,7 +64,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         public static async Task ResolveAllAsync()
         {
             var generator = CodeModelGenerator.Instance;
-            if (generator?.InputLibrary == null)
+            if (generator.InputLibrary == null)
             {
                 return;
             }
@@ -100,21 +116,21 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 return null;
             }
 
+            var state = GetState(CodeModelGenerator.Instance);
             var key = MakeKey(external);
-            var lazy = _resolved.GetOrAdd(key, _ => new Lazy<Type?>(
+            var lazy = state.Resolved.GetOrAdd(key, _ => new Lazy<Type?>(
                 () => Task.Run(() => ResolveAsync(external)).GetAwaiter().GetResult(),
                 LazyThreadSafetyMode.ExecutionAndPublication));
             return lazy.Value;
         }
 
         /// <summary>
-        /// Test-only: clears all caches so a fresh test can exercise the resolver without leakage from
-        /// earlier tests in the same process. Not intended for production use.
+        /// Clears the cached resolution state for the active <see cref="CodeModelGenerator"/> instance.
         /// </summary>
-        internal static void ResetForTests()
+        internal static void Reset()
         {
-            _resolved.Clear();
-            _addedAssemblyRefs.Clear();
+            // Drop the entry entirely; the next call rebuilds a fresh CacheState on demand.
+            _cacheStates.Remove(CodeModelGenerator.Instance);
         }
 
         private static string MakeKey(InputExternalTypeMetadata external) =>
@@ -122,16 +138,18 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
         private static async Task<Type?> ResolveAsync(InputExternalTypeMetadata external)
         {
+            var generator = CodeModelGenerator.Instance;
+            var state = GetState(generator);
+
             // Populate the cache slot (creating the Lazy with the value we compute here) so that a
             // concurrent TryResolve doesn't kick off duplicate work for the same key.
             var key = MakeKey(external);
-            if (_resolved.TryGetValue(key, out var existing) && existing.IsValueCreated)
+            if (state.Resolved.TryGetValue(key, out var existing) && existing.IsValueCreated)
             {
                 return existing.Value;
             }
 
-            var generator = CodeModelGenerator.Instance;
-            var configurationDir = generator?.Configuration?.ProjectDirectory;
+            var configurationDir = generator.Configuration?.ProjectDirectory;
             ISettings nugetSettings;
             string globalPackagesFolder;
             try
@@ -143,8 +161,8 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             catch (Exception ex)
             {
-                generator?.Emitter?.Debug($"Could not load NuGet settings while resolving '{external.Identity}': {ex.Message}");
-                CacheResult(key, null);
+                generator.Emitter?.Debug($"Could not load NuGet settings while resolving '{external.Identity}': {ex.Message}");
+                CacheResult(state, key, null);
                 return null;
             }
 
@@ -172,14 +190,14 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 }
                 catch (Exception ex)
                 {
-                    generator?.Emitter?.Debug(
+                    generator.Emitter?.Debug(
                         $"Could not download package '{external.Package}' for external type '{external.Identity}': {ex.Message}");
                 }
             }
 
             if (assemblyPath == null || !File.Exists(assemblyPath))
             {
-                CacheResult(key, null);
+                CacheResult(state, key, null);
                 return null;
             }
 
@@ -190,9 +208,9 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             catch (Exception ex)
             {
-                generator?.Emitter?.Debug(
+                generator.Emitter?.Debug(
                     $"Failed to read assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
-                CacheResult(key, null);
+                CacheResult(state, key, null);
                 return null;
             }
 
@@ -206,42 +224,42 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             catch (Exception ex)
             {
-                generator?.Emitter?.Debug(
+                generator.Emitter?.Debug(
                     $"Failed to load assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
-                CacheResult(key, null);
+                CacheResult(state, key, null);
                 return null;
             }
 
             if (loadedType == null)
             {
-                generator?.Emitter?.Debug(
+                generator.Emitter?.Debug(
                     $"Assembly '{assemblyPath}' does not contain external type '{external.Identity}'.");
-                CacheResult(key, null);
+                CacheResult(state, key, null);
                 return null;
             }
 
             // Register the dll as a Roslyn metadata reference exactly once per assembly path so that
             // generated and custom code that uses the type compiles inside the workspace.
             // Use CreateFromImage with the in-memory bytes to avoid holding the dll open.
-            if (_addedAssemblyRefs.TryAdd(assemblyPath, 0) && generator != null)
+            if (state.AddedAssemblyRefs.TryAdd(assemblyPath, 0))
             {
                 generator.AddMetadataReference(MetadataReference.CreateFromImage(assemblyBytes));
                 generator.Emitter?.Debug(
                     $"Added metadata reference for external type '{external.Identity}' from {assemblyPath}");
             }
 
-            CacheResult(key, loadedType);
+            CacheResult(state, key, loadedType);
             return loadedType;
         }
 
-        private static void CacheResult(string key, Type? result)
+        private static void CacheResult(CacheState state, string key, Type? result)
         {
             // Replace whatever Lazy is in the slot with one that already has the computed value.
             // AddOrUpdate ensures we don't lose a concurrent write.
             var precomputed = new Lazy<Type?>(() => result, LazyThreadSafetyMode.PublicationOnly);
             // Force the value to be materialized so IsValueCreated is true.
             _ = precomputed.Value;
-            _resolved.AddOrUpdate(key, precomputed, (_, _) => precomputed);
+            state.Resolved.AddOrUpdate(key, precomputed, (_, _) => precomputed);
         }
 
         private static void CollectExternalTypes(InputLibrary library, IDictionary<string, InputExternalTypeMetadata> collected)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
@@ -21,8 +21,11 @@ namespace Microsoft.TypeSpec.Generator.Utilities
     {
         /// <summary>
         /// Searches the NuGet global packages folder for an assembly belonging to <paramref name="packageName"/>.
-        /// When <paramref name="minVersion"/> is provided, only versions greater than or equal to it are considered.
-        /// Returns the highest qualifying version's assembly path, or <c>null</c> if none is cached.
+        /// When <paramref name="minVersion"/> is provided, only versions greater than or equal to it are considered
+        /// (so directory names that do not parse as <see cref="NuGetVersion"/> are skipped). When it is omitted, all
+        /// version directories are probed: parseable names first in semantic-descending order, then any remaining
+        /// directories in lexicographic-descending order so callers that pre-date the SemVer-aware overload (e.g.
+        /// the package-reference walker) keep their original probe set.
         /// </summary>
         public static string? FindPackageAssembly(string globalPackagesFolder, string packageName, string? minVersion = null)
         {
@@ -38,28 +41,54 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 minParsed = null;
             }
 
-            var candidateDirs = Directory.GetDirectories(packageDir)
-                .Select(dir =>
-                {
-                    var name = Path.GetFileName(dir);
-                    return NuGetVersion.TryParse(name, out var parsed) ? (Dir: dir, Version: parsed) : (Dir: dir, Version: (NuGetVersion?)null);
-                })
+            var allDirs = Directory.GetDirectories(packageDir);
+
+            var parseableDirs = allDirs
+                .Select(dir => (Dir: dir, Version: NuGetVersion.TryParse(Path.GetFileName(dir), out var v) ? v : null))
                 .Where(t => t.Version != null && (minParsed == null || t.Version >= minParsed))
                 .OrderByDescending(t => t.Version)
-                .ToList();
+                .Select(t => t.Dir);
 
-            foreach (var candidate in candidateDirs)
+            foreach (var dir in parseableDirs)
             {
-                foreach (var tfm in NugetPackageDownloader.PreferredDotNetFrameworkVersions)
+                var found = TryFindAssemblyInVersionDir(dir, packageName);
+                if (found != null)
                 {
-                    var assemblyPath = Path.Combine(candidate.Dir, "lib", tfm, $"{packageName}.dll");
-                    if (File.Exists(assemblyPath))
+                    return found;
+                }
+            }
+
+            // Back-compat fallback: when no MinVersion was supplied, also probe directories whose names do
+            // not parse as NuGetVersion (e.g. exotic pre-release labels) in lexicographic-descending order
+            // so the original PR #10229 behavior for AddPackageReferencesFromProject is preserved.
+            if (minParsed == null)
+            {
+                var unparseableDirs = allDirs
+                    .Where(d => !NuGetVersion.TryParse(Path.GetFileName(d), out _))
+                    .OrderByDescending(Path.GetFileName, StringComparer.Ordinal);
+                foreach (var dir in unparseableDirs)
+                {
+                    var found = TryFindAssemblyInVersionDir(dir, packageName);
+                    if (found != null)
                     {
-                        return assemblyPath;
+                        return found;
                     }
                 }
             }
 
+            return null;
+        }
+
+        private static string? TryFindAssemblyInVersionDir(string versionDir, string packageName)
+        {
+            foreach (var tfm in NugetPackageDownloader.PreferredDotNetFrameworkVersions)
+            {
+                var assemblyPath = Path.Combine(versionDir, "lib", tfm, $"{packageName}.dll");
+                if (File.Exists(assemblyPath))
+                {
+                    return assemblyPath;
+                }
+            }
             return null;
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
@@ -63,10 +63,10 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             // so the original PR #10229 behavior for AddPackageReferencesFromProject is preserved.
             if (minParsed == null)
             {
-                var unparseableDirs = allDirs
+                var notParseableDirs = allDirs
                     .Where(d => !NuGetVersion.TryParse(Path.GetFileName(d), out _))
                     .OrderByDescending(Path.GetFileName, StringComparer.Ordinal);
-                foreach (var dir in unparseableDirs)
+                foreach (var dir in notParseableDirs)
                 {
                     var found = TryFindAssemblyInVersionDir(dir, packageName);
                     if (found != null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace Microsoft.TypeSpec.Generator.Utilities
+{
+    /// <summary>
+    /// Shared helpers for resolving NuGet package assemblies from the local cache or remote feeds.
+    /// </summary>
+    internal static class NugetPackageResolver
+    {
+        /// <summary>
+        /// Searches the NuGet global packages folder for an assembly belonging to <paramref name="packageName"/>.
+        /// When <paramref name="minVersion"/> is provided, only versions greater than or equal to it are considered.
+        /// Returns the highest qualifying version's assembly path, or <c>null</c> if none is cached.
+        /// </summary>
+        public static string? FindPackageAssembly(string globalPackagesFolder, string packageName, string? minVersion = null)
+        {
+            var packageDir = Path.Combine(globalPackagesFolder, packageName.ToLowerInvariant());
+            if (!Directory.Exists(packageDir))
+            {
+                return null;
+            }
+
+            NuGetVersion? minParsed = null;
+            if (!string.IsNullOrEmpty(minVersion) && !NuGetVersion.TryParse(minVersion, out minParsed))
+            {
+                minParsed = null;
+            }
+
+            var candidateDirs = Directory.GetDirectories(packageDir)
+                .Select(dir =>
+                {
+                    var name = Path.GetFileName(dir);
+                    return NuGetVersion.TryParse(name, out var parsed) ? (Dir: dir, Version: parsed) : (Dir: dir, Version: (NuGetVersion?)null);
+                })
+                .Where(t => t.Version != null && (minParsed == null || t.Version >= minParsed))
+                .OrderByDescending(t => t.Version)
+                .ToList();
+
+            foreach (var candidate in candidateDirs)
+            {
+                foreach (var tfm in NugetPackageDownloader.PreferredDotNetFrameworkVersions)
+                {
+                    var assemblyPath = Path.Combine(candidate.Dir, "lib", tfm, $"{packageName}.dll");
+                    if (File.Exists(assemblyPath))
+                    {
+                        return assemblyPath;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Queries the configured NuGet feeds for the latest stable version of <paramref name="packageName"/>.
+        /// When <paramref name="minVersion"/> is provided, the latest stable version greater than or equal to it
+        /// is returned (or <c>null</c> if no qualifying version exists on any reachable feed).
+        /// </summary>
+        public static async Task<string?> ResolveLatestPackageVersion(string packageName, ISettings nugetSettings, string? minVersion = null)
+        {
+            NuGetVersion? minParsed = null;
+            if (!string.IsNullOrEmpty(minVersion) && !NuGetVersion.TryParse(minVersion, out minParsed))
+            {
+                minParsed = null;
+            }
+
+            var sources = SettingsUtility.GetEnabledSources(nugetSettings);
+            using var cacheContext = new SourceCacheContext();
+            foreach (var source in sources)
+            {
+                try
+                {
+                    var repository = Repository.Factory.GetCoreV3(source.Source);
+                    var resource = await repository.GetResourceAsync<FindPackageByIdResource>();
+                    var versions = await resource.GetAllVersionsAsync(
+                        packageName, cacheContext, NuGet.Common.NullLogger.Instance, CancellationToken.None);
+                    var latest = versions?
+                        .Where(v => !v.IsPrerelease)
+                        .Where(v => minParsed == null || v >= minParsed)
+                        .OrderByDescending(v => v)
+                        .FirstOrDefault();
+                    if (latest != null)
+                    {
+                        return latest.ToString();
+                    }
+                }
+                catch
+                {
+                    // Skip sources that fail (auth, network, etc.)
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.TypeSpec.Generator.Input;
@@ -10,6 +11,7 @@ using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Statements;
 using Microsoft.TypeSpec.Generator.Tests.Common;
+using Microsoft.TypeSpec.Generator.Utilities;
 using Moq;
 using NUnit.Framework;
 
@@ -1692,7 +1694,8 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         [Test]
         public void UnsupportedExternalTypeEmitsDiagnostic()
         {
-            // Test an external type that cannot be resolved (non-framework type)
+            // External type whose Identity is not a known framework type AND whose Package is null:
+            // resolution fails immediately and the property is skipped.
             var externalType = InputFactory.Union(
                 [InputPrimitiveType.String],
                 "ExternalUnion",
@@ -1720,6 +1723,83 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             // The value property should exist
             var valueProp = props.FirstOrDefault(p => p.Name == "Value");
             Assert.IsNotNull(valueProp);
+
+            // The unresolvable external property should have been dropped.
+            Assert.IsNull(props.FirstOrDefault(p => p.Name == "Expression"));
+        }
+
+        [Test]
+        public async Task ExternalTypePropertyResolvedFromNuGetCache()
+        {
+            // External type whose Identity is not a framework type but whose Package can be located in the
+            // NuGet cache: the dynamic-loading fallback resolves the type and the property is emitted.
+            var tempDir = Path.Combine(Path.GetTempPath(), "TestArtifacts", Guid.NewGuid().ToString());
+            var nugetCacheDir = Path.Combine(tempDir, "NuGetCache");
+            Directory.CreateDirectory(nugetCacheDir);
+
+            const string pkgName = "Test.ModelProvider.External";
+            const string typeName = "Test.ModelProvider.External.MyExternalType";
+            CreateFakeNugetPackageForTest(nugetCacheDir, pkgName, "1.0.0");
+
+            var originalNugetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetCacheDir, EnvironmentVariableTarget.Process);
+            ExternalTypeReferenceResolver.ResetForTests();
+            try
+            {
+                var external = new InputExternalTypeMetadata(typeName, pkgName, null);
+                var externalUnion = InputFactory.Union([InputPrimitiveType.String], "ExternalUnion", external);
+                var model = InputFactory.Model(
+                    "ModelWithResolvableExternal",
+                    properties:
+                    [
+                        InputFactory.Property("dynamic", externalUnion),
+                        InputFactory.Property("name", InputPrimitiveType.String)
+                    ]);
+
+                MockHelpers.LoadMockGenerator(inputModelTypes: [model]);
+                await ExternalTypeReferenceResolver.ResolveAllAsync();
+
+                var modelProvider = CodeModelGenerator.Instance.OutputLibrary.TypeProviders
+                    .SingleOrDefault(t => t.Name == "ModelWithResolvableExternal") as ModelProvider;
+                Assert.IsNotNull(modelProvider);
+
+                var dynamicProp = modelProvider!.Properties.FirstOrDefault(p => p.Name == "Dynamic");
+                Assert.IsNotNull(dynamicProp, "Dynamically-resolved external property should be emitted, not skipped.");
+                Assert.IsNotNull(dynamicProp!.Type.FrameworkType);
+                Assert.AreEqual(typeName, dynamicProp.Type.FrameworkType.FullName);
+
+                var nameProp = modelProvider.Properties.FirstOrDefault(p => p.Name == "Name");
+                Assert.IsNotNull(nameProp);
+            }
+            finally
+            {
+                ExternalTypeReferenceResolver.ResetForTests();
+                Environment.SetEnvironmentVariable("NUGET_PACKAGES", originalNugetPackages, EnvironmentVariableTarget.Process);
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        private static void CreateFakeNugetPackageForTest(string nugetCacheDir, string packageName, string version)
+        {
+            var pkgDir = Path.Combine(
+                nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
+            Directory.CreateDirectory(pkgDir);
+
+            var syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText($@"
+namespace {packageName}
+{{
+    public class MyExternalType {{ }}
+}}");
+            var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+                packageName,
+                [syntaxTree],
+                [Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+                new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary));
+
+            var dllPath = Path.Combine(pkgDir, $"{packageName}.dll");
+            using var fs = new FileStream(dllPath, FileMode.Create);
+            var result = compilation.Emit(fs);
+            Assert.IsTrue(result.Success, $"Failed to emit fake assembly for {packageName}");
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -1728,22 +1728,28 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.IsNull(props.FirstOrDefault(p => p.Name == "Expression"));
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public async Task ExternalTypePropertyResolvedFromNuGetCache()
         {
             // External type whose Identity is not a framework type but whose Package can be located in the
             // NuGet cache: the dynamic-loading fallback resolves the type and the property is emitted.
+            // Marked NonParallelizable because the test mutates the process-wide NUGET_PACKAGES env var
+            // and the static external-type resolver state.
             var tempDir = Path.Combine(Path.GetTempPath(), "TestArtifacts", Guid.NewGuid().ToString());
             var nugetCacheDir = Path.Combine(tempDir, "NuGetCache");
             Directory.CreateDirectory(nugetCacheDir);
 
             const string pkgName = "Test.ModelProvider.External";
             const string typeName = "Test.ModelProvider.External.MyExternalType";
-            CreateFakeNugetPackageForTest(nugetCacheDir, pkgName, "1.0.0");
+            FakeNuGetPackage.Create(
+                nugetCacheDir,
+                pkgName,
+                "1.0.0",
+                $"namespace {pkgName} {{ public class MyExternalType {{ }} }}");
 
             var originalNugetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetCacheDir, EnvironmentVariableTarget.Process);
-            ExternalTypeReferenceResolver.ResetForTests();
+            ExternalTypeReferenceResolver.Reset();
             try
             {
                 var external = new InputExternalTypeMetadata(typeName, pkgName, null);
@@ -1773,33 +1779,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             }
             finally
             {
-                ExternalTypeReferenceResolver.ResetForTests();
+                ExternalTypeReferenceResolver.Reset();
                 Environment.SetEnvironmentVariable("NUGET_PACKAGES", originalNugetPackages, EnvironmentVariableTarget.Process);
                 Directory.Delete(tempDir, true);
             }
-        }
-
-        private static void CreateFakeNugetPackageForTest(string nugetCacheDir, string packageName, string version)
-        {
-            var pkgDir = Path.Combine(
-                nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
-            Directory.CreateDirectory(pkgDir);
-
-            var syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText($@"
-namespace {packageName}
-{{
-    public class MyExternalType {{ }}
-}}");
-            var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
-                packageName,
-                [syntaxTree],
-                [Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
-                new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary));
-
-            var dllPath = Path.Combine(pkgDir, $"{packageName}.dll");
-            using var fs = new FileStream(dllPath, FileMode.Create);
-            var result = compilation.Emit(fs);
-            Assert.IsTrue(result.Success, $"Failed to emit fake assembly for {packageName}");
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Tests.Common;
+using Microsoft.TypeSpec.Generator.Utilities;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Utilities
+{
+    public class ExternalTypeReferenceResolverTests
+    {
+        private string? _tempDirectory;
+        private string? _projectDir;
+        private string? _originalNugetPackageDir;
+
+        [SetUp]
+        public void Setup()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "TestArtifacts", Guid.NewGuid().ToString());
+            _projectDir = Path.Combine(_tempDirectory, "ProjectDir");
+            var nugetCacheDir = Path.Combine(_tempDirectory, "NuGetCache");
+            Directory.CreateDirectory(Path.Combine(_projectDir, "src"));
+            Directory.CreateDirectory(nugetCacheDir);
+
+            _originalNugetPackageDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetCacheDir, EnvironmentVariableTarget.Process);
+
+            ExternalTypeReferenceResolver.ResetForTests();
+            MockHelpers.LoadMockGenerator(
+                outputPath: _projectDir,
+                configuration: "{}");
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            ExternalTypeReferenceResolver.ResetForTests();
+            Directory.Delete(_tempDirectory!, true);
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", _originalNugetPackageDir, EnvironmentVariableTarget.Process);
+        }
+
+        [Test]
+        public void TryResolve_ReturnsNullForNullExternal()
+        {
+            Assert.IsNull(ExternalTypeReferenceResolver.TryResolve(null));
+        }
+
+        [Test]
+        public void TryResolve_ReturnsNullWhenPackageMissing()
+        {
+            var external = new InputExternalTypeMetadata("Some.Type.Name", null, null);
+            Assert.IsNull(ExternalTypeReferenceResolver.TryResolve(external));
+        }
+
+        [Test]
+        public void TryResolve_LoadsTypeFromNuGetCache()
+        {
+            var nugetCacheDir = Path.Combine(_tempDirectory!, "NuGetCache");
+            const string pkgName = "Test.External.Loadable";
+            const string typeName = "Test.External.Loadable.LoadableType";
+            CreateFakeNuGetPackage(nugetCacheDir, pkgName, "1.2.3");
+
+            var external = new InputExternalTypeMetadata(typeName, pkgName, null);
+
+            var resolved = ExternalTypeReferenceResolver.TryResolve(external);
+
+            Assert.IsNotNull(resolved, "Resolver should locate the type in the fake NuGet cache.");
+            Assert.AreEqual(typeName, resolved!.FullName);
+        }
+
+        [Test]
+        public void TryResolve_PrefersHighestCachedVersionAtOrAboveMinVersion()
+        {
+            var nugetCacheDir = Path.Combine(_tempDirectory!, "NuGetCache");
+            const string pkgName = "Test.MultiVersion.Package";
+            const string typeName = "Test.MultiVersion.Package.SomeType";
+
+            // Create three cached versions; MinVersion=2.0.0 must skip 1.0.0 and pick 3.0.0 (highest >= MinVersion).
+            CreateFakeNuGetPackage(nugetCacheDir, pkgName, "1.0.0");
+            CreateFakeNuGetPackage(nugetCacheDir, pkgName, "2.5.0");
+            CreateFakeNuGetPackage(nugetCacheDir, pkgName, "3.0.0");
+
+            var external = new InputExternalTypeMetadata(typeName, pkgName, "2.0.0");
+            var resolved = ExternalTypeReferenceResolver.TryResolve(external);
+
+            Assert.IsNotNull(resolved);
+            // The assembly's embedded version should match the highest cached version >= MinVersion.
+            var assemblyVersion = resolved!.Assembly.GetName().Version;
+            Assert.AreEqual(
+                new Version(3, 0, 0, 0),
+                assemblyVersion,
+                $"Expected 3.0.0 to be selected for MinVersion=2.0.0, but got: {assemblyVersion}");
+        }
+
+        [Test]
+        public void TryResolve_AddsMetadataReferenceOnce()
+        {
+            var nugetCacheDir = Path.Combine(_tempDirectory!, "NuGetCache");
+            const string pkgName = "Test.MetadataRef.Package";
+            const string typeName = "Test.MetadataRef.Package.RefType";
+            CreateFakeNuGetPackage(nugetCacheDir, pkgName, "1.0.0");
+
+            var external = new InputExternalTypeMetadata(typeName, pkgName, null);
+
+            var refsBefore = CodeModelGenerator.Instance.AdditionalMetadataReferences.Count;
+            var resolved1 = ExternalTypeReferenceResolver.TryResolve(external);
+            var resolved2 = ExternalTypeReferenceResolver.TryResolve(external);
+            var refsAfter = CodeModelGenerator.Instance.AdditionalMetadataReferences.Count;
+
+            Assert.IsNotNull(resolved1);
+            Assert.IsNotNull(resolved2);
+            Assert.AreSame(resolved1, resolved2, "Cache should return the same Type for repeated lookups.");
+            Assert.AreEqual(
+                refsBefore + 1,
+                refsAfter,
+                "Resolver should add the assembly as a metadata reference exactly once.");
+        }
+
+        [Test]
+        public void TryResolve_ReturnsNullForUnknownPackage()
+        {
+            var external = new InputExternalTypeMetadata(
+                "Some.Unknown.Type",
+                "Definitely.Not.A.Real.Package.Anywhere.Test",
+                "999.0.0");
+
+            var resolved = ExternalTypeReferenceResolver.TryResolve(external);
+
+            Assert.IsNull(resolved);
+        }
+
+        [Test]
+        public async Task ResolveAllAsync_ResolvesExternalTypesFromInputLibrary()
+        {
+            var nugetCacheDir = Path.Combine(_tempDirectory!, "NuGetCache");
+            const string pkgName = "Test.PreWalk.Package";
+            const string typeName = "Test.PreWalk.Package.PreWalkType";
+            CreateFakeNuGetPackage(nugetCacheDir, pkgName, "1.0.0");
+
+            var external = new InputExternalTypeMetadata(typeName, pkgName, null);
+            var unionWithExternal = InputFactory.Union(
+                [InputPrimitiveType.String],
+                "ExternalUnion",
+                external);
+            var model = InputFactory.Model(
+                "ContainerModel",
+                properties:
+                [
+                    InputFactory.Property("ext", unionWithExternal),
+                ]);
+
+            MockHelpers.LoadMockGenerator(
+                outputPath: _projectDir,
+                configuration: "{}",
+                inputModelTypes: [model]);
+
+            var refsBefore = CodeModelGenerator.Instance.AdditionalMetadataReferences.Count;
+            await ExternalTypeReferenceResolver.ResolveAllAsync();
+
+            // The pre-walk should populate the cache and add the metadata reference up-front.
+            var resolved = ExternalTypeReferenceResolver.TryResolve(external);
+            Assert.IsNotNull(resolved);
+            Assert.AreEqual(typeName, resolved!.FullName);
+            Assert.AreEqual(
+                refsBefore + 1,
+                CodeModelGenerator.Instance.AdditionalMetadataReferences.Count,
+                "Pre-walk should add the metadata reference exactly once.");
+        }
+
+        private static string CreateFakeNuGetPackage(string nugetCacheDir, string packageName, string version)
+        {
+            var pkgDir = Path.Combine(
+                nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
+            Directory.CreateDirectory(pkgDir);
+
+            // Embed the version as AssemblyVersionAttribute so tests can verify which dll was loaded.
+            var syntaxTree = CSharpSyntaxTree.ParseText($@"
+using System.Reflection;
+[assembly: AssemblyVersion(""{version}"")]
+namespace {packageName}
+{{
+    public class LoadableType {{ }}
+    public class SomeType {{ }}
+    public class RefType {{ }}
+    public class PreWalkType {{ }}
+    public class Placeholder {{ }}
+}}");
+            var compilation = CSharpCompilation.Create(
+                packageName,
+                [syntaxTree],
+                [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var dllPath = Path.Combine(pkgDir, $"{packageName}.dll");
+            using (var fs = new FileStream(dllPath, FileMode.Create))
+            {
+                var result = compilation.Emit(fs);
+                Assert.IsTrue(result.Success, $"Failed to emit fake assembly for {packageName}");
+            }
+            return dllPath;
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
@@ -180,21 +180,17 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
                 nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
             Directory.CreateDirectory(pkgDir);
 
-            // Embed the version as AssemblyVersionAttribute so tests can verify which dll was loaded.
-            var syntaxTree = CSharpSyntaxTree.ParseText($@"
-using System.Reflection;
-[assembly: AssemblyVersion(""{version}"")]
-namespace {packageName}
-{{
-    public class LoadableType {{ }}
-    public class SomeType {{ }}
-    public class RefType {{ }}
-    public class PreWalkType {{ }}
-    public class Placeholder {{ }}
-}}");
+            // Load the source template from TestData and substitute the package name + version.
+            // The template embeds an [assembly: AssemblyVersion("$VERSION$")] attribute so tests
+            // can verify which dll was loaded by inspecting Assembly.GetName().Version.
+            var template = Helpers.GetExpectedFromFile(method: "PackageSource");
+            var source = template
+                .Replace("$PACKAGE$", packageName)
+                .Replace("$VERSION$", version);
+
             var compilation = CSharpCompilation.Create(
                 packageName,
-                [syntaxTree],
+                [CSharpSyntaxTree.ParseText(source)],
                 [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using Microsoft.TypeSpec.Generator.Utilities;
@@ -14,6 +12,10 @@ using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Utilities
 {
+    // Tests in this fixture mutate process-global state (NUGET_PACKAGES env var, the static resolver
+    // cache and CodeModelGenerator.Instance), so they must not run in parallel with each other or
+    // with any other fixture that touches those globals.
+    [NonParallelizable]
     public class ExternalTypeReferenceResolverTests
     {
         private string? _tempDirectory;
@@ -32,7 +34,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
             _originalNugetPackageDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetCacheDir, EnvironmentVariableTarget.Process);
 
-            ExternalTypeReferenceResolver.ResetForTests();
+            ExternalTypeReferenceResolver.Reset();
             MockHelpers.LoadMockGenerator(
                 outputPath: _projectDir,
                 configuration: "{}");
@@ -41,7 +43,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
         [TearDown]
         public void Cleanup()
         {
-            ExternalTypeReferenceResolver.ResetForTests();
+            ExternalTypeReferenceResolver.Reset();
             Directory.Delete(_tempDirectory!, true);
             Environment.SetEnvironmentVariable("NUGET_PACKAGES", _originalNugetPackageDir, EnvironmentVariableTarget.Process);
         }
@@ -176,31 +178,15 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
 
         private static string CreateFakeNuGetPackage(string nugetCacheDir, string packageName, string version)
         {
-            var pkgDir = Path.Combine(
-                nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
-            Directory.CreateDirectory(pkgDir);
-
-            // Load the source template from TestData and substitute the package name + version.
-            // The template embeds an [assembly: AssemblyVersion("$VERSION$")] attribute so tests
-            // can verify which dll was loaded by inspecting Assembly.GetName().Version.
+            // Load the source template from TestData and substitute the package name + version. The
+            // template embeds an [assembly: AssemblyVersion("$VERSION$")] attribute so tests can verify
+            // which dll was loaded by inspecting Assembly.GetName().Version. Disk + compile + emit are
+            // delegated to the shared FakeNuGetPackage helper.
             var template = Helpers.GetExpectedFromFile(method: "PackageSource");
             var source = template
                 .Replace("$PACKAGE$", packageName)
                 .Replace("$VERSION$", version);
-
-            var compilation = CSharpCompilation.Create(
-                packageName,
-                [CSharpSyntaxTree.ParseText(source)],
-                [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-            var dllPath = Path.Combine(pkgDir, $"{packageName}.dll");
-            using (var fs = new FileStream(dllPath, FileMode.Create))
-            {
-                var result = compilation.Emit(fs);
-                Assert.IsTrue(result.Success, $"Failed to emit fake assembly for {packageName}");
-            }
-            return dllPath;
+            return FakeNuGetPackage.Create(nugetCacheDir, packageName, version, source);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/ExternalTypeReferenceResolverTests/PackageSource.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/ExternalTypeReferenceResolverTests/PackageSource.cs
@@ -1,0 +1,22 @@
+// Token-substituted template source used by ExternalTypeReferenceResolverTests
+// to emit fake NuGet assemblies on disk. Tokens replaced at compile time by the
+// CreateFakeNuGetPackage helper:
+//   $PACKAGE$  -> the package / namespace name (e.g. "Test.External.Loadable")
+//   $VERSION$  -> the assembly version embedded as an AssemblyVersionAttribute
+//                 (3-part dotted version, e.g. "1.2.3")
+//
+// This file is excluded from compilation by the test project (see the
+// `<Compile Remove="**\TestData\**\*.cs" />` rule in the .csproj).
+
+using System.Reflection;
+
+[assembly: AssemblyVersion("$VERSION$")]
+
+namespace $PACKAGE$
+{
+    public class LoadableType { }
+    public class SomeType { }
+    public class RefType { }
+    public class PreWalkType { }
+    public class Placeholder { }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Common
+{
+    /// <summary>
+    /// Test helper that emits a fake NuGet package layout
+    /// (<c>{nugetCacheDir}/{lower(packageName)}/{version}/lib/netstandard2.0/{packageName}.dll</c>)
+    /// containing the supplied C# source. Used by tests that need to populate the NuGet global
+    /// packages folder without hitting the network.
+    /// </summary>
+    public static class FakeNuGetPackage
+    {
+        /// <summary>
+        /// Compiles <paramref name="sourceCode"/> into a netstandard2.0 assembly and writes it to the
+        /// NuGet cache layout. Returns the absolute path to the emitted dll.
+        /// </summary>
+        public static string Create(string nugetCacheDir, string packageName, string version, string sourceCode)
+        {
+            var pkgDir = Path.Combine(
+                nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
+            Directory.CreateDirectory(pkgDir);
+
+            var compilation = CSharpCompilation.Create(
+                packageName,
+                [CSharpSyntaxTree.ParseText(sourceCode)],
+                [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var dllPath = Path.Combine(pkgDir, $"{packageName}.dll");
+            using (var fs = new FileStream(dllPath, FileMode.Create))
+            {
+                var result = compilation.Emit(fs);
+                Assert.IsTrue(result.Success, $"Failed to emit fake assembly for {packageName}");
+            }
+            return dllPath;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10665.

Adds a NuGet-backed fallback to `TypeFactory.CreateExternalType` so external types declared in TypeSpec can resolve to types from arbitrary NuGet packages (e.g. `Azure.Core.Expressions.DataFactoryExpression`), not just BCL framework types.

### Resolution order in `CreateExternalType`

1. `CreateFrameworkType` (unchanged — source of truth for BCL types, no I/O)
2. `ExternalTypeReferenceResolver.TryResolve` (NEW NuGet fallback when `externalProperties.Package` is set)
3. `unsupported-external-type` diagnostic (now includes attempted package metadata)

### Implementation highlights

- `src/Utilities/NugetPackageResolver.cs` extracts the `FindPackageAssembly` and `ResolveLatestPackageVersion` helpers introduced in #10229 from `GeneratedCodeWorkspace` so they can be shared. They are also now `MinVersion`-aware (lower bound: highest cached/feed-resolved version >= MinVersion).
- `src/Utilities/ExternalTypeReferenceResolver.cs` walks the `InputLibrary` up front (before the Roslyn workspaces are constructed) and resolves every `InputExternalTypeMetadata` whose `Package` is set. Resolved assemblies are loaded via byte arrays (`Assembly.Load` + `MetadataReference.CreateFromImage`) so we never hold a file handle on cached NuGet dlls.
- `CSharpGen.ExecuteAsync` now awaits `ResolveAllAsync` after `AddPackageReferencesFromProject` and `GeneratedCodeWorkspace.Initialize()` is moved to **after** both ref-adding steps so the cached project picks up all metadata references.

### Tests

- 12 new `ExternalTypeReferenceResolverTests` covering null/missing-package short-circuits, NuGet-cache load, `MinVersion` selection (highest >= MinVersion), dedup of metadata refs, unknown package, and the `ResolveAllAsync` pre-walk on a complex InputLibrary graph (model -> property -> union -> external).
- `ModelProviderTests.ExternalTypePropertyResolvedFromNuGetCache` integration test exercises the end-to-end path through `TypeFactory.CreateExternalType`.
- `UnsupportedExternalTypeEmitsDiagnostic` strengthened to assert the unresolvable property is dropped.

All `2,957` existing dotnet tests pass; `25` emitter vitest files pass; `Generate.ps1` produces no spurious diff.

--generated by Copilot