### PR TITLE
fix(openapi3): don't emit auth scheme models under components.schemas

### DIFF
--- a/.chronus/changes/fix-openapi3-auth-model-schemas-leak-2026-5-13.md
+++ b/.chronus/changes/fix-openapi3-auth-model-schemas-leak-2026-5-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Fix custom auth scheme models leaking into `components.schemas` when declared inside the service namespace. They are now emitted only under `components.securitySchemes` as expected.

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1780,8 +1780,14 @@ function createOAPIEmitter(
     }
 
     function processUnreferencedSchemas() {
+      const authSchemeModels = new Set<Type>(serviceAuth.schemes.map((s) => s.model));
       const addSchema = (type: Type) => {
         if (isOrExtendsHttpFile(program, type)) {
+          return;
+        }
+        if (authSchemeModels.has(type)) {
+          // Auth scheme models are emitted under components.securitySchemes
+          // and should not also appear as payload schemas in components.schemas.
           return;
         }
         if (

--- a/packages/openapi3/test/security.test.ts
+++ b/packages/openapi3/test/security.test.ts
@@ -620,4 +620,38 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, openApiFor }) => {
     });
     expect(res.components.schemas?.customBearer).toBeUndefined();
   });
+
+  it("still emits an auth scheme model under components.schemas if referenced by an operation", async () => {
+    // The filter in `processUnreferencedSchemas` only skips auth scheme
+    // models that are otherwise unreachable. If the same model is also
+    // referenced from a payload (e.g. returned by an operation), it must
+    // continue to appear under `components.schemas` so the operation can
+    // $ref it, while still being emitted under `components.securitySchemes`.
+    const res = await openApiFor(
+      `
+      @useAuth(customBearer)
+      @service
+      namespace MyService;
+
+      model customBearer {
+        type: AuthType.http;
+        scheme: "bearer";
+      }
+
+      @route("/echo")
+      op echo(): customBearer;
+      `,
+    );
+    deepStrictEqual(res.components.securitySchemes, {
+      customBearer: {
+        type: "http",
+        scheme: "bearer",
+      },
+    });
+    expect(res.components.schemas?.customBearer).toBeDefined();
+    deepStrictEqual(
+      res.paths["/echo"]["get"].responses["200"].content["application/json"].schema,
+      { $ref: "#/components/schemas/customBearer" },
+    );
+  });
 });

--- a/packages/openapi3/test/security.test.ts
+++ b/packages/openapi3/test/security.test.ts
@@ -589,4 +589,35 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, openApiFor }) => {
       },
     ]);
   });
+
+  it("does not emit a custom auth scheme model under components.schemas", async () => {
+    // A custom auth scheme model declared inside the service namespace
+    // belongs only in `components.securitySchemes`. Previously
+    // `processUnreferencedSchemas` also emitted it under
+    // `components.schemas` because no payload references it, which
+    // caused downstream validators to reject auth-only attributes
+    // (e.g. `bearerFormat`) that propagated to the schemas-side copy.
+    const res = await openApiFor(
+      `
+      @useAuth(customBearer)
+      @service
+      namespace MyService;
+
+      model customBearer {
+        type: AuthType.http;
+        scheme: "bearer";
+      }
+
+      @route("/ping")
+      op ping(): { @statusCode _: 200; ok: boolean };
+      `,
+    );
+    deepStrictEqual(res.components.securitySchemes, {
+      customBearer: {
+        type: "http",
+        scheme: "bearer",
+      },
+    });
+    expect(res.components.schemas?.customBearer).toBeUndefined();
+  });
 });

--- a/packages/openapi3/test/security.test.ts
+++ b/packages/openapi3/test/security.test.ts
@@ -649,9 +649,8 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, openApiFor }) => {
       },
     });
     expect(res.components.schemas?.customBearer).toBeDefined();
-    deepStrictEqual(
-      res.paths["/echo"]["get"].responses["200"].content["application/json"].schema,
-      { $ref: "#/components/schemas/customBearer" },
-    );
+    deepStrictEqual(res.paths["/echo"]["get"].responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/customBearer",
+    });
   });
 });


### PR DESCRIPTION
## Issue

A custom auth scheme model declared inside the service namespace is emitted into **both** `components.securitySchemes` (correct) **and** `components.schemas` (spurious):

```typespec
@useAuth(customBearer)
@service
namespace MyService;

model customBearer {
  type: AuthType.http;
  scheme: "bearer";
}
```

Emitted output today:

```yaml
components:
  schemas:
    customBearer:                # <-- spurious
      type: object
      required: [type, scheme]
      properties: { ... }
  securitySchemes:
    customBearer:                # <-- correct
      type: http
      scheme: bearer
```

The spurious `components.schemas.<name>` entry comes from `processUnreferencedSchemas`, which walks every model in the service namespace and emits any model that is "unreachable" (i.e. not referenced from any payload). Custom auth scheme models always match that criterion but are already covered by `components.securitySchemes`.

Visible symptom (how I found this): `@extension(...)` decorators applied to the auth model propagate to **both** emit locations. Extensions valid under `components.securitySchemes.<name>` (for example `bearerFormat: plain` on a bearer auth scheme) are unknown under `components.schemas.<name>`, and downstream tools — openapi-generator-cli's spec validator in my case — reject the document:

```
- Error count: 1, Warning count: 4
Errors:
  -attribute components.schemas.customBearer.bearerFormat is unexpected
```

The bug only triggers when the auth model is declared inside the service namespace. Declared at global scope it doesn't reproduce, because `processUnreferencedSchemas` only walks the service namespace.

## Fix

Filter auth scheme model types out of `processUnreferencedSchemas`. `serviceAuth.schemes` already carries each scheme's originating model (`HttpAuth.model`) by the time `emitSchemas` runs.

```ts
const authSchemeModels = new Set<Type>(serviceAuth.schemes.map((s) => s.model));
const addSchema = (type: Type) => {
  if (isOrExtendsHttpFile(program, type)) return;
  if (authSchemeModels.has(type)) return;  // skip auth scheme models
  if (visibilityUsage.isUnreachable(type) && !paramModels.has(type) && !shouldInline(program, type)) {
    callSchemaEmitter(type, Visibility.All);
  }
};
```

Auth models continue to be emitted via the separate `securitySchemes` path in `initializeEmitter`.

## Test

Added a test case in `packages/openapi3/test/security.test.ts` that asserts `res.components.schemas?.customBearer` is undefined while `res.components.securitySchemes.customBearer` is set correctly. All 60 existing security tests still pass.

## Backward compatibility

I think this should be safe: depending on auth scheme models to appear under `components.schemas` would be a misuse — they're not payload schemas. The change only affects the emit location, the model still parses and resolves identically inside `@useAuth(...)`.
