### PR TITLE
feat(mutator-framework): add multi-subgraph support and fix TypeScript 6 compatibility

### DIFF
--- a/.chronus/changes/fix-mutator-framework-multi-subgraph-ts6-2026-4-14-15-7-47.md
+++ b/.chronus/changes/fix-mutator-framework-multi-subgraph-ts6-2026-4-14-15-7-47.md
@@ -1,0 +1,19 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/mutator-framework"
+---
+
+Add multi-subgraph support to `ModelPropertyMutation` with a new `buildTypeEdges()` override point, an optional `typeOverride` parameter on `mutate()`, and a new `TypeEdgeSpec` interface. Also fixes TypeScript 6 type cast compatibility.
+
+```ts
+// Override buildTypeEdges() to wire independent type edges per subgraph
+class MyPropertyMutation extends ModelPropertyMutation<...> {
+  protected buildTypeEdges(): TypeEdgeSpec[] {
+    return [
+      { referenceToFollow: this.sourceType, halfEdge: this.subgraphAEdge() },
+      { typeToFollow: myExplicitType, halfEdge: this.subgraphBEdge() },
+    ];
+  }
+}
+```

--- a/.chronus/changes/fix-mutator-framework-multi-subgraph-ts6-http-canonicalization-2026-5-19.md
+++ b/.chronus/changes/fix-mutator-framework-multi-subgraph-ts6-http-canonicalization-2026-5-19.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-canonicalization"
+---
+
+Add `alternateType` option to `HttpCanonicalizationOptions` and override `buildTypeEdges()` in `ModelPropertyHttpCanonicalization` to support routing the language edge to an alternate type while keeping the wire edge on the original type. This enables `@alternateType` scenarios where the language representation and wire encoding diverge.

--- a/packages/http-canonicalization/src/model-property.test.ts
+++ b/packages/http-canonicalization/src/model-property.test.ts
@@ -125,6 +125,35 @@ it("applies friendly name", async () => {
   expect(prop.wireType.name).toBe("id");
 });
 
+it("routes language edge to alternateType while wire edge follows original type", async () => {
+  const { Foo, program } = await runner.compile(t.code`
+    model ${t.model("Foo")} {
+      @encode(DateTimeKnownEncoding.rfc7231)
+      ${t.modelProperty("prop")}: utcDateTime;
+    }
+  `);
+
+  const tk = $(program);
+  const canonicalizer = new HttpCanonicalizer(tk);
+
+  // Simulate @alternateType(string): the language representation uses `string`,
+  // while the wire representation keeps the original utcDateTime (with rfc7231 encoding).
+  const canonicalized = canonicalizer.canonicalize(Foo, {
+    visibility: Visibility.Read,
+    contentType: "application/json",
+    alternateType: tk.builtin.string,
+  });
+
+  const prop = canonicalized.properties.get("prop")!;
+  expect(prop).toBeDefined();
+
+  // Language type follows the alternate type (string)
+  expectTypeEquals(prop.languageType.type, tk.builtin.string);
+
+  // Wire type follows the original type (utcDateTime, encoded as string via rfc7231)
+  expectTypeEquals(prop.wireType.type, tk.builtin.utcDateTime);
+});
+
 it("Applies renames", async () => {
   const { program, test } = await runner.compile(t.code`
     op ${t.op("test")}(): Foo;

--- a/packages/http-canonicalization/src/model-property.ts
+++ b/packages/http-canonicalization/src/model-property.ts
@@ -13,6 +13,7 @@ import {
   MutationHalfEdge,
   type MutationNodeForType,
   type MutationTraits,
+  type TypeEdgeSpec,
 } from "@typespec/mutator-framework";
 import type { Codec, EncodingInfo } from "./codecs.js";
 import type { HttpCanonicalizationMutations } from "./http-canonicalization-classes.js";
@@ -142,11 +143,40 @@ export class ModelPropertyHttpCanonicalization
    */
   typeIsNullable: boolean = false;
 
-  protected startTypeEdge() {
-    return new MutationHalfEdge("type", this, (tail) => {
-      this.#languageMutationNode.connectType(tail.languageMutationNode);
-      this.#wireMutationNode.connectType(tail.wireMutationNode);
-    });
+  protected override buildTypeEdges(): TypeEdgeSpec[] {
+    const alternate = this.options.alternateType;
+
+    if (alternate) {
+      // When an alternate type is specified (e.g. via @alternateType), split the
+      // language and wire edges so they resolve to independent tails:
+      //   • language edge follows the alternate type
+      //   • wire edge follows the original source property's reference chain
+      return [
+        {
+          typeToFollow: alternate,
+          halfEdge: new MutationHalfEdge("language-type", this, (tail) => {
+            this.#languageMutationNode.connectType(tail.languageMutationNode);
+          }),
+        },
+        {
+          referenceToFollow: this.sourceType,
+          halfEdge: new MutationHalfEdge("wire-type", this, (tail) => {
+            this.#wireMutationNode.connectType(tail.wireMutationNode);
+          }),
+        },
+      ];
+    }
+
+    // Default: single edge wires both language and wire nodes to the same tail.
+    return [
+      {
+        referenceToFollow: this.sourceType,
+        halfEdge: new MutationHalfEdge("type", this, (tail) => {
+          this.#languageMutationNode.connectType(tail.languageMutationNode);
+          this.#wireMutationNode.connectType(tail.wireMutationNode);
+        }),
+      },
+    ];
   }
 
   static mutationInfo(

--- a/packages/http-canonicalization/src/options.ts
+++ b/packages/http-canonicalization/src/options.ts
@@ -1,3 +1,4 @@
+import type { Type } from "@typespec/compiler";
 import { Visibility } from "@typespec/http";
 import { MutationOptions } from "@typespec/mutator-framework";
 import type { HttpCanonicalization } from "./http-canonicalization-classes.js";
@@ -16,12 +17,24 @@ export interface HttpCanonicalizationOptionsInit {
   location?: HttpCanonicalizationLocation;
   contentType?: string;
   namePolicy?: (canonicalization: HttpCanonicalization) => string | undefined;
+  /**
+   * When set, the language-subgraph type edge for a model property follows this
+   * type instead of the source property's type. The wire-subgraph edge always
+   * follows the source property's original type.
+   *
+   * This is the mechanism that enables `@alternateType` support: callers (e.g.
+   * TCGC) look up the alternate type for a property and pass it here so the
+   * language representation uses the alternate type while serialization still
+   * uses the original wire type.
+   */
+  alternateType?: Type;
 }
 export class HttpCanonicalizationOptions extends MutationOptions {
   visibility: Visibility;
   location: HttpCanonicalizationLocation;
   contentType: string;
   namePolicy?: (canonicalization: HttpCanonicalization) => string | undefined;
+  alternateType?: Type;
 
   constructor(options: HttpCanonicalizationOptionsInit = {}) {
     super();
@@ -29,6 +42,7 @@ export class HttpCanonicalizationOptions extends MutationOptions {
     this.location = options.location ?? "body";
     this.contentType = options.contentType ?? "none";
     this.namePolicy = options.namePolicy;
+    this.alternateType = options.alternateType;
   }
 
   get mutationKey(): string {
@@ -41,6 +55,7 @@ export class HttpCanonicalizationOptions extends MutationOptions {
       location: newOptions.location ?? this.location,
       contentType: newOptions.contentType ?? this.contentType,
       namePolicy: newOptions.namePolicy ?? this.namePolicy,
+      alternateType: newOptions.alternateType ?? this.alternateType,
     });
   }
 }

--- a/packages/mutator-framework/src/mutation-node/mutation-node.ts
+++ b/packages/mutator-framework/src/mutation-node/mutation-node.ts
@@ -140,6 +140,15 @@ export abstract class MutationNode<T extends Type> {
    * Replace this node with a new type. This creates a new mutation node for the
    * replacement type and updates all edges to point to the new node.
    *
+   * **When to use `replace()`**: only when the replacement type is structurally
+   * different from the source type such that rewiring parent edges to a different
+   * type node is genuinely necessary — for example, substituting a `Model` with a
+   * synthetic `Union` that wraps it. Do **not** use `replace()` for field-value
+   * changes (name, type pointer, defaultValue, etc.); use `mutate()` for those.
+   * Misusing `replace()` for value-level changes introduces unnecessary edge
+   * churn and can cause stale-reference issues for nodes that already held
+   * references to the original node.
+   *
    * When a node is replaced:
    * 1. A new mutation node is created for the replacement type
    * 2. The original node is marked as replaced and will ignore future mutations
@@ -151,7 +160,8 @@ export abstract class MutationNode<T extends Type> {
    *    which updates the edge to point to the replacement node and invokes the
    *    head's `onTailReplaced` callback.
    *
-   * @param newType - The type to replace this node with
+   * @param newType - The type to replace this node with. Must be structurally
+   *   different from the source type. For same-shape mutations use `mutate()`.
    * @returns The new mutation node for the replacement type
    */
   replace(newType: Type) {

--- a/packages/mutator-framework/src/mutation/model-property.ts
+++ b/packages/mutator-framework/src/mutation/model-property.ts
@@ -1,10 +1,11 @@
-import type { ModelProperty, Type } from "@typespec/compiler";
+import type { MemberType, ModelProperty, Type } from "@typespec/compiler";
 import type {
   CustomMutationClasses,
   MutationEngine,
   MutationFor,
   MutationHalfEdge,
   MutationOptions,
+  TypeEdgeSpec,
 } from "./mutation-engine.js";
 import { Mutation } from "./mutation.js";
 
@@ -16,13 +17,83 @@ export abstract class ModelPropertyMutation<
   readonly kind = "ModelProperty";
   type!: MutationFor<TCustomMutations, Type["kind"]>;
 
-  mutate(newOptions: MutationOptions = this.options) {
-    this.type = this.engine.mutateReference(
-      this.sourceType,
-      newOptions,
-      this.startTypeEdge(),
-    ) as MutationFor<TCustomMutations, Type["kind"]>;
+  /**
+   * Mutates this model property.
+   *
+   * @param newOptions - Mutation options to apply. Defaults to the current options.
+   * @param typeOverride - When provided, the property's type edge is wired to this explicit
+   *   type instead of the source property's type. Uses `engine.replaceAndMutateReference()`
+   *   internally, which bypasses normal reference-chain resolution. This is an additive
+   *   escape hatch for callers that need to redirect a single edge without overriding
+   *   `buildTypeEdges()`. For multi-subgraph routing, prefer overriding `buildTypeEdges()`.
+   */
+  mutate(newOptions: MutationOptions = this.options, typeOverride?: Type) {
+    if (typeOverride) {
+      this.type = this.engine.replaceAndMutateReference(
+        this.sourceType,
+        typeOverride,
+        newOptions,
+        this.startTypeEdge(),
+      ) as MutationFor<TCustomMutations, Type["kind"]>;
+      return;
+    }
+
+    const edges = this.buildTypeEdges();
+    for (let i = 0; i < edges.length; i++) {
+      const { typeToFollow, referenceToFollow, halfEdge } = edges[i];
+      if (referenceToFollow !== undefined) {
+        const mut = this.engine.mutateReference(
+          referenceToFollow as MemberType,
+          newOptions,
+          halfEdge,
+        );
+        if (i === 0) {
+          this.type = mut as unknown as MutationFor<TCustomMutations, Type["kind"]>;
+        }
+      } else {
+        const mut = this.engine.mutate(typeToFollow!, newOptions, halfEdge);
+        if (i === 0) {
+          this.type = mut as unknown as MutationFor<TCustomMutations, Type["kind"]>;
+        }
+      }
+    }
   }
 
-  protected abstract startTypeEdge(): MutationHalfEdge;
+  /**
+   * Returns the type edge specifications for this property mutation.
+   *
+   * Override this method to emit multiple edge specs — one per subgraph — when the
+   * property must wire its type edge differently in each subgraph (e.g. ARM vs client).
+   * Each spec identifies:
+   *   - `typeToFollow`: an explicit type to mutate directly (uses `engine.mutate()`), or
+   *   - `referenceToFollow`: a MemberType to resolve via the reference chain (uses
+   *     `engine.mutateReference()`, preserving `referenceTypes` context).
+   *   - `halfEdge`: the half-edge that wires the connection when the tail is resolved.
+   *
+   * The default implementation returns a single spec that follows the source property's
+   * reference chain, which preserves the existing single-subgraph behavior.
+   */
+  protected buildTypeEdges(): TypeEdgeSpec[] {
+    return [
+      {
+        referenceToFollow: this.sourceType,
+        halfEdge: this.startTypeEdge(),
+      },
+    ];
+  }
+
+  /**
+   * Returns a half-edge for the property's type connection.
+   *
+   * Override this for single-subgraph cases. For multi-subgraph cases (where the
+   * property needs independent type edges per subgraph), override `buildTypeEdges()`
+   * instead and return one spec per subgraph. If `buildTypeEdges()` is overridden
+   * without also overriding `startTypeEdge()`, this method will throw.
+   */
+  protected startTypeEdge(): MutationHalfEdge {
+    throw new Error(
+      "ModelPropertyMutation: either override startTypeEdge() for single-subgraph " +
+        "mutations, or override buildTypeEdges() for multi-subgraph mutations.",
+    );
+  }
 }

--- a/packages/mutator-framework/src/mutation/model-property.ts
+++ b/packages/mutator-framework/src/mutation/model-property.ts
@@ -21,20 +21,29 @@ export abstract class ModelPropertyMutation<
    * Mutates this model property.
    *
    * @param newOptions - Mutation options to apply. Defaults to the current options.
-   * @param typeOverride - When provided, the property's type edge is wired to this explicit
-   *   type instead of the source property's type. Uses `engine.replaceAndMutateReference()`
-   *   internally, which bypasses normal reference-chain resolution. This is an additive
-   *   escape hatch for callers that need to redirect a single edge without overriding
-   *   `buildTypeEdges()`. For multi-subgraph routing, prefer overriding `buildTypeEdges()`.
+   * @param typeOverride - When provided, this single edge spec replaces the entire
+   *   `buildTypeEdges()` result, allowing callers to redirect the type edge as a
+   *   self-contained codec — including the half-edge — without subclassing. Use
+   *   `referenceToFollow` to preserve reference-chain context, or `typeToFollow`
+   *   to mutate an explicit type directly. For multi-subgraph routing prefer
+   *   overriding `buildTypeEdges()` instead.
    */
-  mutate(newOptions: MutationOptions = this.options, typeOverride?: Type) {
+  mutate(newOptions: MutationOptions = this.options, typeOverride?: TypeEdgeSpec) {
     if (typeOverride) {
-      this.type = this.engine.replaceAndMutateReference(
-        this.sourceType,
-        typeOverride,
-        newOptions,
-        this.startTypeEdge(),
-      ) as MutationFor<TCustomMutations, Type["kind"]>;
+      const { typeToFollow, referenceToFollow, halfEdge } = typeOverride;
+      if (referenceToFollow !== undefined) {
+        this.type = this.engine.mutateReference(
+          referenceToFollow as MemberType,
+          newOptions,
+          halfEdge,
+        ) as unknown as MutationFor<TCustomMutations, Type["kind"]>;
+      } else {
+        this.type = this.engine.mutate(
+          typeToFollow!,
+          newOptions,
+          halfEdge,
+        ) as unknown as MutationFor<TCustomMutations, Type["kind"]>;
+      }
       return;
     }
 

--- a/packages/mutator-framework/src/mutation/model-property.ts
+++ b/packages/mutator-framework/src/mutation/model-property.ts
@@ -21,29 +21,20 @@ export abstract class ModelPropertyMutation<
    * Mutates this model property.
    *
    * @param newOptions - Mutation options to apply. Defaults to the current options.
-   * @param typeOverride - When provided, this single edge spec replaces the entire
-   *   `buildTypeEdges()` result, allowing callers to redirect the type edge as a
-   *   self-contained codec — including the half-edge — without subclassing. Use
-   *   `referenceToFollow` to preserve reference-chain context, or `typeToFollow`
-   *   to mutate an explicit type directly. For multi-subgraph routing prefer
-   *   overriding `buildTypeEdges()` instead.
+   * @param typeOverride - When provided, the property's type edge is wired to this explicit
+   *   type instead of the source property's type. Uses `engine.replaceAndMutateReference()`
+   *   internally, which bypasses normal reference-chain resolution. This is an additive
+   *   escape hatch for callers that need to redirect a single edge without overriding
+   *   `buildTypeEdges()`. For multi-subgraph routing, prefer overriding `buildTypeEdges()`.
    */
-  mutate(newOptions: MutationOptions = this.options, typeOverride?: TypeEdgeSpec) {
+  mutate(newOptions: MutationOptions = this.options, typeOverride?: Type) {
     if (typeOverride) {
-      const { typeToFollow, referenceToFollow, halfEdge } = typeOverride;
-      if (referenceToFollow !== undefined) {
-        this.type = this.engine.mutateReference(
-          referenceToFollow as MemberType,
-          newOptions,
-          halfEdge,
-        ) as unknown as MutationFor<TCustomMutations, Type["kind"]>;
-      } else {
-        this.type = this.engine.mutate(
-          typeToFollow!,
-          newOptions,
-          halfEdge,
-        ) as unknown as MutationFor<TCustomMutations, Type["kind"]>;
-      }
+      this.type = this.engine.replaceAndMutateReference(
+        this.sourceType,
+        typeOverride,
+        newOptions,
+        this.startTypeEdge(),
+      ) as MutationFor<TCustomMutations, Type["kind"]>;
       return;
     }
 

--- a/packages/mutator-framework/src/mutation/mutation-engine.ts
+++ b/packages/mutator-framework/src/mutation/mutation-engine.ts
@@ -296,6 +296,31 @@ export class MutationOptions {
 }
 
 /**
+ * Specifies a type edge to create during mutation of a ModelProperty.
+ * Exactly one of `typeToFollow` or `referenceToFollow` must be provided.
+ *
+ * - Use `typeToFollow` when you need to explicitly control which type is followed,
+ *   such as in multi-subgraph scenarios where each subgraph may follow a different type.
+ *   The type is mutated directly via `engine.mutate()`.
+ * - Use `referenceToFollow` to resolve a MemberType via the standard reference chain,
+ *   which preserves the `referenceTypes` context passed to `mutationInfo` overrides.
+ */
+export interface TypeEdgeSpec {
+  /**
+   * The type whose canonicalization to connect as the tail.
+   * Mutated directly via `engine.mutate()` without reference-chain resolution.
+   */
+  typeToFollow?: Type;
+  /**
+   * A MemberType reference to resolve via the standard reference chain.
+   * Mutated via `engine.mutateReference()`, preserving `referenceTypes` context.
+   */
+  referenceToFollow?: MemberType;
+  /** Half-edge that wires the connection when the tail mutation is resolved. */
+  halfEdge: MutationHalfEdge;
+}
+
+/**
  * Half-edge used to link mutations together. This represents the head-end of a
  * mutation. When the tail is created, it is set on the half-edge and allows the
  * head mutation to connect its nodes to the tail mutation.


### PR DESCRIPTION
## Summary

Extends `ModelPropertyMutation` with multi-subgraph support and fixes TypeScript 6 type cast errors that were breaking the monorepo build.

### Changes

**`mutation-engine.ts`**
- Add new `TypeEdgeSpec` interface for specifying type edges during `ModelProperty` mutation. Supports either a `typeToFollow` (direct mutate) or `referenceToFollow` (reference-chain resolution via `mutateReference()`).

**`model-property.ts`**
- Add optional `typeOverride` parameter to `mutate()` — an escape hatch to redirect the type edge to an explicit type without overriding `buildTypeEdges()`.
- Add `buildTypeEdges()` override point for multi-subgraph scenarios where a property needs independent type edges per subgraph.
- Make `startTypeEdge()` non-abstract with a descriptive error message (throw if neither override is provided).
- Fix TypeScript 6 type cast errors by using intermediate `unknown` casts (`as unknown as MutationFor<...>`).

**`mutation-node.ts`**
- Improve JSDoc for `replace()` to clarify when to use `replace()` vs `mutate()` and prevent misuse.

### Usage example

```ts
// Override buildTypeEdges() to wire independent type edges per subgraph
class MyPropertyMutation extends ModelPropertyMutation<MyMutations, MyOptions> {
  protected buildTypeEdges(): TypeEdgeSpec[] {
    return [
      { referenceToFollow: this.sourceType, halfEdge: this.subgraphAEdge() },
      { typeToFollow: myExplicitType, halfEdge: this.subgraphBEdge() },
    ];
  }
}
```
