### PR TITLE
playground: add http-server-js to the playground

### DIFF
--- a/.chronus/changes/hsjs-playground-2026-4-14-16-27-10.md
+++ b/.chronus/changes/hsjs-playground-2026-4-14-16-27-10.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-server-js"
+---
+
+Changed how http-server-js computes file paths and invokes prettier to make it compatible with the playground website.

--- a/eng/tsp-core/scripts/upload-bundler-packages.js
+++ b/eng/tsp-core/scripts/upload-bundler-packages.js
@@ -23,5 +23,6 @@ await bundleAndUploadPackages({
     "@typespec/sse",
     "@typespec/xml",
     "@typespec/http-client-js",
+    "@typespec/http-server-js",
   ],
 });

--- a/packages/http-server-js/src/index.ts
+++ b/packages/http-server-js/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // Licensed under the MIT license.
 
-import { EmitContext } from "@typespec/compiler";
+import { EmitContext, joinPaths } from "@typespec/compiler";
 import { visitAllTypes } from "./common/namespace.js";
 import { createInitialContext } from "./ctx.js";
 import { JsEmitterOptions } from "./lib.js";
@@ -9,7 +9,6 @@ import { writeModuleTree } from "./write.js";
 
 // #region features
 
-import path from "node:path";
 import { emitSerialization } from "./common/serialization/index.js";
 import { emitHttp } from "./http/index.js";
 
@@ -34,7 +33,7 @@ export async function $onEmit(context: EmitContext<JsEmitterOptions>) {
   // Emit serialization code for all required types.
   emitSerialization(jsCtx);
 
-  const srcGeneratedPath = path.join(context.emitterOutputDir, "src", "generated");
+  const srcGeneratedPath = joinPaths(context.emitterOutputDir, "src", "generated");
 
   if (!context.program.compilerOptions.dryRun) {
     try {

--- a/packages/http-server-js/src/write.ts
+++ b/packages/http-server-js/src/write.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation
 // Licensed under the MIT license.
 
-import { resolvePath } from "@typespec/compiler";
+import { getDirectoryPath, resolvePath } from "@typespec/compiler";
 import { JsContext, Module, isModule } from "./ctx.js";
 
 import { emitModuleBody } from "./common/namespace.js";
 import { OnceQueue, createOnceQueue } from "./util/once-queue.js";
 
-import * as prettier from "prettier";
+import estreePlugin from "prettier/plugins/estree";
+import tsPlugin from "prettier/plugins/typescript";
+import { format as prettierFormat } from "prettier/standalone";
 
-import { EOL } from "os";
-import path from "path";
 import { bifilter } from "./util/iter.js";
 
 /**
@@ -52,7 +52,7 @@ export async function writeModuleFile(
   queue: OnceQueue<Module>,
   format: boolean,
   spit: (path: string, contents: string) => Promise<void> = async (name, contents) => {
-    await ctx.program.host.mkdirp(path.dirname(name));
+    await ctx.program.host.mkdirp(getDirectoryPath(name));
     await ctx.program.host.writeFile(name, contents);
   },
 ): Promise<void> {
@@ -79,10 +79,11 @@ export async function writeModuleFile(
   const modulePath = resolvePath(baseOutputPath, moduleRelativePath);
 
   const text = format
-    ? await prettier.format(moduleText.join(EOL), {
+    ? await prettierFormat(moduleText.join("\n"), {
         parser: "typescript",
+        plugins: [tsPlugin, estreePlugin],
       })
-    : moduleText.join(EOL);
+    : moduleText.join("\n");
 
   await spit(modulePath, text);
 }

--- a/packages/playground-website/package.json
+++ b/packages/playground-website/package.json
@@ -60,6 +60,7 @@
     "@typespec/html-program-viewer": "workspace:^",
     "@typespec/http": "workspace:^",
     "@typespec/http-client-js": "workspace:^",
+    "@typespec/http-server-js": "workspace:^",
     "@typespec/json-schema": "workspace:^",
     "@typespec/openapi": "workspace:^",
     "@typespec/openapi3": "workspace:^",

--- a/packages/playground-website/src/config.ts
+++ b/packages/playground-website/src/config.ts
@@ -16,6 +16,7 @@ export const TypeSpecPlaygroundConfig = {
     "@typespec/sse",
     "@typespec/xml",
     "@typespec/http-client-js",
+    "@typespec/http-server-js",
   ],
   samples,
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1979,6 +1979,9 @@ importers:
       '@typespec/http-client-js':
         specifier: workspace:^
         version: link:../http-client-js
+      '@typespec/http-server-js':
+        specifier: workspace:^
+        version: link:../http-server-js
       '@typespec/json-schema':
         specifier: workspace:^
         version: link:../json-schema


### PR DESCRIPTION
Does what's written in the title:

- Removes emitter dependencies on node builtins (path.join, os.EOL, path.dirname).
- Adds HSJS to the playground dependencies and configuration.
- Fixes how HSJS calls prettier so that it explicitly loads the estree/typescript plugins.