### PR TITLE
fix(http-client-csharp): treat nullable and non-nullable return types as distinct in conversion-operator dedup

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/MethodSignatureBase.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/MethodSignatureBase.cs
@@ -129,10 +129,14 @@ namespace Microsoft.TypeSpec.Generator.Primitives
                         return false;
                     }
 
-                    // For operators, the return type is crucial for matching
+                    // For operators, the return type is crucial for matching.
+                    // Nullability is part of the conversion-operator signature in C#
+                    // (e.g., `implicit operator T(string)` and `implicit operator T?(string)`
+                    // are distinct), so we compare both the type name and the nullability.
                     if (x.ReturnType != null && y.ReturnType != null)
                     {
-                        if (!x.ReturnType.AreNamesEqual(y.ReturnType))
+                        if (!x.ReturnType.AreNamesEqual(y.ReturnType)
+                            || x.ReturnType.IsNullable != y.ReturnType.IsNullable)
                         {
                             return false;
                         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Primitives/MethodSignatureComparerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Primitives/MethodSignatureComparerTests.cs
@@ -97,6 +97,24 @@ namespace Microsoft.TypeSpec.Generator.Tests.Primitives
 
             Assert.IsFalse(MethodSignatureBase.SignatureComparer.Equals(implicitOp, explicitOp));
         }
+
+        // Conversion operators returning a nullable type and its non-nullable counterpart
+        // must NOT be considered equal — `implicit operator T(string)` and
+        // `implicit operator T?(string)` are distinct C# operators.
+        [Test]
+        public void ImplicitConversionOperators_NullableAndNonNullableReturnTypes_AreNotEqual()
+        {
+            var enumType = new CSharpType(typeof(int));
+            var nullableEnumType = enumType.WithNullable(true);
+            var valueParam = new ParameterProvider("value", $"value", typeof(string));
+            var modifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static | MethodSignatureModifiers.Implicit | MethodSignatureModifiers.Operator;
+
+            var nonNullable = new MethodSignature(string.Empty, null, modifiers, enumType, null, [valueParam]);
+            var nullable = new MethodSignature(string.Empty, null, modifiers, nullableEnumType, null, [valueParam]);
+
+            Assert.IsFalse(MethodSignatureBase.SignatureComparer.Equals(nonNullable, nullable));
+            Assert.IsFalse(MethodSignatureBase.SignatureComparer.Equals(nullable, nonNullable));
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #10705

The operator-dedup path added in #10639 uses `CSharpType.AreNamesEqual` to compare conversion-operator return types. `AreNamesEqual` only compares the type `Name`/`FullyQualifiedName` and the generic `Arguments` list — it never reads `IsNullable`. Because the `CSharpType` constructor explicitly unwraps `Nullable<T>` for value types and stores nullability on a separate flag, `T` and `T?` produce identical results from `AreNamesEqual`.

The practical effect (seen in azure-sdk-for-net PR [#59283](https://github.com/Azure/azure-sdk-for-net/pull/59283)): a customization partial that declares `implicit operator T(string)` causes the dedup comparer to drop **both** the matching generated operator **and** the generated `implicit operator T?(string)`. When those were the only members in the generated partial, the file is emitted empty and the writer drops it — silently removing the nullable conversion operator from the SDK's public surface.

### Change

In `MethodSignatureBaseEqualityComparer.Equals` (operator branch) compare `ReturnType.IsNullable` alongside `AreNamesEqual`. Conversion operators returning `T` and `T?` are now correctly treated as distinct.

### Tests

Added `ImplicitConversionOperators_NullableAndNonNullableReturnTypes_AreNotEqual` to `MethodSignatureComparerTests`. All 290 tests in the affected suites pass.
