### PR TITLE
Patch stale @typespec/openapi3 in target emitter-package.json before tsp-client run

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -385,31 +385,21 @@ try {
             Write-Host "No .npmrc file found - tsp-client will use default npm registry"
         }
 
-        # Patch any leftover @typespec/openapi3 devDependency in the existing target
-        # emitter-package.json so its version matches the source emitter's pinned
-        # @typespec/openapi version. tsp-client generate-config-files preserves
-        # unknown devDependencies, and a stale @typespec/openapi3 (with a peerOptional
-        # on an older @typespec/streams) can break tsp-client's internal npm install
-        # with ERESOLVE once the new compiler/http/streams versions are merged in.
+        # Align any leftover @typespec/openapi3 in the target emitter-package.json with
+        # the source emitter's @typespec/openapi version. tsp-client generate-config-files
+        # preserves unknown devDependencies, so a stale @typespec/openapi3 (peerOptional
+        # @typespec/streams ^X.Y.0) breaks the internal npm install with ERESOLVE once
+        # the source bumps the typespec family.
         if (Test-Path $emitterPackageJsonPath) {
             try {
-                $targetEmitterJson = Get-Content $emitterPackageJsonPath -Raw | ConvertFrom-Json -AsHashtable
-                $sourcePackageJson = Get-Content $TypeSpecSourcePackageJsonPath -Raw | ConvertFrom-Json -AsHashtable
-
-                $sourceOpenApiVersion = $null
-                if ($sourcePackageJson.ContainsKey("devDependencies") -and $sourcePackageJson["devDependencies"].ContainsKey("@typespec/openapi")) {
-                    $sourceOpenApiVersion = $sourcePackageJson["devDependencies"]["@typespec/openapi"]
-                }
-
-                if ($sourceOpenApiVersion -and $targetEmitterJson.ContainsKey("devDependencies") -and $targetEmitterJson["devDependencies"].ContainsKey("@typespec/openapi3")) {
-                    $oldOpenApi3Version = $targetEmitterJson["devDependencies"]["@typespec/openapi3"]
-                    if ($oldOpenApi3Version -ne $sourceOpenApiVersion) {
-                        Write-Host "Patching @typespec/openapi3 in $emitterPackageJsonPath : $oldOpenApi3Version -> $sourceOpenApiVersion (matching source @typespec/openapi)"
-                        $targetEmitterJson["devDependencies"]["@typespec/openapi3"] = $sourceOpenApiVersion
-                        ($targetEmitterJson | ConvertTo-Json -Depth 100) | Set-Content -Path $emitterPackageJsonPath -NoNewline
-                    } else {
-                        Write-Host "@typespec/openapi3 in target emitter-package.json already matches source @typespec/openapi ($sourceOpenApiVersion); no patch needed."
-                    }
+                $target = Get-Content $emitterPackageJsonPath -Raw | ConvertFrom-Json -AsHashtable
+                $source = Get-Content $TypeSpecSourcePackageJsonPath -Raw | ConvertFrom-Json -AsHashtable
+                $newVersion = $source.devDependencies.'@typespec/openapi'
+                $oldVersion = $target.devDependencies.'@typespec/openapi3'
+                if ($newVersion -and $oldVersion -and $oldVersion -ne $newVersion) {
+                    Write-Host "Patching @typespec/openapi3 in target emitter-package.json: $oldVersion -> $newVersion"
+                    $target.devDependencies.'@typespec/openapi3' = $newVersion
+                    ($target | ConvertTo-Json -Depth 100) | Set-Content -Path $emitterPackageJsonPath -NoNewline
                 }
             } catch {
                 Write-Warning "Failed to patch @typespec/openapi3 in target emitter-package.json: $_"

--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -385,6 +385,37 @@ try {
             Write-Host "No .npmrc file found - tsp-client will use default npm registry"
         }
 
+        # Patch any leftover @typespec/openapi3 devDependency in the existing target
+        # emitter-package.json so its version matches the source emitter's pinned
+        # @typespec/openapi version. tsp-client generate-config-files preserves
+        # unknown devDependencies, and a stale @typespec/openapi3 (with a peerOptional
+        # on an older @typespec/streams) can break tsp-client's internal npm install
+        # with ERESOLVE once the new compiler/http/streams versions are merged in.
+        if (Test-Path $emitterPackageJsonPath) {
+            try {
+                $targetEmitterJson = Get-Content $emitterPackageJsonPath -Raw | ConvertFrom-Json -AsHashtable
+                $sourcePackageJson = Get-Content $TypeSpecSourcePackageJsonPath -Raw | ConvertFrom-Json -AsHashtable
+
+                $sourceOpenApiVersion = $null
+                if ($sourcePackageJson.ContainsKey("devDependencies") -and $sourcePackageJson["devDependencies"].ContainsKey("@typespec/openapi")) {
+                    $sourceOpenApiVersion = $sourcePackageJson["devDependencies"]["@typespec/openapi"]
+                }
+
+                if ($sourceOpenApiVersion -and $targetEmitterJson.ContainsKey("devDependencies") -and $targetEmitterJson["devDependencies"].ContainsKey("@typespec/openapi3")) {
+                    $oldOpenApi3Version = $targetEmitterJson["devDependencies"]["@typespec/openapi3"]
+                    if ($oldOpenApi3Version -ne $sourceOpenApiVersion) {
+                        Write-Host "Patching @typespec/openapi3 in $emitterPackageJsonPath : $oldOpenApi3Version -> $sourceOpenApiVersion (matching source @typespec/openapi)"
+                        $targetEmitterJson["devDependencies"]["@typespec/openapi3"] = $sourceOpenApiVersion
+                        ($targetEmitterJson | ConvertTo-Json -Depth 100) | Set-Content -Path $emitterPackageJsonPath -NoNewline
+                    } else {
+                        Write-Host "@typespec/openapi3 in target emitter-package.json already matches source @typespec/openapi ($sourceOpenApiVersion); no patch needed."
+                    }
+                }
+            } catch {
+                Write-Warning "Failed to patch @typespec/openapi3 in target emitter-package.json: $_"
+            }
+        }
+
         try {
             Invoke "tsp-client generate-config-files --package-json $TypeSpecSourcePackageJsonPath --emitter-package-json-path $emitterPackageJsonPath --output-dir $configFilesOutputDir" $tempDir
             if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Why

`tsp-client generate-config-files` merges the source emitter's pinned peerDeps (compiler, http, openapi, rest, sse, streams, versioning, tcgc) into the existing target `emitter-package.json` but **preserves any other devDependencies** at their existing versions.

The current target `eng/http-client-csharp-emitter-package.json` in azure-sdk-for-net has `@typespec/openapi3@1.11.0` left over from a previous regen. When the new source pins typespec to `1.12.0`/`0.82.0`, that leftover `@typespec/openapi3@1.11.0` (whose peerOptional is `@typespec/streams@^0.81.0`) conflicts with the freshly pinned `@typespec/streams@0.82.0`, causing tsp-client's internal `npm install` to fail with ERESOLVE:

```
npm error ERESOLVE unable to resolve dependency tree
npm error Found: @typespec/streams@0.82.0
npm error   peerOptional @typespec/streams@"^0.82.0" from @typespec/http@1.12.0
npm error Could not resolve dependency:
npm error   peerOptional @typespec/streams@"^0.81.0" from @typespec/openapi3@1.11.0
```

## What

In `Submit-AzureSdkForNetPr.ps1`, right before invoking `tsp-client generate-config-files`:

1. Read the existing target `http-client-csharp-emitter-package.json`.
2. If it has a `devDependencies["@typespec/openapi3"]` entry, look up the source emitter's `devDependencies["@typespec/openapi"]` version.
3. Set the target's `@typespec/openapi3` to that same version and write it back.
4. Log the old → new transition.
5. Silently skip if either side is missing.

Notes:
- Uses `ConvertFrom-Json -AsHashtable` to round-trip without dropping unknown fields.
- Does **not** add `@typespec/openapi3` if it isn't already present — only fixes stale entries.
- Scoped strictly to `@typespec/openapi3`; not broadened to the `@azure-tools/typespec-azure-*` family.
- Wrapped in try/catch so a malformed JSON won't abort the whole submit script.
