### PR TITLE
Enable Application Insights instrumentation in csharp playground-server

### DIFF
--- a/packages/http-client-csharp/playground-server/Program.cs
+++ b/packages/http-client-csharp/playground-server/Program.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.RateLimiting;
 
 const int MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB
@@ -34,6 +36,16 @@ if (!string.IsNullOrEmpty(playgroundUrls))
         }
     }
 }
+
+// Application Insights instrumentation. The SDK reads the connection string from the
+// APPLICATIONINSIGHTS_CONNECTION_STRING environment variable (or ApplicationInsights:ConnectionString
+// configuration value). When neither is set, telemetry is silently dropped.
+builder.Services.AddApplicationInsightsTelemetry();
+var appInsightsConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")
+    ?? builder.Configuration["ApplicationInsights:ConnectionString"];
+Console.WriteLine(string.IsNullOrWhiteSpace(appInsightsConnectionString)
+    ? "Application Insights connection string not set; telemetry disabled."
+    : "Application Insights telemetry enabled.");
 
 builder.Services.AddCors();
 builder.Services.AddRateLimiter(options =>
@@ -110,11 +122,27 @@ app.MapGet("/health", () =>
     });
 });
 
-app.MapPost("/generate", async (HttpRequest request) =>
+app.MapPost("/generate", async (HttpRequest request, TelemetryClient? telemetryClient) =>
 {
+    var stopwatch = Stopwatch.StartNew();
+    var telemetryProperties = new Dictionary<string, string>();
+
+    void TrackGenerateEvent(string outcome)
+    {
+        if (telemetryClient is null) return;
+        stopwatch.Stop();
+        telemetryProperties["outcome"] = outcome;
+        telemetryProperties["durationMs"] = stopwatch.Elapsed.TotalMilliseconds.ToString("F0", System.Globalization.CultureInfo.InvariantCulture);
+        var evt = new EventTelemetry("PlaygroundGenerate");
+        foreach (var kvp in telemetryProperties) evt.Properties[kvp.Key] = kvp.Value;
+        telemetryClient.TrackEvent(evt);
+        telemetryClient.GetMetric("PlaygroundGenerateDurationMs", "outcome").TrackValue(stopwatch.Elapsed.TotalMilliseconds, outcome);
+    }
+
     // Validate content type
     if (!request.ContentType?.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) ?? true)
     {
+        TrackGenerateEvent("invalid_content_type");
         return Results.BadRequest(new { error = "Content-Type must be application/json" });
     }
 
@@ -126,18 +154,23 @@ app.MapPost("/generate", async (HttpRequest request) =>
     }
     catch (JsonException)
     {
+        TrackGenerateEvent("invalid_json");
         return Results.BadRequest(new { error = "Invalid JSON in request body" });
     }
 
     if (body?.CodeModel is null || body?.Configuration is null)
     {
+        TrackGenerateEvent("missing_fields");
         return Results.BadRequest(new { error = "Missing 'codeModel' or 'configuration' fields" });
     }
 
     var generatorName = body.GeneratorName ?? "ScmCodeModelGenerator";
+    telemetryProperties["generatorName"] = generatorName;
+    telemetryProperties["codeModelSizeBytes"] = body.CodeModel.Length.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
     if (!File.Exists(generatorPath))
     {
+        TrackGenerateEvent("generator_missing");
         return Results.StatusCode(503);
     }
 
@@ -197,6 +230,7 @@ app.MapPost("/generate", async (HttpRequest request) =>
         catch (OperationCanceledException)
         {
             process.Kill(entireProcessTree: true);
+            TrackGenerateEvent("timeout");
             return Results.Json(
                 new GenerateErrorResponse("Generator timed out", $"Process did not complete within {GeneratorTimeoutSeconds} seconds"),
                 GenerateJsonContext.Default.GenerateErrorResponse,
@@ -206,11 +240,18 @@ app.MapPost("/generate", async (HttpRequest request) =>
 
         var exitCode = process.ExitCode;
         Console.WriteLine($"Generator exited with code {exitCode}");
+        telemetryProperties["exitCode"] = exitCode.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
         if (exitCode != 0)
         {
+            var stderrTail = string.Join("\n", stderrLines.TakeLast(50));
+            telemetryClient?.TrackTrace(
+                $"Generator failed (exit {exitCode}): {stderrTail}",
+                SeverityLevel.Error,
+                telemetryProperties);
+            TrackGenerateEvent("generator_failed");
             return Results.Json(
-                new GenerateErrorResponse($"Generator failed with exit code {exitCode}", string.Join("\n", stderrLines.TakeLast(50))),
+                new GenerateErrorResponse($"Generator failed with exit code {exitCode}", stderrTail),
                 GenerateJsonContext.Default.GenerateErrorResponse,
                 statusCode: 500);
         }
@@ -232,9 +273,22 @@ app.MapPost("/generate", async (HttpRequest request) =>
             }
         }
 
+        telemetryProperties["generatedFileCount"] = files.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        TrackGenerateEvent("success");
         return Results.Json(
             new GenerateResponse(files),
             GenerateJsonContext.Default.GenerateResponse);
+    }
+    catch (Exception ex)
+    {
+        if (telemetryClient is not null)
+        {
+            var exTelemetry = new ExceptionTelemetry(ex);
+            foreach (var kvp in telemetryProperties) exTelemetry.Properties[kvp.Key] = kvp.Value;
+            telemetryClient.TrackException(exTelemetry);
+        }
+        TrackGenerateEvent("exception");
+        throw;
     }
     finally
     {

--- a/packages/http-client-csharp/playground-server/playground-server.csproj
+++ b/packages/http-client-csharp/playground-server/playground-server.csproj
@@ -7,4 +7,8 @@
     <RootNamespace>PlaygroundServer</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Wires Application Insights telemetry into `packages/http-client-csharp/playground-server` so we can observe the `csharp-playground-server` App Service in production.

## Changes

- Add `Microsoft.ApplicationInsights.AspNetCore` (3.1.1) package reference.
- Register the SDK unconditionally in `Program.cs`. The connection string is read from the standard `APPLICATIONINSIGHTS_CONNECTION_STRING` env var (or the `ApplicationInsights:ConnectionString` config key); when neither is set the SDK is a no-op and startup logs `Application Insights telemetry disabled.`.
- Instrument the `/generate` endpoint with a `PlaygroundGenerate` custom event tagged with:
  - `outcome` — one of `success`, `generator_failed`, `timeout`, `exception`, `invalid_json`, `invalid_content_type`, `missing_fields`, `generator_missing`
  - `generatorName`, `codeModelSizeBytes`, `exitCode`, `generatedFileCount`, `durationMs`
- Track a `PlaygroundGenerateDurationMs` metric per outcome and report unhandled exceptions via `TrackException`.

Auto-collected request/dependency telemetry from the AspNetCore SDK is also enabled for free.

## Deployment

No pipeline changes required — the existing deploy step (`az webapp config container set`) just swaps the container image and leaves app settings alone. Telemetry only starts flowing once `APPLICATIONINSIGHTS_CONNECTION_STRING` is set on the `csharp-playground-server` App Service (one-time Azure config).