### PR TITLE
Fix Submit-AzureSdkForNetPr.ps1 push auth for GitHub App installation tokens

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -689,9 +689,10 @@ try {
         throw "Failed to commit changes"
     }
 
-    # Push the branch
+    # Push the branch. Use the x-access-token username scheme so the URL works
+    # both with classic PATs and with GitHub App installation tokens (ghs_*).
     Write-Host "Pushing branch to remote..."
-    $remoteUrl = "https://$AuthToken@github.com/$RepoOwner/$RepoName.git"
+    $remoteUrl = "https://x-access-token:$AuthToken@github.com/$RepoOwner/$RepoName.git"
     git push $remoteUrl $PRBranch
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to push branch"


### PR DESCRIPTION
## Why

#10594 transitioned the publish pipeline from a static PAT (`azuresdk-github-pat`) to a GitHub App installation token minted via `eng/common/scripts/login-to-github.ps1`. The token is then passed into `Submit-AzureSdkForNetPr.ps1` as `-AuthToken '$(GH_TOKEN)'`.

The script builds the push URL like this:

```powershell
$remoteUrl = "https://$AuthToken@github.com/$RepoOwner/$RepoName.git"
git push $remoteUrl $PRBranch
```

That bare-token form works with classic PATs (GitHub accepts username=PAT, empty password) but **fails with GitHub App installation tokens** (`ghs_*`). git treats the token as the username and prompts for a password, producing the failure observed in the latest pipeline run:

```
fatal: could not read Password for 'https://***@github.com': terminal prompts disabled
```

## Fix

Use the `x-access-token` username scheme, which is the documented form that works for **both** classic PATs and GitHub App installation tokens:

```powershell
$remoteUrl = "https://x-access-token:$AuthToken@github.com/$RepoOwner/$RepoName.git"
```

One-line change. No behavior difference for the previous PAT path.
