### PR TITLE
[python] update python emitter install with helpful 401 error output

### DIFF
--- a/.chronus/changes/cfs-error-message-2026-4-18-15-8-34.md
+++ b/.chronus/changes/cfs-error-message-2026-4-18-15-8-34.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-python"
+---
+
+When python emitter install fails due to 401 error, output informative instructions linking to resolution steps in the Python SDK's repo docs. 

--- a/packages/http-client-python/eng/scripts/setup/package_manager.py
+++ b/packages/http-client-python/eng/scripts/setup/package_manager.py
@@ -100,10 +100,20 @@ def install_packages(packages: list, venv_context=None, package_manager: str = N
 
     try:
         if cwd:
-            subprocess.check_call(install_cmd + packages, cwd=cwd)
+            result = subprocess.run(install_cmd + packages, cwd=cwd, capture_output=True, text=True)
         else:
-            subprocess.check_call(install_cmd + packages)
-    except subprocess.CalledProcessError as e:
+            result = subprocess.run(install_cmd + packages, capture_output=True, text=True)
+        if result.returncode != 0:
+            error_output = (result.stderr or "") + (result.stdout or "")
+            error_msg = f"Failed to install packages with {package_manager}: command exited with code {result.returncode}\n{error_output}"
+            if "401" in error_output or "Unauthorized" in error_output:
+                error_msg += (
+                    "\n\nReceived a 401 Unauthorized error from the Azure feed. "
+                    "A pip dependency may not yet be cached. To fix this, follow the authentication steps at: "
+                    "https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md#authentication-for-upstream-pull-through"
+                )
+            raise RuntimeError(error_msg)
+    except OSError as e:
         raise RuntimeError(f"Failed to install packages with {package_manager}: {e}")
 
 


### PR DESCRIPTION
closes https://github.com/Azure/azure-sdk-for-python/issues/46964 

Because the python emitter's `install.ts` may use `uv pip` to install packages, it can run into authentication errors if a package version isn't cached in our central feed service, which we now default to pulling from instead of PyPI (see https://github.com/Azure/azure-sdk-for-python/pull/46281 )

updates the error point to link to python repo's authentication docs