### PR TITLE
[http-client-csharp] Adopt Spector payload/head contentTypeHeaderInResponse scenario test

### DIFF
--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Head/HeadTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Payload/Head/HeadTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Payload.Head;
+
+namespace TestProjects.Spector.Tests.Http.Payload.Head
+{
+    public class HeadTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task ContentTypeHeaderInResponse() => Test(async (host) =>
+        {
+            var response = await new HeadClient(host, null).ContentTypeHeaderInResponseAsync();
+            var rawResponse = response.GetRawResponse();
+            Assert.AreEqual(200, rawResponse.Status);
+            Assert.IsTrue(rawResponse.Headers.TryGetValue("Content-Type", out string? contentType));
+            Assert.AreEqual("text/plain; charset=utf-8", contentType);
+            Assert.IsTrue(rawResponse.Headers.TryGetValue("x-ms-meta", out string? metadata));
+            Assert.AreEqual("hello", metadata);
+        });
+    }
+}

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\parameters\path\src\Parameters.Path.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\parameters\query\src\Parameters.Query.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\payload\content-negotiation\src\Payload.ContentNegotiation.csproj" />
+    <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\payload\head\src\Payload.Head.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\payload\json-merge-patch\src\Payload.JsonMergePatch.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\payload\media-type\src\Payload.MediaType.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\payload\multipart\src\Payload.MultiPart.csproj" />


### PR DESCRIPTION
## Summary

Adopt the `contentTypeHeaderInResponse` Spector scenario test for the `payload/head` spec. The generator already supports HEAD operations with response headers — this PR adds the missing test wiring.

## Changes

1. **Project reference** — Added `Payload.Head.csproj` reference to `Spector.Tests.csproj`
2. **Test class** — Added `HeadTests.cs` with a `[SpectorTest]` for the `ContentTypeHeaderInResponse` operation
3. **Changelog** — Internal change entry for `@typespec/http-client-csharp`

## Validation

- Build: 0 errors
- Stub tests: 1 discovered, 1 Skipped (expected for stubs)
- Real generator tests: 1 Passed against Spector mock server (HEAD returns 200 with Content-Type and x-ms-meta headers)

---

🤖 Created with JonathanCrd's copilot