### PR TITLE
http-client-java, support advanced-versioning on mixed-versions

### DIFF
--- a/.chronus/changes/http-client-java_support-advanced-versioning-on-mixed-2026-4-19-13-54-27.md
+++ b/.chronus/changes/http-client-java_support-advanced-versioning-on-mixed-2026-4-19-13-54-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-java"
+---
+
+Support advanced-versioning for mixed api-version client

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -171,6 +171,7 @@ import {
   InconsistentVersions,
   getFilteredApiVersions,
   getServiceApiVersions,
+  isStableApiVersionString,
 } from "./versioning-utils.js";
 const { isEqual } = pkg;
 
@@ -246,6 +247,7 @@ export class CodeModelBuilder {
   );
 
   // current apiVersion name to generate code
+  // it would be undefined, if mixed api-versions
   private apiVersion: string | undefined;
 
   public constructor(program1: Program, context: EmitContext<EmitterOptions>) {
@@ -706,7 +708,7 @@ export class CodeModelBuilder {
         this.program,
         this.apiVersion,
         versions,
-        this.options["service-version-exclude-preview"],
+        !(this.options["service-version-exclude-preview"] === false),
       )) {
         const apiVersion = new ApiVersion();
         apiVersion.version = version.value;
@@ -746,6 +748,7 @@ export class CodeModelBuilder {
     });
 
     const clientContext = new ClientContext(
+      this.program,
       baseUri,
       hostParameters,
       codeModelClient.globalParameters!,
@@ -753,6 +756,11 @@ export class CodeModelBuilder {
       versions === InconsistentVersions.MixedVersions
         ? InconsistentVersions.MixedVersions
         : codeModelClient.apiVersions,
+      this.codeModel.apiVersionMap === undefined
+        ? false
+        : Object.values(this.codeModel.apiVersionMap).every((version) =>
+            isStableApiVersionString(version),
+          ) && !(this.options["service-version-exclude-preview"] === false),
     );
 
     const enableSubclient: boolean = optionBoolean(this.options["enable-subclient"]) ?? false;
@@ -1454,7 +1462,11 @@ export class CodeModelBuilder {
         const addedOn = getAddedOnVersions(this.program, param.__raw);
         if (addedOn) {
           extensions = extensions ?? {};
-          extensions["x-ms-versioning-added"] = clientContext.getAddedVersions(addedOn);
+          extensions["x-ms-versioning-added"] = clientContext.getAddedVersions(
+            this.program,
+            param.__raw,
+            addedOn,
+          );
         }
       }
 

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -1463,7 +1463,6 @@ export class CodeModelBuilder {
         if (addedOn) {
           extensions = extensions ?? {};
           extensions["x-ms-versioning-added"] = clientContext.getAddedVersions(
-            this.program,
             param.__raw,
             addedOn,
           );

--- a/packages/http-client-java/emitter/src/models.ts
+++ b/packages/http-client-java/emitter/src/models.ts
@@ -1,25 +1,31 @@
 import { ApiVersions, Parameter } from "@autorest/codemodel";
-import { Operation } from "@typespec/compiler";
-import { Version } from "@typespec/versioning";
+import { ModelProperty, Namespace, Operation, Program } from "@typespec/compiler";
+import { findVersionedNamespace, getVersions, Version } from "@typespec/versioning";
 import {
+  getFilteredApiVersions,
   InconsistentVersions,
   isVersionEarlierThan,
   isVersionedByDate,
 } from "./versioning-utils.js";
 
 export class ClientContext {
+  program: Program;
   baseUri: string;
   hostParameters: Parameter[];
   globalParameters: Parameter[];
-  apiVersions?: string[] | InconsistentVersions.MixedVersions;
+  apiVersions: string[] | InconsistentVersions.MixedVersions | undefined;
+  excludePreview: boolean;
   ignoredOperations: Set<Operation>;
 
   constructor(
+    program: Program,
     baseUri: string,
     hostParameters: Parameter[],
     globalParameters: Parameter[],
-    apiVersions?: ApiVersions | InconsistentVersions.MixedVersions,
+    apiVersions: ApiVersions | InconsistentVersions.MixedVersions | undefined,
+    excludePreview: boolean,
   ) {
+    this.program = program;
     this.baseUri = baseUri;
     this.hostParameters = hostParameters;
     this.globalParameters = globalParameters;
@@ -27,6 +33,7 @@ export class ClientContext {
       apiVersions === InconsistentVersions.MixedVersions
         ? InconsistentVersions.MixedVersions
         : apiVersions?.map((it) => it.version);
+    this.excludePreview = excludePreview;
     this.ignoredOperations = new Set<Operation>();
   }
 
@@ -41,18 +48,21 @@ export class ClientContext {
     }
   }
 
-  getAddedVersions(versions: Version[]): string[] | undefined {
+  getAddedVersions(property: ModelProperty | undefined, versions: Version[]): string[] | undefined {
+    let serviceApiVersions: string[] | undefined;
     if (this.apiVersions === InconsistentVersions.MixedVersions) {
-      // TODO: handle mixed versions scenario
-      return undefined;
+      // retrieve and filter api-versions for the service namespace of this model property
+      serviceApiVersions = this.getFilteredApiVersionsForProperty(property);
+    } else {
+      serviceApiVersions = this.apiVersions;
     }
 
     // currently only allow one added version
     const addedVersions: string[] = [];
     const addedVersion = versions.shift()!.value;
-    if (this.apiVersions) {
+    if (serviceApiVersions) {
       let includeVersion = false;
-      for (const version of this.apiVersions) {
+      for (const version of serviceApiVersions) {
         if (version === addedVersion) {
           includeVersion = true;
         }
@@ -63,8 +73,9 @@ export class ClientContext {
 
       if (addedVersions.length === 0 && isVersionedByDate(addedVersion)) {
         // try again with versioning by YYYY-MM-DD(-preview)
+        // this logic is for the scenario that the client has api-versions like "2020-01-01", "2021-01-01" and the addedVersion is "2020-09-01-preview", which is excluded due to it being a preview
         let includeVersion = false;
-        for (const version of this.apiVersions) {
+        for (const version of serviceApiVersions) {
           if (isVersionedByDate(version) && isVersionEarlierThan(addedVersion, version)) {
             includeVersion = true;
           }
@@ -78,11 +89,35 @@ export class ClientContext {
     if (addedVersions.length === 0) {
       // could not find matching version in client apiVersions
       return undefined;
-    } else if (addedVersions.length === this.apiVersions?.length) {
+    } else if (addedVersions.length === serviceApiVersions?.length) {
       // it is added in the 1st api-version, this is the default scenario, no need to specify addedVersions
       return undefined;
     } else {
       return addedVersions;
     }
+  }
+
+  // this method is only used when the client has mixed api-versions
+  // in this scenario, targetApiVersion is just the latest api-version of the service namespace
+  getFilteredApiVersionsForProperty(property: ModelProperty | undefined): string[] | undefined {
+    if (property && property.model && property.model.namespace) {
+      const versionedNamespace: Namespace | undefined = findVersionedNamespace(
+        this.program,
+        property.model.namespace,
+      );
+      if (versionedNamespace) {
+        const versions =
+          getVersions(this.program, versionedNamespace)[1]?.getVersions() ?? undefined;
+        if (versions) {
+          return getFilteredApiVersions(
+            this.program,
+            versions[versions.length - 1].value,
+            versions,
+            this.excludePreview,
+          ).map((v) => v.value);
+        }
+      }
+    }
+    return undefined;
   }
 }

--- a/packages/http-client-java/emitter/src/versioning-utils.ts
+++ b/packages/http-client-java/emitter/src/versioning-utils.ts
@@ -69,23 +69,24 @@ export function getServiceApiVersions(
  * TODO(xiaofei) pending TCGC design: https://github.com/Azure/typespec-azure/issues/965
  * We still cannot move to TCGC, due to it only recognizes api-versions from 1 service.
  *
- * @param pinnedApiVersion the api-version to use as filter base
+ * @param program the program
+ * @param targetApiVersion the api-version to use as filter base
  * @param versions api-versions to filter
- * @param excludePreview whether to exclude preview api-versions when pinnedApiVersion is stable, default is `true`
+ * @param excludePreview whether to exclude preview api-versions when targetApiVersion is stable, default is `true`
  * @returns filtered api-versions
  */
 export function getFilteredApiVersions(
   program: Program,
-  pinnedApiVersion: string | undefined,
+  targetApiVersion: string | undefined,
   versions: Version[],
   excludePreview: boolean = true,
 ): Version[] {
-  if (!pinnedApiVersion) {
+  if (!targetApiVersion) {
     return versions;
   }
-  const filterPreviewApiVersions = excludePreview && isStableApiVersionString(pinnedApiVersion);
+  const filterPreviewApiVersions = excludePreview && isStableApiVersionString(targetApiVersion);
   return versions
-    .slice(0, versions.findIndex((it) => it.value === pinnedApiVersion) + 1)
+    .slice(0, versions.findIndex((it) => it.value === targetApiVersion) + 1)
     .filter((version) => !filterPreviewApiVersions || isStableApiVersion(program, version));
 }
 

--- a/packages/http-client-java/emitter/src/versioning-utils.ts
+++ b/packages/http-client-java/emitter/src/versioning-utils.ts
@@ -81,13 +81,27 @@ export function getFilteredApiVersions(
   versions: Version[],
   excludePreview: boolean = true,
 ): Version[] {
+  return filterApiVersionsByStability(
+    targetApiVersion,
+    versions,
+    (version) => isStableApiVersion(program, version),
+    excludePreview,
+  );
+}
+
+export function filterApiVersionsByStability(
+  targetApiVersion: string | undefined,
+  versions: Version[],
+  isStableVersion: (version: Version) => boolean,
+  excludePreview: boolean = true,
+): Version[] {
   if (!targetApiVersion) {
     return versions;
   }
   const filterPreviewApiVersions = excludePreview && isStableApiVersionString(targetApiVersion);
   return versions
     .slice(0, versions.findIndex((it) => it.value === targetApiVersion) + 1)
-    .filter((version) => !filterPreviewApiVersions || isStableApiVersion(program, version));
+    .filter((version) => !filterPreviewApiVersions || isStableVersion(version));
 }
 
 function isStableApiVersion(program: Program, version: Version): boolean {

--- a/packages/http-client-java/emitter/test/utils.test.ts
+++ b/packages/http-client-java/emitter/test/utils.test.ts
@@ -1,3 +1,5 @@
+import type { EnumMember, Namespace } from "@typespec/compiler";
+import type { Version } from "@typespec/versioning";
 import { describe, expect, it } from "vitest";
 import { scopeExplicitlyIncludeJava, scopeImplicitlyIncludeJava } from "../src/type-utils.js";
 import {
@@ -7,10 +9,21 @@ import {
   stringArrayContainsIgnoreCase,
 } from "../src/utils.js";
 import {
+  filterApiVersionsByStability,
   isStableApiVersionString,
   isVersionEarlierThan,
   isVersionedByDate,
 } from "../src/versioning-utils.js";
+
+function createMockVersion(value: string, index: number): Version {
+  return {
+    name: value,
+    value,
+    index,
+    namespace: {} as Namespace,
+    enumMember: {} as EnumMember,
+  };
+}
 
 describe("utils", () => {
   it("pascalCase", () => {
@@ -45,6 +58,44 @@ describe("versioning-utils", () => {
   it("isStableApiVersion", () => {
     expect(isStableApiVersionString("2022-09-01")).toBe(true);
     expect(isStableApiVersionString("2023-12-01-preview")).toBe(false);
+  });
+
+  it("filterApiVersionsByStability filters preview versions for stable target", () => {
+    const versions = [
+      createMockVersion("2024-01-01-preview", 0),
+      createMockVersion("2024-01-01", 1),
+      createMockVersion("2024-06-01-preview", 2),
+      createMockVersion("2024-06-01", 3),
+    ];
+
+    const filtered = filterApiVersionsByStability(
+      "2024-06-01",
+      versions,
+      (version) => !version.value.endsWith("-preview"),
+    );
+
+    expect(filtered.map((version) => version.value)).toEqual(["2024-01-01", "2024-06-01"]);
+  });
+
+  it("filterApiVersionsByStability keeps preview versions for preview target", () => {
+    const versions = [
+      createMockVersion("2024-01-01-preview", 0),
+      createMockVersion("2024-01-01", 1),
+      createMockVersion("2024-06-01-preview", 2),
+      createMockVersion("2024-06-01", 3),
+    ];
+
+    const filtered = filterApiVersionsByStability(
+      "2024-06-01-preview",
+      versions,
+      (version) => !version.value.endsWith("-preview"),
+    );
+
+    expect(filtered.map((version) => version.value)).toEqual([
+      "2024-01-01-preview",
+      "2024-01-01",
+      "2024-06-01-preview",
+    ]);
   });
 
   it("isVersionedByDate - valid date versions", () => {

--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -1084,6 +1084,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2558,9 +2571,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3327,9 +3340,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "dev": true,
       "funding": [
         {
@@ -3339,9 +3352,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6157,9 +6172,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/10615

tested on compute service, works as expected

I will run a test regen (downstream use https://github.com/Azure/autorest.java/pull/3339)
seems OK https://github.com/Azure/azure-sdk-for-java/pull/49213