### PR TITLE
[http-client-csharp] Fix BinaryContent wrapping in MethodParameterSegments navigation

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -804,7 +804,17 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     if (ScmCodeModelGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(convenienceParam.Type, out var typeProvider) &&
                         typeProvider is ModelProvider paramModel)
                     {
-                        AddArgument(protocolParam, paramModel.GetPropertyExpression(convenienceParam, propertySegments));
+                        var propertyExpression = paramModel.GetPropertyExpression(convenienceParam, propertySegments);
+                        // When the protocol parameter expects BinaryContent (i.e., it's a content parameter),
+                        // wrap the resolved BinaryData property expression with BinaryContent.Create().
+                        if (protocolParam.IsContentParameter)
+                        {
+                            AddArgument(protocolParam, RequestContentApiSnippets.Create(propertyExpression));
+                        }
+                        else
+                        {
+                            AddArgument(protocolParam, propertyExpression);
+                        }
                     }
                 }
                 else

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1618,6 +1618,51 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         }
 
         [Test]
+        public async Task MethodParameterSegments_BodyBinaryDataProperty_WrapsWithBinaryContentCreate()
+        {
+            // Test scenario: When a body parameter navigates to a BinaryData property via MethodParameterSegments,
+            // the convenience method should wrap the expression with BinaryContent.Create().
+            var streamModel = InputFactory.Model(
+                "StreamModel",
+                properties:
+                [
+                    InputFactory.Property("body", InputPrimitiveType.Base64, isRequired: true),
+                ]);
+
+            var bodyParam = InputFactory.BodyParameter("body", InputPrimitiveType.Base64, isRequired: true,
+                contentTypes: ["application/jsonl"], defaultContentType: "application/jsonl");
+            bodyParam.Update(methodParameterSegments: [
+                InputFactory.MethodParameter("stream", streamModel, isRequired: true, location: InputRequestLocation.None),
+                InputFactory.MethodParameter("body", InputPrimitiveType.Base64, isRequired: true)
+            ]);
+
+            var serviceMethod = InputFactory.BasicServiceMethod(
+                "send",
+                InputFactory.Operation(
+                    "send",
+                    parameters: [bodyParam],
+                    requestMediaTypes: ["application/jsonl"],
+                    responses: [InputFactory.OperationResponse([204])]),
+                parameters: [InputFactory.MethodParameter("stream", streamModel, isRequired: true, location: InputRequestLocation.None)]);
+
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+            await MockHelpers.LoadMockGeneratorAsync(clients: () => [inputClient], inputModels: () => [streamModel]);
+
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+            var convenienceMethod = methodCollection.FirstOrDefault(
+                m => m.Signature.Parameters.Any(p => p.Name == "stream") && m.Signature.Name == "Send");
+            Assert.IsNotNull(convenienceMethod);
+
+            var methodBody = convenienceMethod!.BodyStatements!.ToDisplayString();
+            // Verify that BinaryContent.Create() wraps the property access
+            Assert.IsTrue(methodBody.Contains("BinaryContent.Create(stream.Body)"),
+                $"Expected 'BinaryContent.Create(stream.Body)' in method body but got: {methodBody}");
+        }
+
+        [Test]
         public async Task MissingOperationParamsResultInNamedArgsForSubsequent()
         {
             var idParam = InputFactory.PathParameter("id", InputPrimitiveType.String, isRequired: true);

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
@@ -334,7 +334,7 @@ namespace SampleTypeSpec
         {
             Argument.AssertNotNull(info, nameof(info));
 
-            ClientResult result = NoContentType(info.P2, info.P1, info.Action, cancellationToken.ToRequestOptions());
+            ClientResult result = NoContentType(info.P2, info.P1, BinaryContent.Create(info.Action), cancellationToken.ToRequestOptions());
             return ClientResult.FromValue((RoundTripModel)result, result.GetRawResponse());
         }
 
@@ -347,7 +347,7 @@ namespace SampleTypeSpec
         {
             Argument.AssertNotNull(info, nameof(info));
 
-            ClientResult result = await NoContentTypeAsync(info.P2, info.P1, info.Action, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+            ClientResult result = await NoContentTypeAsync(info.P2, info.P1, BinaryContent.Create(info.Action), cancellationToken.ToRequestOptions()).ConfigureAwait(false);
             return ClientResult.FromValue((RoundTripModel)result, result.GetRawResponse());
         }
 


### PR DESCRIPTION
## Summary

Fixes a generator bug where `MethodParameterSegments` navigation resolving to a `BinaryData` property was passed directly as a `BinaryContent` protocol argument without wrapping in `BinaryContent.Create()`, causing a `CS1503` compilation error.

### Bug Fix

When `ScmMethodProviderCollection.GetProtocolMethodArguments()` navigates `MethodParameterSegments` to resolve a property path (e.g., `stream` → `stream.Body`), the resolved `BinaryData` expression was passed directly as a `BinaryContent` protocol argument. The fix wraps the expression with `BinaryContent.Create()` when the protocol parameter is a content parameter.

This also fixed a pre-existing latent bug in the `Sample-TypeSpec` `NoContentType` method (`info.Action` had the same issue).

### Changes

- Fix `ScmMethodProviderCollection.GetProtocolMethodArguments()` to wrap with `RequestContentApiSnippets.Create()` when the protocol param is a content parameter
- Add unit test for the BinaryData-to-BinaryContent wrapping case
- Regenerate `Sample-TypeSpec` (side-effect of the fix)

### Validation

- All 1335 ClientModel generator tests pass
- All 37 Local tests pass

---
🤖 Created with JonathanCrd's copilot