### PR TITLE
ci: add dedicated nightly pipeline for C# emitter against TypeSpec Next

### DIFF
--- a/packages/http-client-csharp/eng/pipeline/nightly.yml
+++ b/packages/http-client-csharp/eng/pipeline/nightly.yml
@@ -1,0 +1,89 @@
+# Dedicated nightly pipeline for the C# emitter against TypeSpec Next.
+#
+# This pipeline builds and tests the C# emitter with TypeSpec @next dependencies
+# but does NOT publish packages and does NOT open an azure-sdk-for-net PR. The
+# schedule itself is configured on the ADO pipeline definition, so reporting and
+# triage of nightly TypeSpec Next failures is separated from release/publish runs.
+#
+# The publish pipeline (publish.yml) still exposes a UseTypeSpecNext parameter for
+# manual runs that need a published @next-based build.
+
+trigger: none
+pr: none
+
+parameters:
+  - name: UseTypeSpecNext
+    displayName: Use TypeSpec Next (update dependencies to @next versions)
+    type: boolean
+    default: true
+
+  - name: RunRegenChecks
+    displayName: Run regen/generation checks against TypeSpec Next
+    type: boolean
+    default: true
+
+  # Primary Node.js version used by the artifact-emitting Build_linux job. Must match
+  # the PrimaryNodeVersion default in eng/emitters/pipelines/templates/stages/emitter-stages.yml.
+  - name: PrimaryNodeVersion
+    type: string
+    default: "24.x"
+
+extends:
+  template: /eng/common/pipelines/templates/1es-redirect.yml
+
+  parameters:
+    stages:
+      - template: /eng/emitters/pipelines/templates/stages/emitter-stages.yml
+        parameters:
+          BuildPrereleaseVersion: true
+          UseTypeSpecNext: ${{ parameters.UseTypeSpecNext }}
+          Publish: "none"
+          PackagePath: /packages/http-client-csharp
+          EmitterPackageJsonPath: packages/http-client-csharp/package.json
+          PrimaryNodeVersion: ${{ parameters.PrimaryNodeVersion }}
+          Packages:
+            - name: typespec-http-client-csharp
+              file: typespec-http-client-csharp-*.tgz
+              type: npm
+            - name: Microsoft.TypeSpec.Generator
+              file: Microsoft.TypeSpec.Generator.*.nupkg
+              type: nuget
+            - name: Microsoft.TypeSpec.Generator.ClientModel
+              file: Microsoft.TypeSpec.Generator.ClientModel.*.nupkg
+              type: nuget
+            - name: Microsoft.TypeSpec.Generator.Input
+              file: Microsoft.TypeSpec.Generator.Input.*.nupkg
+              type: nuget
+            - name: Microsoft.TypeSpec.Generator.Customization
+              file: Microsoft.TypeSpec.Generator.Customization.*.nupkg
+              type: nuget
+          UnitTestArgs: -UnitTests
+          ${{ if parameters.RunRegenChecks }}:
+            TestMatrix:
+              RegenCheck:
+                TestArguments: -GenerationChecks
+          StagePrefix: "CSharp"
+          LanguageShortName: "csharp"
+          HasNugetPackages: true
+          CadlRanchName: "@typespec/http-client-csharp"
+          AdditionalInitializeSteps:
+            - task: UseDotNet@2
+              inputs:
+                displayName: "Install .NET 8"
+                performMultiLevelLookup: true
+                useGlobalJson: false
+                version: 8.x
+                workingDirectory: $(Build.SourcesDirectory)/packages/http-client-csharp
+            - task: UseDotNet@2
+              inputs:
+                displayName: "Install .NET 9"
+                performMultiLevelLookup: true
+                useGlobalJson: false
+                version: 9.x
+                workingDirectory: $(Build.SourcesDirectory)/packages/http-client-csharp
+            - task: UseDotNet@2
+              inputs:
+                displayName: "Install .NET 10"
+                performMultiLevelLookup: true
+                useGlobalJson: true
+                workingDirectory: $(Build.SourcesDirectory)/packages/http-client-csharp


### PR DESCRIPTION
Adds `packages/http-client-csharp/eng/pipeline/nightly.yml` so the nightly TypeSpec Next validation for the C# emitter runs on its own ADO pipeline definition.

## Why
Today the nightly TypeSpec Next validation piggybacks on `publish.yml` (scheduled runs flip `UseTypeSpecNext` on). That has two downsides:
- It conflates nightly @next failures with release/publish failures, making reporting and triage harder.
- It still runs the Publish stage, which we don't want for a nightly compatibility check.

## What
- New file: `packages/http-client-csharp/eng/pipeline/nightly.yml`
  - `trigger: none` / `pr: none` — schedule will be configured on the ADO pipeline definition (matching repo convention; no other emitter pipelines define schedules in YAML).
  - `UseTypeSpecNext` parameter defaults to `true`.
  - `Publish: ""none""` passed to `emitter-stages.yml` → Publish stage and the `CreateAzureSdkForNetPR` stage are not included.
  - Runs unit tests (`-UnitTests`) plus the `RegenCheck` matrix (toggleable via `RunRegenChecks` parameter) so generation diffs against @next are surfaced in a separate `CSharp_Regen_Test` stage.
  - Same .NET 8/9/10 install steps and PrimaryNodeVersion default as `publish.yml`.
- `publish.yml` is intentionally left untouched. Its `UseTypeSpecNext` parameter and `Build.Reason == 'Schedule'` override still work, so the existing capability is preserved. Once this pipeline is wired up in ADO, the schedule trigger can be moved off the publish definition.

## Follow-up (outside this PR)
- Create the ADO pipeline definition pointing at `packages/http-client-csharp/eng/pipeline/nightly.yml` and set the nightly schedule there.
- Once active, remove the nightly schedule from the publish pipeline definition.