### PR TITLE
http-client-java, support exact in clientName

### DIFF
--- a/.chronus/changes/http-client-java_support-exact-2026-4-21-17-10-37.md
+++ b/.chronus/changes/http-client-java_support-exact-2026-4-21-17-10-37.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-java"
+---
+
+Support exact name from TCGC.

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -999,7 +999,7 @@ export class CodeModelBuilder {
       codeModelOperation.convenienceApi = new ConvenienceApi(convenienceApiName);
     }
     if (diagnostic) {
-      codeModelOperation.language.java = new Language();
+      codeModelOperation.language.java = codeModelOperation.language.java ?? new Language();
       codeModelOperation.language.java.comment = diagnostic.message;
     }
 
@@ -2282,7 +2282,7 @@ export class CodeModelBuilder {
           break;
         }
 
-        const codeModelHeader = new HttpHeader(header.serializedName, schema, {
+        const httpHeader = new HttpHeader(header.serializedName, schema, {
           language: {
             default: {
               name: header.name,
@@ -2291,10 +2291,10 @@ export class CodeModelBuilder {
           },
         });
         if (header.isExactName) {
-          codeModelHeader.language.java = new Language();
-          codeModelHeader.language.java.name = header.name;
+          httpHeader.language.java = httpHeader.language.java ?? new Language();
+          httpHeader.language.java.name = header.name;
         }
-        headers.push(codeModelHeader);
+        headers.push(httpHeader);
       }
     }
 

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -400,6 +400,9 @@ export class CodeModelBuilder {
           },
           clientDefaultValue: arg.clientDefaultValue,
         });
+        if (arg.isExactName && parameter.language.java) {
+          parameter.language.java.name = arg.name;
+        }
       }
       hostParameters.push(this.codeModel.addGlobalParameter(parameter));
     });
@@ -1558,6 +1561,9 @@ export class CodeModelBuilder {
         },
         extensions: extensions,
       });
+      if (param.isExactName && parameter.language.java) {
+        parameter.language.java.name = param.name;
+      }
       op.addParameter(parameter);
 
       if (parameterOnClient) {
@@ -2221,26 +2227,28 @@ export class CodeModelBuilder {
         !existBodyProperty.readOnly &&
         !(existBodyProperty.schema instanceof ConstantSchema)
       ) {
-        request.parameters.push(
-          new VirtualParameter(
-            existBodyProperty.language.default.name,
-            existBodyProperty.language.default.description,
-            existBodyProperty.schema,
-            {
-              originalParameter: originalParameter,
-              targetProperty: existBodyProperty,
-              language: {
-                default: {
-                  serializedName: existBodyProperty.serializedName,
-                },
+        const virtualParameter = new VirtualParameter(
+          existBodyProperty.language.default.name,
+          existBodyProperty.language.default.description,
+          existBodyProperty.schema,
+          {
+            originalParameter: originalParameter,
+            targetProperty: existBodyProperty,
+            language: {
+              default: {
+                serializedName: existBodyProperty.serializedName,
               },
-              summary: existBodyProperty.summary,
-              implementation: ImplementationLocation.Method,
-              required: existBodyProperty.required,
-              nullable: existBodyProperty.nullable,
             },
-          ),
+            summary: existBodyProperty.summary,
+            implementation: ImplementationLocation.Method,
+            required: existBodyProperty.required,
+            nullable: existBodyProperty.nullable,
+          },
         );
+        if (existBodyProperty.language?.java?.name) {
+          virtualParameter.language.java = virtualParameter.language.java;
+        }
+        request.parameters.push(virtualParameter);
       }
     }
   }
@@ -2274,16 +2282,19 @@ export class CodeModelBuilder {
           break;
         }
 
-        headers.push(
-          new HttpHeader(header.serializedName, schema, {
-            language: {
-              default: {
-                name: header.name,
-                description: header.summary ?? header.doc,
-              },
+        const codeModelHeader = new HttpHeader(header.serializedName, schema, {
+          language: {
+            default: {
+              name: header.name,
+              description: header.summary ?? header.doc,
             },
-          }),
-        );
+          },
+        });
+        if (header.isExactName) {
+          codeModelHeader.language.java = new Language();
+          codeModelHeader.language.java.name = header.name;
+        }
+        headers.push(codeModelHeader);
       }
     }
 
@@ -2716,6 +2727,9 @@ export class CodeModelBuilder {
         },
       },
     });
+    if (type.isExactName && schema.language.java) {
+      schema.language.java.name = type.name;
+    }
     if (type.external) {
       // java name
       schema.language.java = schema.language.java ?? new Language();
@@ -2832,6 +2846,9 @@ export class CodeModelBuilder {
         },
       },
     });
+    if (type.isExactName && objectSchema.language.java) {
+      objectSchema.language.java.name = type.name;
+    }
     objectSchema.language.default.crossLanguageDefinitionId = type.crossLanguageDefinitionId;
 
     if (type.external) {
@@ -3054,6 +3071,9 @@ export class CodeModelBuilder {
           },
         },
       });
+      if (type.isExactName && objectSchema.language.java) {
+        objectSchema.language.java.name = type.name;
+      }
 
       const variantSchema = this.processSchema(it, variantName);
       objectSchema.addProperty(

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -1561,7 +1561,8 @@ export class CodeModelBuilder {
         },
         extensions: extensions,
       });
-      if (param.isExactName && parameter.language.java) {
+      if (param.isExactName) {
+        parameter.language.java = parameter.language.java ?? {};
         parameter.language.java.name = param.name;
       }
       op.addParameter(parameter);

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -3014,6 +3014,10 @@ export class CodeModelBuilder {
       serializedName: getPropertySerializedName(modelProperty),
       extensions: extensions,
     });
+    if (modelProperty.isExactName) {
+      codeModelProperty.language.java = codeModelProperty.language.java ?? new Language();
+      codeModelProperty.language.java.name = modelProperty.name;
+    }
     if (modelProperty.encode) {
       if (schema instanceof ArraySchema) {
         // ArrayEncoding

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -2246,7 +2246,7 @@ export class CodeModelBuilder {
           },
         );
         if (existBodyProperty.language?.java?.name) {
-          virtualParameter.language.java = virtualParameter.language.java;
+          virtualParameter.language.java = existBodyProperty.language.java;
         }
         request.parameters.push(virtualParameter);
       }

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -400,7 +400,8 @@ export class CodeModelBuilder {
           },
           clientDefaultValue: arg.clientDefaultValue,
         });
-        if (arg.isExactName && parameter.language.java) {
+        if (arg.isExactName) {
+          parameter.language.java = parameter.language.java ?? new Language();
           parameter.language.java.name = arg.name;
         }
       }
@@ -1562,7 +1563,7 @@ export class CodeModelBuilder {
         extensions: extensions,
       });
       if (param.isExactName) {
-        parameter.language.java = parameter.language.java ?? {};
+        parameter.language.java = parameter.language.java ?? new Language();
         parameter.language.java.name = param.name;
       }
       op.addParameter(parameter);
@@ -2728,7 +2729,8 @@ export class CodeModelBuilder {
         },
       },
     });
-    if (type.isExactName && schema.language.java) {
+    if (type.isExactName) {
+      schema.language.java = schema.language.java ?? new Language();
       schema.language.java.name = type.name;
     }
     if (type.external) {
@@ -2847,7 +2849,8 @@ export class CodeModelBuilder {
         },
       },
     });
-    if (type.isExactName && objectSchema.language.java) {
+    if (type.isExactName) {
+      objectSchema.language.java = objectSchema.language.java ?? new Language();
       objectSchema.language.java.name = type.name;
     }
     objectSchema.language.default.crossLanguageDefinitionId = type.crossLanguageDefinitionId;
@@ -3076,7 +3079,8 @@ export class CodeModelBuilder {
           },
         },
       });
-      if (type.isExactName && objectSchema.language.java) {
+      if (type.isExactName) {
+        objectSchema.language.java = objectSchema.language.java ?? new Language();
         objectSchema.language.java.name = type.name;
       }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/tranformer/Transformer.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/preprocessor/tranformer/Transformer.java
@@ -588,7 +588,10 @@ public class Transformer {
     private void renameProperty(Property property) {
         Language language = property.getLanguage().getDefault();
         Language java = addJavaLanguage(property);
-        java.setName(CodeNamer.getPropertyName(language.getName()));
+        if (property.getLanguage().getJava().getName() == null
+            || property.getLanguage().getJava().getName().isEmpty()) {
+            java.setName(CodeNamer.getPropertyName(language.getName()));
+        }
         java.setSerializedName(language.getSerializedName());
         java.setDescription(language.getDescription());
         property.getLanguage().setJava(java);
@@ -606,7 +609,9 @@ public class Transformer {
     private void renameClient(Metadata client) {
         Language language = client.getLanguage().getDefault();
         Language java = addJavaLanguage(client);
-        java.setName(CodeNamer.getClientName(language.getName()));
+        if (client.getLanguage().getJava().getName() == null || client.getLanguage().getJava().getName().isEmpty()) {
+            java.setName(CodeNamer.getClientName(language.getName()));
+        }
         java.setDescription(language.getDescription());
         client.getLanguage().setJava(java);
     }
@@ -614,7 +619,9 @@ public class Transformer {
     private void renameVariable(Metadata schema) {
         Language language = schema.getLanguage().getDefault();
         Language java = addJavaLanguage(schema);
-        java.setName(CodeNamer.getParameterName(language.getName()));
+        if (schema.getLanguage().getJava().getName() == null || schema.getLanguage().getJava().getName().isEmpty()) {
+            java.setName(CodeNamer.getParameterName(language.getName()));
+        }
         java.setSerializedName(language.getSerializedName());
         java.setDescription(language.getDescription());
         schema.getLanguage().setJava(java);
@@ -623,7 +630,9 @@ public class Transformer {
     private void renameMethodGroup(Metadata schema) {
         Language language = schema.getLanguage().getDefault();
         Language java = addJavaLanguage(schema);
-        java.setName(CodeNamer.getMethodGroupName(language.getName()));
+        if (schema.getLanguage().getJava().getName() == null || schema.getLanguage().getJava().getName().isEmpty()) {
+            java.setName(CodeNamer.getMethodGroupName(language.getName()));
+        }
         java.setSerializedName(language.getSerializedName());
         java.setDescription(language.getDescription());
         schema.getLanguage().setJava(java);
@@ -632,7 +641,9 @@ public class Transformer {
     private void renameMethod(Metadata schema) {
         Language language = schema.getLanguage().getDefault();
         Language java = addJavaLanguage(schema);
-        java.setName(CodeNamer.getMethodName(language.getName()));
+        if (schema.getLanguage().getJava().getName() == null || schema.getLanguage().getJava().getName().isEmpty()) {
+            java.setName(CodeNamer.getMethodName(language.getName()));
+        }
         java.setSerializedName(language.getSerializedName());
         java.setDescription(language.getDescription());
     }


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/3340

manual tested on https://github.com/Azure/typespec-azure/blob/main/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
need its release to write e2e

---

Impl is relatively simple. If `isExactName`, set the name directly to `language.java.name`. And later in Java code this name will not get transformed (otherwise, Java code will do a transform from `language.default.name` to `language.java.name`).

---

It is not complete though. There is `isExactName` missing from some types. TCGC fixed but not released.
https://github.com/Azure/typespec-azure/pull/4480