### PR TITLE
feat: add azure-mode spector coverage upload to shared emitter pipeline

### DIFF
--- a/eng/emitters/pipelines/templates/jobs/test-job.yml
+++ b/eng/emitters/pipelines/templates/jobs/test-job.yml
@@ -44,6 +44,10 @@ parameters:
     type: string
     default: ""
 
+  - name: AzureCadlRanchName
+    type: string
+    default: ""
+
   - name: EnableCadlRanchReport
     type: boolean
     default: true
@@ -85,6 +89,7 @@ jobs:
             TestArgs: ${{ parameters.TestArgs }}
           EmitArtifacts: ${{ parameters.EmitArtifacts }}
           CadlRanchName: ${{ parameters.CadlRanchName }}
+          AzureCadlRanchName: ${{ parameters.AzureCadlRanchName }}
           EnableCadlRanchReport: ${{ parameters.EnableCadlRanchReport }}
           PythonVersion: ${{ parameters.PythonVersion }}
           UseTypeSpecNext: ${{ parameters.UseTypeSpecNext }}

--- a/eng/emitters/pipelines/templates/stages/emitter-stages.yml
+++ b/eng/emitters/pipelines/templates/stages/emitter-stages.yml
@@ -74,6 +74,10 @@ parameters:
     type: string
     default: ""
 
+  - name: AzureCadlRanchName
+    type: string
+    default: ""
+
   - name: EnableCadlRanchReport
     type: boolean
     default: true
@@ -221,6 +225,7 @@ stages:
                   Os: linux
                   EmitArtifacts: true # Emit artifacts only for the first job
                   CadlRanchName: ${{ parameters.CadlRanchName }} # only needed for first job
+                  AzureCadlRanchName: ${{ parameters.AzureCadlRanchName }}
                   EnableCadlRanchReport: ${{ parameters.EnableCadlRanchReport }}
                   PythonVersion: ${{ parameters.PythonVersion }}
                   UseTypeSpecNext: ${{ parameters.UseTypeSpecNext }}

--- a/eng/emitters/pipelines/templates/steps/test-step.yml
+++ b/eng/emitters/pipelines/templates/steps/test-step.yml
@@ -36,6 +36,10 @@ parameters:
     type: string
     default: ""
 
+  - name: AzureCadlRanchName
+    type: string
+    default: ""
+
   - name: EnableCadlRanchReport
     type: boolean
     default: true
@@ -93,4 +97,15 @@ steps:
           scriptType: "bash"
           scriptLocation: "inlineScript"
           inlineScript: npx tsp-spector upload-coverage --coverageFile ./generator/artifacts/coverage/tsp-spector-coverage-${{ parameters.LanguageShortName }}-standard.json --generatorName ${{ coalesce(parameters.CadlRanchName, parameters.LanguageShortName) }} --storageAccountName typespec --containerName coverages --generatorVersion $(node -p -e "require('./package.json').version") --generatorMode standard
+          workingDirectory: $(selfRepositoryPath)${{ parameters.PackagePath }}
+
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.EnableCadlRanchReport, true), ne(parameters.AzureCadlRanchName, '')) }}:
+      - task: AzureCLI@2
+        displayName: "Upload Cadl Ranch Azure Coverage Report"
+        condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq('${{ parameters.EmitArtifacts }}', true))
+        inputs:
+          azureSubscription: "TypeSpec Storage"
+          scriptType: "bash"
+          scriptLocation: "inlineScript"
+          inlineScript: npx tsp-spector upload-coverage --coverageFile ./generator/artifacts/coverage/tsp-spector-coverage-${{ parameters.LanguageShortName }}-azure.json --generatorName ${{ parameters.AzureCadlRanchName }} --storageAccountName typespec --containerName coverages --generatorVersion $(node -p -e "require('./package.json').version") --generatorMode azure
           workingDirectory: $(selfRepositoryPath)${{ parameters.PackagePath }}


### PR DESCRIPTION
## Summary

Add support for uploading azure-mode spector coverage reports in the shared emitter pipeline templates.

### Changes
- **`test-step.yml`**: New `AzureCadlRanchName` parameter and a second upload step for `generatorMode azure`
- **`test-job.yml`** / **`emitter-stages.yml`**: Thread the new parameter through the template chain
- **`publish.yml` (http-client-python)**: Enable coverage reporting and set `AzureCadlRanchName: "@azure-tools/typespec-python"`

### Design
- Opt-in: emitters that don't pass `AzureCadlRanchName` are unaffected (guarded by `ne(parameters.AzureCadlRanchName, '')`)
- Runs only after merge to main (same conditions as existing standard upload)
- Coverage file convention: `tsp-spector-coverage-<lang>-azure.json`
- Other emitters (C#, Java, JS) can adopt by adding `AzureCadlRanchName` to their `publish.yml`

This is part of moving the branded emitter (`@azure-tools/typespec-python`) from autorest.python to typespec-azure.