### PR TITLE
feat(website): improve search by filtering JS API docs and release notes

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -92,6 +92,7 @@ export default defineConfig({
       customCss: ["./src/css/custom.css"],
       components: {
         Header: "./src/components/header/header.astro",
+        Head: "./src/components/starlight-overrides/Head.astro",
         PageFrame: "./src/components/starlight-overrides/PageFrame.astro",
         Sidebar: "./src/components/starlight-overrides/Sidebar.astro",
       },

--- a/website/src/components/header/search.astro
+++ b/website/src/components/header/search.astro
@@ -24,7 +24,7 @@ import "@docsearch/css";
           stroke-linecap="round"
           stroke-linejoin="round"></path>
       </svg>
-      <span class="DocSearch-Button-Placeholder">Search...</span>
+      <span class="DocSearch-Button-Placeholder">Search… ($ for all)</span>
     </span>
     <span class="DocSearch-Button-Keys"></span>
   </button>
@@ -33,15 +33,50 @@ import "@docsearch/css";
 <script>
   import algoliaConfig from "@site/algolia";
 
+  const EXCLUDED_URL_PATTERNS = ["/reference/js-api/", "/release-notes/"];
+
   class StarlightDocSearch extends HTMLElement {
     constructor() {
       super();
       window.addEventListener("DOMContentLoaded", async () => {
         const { default: docsearch } = await import("@docsearch/js");
+
+        let showAllResults = false;
+
         const options: Parameters<typeof docsearch>[0] = {
           ...algoliaConfig,
           container: "sl-doc-search",
           keyboardShortcuts: { "/": false },
+          transformSearchClient(searchClient) {
+            return {
+              ...searchClient,
+              search(requests: any[]) {
+                return searchClient.search(
+                  requests.map((req: any) => {
+                    const query: string = req.params?.query ?? "";
+                    if (query.startsWith("$")) {
+                      showAllResults = true;
+                      return {
+                        ...req,
+                        params: {
+                          ...req.params,
+                          query: query.slice(1),
+                        },
+                      };
+                    }
+                    showAllResults = false;
+                    return req;
+                  }),
+                );
+              },
+            };
+          },
+          transformItems(items) {
+            if (showAllResults) return items;
+            return items.filter(
+              (item) => !EXCLUDED_URL_PATTERNS.some((pattern) => item.url.includes(pattern)),
+            );
+          },
         };
         docsearch(options);
       });

--- a/website/src/components/starlight-overrides/Head.astro
+++ b/website/src/components/starlight-overrides/Head.astro
@@ -1,0 +1,14 @@
+---
+import Default from "@astrojs/starlight/components/Head.astro";
+
+const route = Astro.locals.starlightRoute;
+const isJsApi = route.entry.data.jsApi === true;
+const isReleaseNotes = route.id.includes("release-notes");
+
+let tag = "docs";
+if (isJsApi) tag = "js-api";
+else if (isReleaseNotes) tag = "release-notes";
+---
+
+<Default {...Astro.props} />
+<meta name="docsearch:tag" content={tag} />

--- a/website/src/components/starlight-overrides/Sidebar.astro
+++ b/website/src/components/starlight-overrides/Sidebar.astro
@@ -42,10 +42,12 @@ if (isReleaseNotes) {
 }
 ---
 
-<SidebarPersister>
-  <SidebarSublist sublist={filtered} />
-</SidebarPersister>
+<div data-docsearch-ignore>
+  <SidebarPersister>
+    <SidebarSublist sublist={filtered} />
+  </SidebarPersister>
 
-<div class="md:sl-hidden">
-  <MobileMenuFooter />
+  <div class="md:sl-hidden">
+    <MobileMenuFooter />
+  </div>
 </div>


### PR DESCRIPTION
## Problem

The website search (Algolia DocSearch) returns excessive noise:
- **909 out of 1066 docs (85%) are JS API reference pages** — these dominate results
- Release notes produce many matches for any term mentioned across versions
- Sidebar navigation labels get indexed into result titles, creating absurdly long concatenated breadcrumbs

## Changes

### 1. Fix long concatenated titles
- Added `data-docsearch-ignore` to the sidebar component so the crawler skips it when building the search index

### 2. Filter JS API & release notes from default search
- Added `transformSearchClient` + `transformItems` to filter results whose URL contains `/reference/js-api/` or `/release-notes/`
- Use `$` prefix (e.g., `$tagMetadata`) to search all content including JS API and release notes
- Updated search placeholder to `Search… ($ for all)`

### 3. Prepare for server-side filtering (future)
- Added `Head.astro` override that injects `<meta name="docsearch:tag" content="docs|js-api|release-notes">` based on page frontmatter
- Once the crawler re-indexes, this enables server-side `tagFilters` for more efficient filtering

## Testing
- Search `tagMetadata` → should show only decorator/guide docs
- Search `$tagMetadata` → should show all results including JS API and release notes
- Inspect page HTML to verify `<meta name="docsearch:tag">` is present