### PR TITLE
Fix tagMetadata extension diagnostic targets

### DIFF
--- a/.chronus/changes/fix-openapi-tagmetadata-extension-target-2026-6-1-14-45-0.md
+++ b/.chronus/changes/fix-openapi-tagmetadata-extension-target-2026-6-1-14-45-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/openapi"
+---
+
+Fix tagMetadata extension diagnostic targets

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -400,7 +400,7 @@ export const tagMetadataDecorator: TagMetadataDecorator = (
     if (
       !validateAdditionalInfoModel(
         context.program,
-        context.getArgumentTarget(0)!,
+        context.getArgumentTarget(1)!,
         resolvedMetadata,
         "TypeSpec.OpenAPI.TagMetadata",
       )
@@ -413,7 +413,7 @@ export const tagMetadataDecorator: TagMetadataDecorator = (
       if (
         !validateIsUri(
           context.program,
-          context.getArgumentTarget(0)!,
+          context.getArgumentTarget(1)!,
           resolvedMetadata.externalDocs.url,
           "externalDocs.url",
         )

--- a/packages/openapi/src/helpers.ts
+++ b/packages/openapi/src/helpers.ts
@@ -16,6 +16,11 @@ import {
   Type,
   TypeNameOptions,
 } from "@typespec/compiler";
+import {
+  SyntaxKind,
+  type ObjectLiteralNode,
+  type ObjectLiteralPropertyNode,
+} from "@typespec/compiler/ast";
 import { getOperationId } from "./decorators.js";
 import { createDiagnostic, reportDiagnostic } from "./lib.js";
 import { ExtensionKey } from "./types.js";
@@ -254,16 +259,29 @@ function checkNoAdditionalProperties(
   target: DiagnosticTarget,
   source: Model,
 ): Diagnostic[] {
+  const targetNode = getObjectLiteralNode(target);
+  return checkNoAdditionalPropertiesInternal(jsonObject, target, source, targetNode);
+}
+
+function checkNoAdditionalPropertiesInternal(
+  jsonObject: any,
+  target: DiagnosticTarget,
+  source: Model,
+  targetNode: ObjectLiteralNode | undefined,
+): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
 
   for (const name of Object.keys(jsonObject)) {
     const sourceProperty = getProperty(source, name);
+    const propertyNode = getObjectLiteralProperty(targetNode, name);
     if (sourceProperty) {
       if (sourceProperty.type.kind === "Model") {
-        const nestedDiagnostics = checkNoAdditionalProperties(
+        const nestedTarget = getObjectLiteralNode(propertyNode?.value);
+        const nestedDiagnostics = checkNoAdditionalPropertiesInternal(
           jsonObject[name],
-          target,
+          propertyNode?.value ?? target,
           sourceProperty.type,
+          nestedTarget,
         );
         diagnostics.push(...nestedDiagnostics);
       }
@@ -272,11 +290,27 @@ function checkNoAdditionalProperties(
         createDiagnostic({
           code: "invalid-extension-key",
           format: { value: name },
-          target,
+          target: propertyNode?.id ?? target,
         }),
       );
     }
   }
 
   return diagnostics;
+}
+
+function getObjectLiteralNode(target: DiagnosticTarget | undefined): ObjectLiteralNode | undefined {
+  return target !== undefined && "kind" in target && target.kind === SyntaxKind.ObjectLiteral
+    ? target
+    : undefined;
+}
+
+function getObjectLiteralProperty(
+  node: ObjectLiteralNode | undefined,
+  name: string,
+): ObjectLiteralPropertyNode | undefined {
+  return node?.properties.find(
+    (property): property is ObjectLiteralPropertyNode =>
+      property.kind === SyntaxKind.ObjectLiteralProperty && property.id.sv === name,
+  );
 }

--- a/packages/openapi/test/decorators.test.ts
+++ b/packages/openapi/test/decorators.test.ts
@@ -366,6 +366,20 @@ describe("openapi: decorators", () => {
     });
 
     describe("emit diagnostics when passing extension key not starting with `x-` in metadata", () => {
+      it("reports the diagnostic on the invalid metadata property", async () => {
+        const [{ pos }, diagnostics] = await Tester.compileAndDiagnose(`
+          @service
+          @tagMetadata("tagName", #{ /*custom*/custom: "Bar" })
+          namespace PetStore{};
+        `);
+
+        expectDiagnostics(diagnostics, {
+          code: "@typespec/openapi/invalid-extension-key",
+          message: `OpenAPI extension must start with 'x-' but was 'custom'`,
+          pos: pos.custom.pos,
+        });
+      });
+
       it.each([
         ["root", `#{ foo:"Bar" }`],
         ["externalDocs", `#{ externalDocs: #{ url: "https://example.com", foo:"Bar"} }`],


### PR DESCRIPTION
Closes #10767

This keeps the OpenAPI extension-key validation tied to the metadata object literal, so invalid keys such as `custom` are reported on the offending property instead of the tag name.

Verification:
- `npx pnpm --filter @typespec/openapi build`
- `npx pnpm --filter @typespec/openapi test -- decorators.test.ts`