### PR TITLE
Fix inheritable system model replacements

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -474,6 +474,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private static ModelProvider? GetModelToInstantiateForFactoryMethod(ModelProvider modelProvider)
         {
+            if (modelProvider is SystemObjectModelProvider)
+            {
+                return null;
+            }
+
             var fullConstructor = modelProvider.FullConstructor;
             if (modelProvider.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Internal)
                 || fullConstructor.Signature.Parameters.Any(p => !p.Type.IsPublic))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -534,6 +534,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var properties = new List<PropertyProvider>(propertiesCount + 1);
             Dictionary<string, InputModelProperty> baseProperties = [];
             HashSet<string> skippedBasePropertyNames = [];
+            HashSet<string> skippedBasePropertySerializedNames = [];
             foreach (var baseModelProvider in EnumerateBaseModelProviders())
             {
                 foreach (var baseProperty in baseModelProvider._inputModel.Properties)
@@ -546,6 +547,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     if (baseModelProvider.ShouldSkipDerivedModelProperties)
                     {
                         skippedBasePropertyNames.Add(baseProperty.Name);
+                        if (baseProperty.SerializedName is not null)
+                        {
+                            skippedBasePropertySerializedNames.Add(baseProperty.SerializedName);
+                        }
                     }
                     else
                     {
@@ -564,11 +569,21 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 var property = _inputModel.Properties[i];
                 var isDiscriminator = IsDiscriminator(property);
+                var isSkippedBaseProperty = skippedBasePropertyNames.Contains(property.Name)
+                    || (property.SerializedName is not null && skippedBasePropertySerializedNames.Contains(property.SerializedName));
 
                 // Skip discriminator properties that already exist in the base class
                 // Check both by C# property name and by serialized name to handle cases where
                 // the derived model has a discriminator with a different C# name but the same wire name
-                if (isDiscriminator && (baseProperties.ContainsKey(property.Name) || skippedBasePropertyNames.Contains(property.Name) || (property.SerializedName is not null && baseDiscriminatorSerializedNames.Contains(property.SerializedName))))
+                if (isDiscriminator &&
+                    (baseProperties.ContainsKey(property.Name) ||
+                     isSkippedBaseProperty ||
+                     (property.SerializedName is not null && baseDiscriminatorSerializedNames.Contains(property.SerializedName))))
+                {
+                    continue;
+                }
+
+                if (!isDiscriminator && isSkippedBaseProperty)
                 {
                     continue;
                 }
@@ -609,11 +624,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
                             outputProperty.Modifiers |= MethodSignatureModifiers.Virtual;
                         }
                     }
-                    if (skippedBasePropertyNames.Contains(property.Name))
-                    {
-                        continue;
-                    }
-
                     if (baseProperties.TryGetValue(property.Name, out var baseProperty))
                     {
                         if (DomainEqual(baseProperty, property))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/SystemObjectModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/SystemObjectModelProvider.cs
@@ -62,6 +62,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
         protected override bool ShouldSkipDerivedModelProperties => true;
 
         /// <inheritdoc/>
+        protected override bool CanUpdateIdentity => false;
+
+        /// <inheritdoc/>
         public override bool ShouldSkipDerivedSerializationMethodOverrides => true;
 
         /// <summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -606,19 +606,24 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 _attributes = (attributes as IReadOnlyList<AttributeStatement>) ?? [.. attributes];
             }
 
-            if (name != null)
+            if (CanUpdateIdentity)
             {
-                ResetMembersBasedOnIdentityChange(name);
-            }
+                if (name != null)
+                {
+                    ResetMembersBasedOnIdentityChange(name);
+                }
 
-            if (@namespace != null)
-            {
-                ResetMembersBasedOnIdentityChange(@namespace: @namespace);
+                if (@namespace != null)
+                {
+                    ResetMembersBasedOnIdentityChange(@namespace: @namespace);
+                }
             }
 
             // Rebuild the canonical view
             _canonicalView = new(BuildCanonicalView);
         }
+
+        protected virtual bool CanUpdateIdentity => true;
 
         private void ResetMembersBasedOnIdentityChange(string? name = null, string? @namespace = null)
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -197,10 +197,20 @@ namespace Microsoft.TypeSpec.Generator
                     CodeModelGenerator.Instance.AddTypeToKeep(modelProvider);
                 }
 
-                CSharpTypeMap[modelProvider.Type] = modelProvider;
-                TypeProvidersByName[modelProvider.Type.Name] = modelProvider;
+                RegisterModelProvider(modelProvider);
             }
             return modelProvider;
+        }
+
+        private void RegisterModelProvider(ModelProvider modelProvider)
+        {
+            CSharpTypeMap[modelProvider.Type] = modelProvider;
+            TypeProvidersByName[modelProvider.Type.Name] = modelProvider;
+
+            if (modelProvider is SystemObjectModelProvider systemObjectModelProvider)
+            {
+                CSharpTypeMap[systemObjectModelProvider.SystemType] = systemObjectModelProvider;
+            }
         }
 
         protected virtual ModelProvider? CreateModelCore(InputModelType model) => new ModelProvider(model);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -33,6 +33,29 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         }
 
         [Test]
+        public void SkipSystemObjectModelProvider()
+        {
+            var inputModel = InputFactory.Model("Resource", properties: [], access: "public");
+            var systemType = new CSharpType(
+                "ResourceData",
+                "TestFramework",
+                isValueType: false,
+                isNullable: false,
+                declaringType: null,
+                args: Array.Empty<CSharpType>(),
+                isPublic: true,
+                isStruct: false);
+            _instance = MockHelpers.LoadMockGenerator(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: [inputModel],
+                createModelCore: model => new SystemObjectModelProvider(systemType, model)).Object;
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+
+            Assert.IsFalse(modelFactory.Methods.Any(m => m.Signature.Name == "ResourceData"));
+        }
+
+        [Test]
         public void ListParamShape()
         {
             var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/SystemObjectModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/SystemObjectModelProviderTests.cs
@@ -174,6 +174,41 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         }
 
         [Test]
+        public void DerivedModel_SkipsPropertiesWithSameWireNameDefinedInSystemObjectBase()
+        {
+            var baseProp = InputFactory.Property("Name", InputPrimitiveType.String, serializedName: "name");
+            var baseInputModel = InputFactory.Model("Resource", properties: [baseProp]);
+
+            var derivedNameProp = InputFactory.Property("Name0", InputPrimitiveType.String, serializedName: "name");
+            var derivedLocationProp = InputFactory.Property("Location", InputPrimitiveType.String, serializedName: "location");
+            var derivedInputModel = InputFactory.Model(
+                "TrackedResource",
+                properties: [derivedNameProp, derivedLocationProp],
+                baseModel: baseInputModel);
+
+            var systemType = CreateSystemCSharpType("ResourceData", "TestFramework");
+            MockHelpers.LoadMockGenerator(
+                inputModelTypes: [baseInputModel, derivedInputModel],
+                createModelCore: (model) =>
+                {
+                    if (model.Name == "Resource")
+                        return new SystemObjectModelProvider(systemType, model);
+                    return new ModelProvider(model);
+                });
+
+            var derived = CodeModelGenerator.Instance.TypeFactory.CreateModel(derivedInputModel) as ModelProvider;
+            Assert.IsNotNull(derived);
+
+            var propertyNames = derived!.Properties.Select(p => p.Name).ToList();
+            Assert.IsFalse(propertyNames.Contains("Name0"),
+                "Property 'Name0' should be skipped because its wire name is defined in the SystemObjectModelProvider base");
+            Assert.IsTrue(propertyNames.Contains("Location"),
+                "Property 'Location' should be generated because its wire name is NOT in the base");
+            Assert.IsFalse(derived.FullConstructor.Signature.Parameters.Any(p => p.Name == "name0"),
+                "Skipped wire-name duplicate properties should not be emitted as constructor parameters");
+        }
+
+        [Test]
         public void RegularBaseModel_DoesNotSkipMatchingProperties()
         {
             // Same setup but with a regular ModelProvider base (not SystemObjectModelProvider)
@@ -337,6 +372,44 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         }
 
         [Test]
+        public void Update_DoesNotChangeSystemTypeIdentity()
+        {
+            var systemType = CreateSystemCSharpType("TrackedResourceData", "Azure.ResourceManager.Models");
+            var inputModel = InputFactory.Model("TrackedResource", properties: [], access: "internal");
+            var provider = new SystemObjectModelProvider(systemType, inputModel);
+
+            provider.Update(name: "TrackedResource", @namespace: "Generated.Models");
+
+            Assert.AreEqual("TrackedResourceData", provider.Name);
+            Assert.AreEqual("Azure.ResourceManager.Models", provider.Type.Namespace);
+        }
+
+        [Test]
+        public void BaseModelProvider_ResolvesSystemTypeAlias()
+        {
+            var baseInputModel = InputFactory.Model("Resource", properties: []);
+            var derivedInputModel = InputFactory.Model("TrackedResource", properties: [], baseModel: baseInputModel);
+            var systemType = new CSharpType(typeof(InvalidOperationException));
+
+            MockHelpers.LoadMockGenerator(
+                inputModelTypes: [baseInputModel, derivedInputModel],
+                createModelCore: (model) =>
+                {
+                    if (model == baseInputModel)
+                        return new SystemObjectModelProvider(systemType, model);
+                    if (model == derivedInputModel)
+                        return new BuildBaseTypeOverridingModelProvider(model, systemType);
+                    return new ModelProvider(model);
+                });
+
+            var systemBase = CodeModelGenerator.Instance.TypeFactory.CreateModel(baseInputModel);
+            var derived = CodeModelGenerator.Instance.TypeFactory.CreateModel(derivedInputModel);
+
+            Assert.IsNotNull(systemBase);
+            Assert.AreSame(systemBase, derived!.BaseModelProvider);
+        }
+
+        [Test]
         public void CrossLanguageDefinitionId_ComesFromInputModel()
         {
             var systemType = CreateSystemCSharpType("ResourceData", "TestFramework");
@@ -369,6 +442,18 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         {
             var inputModel = InputFactory.Model("Resource", properties: []);
             Assert.Throws<ArgumentNullException>(() => new SystemObjectModelProvider(null!, inputModel));
+        }
+
+        private class BuildBaseTypeOverridingModelProvider : ModelProvider
+        {
+            private readonly CSharpType _baseType;
+
+            public BuildBaseTypeOverridingModelProvider(InputModelType inputModel, CSharpType baseType) : base(inputModel)
+            {
+                _baseType = baseType;
+            }
+
+            protected override CSharpType? BuildBaseType() => _baseType;
         }
     }
 }


### PR DESCRIPTION
Fixes #10787

## Summary
- add first-class support for inheritable `SystemObjectModelProvider` replacements
- dedupe derived model properties by serialized wire name when a system base owns the property
- preserve system provider identity through visitor `Update(...)` calls
- register system providers by their wrapped framework type and skip model factory methods for them

## Validation
- `dotnet test packages\http-client-csharp\generator\Microsoft.TypeSpec.Generator\test\Microsoft.TypeSpec.Generator.Tests.csproj --filter "FullyQualifiedName~SystemObjectModelProviderTests|FullyQualifiedName~ModelFactoryProviderTests.SkipSystemObjectModelProvider" --no-restore`
- `npm ci && npm run build` in `packages\http-client-csharp`
- `npm run test:generator` in `packages\http-client-csharp`
- `npm test` in `packages\http-client-csharp`