### PR TITLE
Use newer node in publish pipeline

### DIFF
--- a/eng/tsp-core/pipelines/jobs/build-for-publish.yml
+++ b/eng/tsp-core/pipelines/jobs/build-for-publish.yml
@@ -39,10 +39,11 @@ jobs:
           Contents: "*.vsix"
           TargetFolder: "$(Build.ArtifactStagingDirectory)/vs-extension"
 
-      - task: AzureCLI@1
+      - task: AzureCLI@2
         displayName: "Publish bundled packages to package storage"
         inputs:
           azureSubscription: "Azure SDK Engineering System"
+          scriptType: batch
           scriptLocation: inlineScript
           inlineScript: node ./eng/tsp-core/scripts/upload-bundler-packages.js
 
@@ -69,10 +70,11 @@ jobs:
           name: npm_packages_next
 
       # Publish Next playground
-      - task: AzureCLI@1
+      - task: AzureCLI@2
         displayName: "Publish playground"
         inputs:
           azureSubscription: "Azure SDK Engineering System"
+          scriptType: batch
           scriptLocation: inlineScript
           inlineScript: |
             az storage blob upload-batch ^

--- a/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
+++ b/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
@@ -33,7 +33,7 @@ jobs:
         os: windows
 
     steps:
-      - task: NodeTool@0
+      - task: UseNode@1
         displayName: Install Node.js
         retryCountOnTaskFailure: 3
         inputs:

--- a/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
+++ b/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
@@ -37,7 +37,7 @@ jobs:
         displayName: Install Node.js
         retryCountOnTaskFailure: 3
         inputs:
-          version: 26.x
+          version: 22.x
 
       # - script: npm install -g bun
       #   displayName: Install bun

--- a/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
+++ b/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
@@ -37,7 +37,7 @@ jobs:
         displayName: Install Node.js
         retryCountOnTaskFailure: 3
         inputs:
-          versionSpec: 22.x
+          version: 26.x
 
       # - script: npm install -g bun
       #   displayName: Install bun

--- a/eng/tsp-core/pipelines/jobs/cli/publish-artifacts.yml
+++ b/eng/tsp-core/pipelines/jobs/cli/publish-artifacts.yml
@@ -72,10 +72,11 @@ jobs:
                 ls ./release
               displayName: Prepare for packaging
 
-            - task: AzureCLI@1
+            - task: AzureCLI@2
               displayName: "Upload to storage"
               inputs:
                 azureSubscription: "Azure SDK Engineering System"
+                scriptType: bash
                 scriptLocation: inlineScript
                 inlineScript: |
                   echo -n "$(PACKAGE_VERSION)" > latest.txt

--- a/eng/tsp-core/pipelines/jobs/e2e.yml
+++ b/eng/tsp-core/pipelines/jobs/e2e.yml
@@ -23,10 +23,11 @@ jobs:
       - template: /eng/tsp-core/pipelines/templates/build.yml
 
       - ${{ if parameters.azLogin }}:
-          - task: AzureCLI@1
+          - task: AzureCLI@2
             displayName: E2E Tests
             inputs:
               azureSubscription: "Azure SDK Engineering System"
+              scriptType: bash
               scriptLocation: inlineScript
               inlineScript: pnpm run test:e2e
       - ${{ else }}:

--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -13,7 +13,7 @@ parameters:
     default: $(Pipeline.Workspace)/.pnpm-store
 
 steps:
-  - task: NodeTool@0
+  - task: UseNode@1
     displayName: Install Node.js
     retryCountOnTaskFailure: 3
     inputs:

--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -2,7 +2,7 @@
 parameters:
   - name: nodeVersion
     type: string
-    default: 24.x
+    default: 26.x
 
   - name: useDotNet
     type: string

--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -2,7 +2,7 @@
 parameters:
   - name: nodeVersion
     type: string
-    default: 26.x
+    default: 24.x
 
   - name: useDotNet
     type: string

--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -2,7 +2,7 @@
 parameters:
   - name: nodeVersion
     type: string
-    default: 24.x
+    default: 24.16.0
 
   - name: useDotNet
     type: string

--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -17,7 +17,7 @@ steps:
     displayName: Install Node.js
     retryCountOnTaskFailure: 3
     inputs:
-      versionSpec: ${{ parameters.nodeVersion }}
+      version: ${{ parameters.nodeVersion }}
   - ${{ if parameters.useDotNet }}:
       - task: UseDotNet@2
         displayName: Install .NET

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@alloy-js/cli':
       specifier: ^0.23.0
       version: 0.23.0
+    '@alloy-js/core':
+      specifier: ^0.23.0
+      version: 0.23.1
     '@alloy-js/csharp':
       specifier: ^0.23.0
       version: 0.23.0
@@ -103,8 +106,8 @@ catalogs:
       specifier: ^17.0.0
       version: 17.0.0
     '@playwright/test':
-      specifier: ^1.59.1
-      version: 1.59.1
+      specifier: ^1.60.0
+      version: 1.60.0
     '@pnpm/workspace.find-packages':
       specifier: ^1000.0.65
       version: 1000.0.65
@@ -364,8 +367,8 @@ catalogs:
       specifier: ^1.1.1
       version: 1.1.1
     playwright:
-      specifier: ^1.59.1
-      version: 1.59.1
+      specifier: ^1.60.0
+      version: 1.60.0
     plist:
       specifier: ^3.1.0
       version: 3.1.0
@@ -525,7 +528,6 @@ overrides:
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
   dompurify: ^3.3.3
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'
-  '@alloy-js/core': 0.23.1
 
 importers:
 
@@ -590,7 +592,7 @@ importers:
         version: 1.1.1
       playwright:
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.60.0
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
@@ -905,7 +907,7 @@ importers:
         specifier: 'catalog:'
         version: 0.23.0
       '@alloy-js/core':
-        specifier: 0.23.1
+        specifier: 'catalog:'
         version: 0.23.1
       '@alloy-js/python':
         specifier: 'catalog:'
@@ -1163,7 +1165,7 @@ importers:
         specifier: 'catalog:'
         version: 0.23.0
       '@alloy-js/core':
-        specifier: 0.23.1
+        specifier: 'catalog:'
         version: 0.23.1
       '@alloy-js/rollup-plugin':
         specifier: 'catalog:'
@@ -1199,7 +1201,7 @@ importers:
   packages/http-client-js:
     dependencies:
       '@alloy-js/core':
-        specifier: 0.23.1
+        specifier: 'catalog:'
         version: 0.23.1
       '@alloy-js/typescript':
         specifier: 'catalog:'
@@ -1290,7 +1292,7 @@ importers:
   packages/http-server-csharp:
     dependencies:
       '@alloy-js/core':
-        specifier: 0.23.1
+        specifier: 'catalog:'
         version: 0.23.1
       '@alloy-js/csharp':
         specifier: 'catalog:'
@@ -1921,7 +1923,7 @@ importers:
         version: 7.29.0
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.60.0
       '@storybook/cli':
         specifier: 'catalog:'
         version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2060,7 +2062,7 @@ importers:
         version: 7.29.0
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.60.0
       '@types/debounce':
         specifier: 'catalog:'
         version: 1.2.4
@@ -2711,7 +2713,7 @@ importers:
   packages/tspd:
     dependencies:
       '@alloy-js/core':
-        specifier: 0.23.1
+        specifier: 'catalog:'
         version: 0.23.1
       '@alloy-js/markdown':
         specifier: 'catalog:'
@@ -2848,7 +2850,7 @@ importers:
         version: 0.28.0
       playwright:
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.60.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -3068,7 +3070,7 @@ importers:
         version: 0.41.7(astro@6.3.1(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@types/node@25.5.2)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       rehype-mermaid:
         specifier: 'catalog:'
-        version: 3.0.0(playwright@1.59.1)
+        version: 3.0.0(playwright@1.60.0)
       remark-heading-id:
         specifier: 'catalog:'
         version: 1.0.1
@@ -5503,8 +5505,8 @@ packages:
     resolution: {integrity: sha512-/HHFVVP2pzEtqBVOFRoWlDtBoO8bzIWOqS62APdm3OhYbE2+kVUs/ALpkevvAKKfY0DMDVezYN22bDBh77UQ9Q==}
     engines: {node: '>=18'}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7456,12 +7458,12 @@ packages:
       '@yarnpkg/cli': ^4.9.2
       '@yarnpkg/core': ^4.4.2
 
-  '@yarnpkg/plugin-essentials@4.5.0':
-    resolution: {integrity: sha512-LGQYbgPpeorHAJtscrGOLdNCaSyqee3wo4NnkfJmeGWvlPZyG6eRguthY1AXixo2ZxdN/YkeoI/GAhZH5bRvZA==}
+  '@yarnpkg/plugin-essentials@4.6.0':
+    resolution: {integrity: sha512-W7pUCj0bowYN31hH3RO88kGQ6TXPshRzhoaz8MGDeTz2txrFdBrxL9V4aghtBZWALeapJzWwKBmpUTOUhfWNfw==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/cli': ^4.14.0
-      '@yarnpkg/core': ^4.7.0
+      '@yarnpkg/cli': ^4.15.0
+      '@yarnpkg/core': ^4.8.0
       '@yarnpkg/plugin-git': ^3.2.0
 
   '@yarnpkg/plugin-exec@3.1.0':
@@ -7529,13 +7531,20 @@ packages:
       '@yarnpkg/cli': ^4.10.0
       '@yarnpkg/core': ^4.4.4
 
-  '@yarnpkg/plugin-npm-cli@4.4.1':
-    resolution: {integrity: sha512-GyrHRYqq0y2MIxBzxuHv1Clus6GgssBfb93WZZClWRLJeFc7v8iaIFczFIQQSggc4/ltvNCXF98whSLRd7cKLA==}
+  '@yarnpkg/plugin-nm@4.0.9':
+    resolution: {integrity: sha512-4c5UzuI5IEfhXreOhoREjct3gI16VQ9xc6Gex4Aio6foVw34KTRmJxNzkZ2MrmrPd3dGgsb405J9Vf3wo7Kazw==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/cli': ^4.13.0
-      '@yarnpkg/core': ^4.6.0
-      '@yarnpkg/plugin-npm': ^3.4.1
+      '@yarnpkg/cli': ^4.15.0
+      '@yarnpkg/core': ^4.8.0
+
+  '@yarnpkg/plugin-npm-cli@4.4.2':
+    resolution: {integrity: sha512-r4IcxE/sgHsp2WtSkwebLYv0KMIglfClxCPeTzuWNMJeKBLW8wvf+8aFK4ldDyZM0f0dj9Pnpv+lZQ7ZEKdXww==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@yarnpkg/cli': ^4.15.0
+      '@yarnpkg/core': ^4.8.0
+      '@yarnpkg/plugin-npm': ^3.6.0
       '@yarnpkg/plugin-pack': ^4.0.4
 
   '@yarnpkg/plugin-npm@3.4.1':
@@ -7545,11 +7554,11 @@ packages:
       '@yarnpkg/core': ^4.6.0
       '@yarnpkg/plugin-pack': ^4.0.4
 
-  '@yarnpkg/plugin-npm@3.5.0':
-    resolution: {integrity: sha512-Bs0timHs48gAu8IBCHsevRq8BqZNAnNCXgdnHEeKJE97H9gds0+tY7BsBzSYCtCdVVmsDB+l0Ia38QZAG8RMMw==}
+  '@yarnpkg/plugin-npm@3.6.0':
+    resolution: {integrity: sha512-q714z9UVuWShcMxpw5Vawz/aVvtXg/Jg/qLqt98aUpFkdGX3CDhINp/5aXYYd0Oh/HkOL7Q23t+CA7OU4xNUYw==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/core': ^4.7.0
+      '@yarnpkg/core': ^4.8.0
       '@yarnpkg/plugin-pack': ^4.0.4
 
   '@yarnpkg/plugin-pack@4.0.4':
@@ -7559,12 +7568,12 @@ packages:
       '@yarnpkg/cli': ^4.10.1
       '@yarnpkg/core': ^4.4.4
 
-  '@yarnpkg/plugin-patch@4.0.3':
-    resolution: {integrity: sha512-SpPMvXNs9IpO6Ik8EGsbh1KXTTuH/FJQhKv6LpZgovqNBBm08rMJjxxFyFTyvKueIp0CSqge9b/fUP+dtFUxVg==}
+  '@yarnpkg/plugin-patch@4.0.4':
+    resolution: {integrity: sha512-kUh3A21WpiEG7dmKJ2/BF7AmCt2loTHLfkhng0MPFqg7JDyL35jT3POjtCEgDa/WA1c6u077GLp2GSI/zgdtIQ==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/cli': ^4.9.2
-      '@yarnpkg/core': ^4.4.2
+      '@yarnpkg/cli': ^4.15.0
+      '@yarnpkg/core': ^4.8.0
 
   '@yarnpkg/plugin-pnp@4.1.3':
     resolution: {integrity: sha512-kH1IZYSICyVyc2UFEgiKmKi1wATlerTYQRifHy2nXPejZpeaLDcs16+KdUDE7bHAYYnL4r0l5VcMMAIKaAHlpw==}
@@ -7573,19 +7582,19 @@ packages:
       '@yarnpkg/cli': ^4.11.0
       '@yarnpkg/core': ^4.5.0
 
-  '@yarnpkg/plugin-pnp@4.1.5':
-    resolution: {integrity: sha512-KdrC2/kcr2WSD7yehBQPXCVIZSk7Cf3V6TUxnlUrdqC4T65XrJH423f77GtUJnsG36BE0aPYDUKIcIliPBcq6g==}
+  '@yarnpkg/plugin-pnp@4.1.6':
+    resolution: {integrity: sha512-T8IgdHCWdjByOK5YvBE/CQ3W5iDOpAPD/6CKziYWef121IeW3S56B+ubA5njE4eukFeGohLrUwteRJs9Ukgd1w==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/cli': ^4.14.1
-      '@yarnpkg/core': ^4.7.0
+      '@yarnpkg/cli': ^4.15.0
+      '@yarnpkg/core': ^4.8.0
 
-  '@yarnpkg/plugin-pnpm@2.1.2':
-    resolution: {integrity: sha512-6lR84Gu0LnS2MUKu3dFxyGTXmHbODVghHH0x9OyCsdMwWQp2GHJIsuda1dF+lbJdVZJleGbAUSchnqIFx8QY9A==}
+  '@yarnpkg/plugin-pnpm@2.2.0':
+    resolution: {integrity: sha512-7UjOBSC4cFBTtah/3uuXod7UiiiW49Rr/P8NJZSz8pBnT57cMehoitufVK5MZBIBZl7V2B8RrQbvZU/iS9LZFg==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/cli': ^4.9.3
-      '@yarnpkg/core': ^4.4.3
+      '@yarnpkg/cli': ^4.15.0
+      '@yarnpkg/core': ^4.8.0
 
   '@yarnpkg/plugin-stage@4.0.2':
     resolution: {integrity: sha512-hhH7+5S3U00ms3PIvGV1d6zErD7LVia0+TlwGz25eP04ZWYUQenaNSYYXyKECnilkLQGXDqQo3g1WL9UZTbpgw==}
@@ -7622,8 +7631,8 @@ packages:
     resolution: {integrity: sha512-PsRujup+6DpgXexQe0Wh4h+syQhdruhounJjqbBMXV3meOzqr7k0Nj9+jwQ4t16EZJrhVxH7vRvjZ+VitH5aWQ==}
     engines: {node: '>=18.12.0'}
 
-  '@yarnpkg/pnp@4.1.5':
-    resolution: {integrity: sha512-hDqB3Kke873wdx3rip1zlblfBIx2sGJH0BoNPh435A5rSEVT1sDKuCykLxNlLUnGhIZc83FXLGDGZJn23ggAQg==}
+  '@yarnpkg/pnp@4.1.6':
+    resolution: {integrity: sha512-Q4vEB6OxJbY+XbJvX+6DL6qEx5OwJ8KPf2ByeHuow7lfgLQkvzjoG/bC235dpUWko/MjdLMy9frIWccMSlyIOw==}
     engines: {node: '>=18.12.0'}
 
   '@yarnpkg/shell@4.0.0':
@@ -7988,8 +7997,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  bole@5.0.28:
-    resolution: {integrity: sha512-l+yybyZLV7zTD6EuGxoXsilpER1ctMCpdOqjSYNigJJma39ha85fzCtYccPx06oR1u7uCQLOcUAFFzvfXVBmuQ==}
+  bole@5.0.29:
+    resolution: {integrity: sha512-eYR9i2ubLv5/4TFGyZsQ1cVH4jF9+qLJA72Aow+E7ZZQfqHqQNUZeX3w+pVWF76PQyjl5eDKf2xylyOOX76ozA==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -9042,6 +9051,9 @@ packages:
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -9413,6 +9425,10 @@ packages:
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fs-minipass@3.0.3:
@@ -10176,6 +10192,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -11457,13 +11476,13 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -12110,6 +12129,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -12149,6 +12173,10 @@ packages:
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@3.23.0:
@@ -13546,8 +13574,8 @@ packages:
     resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
     engines: {node: '>=16.14'}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -17093,9 +17121,9 @@ snapshots:
     dependencies:
       playwright-core: 1.58.2
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   '@pnpm/byline@1.0.0': {}
 
@@ -17422,7 +17450,7 @@ snapshots:
       '@pnpm/store-controller-types': 1004.5.1
       '@reflink/reflink': 0.1.19
       '@zkochan/rimraf': 3.0.2
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       make-empty-dir: 3.0.2
       p-limit: 3.1.0
       path-temp: 2.1.1
@@ -17550,7 +17578,7 @@ snapshots:
 
   '@pnpm/logger@1001.0.1':
     dependencies:
-      bole: 5.0.28
+      bole: 5.0.29
       split2: 4.2.0
 
   '@pnpm/manifest-utils@1002.0.5(@pnpm/logger@1001.0.1)':
@@ -19541,7 +19569,7 @@ snapshots:
       koa-mount: 4.2.0
       koa-static: 5.0.0
       minimist: 1.2.8
-      playwright: 1.59.1
+      playwright: 1.60.0
       tar-fs: 3.1.2
       tinyglobby: 0.2.15
       vscode-uri: 3.1.0
@@ -19674,34 +19702,34 @@ snapshots:
       '@yarnpkg/libzip': 3.2.2(@yarnpkg/fslib@3.1.5)
       '@yarnpkg/parsers': 3.0.3
       '@yarnpkg/plugin-catalog': 1.0.2(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
-      '@yarnpkg/plugin-compat': 4.0.12(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-patch@4.0.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
+      '@yarnpkg/plugin-compat': 4.0.12(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-patch@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       '@yarnpkg/plugin-constraints': 4.0.5(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       '@yarnpkg/plugin-dlx': 4.0.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/plugin-essentials': 4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
+      '@yarnpkg/plugin-essentials': 4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       '@yarnpkg/plugin-exec': 3.1.0(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/plugin-file': 3.0.2(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/plugin-git': 3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       '@yarnpkg/plugin-github': 3.0.2(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       '@yarnpkg/plugin-http': 3.0.3(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/plugin-init': 4.1.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/plugin-interactive-tools': 4.1.0(@types/react@19.2.14)(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))
+      '@yarnpkg/plugin-interactive-tools': 4.1.0(@types/react@19.2.14)(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))
       '@yarnpkg/plugin-jsr': 1.1.1(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/plugin-link': 3.0.2(@yarnpkg/core@4.6.0(typanion@3.14.0))
-      '@yarnpkg/plugin-nm': 4.0.8(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/plugin-npm': 3.5.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
-      '@yarnpkg/plugin-npm-cli': 4.4.1(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-npm@3.5.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
+      '@yarnpkg/plugin-nm': 4.0.9(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
+      '@yarnpkg/plugin-npm': 3.6.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
+      '@yarnpkg/plugin-npm-cli': 4.4.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-npm@3.6.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       '@yarnpkg/plugin-pack': 4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/plugin-patch': 4.0.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/plugin-pnp': 4.1.5(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/plugin-pnpm': 2.1.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
+      '@yarnpkg/plugin-patch': 4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
+      '@yarnpkg/plugin-pnp': 4.1.6(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
+      '@yarnpkg/plugin-pnpm': 2.2.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       '@yarnpkg/plugin-stage': 4.0.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/plugin-typescript': 4.1.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(typanion@3.14.0)
+      '@yarnpkg/plugin-typescript': 4.1.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(typanion@3.14.0)
       '@yarnpkg/plugin-version': 4.2.0(@types/react@19.2.14)(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))(typanion@3.14.0)
       '@yarnpkg/plugin-workspace-tools': 4.1.7(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       '@yarnpkg/shell': 4.1.3(typanion@3.14.0)
       ci-info: 4.4.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
-      semver: 7.7.4
+      semver: 7.8.1
       tslib: 2.8.1
       typanion: 3.14.0
     transitivePeerDependencies:
@@ -19781,11 +19809,11 @@ snapshots:
       '@yarnpkg/plugin-pack': 4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       tslib: 2.8.1
 
-  '@yarnpkg/plugin-compat@4.0.12(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-patch@4.0.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
+  '@yarnpkg/plugin-compat@4.0.12(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-patch@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
     dependencies:
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/extensions': 2.0.6(@yarnpkg/core@4.6.0(typanion@3.14.0))
-      '@yarnpkg/plugin-patch': 4.0.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
+      '@yarnpkg/plugin-patch': 4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
 
   '@yarnpkg/plugin-constraints@4.0.5(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
     dependencies:
@@ -19793,7 +19821,7 @@ snapshots:
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
-      es-toolkit: 1.45.1
+      es-toolkit: 1.47.0
       tau-prolog: 0.2.81
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -19809,7 +19837,7 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/plugin-essentials@4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
+  '@yarnpkg/plugin-essentials@4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
     dependencies:
       '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
@@ -19819,9 +19847,9 @@ snapshots:
       ci-info: 4.4.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       enquirer: 2.4.1
-      es-toolkit: 1.45.1
+      es-toolkit: 1.47.0
       micromatch: 4.0.8
-      semver: 7.7.4
+      semver: 7.8.1
       tslib: 2.8.1
       typanion: 3.14.0
 
@@ -19844,9 +19872,9 @@ snapshots:
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
-      es-toolkit: 1.45.1
+      es-toolkit: 1.47.0
       git-url-parse: 13.1.1
-      semver: 7.7.4
+      semver: 7.8.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - typanion
@@ -19873,19 +19901,19 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/plugin-interactive-tools@4.1.0(@types/react@19.2.14)(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))':
+  '@yarnpkg/plugin-interactive-tools@4.1.0(@types/react@19.2.14)(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))':
     dependencies:
       '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/libui': 3.1.0(ink@3.2.0(@types/react@19.2.14)(react@17.0.2))(react@17.0.2)
-      '@yarnpkg/plugin-essentials': 4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
+      '@yarnpkg/plugin-essentials': 4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       algoliasearch: 4.27.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.2
       ink: 3.2.0(@types/react@19.2.14)(react@19.2.5)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.2.14)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       tslib: 2.8.1
       typanion: 3.14.0
     transitivePeerDependencies:
@@ -19921,17 +19949,33 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/plugin-npm-cli@4.4.1(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-npm@3.5.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
+  '@yarnpkg/plugin-nm@4.0.9(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
-      '@yarnpkg/plugin-npm': 3.5.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
+      '@yarnpkg/libzip': 3.2.2(@yarnpkg/fslib@3.1.5)
+      '@yarnpkg/nm': 4.0.7(typanion@3.14.0)
+      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/plugin-pnp': 4.1.6(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
+      '@yarnpkg/pnp': 4.1.6
+      '@zkochan/cmd-shim': 5.4.1
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - typanion
+
+  '@yarnpkg/plugin-npm-cli@4.4.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-npm@3.6.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
+    dependencies:
+      '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
+      '@yarnpkg/core': 4.6.0(typanion@3.14.0)
+      '@yarnpkg/fslib': 3.1.5
+      '@yarnpkg/plugin-npm': 3.6.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       '@yarnpkg/plugin-pack': 4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       enquirer: 2.4.1
       micromatch: 4.0.8
-      semver: 7.7.4
+      semver: 7.8.1
       tslib: 2.8.1
       typanion: 3.14.0
 
@@ -19950,15 +19994,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@yarnpkg/plugin-npm@3.5.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
+  '@yarnpkg/plugin-npm@3.6.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-pack@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))':
     dependencies:
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
       '@yarnpkg/plugin-pack': 4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       enquirer: 2.4.1
-      es-toolkit: 1.45.1
+      es-toolkit: 1.47.0
       micromatch: 4.0.8
-      semver: 7.7.4
+      semver: 7.8.1
       sigstore: 3.1.0
       ssri: 12.0.0
       tslib: 2.8.1
@@ -19977,7 +20021,7 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/plugin-patch@4.0.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
+  '@yarnpkg/plugin-patch@4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
@@ -20001,25 +20045,25 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/plugin-pnp@4.1.5(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
+  '@yarnpkg/plugin-pnp@4.1.6(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
       '@yarnpkg/plugin-stage': 4.0.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
-      '@yarnpkg/pnp': 4.1.5
+      '@yarnpkg/pnp': 4.1.6
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       micromatch: 4.0.8
       tslib: 2.8.1
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/plugin-pnpm@2.1.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
+  '@yarnpkg/plugin-pnpm@2.2.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
-      '@yarnpkg/plugin-pnp': 4.1.5(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
+      '@yarnpkg/plugin-pnp': 4.1.6(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       '@yarnpkg/plugin-stage': 4.0.2(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       p-limit: 2.3.0
@@ -20037,15 +20081,15 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/plugin-typescript@4.1.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(typanion@3.14.0)':
+  '@yarnpkg/plugin-typescript@4.1.3(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-essentials@4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)))(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/cli': 4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0))
       '@yarnpkg/core': 4.6.0(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
-      '@yarnpkg/plugin-essentials': 4.5.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
+      '@yarnpkg/plugin-essentials': 4.6.0(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(@yarnpkg/plugin-git@3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0))
       '@yarnpkg/plugin-pack': 4.0.4(@yarnpkg/cli@4.12.0(@types/react@19.2.14)(@yarnpkg/core@4.6.0(typanion@3.14.0)))(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       algoliasearch: 4.27.0
-      semver: 7.7.4
+      semver: 7.8.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - typanion
@@ -20059,10 +20103,10 @@ snapshots:
       '@yarnpkg/parsers': 3.0.3
       '@yarnpkg/plugin-git': 3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
-      es-toolkit: 1.45.1
+      es-toolkit: 1.47.0
       ink: 3.2.0(@types/react@19.2.14)(react@17.0.2)
       react: 17.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/react'
@@ -20077,7 +20121,7 @@ snapshots:
       '@yarnpkg/fslib': 3.1.5
       '@yarnpkg/plugin-git': 3.2.0(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
-      es-toolkit: 1.45.1
+      es-toolkit: 1.47.0
       micromatch: 4.0.8
       p-limit: 2.3.0
       tslib: 2.8.1
@@ -20088,7 +20132,7 @@ snapshots:
       '@types/node': 18.19.130
       '@yarnpkg/fslib': 3.1.5
 
-  '@yarnpkg/pnp@4.1.5':
+  '@yarnpkg/pnp@4.1.6':
     dependencies:
       '@types/node': 18.19.130
       '@yarnpkg/fslib': 3.1.5
@@ -20550,7 +20594,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bole@5.0.28:
+  bole@5.0.29:
     dependencies:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
@@ -21664,6 +21708,8 @@ snapshots:
 
   es-toolkit@1.45.1: {}
 
+  es-toolkit@1.47.0: {}
+
   esast-util-from-estree@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -22175,6 +22221,12 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs-minipass@3.0.3:
@@ -22834,7 +22886,7 @@ snapshots:
       type-fest: 0.12.0
       widest-line: 3.1.0
       wrap-ansi: 6.2.0
-      ws: 7.5.10
+      ws: 7.5.11
       yoga-layout-prebuilt: 1.10.0
     optionalDependencies:
       '@types/react': 19.2.14
@@ -22866,7 +22918,7 @@ snapshots:
       type-fest: 0.12.0
       widest-line: 3.1.0
       wrap-ansi: 6.2.0
-      ws: 7.5.10
+      ws: 7.5.11
       yoga-layout-prebuilt: 1.10.0
     optionalDependencies:
       '@types/react': 19.2.14
@@ -23115,6 +23167,12 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -23712,13 +23770,13 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid-isomorphic@3.1.0(playwright@1.59.1):
+  mermaid-isomorphic@3.1.0(playwright@1.60.0):
     dependencies:
       '@fortawesome/fontawesome-free': 6.7.2
       katex: 0.16.38
       mermaid: 11.13.0
     optionalDependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   mermaid@11.13.0:
     dependencies:
@@ -24744,11 +24802,11 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -24977,8 +25035,8 @@ snapshots:
 
   react-devtools-core@4.28.5:
     dependencies:
-      shell-quote: 1.8.3
-      ws: 7.5.10
+      shell-quote: 1.8.4
+      ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -25184,19 +25242,19 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-format: 1.1.0
 
-  rehype-mermaid@3.0.0(playwright@1.59.1):
+  rehype-mermaid@3.0.0(playwright@1.60.0):
     dependencies:
       '@types/hast': 3.0.4
       hast-util-from-html-isomorphic: 2.0.0
       hast-util-to-text: 4.0.2
-      mermaid-isomorphic: 3.1.0(playwright@1.59.1)
+      mermaid-isomorphic: 3.1.0(playwright@1.60.0)
       mini-svg-data-uri: 1.4.4
       space-separated-tokens: 2.0.2
       unified: 11.0.5
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
     optionalDependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   rehype-parse@9.0.1:
     dependencies:
@@ -25564,6 +25622,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.1: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -25641,6 +25701,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  shell-quote@1.8.4: {}
 
   shiki@3.23.0:
     dependencies:
@@ -26979,7 +27041,7 @@ snapshots:
       js-yaml: 4.1.1
       write-file-atomic: 5.0.1
 
-  ws@7.5.10: {}
+  ws@7.5.11: {}
 
   ws@8.20.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ catalog:
   "@octokit/core": ^7.0.6
   "@octokit/plugin-paginate-graphql": ^6.0.0
   "@octokit/plugin-rest-endpoint-methods": ^17.0.0
-  "@playwright/test": ^1.59.1
+  "@playwright/test": ^1.60.0
   "@pnpm/workspace.find-packages": ^1000.0.65
   "@scalar/json-magic": ^0.12.5
   "@scalar/openapi-parser": ^0.25.8
@@ -127,7 +127,7 @@ catalog:
   p-limit: ^7.3.0
   pathe: ^2.0.3
   picocolors: ^1.1.1
-  playwright: ^1.59.1
+  playwright: ^1.60.0
   plist: ^3.1.0
   postject: 1.0.0-alpha.6
   prettier: ^3.8.1
@@ -190,4 +190,3 @@ overrides:
   diff@>=6.0.0 <8.0.3: ">=8.0.3"
   dompurify: ^3.3.3
   yaml@>=2.0.0 <2.8.3: ">=2.8.3"
-  "@alloy-js/core": 0.23.1


### PR DESCRIPTION
Resoilve an issue with a package that fail to install in standalone cli e2e tests 
```
typespec/standalone-cli:test:e2e:     'npm warn Unknown global config "store-dir". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.\n' +
@typespec/standalone-cli:test:e2e:     'npm error code EBADENGINE\n' +
@typespec/standalone-cli:test:e2e:     'npm error engine Unsupported engine\n' +
@typespec/standalone-cli:test:e2e:     'npm error engine Not compatible with your version of node/npm: mute-stream@4.0.0\n' +
@typespec/standalone-cli:test:e2e:     'npm error notsup Not compatible with your version of node/npm: mute-stream@4.0.0\n' +
@typespec/standalone-cli:test:e2e:     'npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}\n' +
@typespec/standalone-cli:test:e2e:     'npm error notsup Actual:   {"node":"v24.14.1","npm":"11.15.0"}\n' +
@typespec/standalone-cli:test:e2e:     'npm error A complete log of this run can be found in: /home/cloudtest/.npm/_logs/2026-05-27T14_28_43_340Z-debug-0.log\n' +
@typespec/standalone-cli:test:e2e:     'Internal compiler error!\n' +
```

successful run https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6359597&view=results