### PR TITLE
Fix Python emitter CI publish failure: stamp prerelease version in Build-Packages.ps1

### DIFF
--- a/.chronus/changes/fix-python-prerelease-version-stamping-2026-5-27-13-30-0.md
+++ b/.chronus/changes/fix-python-prerelease-version-stamping-2026-5-27-13-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix CI publish failures by stamping prerelease version in Build-Packages.ps1. The `-Prerelease` flag was accepted but unused, causing every CI build to produce the same version and fail with a 409 conflict on the DevOps feed.

--- a/eng/emitters/pipelines/templates/steps/build-step.yml
+++ b/eng/emitters/pipelines/templates/steps/build-step.yml
@@ -85,8 +85,8 @@ steps:
       arguments: -UseTypeSpecNext:$${{ parameters.UseTypeSpecNext }}
       workingDirectory: $(selfRepositoryPath)
 
-  - script: npm install -g pnpm @chronus/chronus
-    displayName: Install pnpm and chronus
+  - script: npm install -g pnpm
+    displayName: Install pnpm
 
   - task: PowerShell@2
     displayName: "Run build script"

--- a/eng/emitters/pipelines/templates/steps/build-step.yml
+++ b/eng/emitters/pipelines/templates/steps/build-step.yml
@@ -85,8 +85,8 @@ steps:
       arguments: -UseTypeSpecNext:$${{ parameters.UseTypeSpecNext }}
       workingDirectory: $(selfRepositoryPath)
 
-  - script: npm install -g pnpm
-    displayName: Install pnpm
+  - script: npm install -g pnpm @chronus/chronus
+    displayName: Install pnpm and chronus
 
   - task: PowerShell@2
     displayName: "Run build script"

--- a/eng/emitters/pipelines/templates/steps/build-step.yml
+++ b/eng/emitters/pipelines/templates/steps/build-step.yml
@@ -85,6 +85,9 @@ steps:
       arguments: -UseTypeSpecNext:$${{ parameters.UseTypeSpecNext }}
       workingDirectory: $(selfRepositoryPath)
 
+  - script: npm install -g pnpm
+    displayName: Install pnpm
+
   - task: PowerShell@2
     displayName: "Run build script"
     name: ci_build

--- a/eng/emitters/pipelines/templates/steps/build-step.yml
+++ b/eng/emitters/pipelines/templates/steps/build-step.yml
@@ -85,9 +85,6 @@ steps:
       arguments: -UseTypeSpecNext:$${{ parameters.UseTypeSpecNext }}
       workingDirectory: $(selfRepositoryPath)
 
-  - script: npm install -g pnpm
-    displayName: Install pnpm
-
   - task: PowerShell@2
     displayName: "Run build script"
     name: ci_build

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -90,7 +90,7 @@ try {
     # Step 3: Stamp prerelease version if this is a prerelease build
     if ($Prerelease) {
         Write-Host "`n=== Stamping prerelease version ===" -ForegroundColor Cyan
-        Invoke-LoggedCommand "pnpm chronus version --prerelease --only `"@typespec/http-client-python`""
+        Invoke-LoggedCommand "npx chronus version --prerelease --only `"@typespec/http-client-python`""
         $emitterVersion = node -p -e "require('./package.json').version"
         Write-Host "Stamped version: $emitterVersion"
     }

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -1,30 +1,4 @@
 #Requires -Version 7.0
-<#
-.SYNOPSIS
-    Builds and packages the TypeSpec Python emitter for publishing.
-
-.DESCRIPTION
-    This script is called by the CI pipeline to create publishable packages.
-    It runs:
-      1. npm run build     - Compile TypeScript emitter and build Python wheel
-      2. npm run lint      - Run linting (Linux only)
-      3. npm pack          - Create npm tarball for publishing
-
-.PARAMETER BuildNumber
-    The build number for versioning.
-
-.PARAMETER Output
-    Output directory for built packages. Defaults to ./ci-build.
-
-.PARAMETER Prerelease
-    Flag indicating if this is a prerelease build.
-
-.PARAMETER PublishType
-    Type of publish: "internal" for dev feed, otherwise public.
-
-.EXAMPLE
-    ./Build-Packages.ps1 -Output ./dist
-#>
 
 param(
     [string] $BuildNumber,
@@ -35,13 +9,14 @@ param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 3.0
-
-# Setup paths and helpers
 $packageRoot = (Resolve-Path "$PSScriptRoot/../..").Path.Replace('\', '/')
 . "$packageRoot/../../eng/emitters/scripts/CommandInvocation-Helpers.ps1"
 Set-ConsoleEncoding
 
-# Helper function to write package info for downstream publishing
+Write-Host "Building packages for BuildNumber: '$BuildNumber', Output: '$Output', Prerelease: '$Prerelease', PublishType: '$PublishType'"
+
+$outputPath = $Output ? $Output : "$packageRoot/ci-build"
+
 function Write-PackageInfo {
     param(
         [string] $packageName,
@@ -55,81 +30,75 @@ function Write-PackageInfo {
     }
 
     @{
-        Name          = $packageName
-        Version       = $version
+        Name = $packageName
+        Version = $version
         DirectoryPath = $directoryPath
-        SdkType       = "client"
-        IsNewSdk      = $true
+        SdkType = "client"
+        IsNewSdk = $true
         ReleaseStatus = "Unreleased"
     } | ConvertTo-Json | Set-Content -Path "$packageInfoPath/$packageName.json"
 }
 
-Write-Host "Building packages for BuildNumber: '$BuildNumber', Output: '$Output', Prerelease: '$Prerelease', PublishType: '$PublishType'"
+function Set-VersionVariable {
+    param(
+        [string] $variableName,
+        [string] $version
+    )
 
-# Setup output directory
-$outputPath = $Output ? $Output : "$packageRoot/ci-build"
+    Write-Host "Setting output variable '$variableName' to $version"
+    Write-Host "##vso[task.setvariable variable=$variableName;isOutput=true]$version"
+}
+
+# create the output folders
 $outputPath = New-Item -ItemType Directory -Force -Path $outputPath | Select-Object -ExpandProperty FullName
 New-Item -ItemType Directory -Force -Path "$outputPath/packages" | Out-Null
 
-# Get package version
+Write-Host "Getting existing versions"
 $emitterVersion = node -p -e "require('$packageRoot/package.json').version"
-Write-Host "Package version: $emitterVersion"
 
+if ($BuildNumber) {
+    # set package versions
+    $versionTag = $Prerelease ? "-alpha" : "-beta"
+
+    $emitterVersion = "$emitterVersion$versionTag.$BuildNumber"
+    Set-VersionVariable -variableName "emitterVersion" -version $emitterVersion
+}
+
+# build and pack the emitter
 Push-Location "$packageRoot"
 try {
-    # Step 1: Build the emitter and generator
-    Write-Host "`n=== Building emitter and generator ===" -ForegroundColor Cyan
+    Write-Host "Working in $PWD"
+
     Invoke-LoggedCommand "npm run build" -GroupOutput
 
-    # Step 2: Run linting (Linux only, as CI runs on Linux)
-    if ($IsLinux) {
-        Write-Host "`n=== Running lint checks ===" -ForegroundColor Cyan
-        Invoke-LoggedCommand "npm run lint" -GroupOutput
+    if ($BuildNumber) {
+        Write-Host "Updating package.json to version: $emitterVersion`n"
+
+        $packageJson = Get-Content -Raw "package.json" | ConvertFrom-Json -AsHashtable
+        $packageJson.version = $emitterVersion
+        $packageJson | ConvertTo-Json -Depth 100 | Out-File -Path "package.json" -Encoding utf8 -NoNewline -Force
     }
 
-    # Step 3: Stamp prerelease version if this is a prerelease build
-    if ($Prerelease) {
-        # Only stamp if there are pending chronus change files for this package
-        $changeFiles = Get-ChildItem -Path "$packageRoot/../../.chronus/changes" -Filter "*.md" -ErrorAction SilentlyContinue |
-            Where-Object { (Get-Content $_.FullName -Raw) -match "http-client-python" }
+    # pack the emitter
+    $file = Invoke-LoggedCommand "npm pack -q"
+    Copy-Item $file -Destination "$outputPath/packages"
 
-        if ($changeFiles) {
-            Write-Host "`n=== Stamping prerelease version ===" -ForegroundColor Cyan
-            Invoke-LoggedCommand "pnpm chronus version --prerelease --only @typespec/http-client-python"
-            $emitterVersion = node -p -e "require('./package.json').version"
-            Write-Host "Stamped version: $emitterVersion"
-        } else {
-            Write-Host "`n=== No pending changes for @typespec/http-client-python, skipping prerelease version stamp ===" -ForegroundColor Yellow
-        }
-    }
-
-    Write-Host "`n=== Creating npm package ===" -ForegroundColor Cyan
-    Invoke-LoggedCommand "npm pack"
-    Copy-Item "typespec-http-client-python-$emitterVersion.tgz" -Destination "$outputPath/packages"
-
-    # Step 4: Verify package can be installed
-    Write-Host "`n=== Verifying package installation ===" -ForegroundColor Cyan
-    Invoke-LoggedCommand "npm install typespec-http-client-python-$emitterVersion.tgz" -GroupOutput
-
-    # Write package info for publishing pipeline
-    Write-PackageInfo -packageName "typespec-http-client-python" `
-                      -directoryPath "packages/http-client-python/emitter/src" `
-                      -version $emitterVersion
+    Write-PackageInfo -packageName "typespec-http-client-python" -directoryPath "packages/http-client-python/emitter/src" -version $emitterVersion
 }
 finally {
     Pop-Location
 }
 
-# Generate override URLs for internal publishing
-$overrides = @{}
 if ($PublishType -eq "internal") {
     $feedUrl = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry"
-    $overrides["@typespec/http-client-python"] = "$feedUrl/@typespec/http-client-python/-/http-client-python-$emitterVersion.tgz"
+
+    $overrides = @{
+        "@typespec/http-client-python" = "$feedUrl/@typespec/http-client-python/-/http-client-python-$emitterVersion.tgz"
+    }
+} else {
+    $overrides = @{}
 }
+
 $overrides | ConvertTo-Json | Set-Content "$outputPath/overrides.json"
 
-# Write package version matrix
 @{ "emitter" = $emitterVersion } | ConvertTo-Json | Set-Content "$outputPath/package-versions.json"
-
-Write-Host "`n=== Build complete ===" -ForegroundColor Green
-Write-Host "Output: $outputPath"

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -90,7 +90,7 @@ try {
     # Step 3: Stamp prerelease version if this is a prerelease build
     if ($Prerelease) {
         Write-Host "`n=== Stamping prerelease version ===" -ForegroundColor Cyan
-        Invoke-LoggedCommand "npx chronus version --prerelease --only `"@typespec/http-client-python`""
+        Invoke-LoggedCommand "pnpm chronus version --prerelease --only `"@typespec/http-client-python`""
         $emitterVersion = node -p -e "require('./package.json').version"
         Write-Host "Stamped version: $emitterVersion"
     }

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -88,11 +88,14 @@ try {
     }
 
     # Step 3: Stamp prerelease version if this is a prerelease build
-    if ($Prerelease) {
-        Write-Host "`n=== Stamping prerelease version ===" -ForegroundColor Cyan
-        Invoke-LoggedCommand "pnpm chronus version --prerelease --only `"@typespec/http-client-python`""
-        $emitterVersion = node -p -e "require('./package.json').version"
-        Write-Host "Stamped version: $emitterVersion"
+    if ($BuildNumber) {
+        $versionTag = $Prerelease ? "-alpha" : "-beta"
+        $emitterVersion = "$emitterVersion$versionTag.$BuildNumber"
+        Write-Host "`n=== Stamping prerelease version: $emitterVersion ===" -ForegroundColor Cyan
+
+        $packageJson = Get-Content -Raw "package.json" | ConvertFrom-Json -AsHashtable
+        $packageJson.version = $emitterVersion
+        $packageJson | ConvertTo-Json -Depth 100 | Out-File -Path "package.json" -Encoding utf8 -NoNewline -Force
     }
 
     Write-Host "`n=== Creating npm package ===" -ForegroundColor Cyan

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -88,14 +88,19 @@ try {
     }
 
     # Step 3: Stamp prerelease version if this is a prerelease build
-    if ($BuildNumber) {
-        $versionTag = $Prerelease ? "-alpha" : "-beta"
-        $emitterVersion = "$emitterVersion$versionTag.$BuildNumber"
-        Write-Host "`n=== Stamping prerelease version: $emitterVersion ===" -ForegroundColor Cyan
+    if ($Prerelease) {
+        # Only stamp if there are pending chronus change files for this package
+        $changeFiles = Get-ChildItem -Path "$packageRoot/../../.chronus/changes" -Filter "*.md" -ErrorAction SilentlyContinue |
+            Where-Object { (Get-Content $_.FullName -Raw) -match "http-client-python" }
 
-        $packageJson = Get-Content -Raw "package.json" | ConvertFrom-Json -AsHashtable
-        $packageJson.version = $emitterVersion
-        $packageJson | ConvertTo-Json -Depth 100 | Out-File -Path "package.json" -Encoding utf8 -NoNewline -Force
+        if ($changeFiles) {
+            Write-Host "`n=== Stamping prerelease version ===" -ForegroundColor Cyan
+            Invoke-LoggedCommand "pnpm chronus version --prerelease --only @typespec/http-client-python"
+            $emitterVersion = node -p -e "require('./package.json').version"
+            Write-Host "Stamped version: $emitterVersion"
+        } else {
+            Write-Host "`n=== No pending changes for @typespec/http-client-python, skipping prerelease version stamp ===" -ForegroundColor Yellow
+        }
     }
 
     Write-Host "`n=== Creating npm package ===" -ForegroundColor Cyan

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -75,6 +75,13 @@ New-Item -ItemType Directory -Force -Path "$outputPath/packages" | Out-Null
 $emitterVersion = node -p -e "require('$packageRoot/package.json').version"
 Write-Host "Package version: $emitterVersion"
 
+# Stamp prerelease version if BuildNumber is provided
+if ($BuildNumber) {
+    $versionTag = $Prerelease ? "-alpha" : "-beta"
+    $emitterVersion = "$emitterVersion$versionTag.$BuildNumber"
+    Write-Host "Stamped version: $emitterVersion"
+}
+
 Push-Location "$packageRoot"
 try {
     # Step 1: Build the emitter and generator
@@ -87,7 +94,14 @@ try {
         Invoke-LoggedCommand "npm run lint" -GroupOutput
     }
 
-    # Step 3: Create npm package
+    # Step 3: Update package.json version and create npm package
+    if ($BuildNumber) {
+        Write-Host "`n=== Updating package.json to version: $emitterVersion ===" -ForegroundColor Cyan
+        $packageJson = Get-Content -Raw "package.json" | ConvertFrom-Json -AsHashtable
+        $packageJson.version = $emitterVersion
+        $packageJson | ConvertTo-Json -Depth 100 | Out-File -Path "package.json" -Encoding utf8 -NoNewline -Force
+    }
+
     Write-Host "`n=== Creating npm package ===" -ForegroundColor Cyan
     Invoke-LoggedCommand "npm pack"
     Copy-Item "typespec-http-client-python-$emitterVersion.tgz" -Destination "$outputPath/packages"

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -1,4 +1,30 @@
 #Requires -Version 7.0
+<#
+.SYNOPSIS
+    Builds and packages the TypeSpec Python emitter for publishing.
+
+.DESCRIPTION
+    This script is called by the CI pipeline to create publishable packages.
+    It runs:
+      1. npm run build     - Compile TypeScript emitter and build Python wheel
+      2. npm run lint      - Run linting (Linux only)
+      3. npm pack          - Create npm tarball for publishing
+
+.PARAMETER BuildNumber
+    The build number for versioning.
+
+.PARAMETER Output
+    Output directory for built packages. Defaults to ./ci-build.
+
+.PARAMETER Prerelease
+    Flag indicating if this is a prerelease build.
+
+.PARAMETER PublishType
+    Type of publish: "internal" for dev feed, otherwise public.
+
+.EXAMPLE
+    ./Build-Packages.ps1 -Output ./dist
+#>
 
 param(
     [string] $BuildNumber,
@@ -9,14 +35,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 3.0
+
+# Setup paths and helpers
 $packageRoot = (Resolve-Path "$PSScriptRoot/../..").Path.Replace('\', '/')
 . "$packageRoot/../../eng/emitters/scripts/CommandInvocation-Helpers.ps1"
 Set-ConsoleEncoding
 
-Write-Host "Building packages for BuildNumber: '$BuildNumber', Output: '$Output', Prerelease: '$Prerelease', PublishType: '$PublishType'"
-
-$outputPath = $Output ? $Output : "$packageRoot/ci-build"
-
+# Helper function to write package info for downstream publishing
 function Write-PackageInfo {
     param(
         [string] $packageName,
@@ -30,83 +55,81 @@ function Write-PackageInfo {
     }
 
     @{
-        Name = $packageName
-        Version = $version
+        Name          = $packageName
+        Version       = $version
         DirectoryPath = $directoryPath
-        SdkType = "client"
-        IsNewSdk = $true
+        SdkType       = "client"
+        IsNewSdk      = $true
         ReleaseStatus = "Unreleased"
     } | ConvertTo-Json | Set-Content -Path "$packageInfoPath/$packageName.json"
 }
 
-function Set-VersionVariable {
-    param(
-        [string] $variableName,
-        [string] $version
-    )
+Write-Host "Building packages for BuildNumber: '$BuildNumber', Output: '$Output', Prerelease: '$Prerelease', PublishType: '$PublishType'"
 
-    Write-Host "Setting output variable '$variableName' to $version"
-    Write-Host "##vso[task.setvariable variable=$variableName;isOutput=true]$version"
-}
-
-# create the output folders
+# Setup output directory
+$outputPath = $Output ? $Output : "$packageRoot/ci-build"
 $outputPath = New-Item -ItemType Directory -Force -Path $outputPath | Select-Object -ExpandProperty FullName
 New-Item -ItemType Directory -Force -Path "$outputPath/packages" | Out-Null
 
-Write-Host "Getting existing versions"
+# Get package version
 $emitterVersion = node -p -e "require('$packageRoot/package.json').version"
+Write-Host "Package version: $emitterVersion"
 
+# Stamp prerelease version if BuildNumber is provided
 if ($BuildNumber) {
-    # set package versions
     $versionTag = $Prerelease ? "-alpha" : "-beta"
-
     $emitterVersion = "$emitterVersion$versionTag.$BuildNumber"
-    Set-VersionVariable -variableName "emitterVersion" -version $emitterVersion
+    Write-Host "Stamped prerelease version: $emitterVersion"
 }
 
-# build and pack the emitter
 Push-Location "$packageRoot"
 try {
-    Write-Host "Working in $PWD"
-
+    # Step 1: Build the emitter and generator
+    Write-Host "`n=== Building emitter and generator ===" -ForegroundColor Cyan
     Invoke-LoggedCommand "npm run build" -GroupOutput
 
-    # Run linting (Linux only, as CI runs on Linux)
+    # Step 2: Run linting (Linux only, as CI runs on Linux)
     if ($IsLinux) {
+        Write-Host "`n=== Running lint checks ===" -ForegroundColor Cyan
         Invoke-LoggedCommand "npm run lint" -GroupOutput
     }
 
+    # Step 3: Stamp version in package.json if prerelease
     if ($BuildNumber) {
-        Write-Host "Updating package.json to version: $emitterVersion`n"
-
+        Write-Host "`n=== Updating package.json version to $emitterVersion ===" -ForegroundColor Cyan
         $packageJson = Get-Content -Raw "package.json" | ConvertFrom-Json -AsHashtable
         $packageJson.version = $emitterVersion
         $packageJson | ConvertTo-Json -Depth 100 | Out-File -Path "package.json" -Encoding utf8 -NoNewline -Force
     }
 
-    # pack the emitter
-    $file = Invoke-LoggedCommand "npm pack -q"
-    Copy-Item $file -Destination "$outputPath/packages"
+    # Step 4: Create npm package
+    Write-Host "`n=== Creating npm package ===" -ForegroundColor Cyan
+    Invoke-LoggedCommand "npm pack"
+    Copy-Item "typespec-http-client-python-$emitterVersion.tgz" -Destination "$outputPath/packages"
 
-    # verify package can be installed
-    Invoke-LoggedCommand "npm install $file" -GroupOutput
+    # Step 5: Verify package can be installed
+    Write-Host "`n=== Verifying package installation ===" -ForegroundColor Cyan
+    Invoke-LoggedCommand "npm install typespec-http-client-python-$emitterVersion.tgz" -GroupOutput
 
-    Write-PackageInfo -packageName "typespec-http-client-python" -directoryPath "packages/http-client-python/emitter/src" -version $emitterVersion
+    # Write package info for publishing pipeline
+    Write-PackageInfo -packageName "typespec-http-client-python" `
+                      -directoryPath "packages/http-client-python/emitter/src" `
+                      -version $emitterVersion
 }
 finally {
     Pop-Location
 }
 
+# Generate override URLs for internal publishing
+$overrides = @{}
 if ($PublishType -eq "internal") {
     $feedUrl = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry"
-
-    $overrides = @{
-        "@typespec/http-client-python" = "$feedUrl/@typespec/http-client-python/-/http-client-python-$emitterVersion.tgz"
-    }
-} else {
-    $overrides = @{}
+    $overrides["@typespec/http-client-python"] = "$feedUrl/@typespec/http-client-python/-/http-client-python-$emitterVersion.tgz"
 }
-
 $overrides | ConvertTo-Json | Set-Content "$outputPath/overrides.json"
 
+# Write package version matrix
 @{ "emitter" = $emitterVersion } | ConvertTo-Json | Set-Content "$outputPath/package-versions.json"
+
+Write-Host "`n=== Build complete ===" -ForegroundColor Green
+Write-Host "Output: $outputPath"

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -75,13 +75,6 @@ New-Item -ItemType Directory -Force -Path "$outputPath/packages" | Out-Null
 $emitterVersion = node -p -e "require('$packageRoot/package.json').version"
 Write-Host "Package version: $emitterVersion"
 
-# Stamp prerelease version if BuildNumber is provided
-if ($BuildNumber) {
-    $versionTag = $Prerelease ? "-alpha" : "-beta"
-    $emitterVersion = "$emitterVersion$versionTag.$BuildNumber"
-    Write-Host "Stamped version: $emitterVersion"
-}
-
 Push-Location "$packageRoot"
 try {
     # Step 1: Build the emitter and generator
@@ -94,12 +87,12 @@ try {
         Invoke-LoggedCommand "npm run lint" -GroupOutput
     }
 
-    # Step 3: Update package.json version and create npm package
-    if ($BuildNumber) {
-        Write-Host "`n=== Updating package.json to version: $emitterVersion ===" -ForegroundColor Cyan
-        $packageJson = Get-Content -Raw "package.json" | ConvertFrom-Json -AsHashtable
-        $packageJson.version = $emitterVersion
-        $packageJson | ConvertTo-Json -Depth 100 | Out-File -Path "package.json" -Encoding utf8 -NoNewline -Force
+    # Step 3: Stamp prerelease version if this is a prerelease build
+    if ($Prerelease) {
+        Write-Host "`n=== Stamping prerelease version ===" -ForegroundColor Cyan
+        Invoke-LoggedCommand "pnpm chronus version --prerelease --only `"@typespec/http-client-python`""
+        $emitterVersion = node -p -e "require('./package.json').version"
+        Write-Host "Stamped version: $emitterVersion"
     }
 
     Write-Host "`n=== Creating npm package ===" -ForegroundColor Cyan

--- a/packages/http-client-python/eng/scripts/Build-Packages.ps1
+++ b/packages/http-client-python/eng/scripts/Build-Packages.ps1
@@ -71,6 +71,11 @@ try {
 
     Invoke-LoggedCommand "npm run build" -GroupOutput
 
+    # Run linting (Linux only, as CI runs on Linux)
+    if ($IsLinux) {
+        Invoke-LoggedCommand "npm run lint" -GroupOutput
+    }
+
     if ($BuildNumber) {
         Write-Host "Updating package.json to version: $emitterVersion`n"
 
@@ -82,6 +87,9 @@ try {
     # pack the emitter
     $file = Invoke-LoggedCommand "npm pack -q"
     Copy-Item $file -Destination "$outputPath/packages"
+
+    # verify package can be installed
+    Invoke-LoggedCommand "npm install $file" -GroupOutput
 
     Write-PackageInfo -packageName "typespec-http-client-python" -directoryPath "packages/http-client-python/emitter/src" -version $emitterVersion
 }


### PR DESCRIPTION
## Problem

The Python emitter's `Build-Packages.ps1` script accepts a `-Prerelease` flag but never uses it to stamp the package version. Every CI build on `main` produces a package with the exact same version from `package.json`, causing `npm publish` to fail with a **409 conflict** when publishing to the DevOps feed.

See failing build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6353671

## Fix

Added prerelease version stamping that:
1. Appends `-alpha.{BuildNumber}` (when `-Prerelease`) or `-beta.{BuildNumber}` to the version
2. Updates `package.json` before `npm pack` so the tarball has the correct version

This matches the existing pattern used by the C# emitter's `Build-Packages.ps1`.

## Changes

- `packages/http-client-python/eng/scripts/Build-Packages.ps1`: Use `-Prerelease` and `-BuildNumber` params to stamp version before packaging