### PR TITLE
Replace deepClone with structuredClone

### DIFF
--- a/.chronus/changes/replace-deepclone-structuredclone-http-specs-2026-6-3-13-42-0.md
+++ b/.chronus/changes/replace-deepclone-structuredclone-http-specs-2026-6-3-13-42-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-specs"
+---
+
+Replace `JSON.parse(JSON.stringify(...))` with `structuredClone`.

--- a/.chronus/changes/replace-deepclone-structuredclone-internal-2026-6-3-13-40-0.md
+++ b/.chronus/changes/replace-deepclone-structuredclone-internal-2026-6-3-13-40-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+
+Replace internal `deepClone` usage with `structuredClone`.

--- a/.chronus/changes/replace-deepclone-with-structuredclone-2026-6-3-12-53-0.md
+++ b/.chronus/changes/replace-deepclone-with-structuredclone-2026-6-3-12-53-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: deprecation
+packages:
+  - "@typespec/compiler"
+---
+
+Deprecated `deepClone` utility in favor of `structuredClone`. All internal usages have been replaced with the native `structuredClone` API.

--- a/packages/compiler/src/config/config-loader.ts
+++ b/packages/compiler/src/config/config-loader.ts
@@ -11,7 +11,7 @@ import { createJSONSchemaValidator } from "../core/schema-validator.js";
 import { createSourceFile } from "../core/source-file.js";
 import { Diagnostic, NoTarget, SourceFile, SystemHost } from "../core/types.js";
 import { doIO } from "../utils/io.js";
-import { deepClone, deepFreeze, omitUndefined } from "../utils/misc.js";
+import { deepFreeze, omitUndefined } from "../utils/misc.js";
 import { getLocationInYamlScript } from "../yaml/index.js";
 import { parseYaml } from "../yaml/parser.js";
 import { YamlScript } from "../yaml/types.js";
@@ -93,7 +93,7 @@ export async function loadTypeSpecConfigForPath(
   const typespecConfigPath = await findTypeSpecConfigPath(host, path, lookup);
   if (typespecConfigPath === undefined) {
     const projectRoot = getDirectoryPath(path);
-    const tsConfig = { ...deepClone(defaultConfig), projectRoot: projectRoot };
+    const tsConfig = { ...structuredClone(defaultConfig), projectRoot: projectRoot };
     if (errorIfNotFound) {
       tsConfig.diagnostics.push(
         createDiagnostic({
@@ -138,7 +138,7 @@ export async function loadTypeSpecConfigFile(
   }
 
   return {
-    ...deepClone(defaultConfig),
+    ...structuredClone(defaultConfig),
     ...config,
   };
 }
@@ -182,7 +182,7 @@ async function loadConfigFile(
     // NOTE: Don't trust the data if there are errors and use default
     // config. Otherwise, we may return an object that does not conform to
     // TypeSpecConfig's typing.
-    data = deepClone(defaultConfig) as TypeSpecRawConfig;
+    data = structuredClone(defaultConfig) as TypeSpecRawConfig;
   }
 
   // Validate project-specific constraints

--- a/packages/compiler/src/config/config-to-options.ts
+++ b/packages/compiler/src/config/config-to-options.ts
@@ -4,7 +4,7 @@ import { CompilerOptions } from "../core/options.js";
 import { getDirectoryPath, normalizePath } from "../core/path-utils.js";
 import { Diagnostic, NoTarget, SystemHost } from "../core/types.js";
 import { doIO } from "../utils/io.js";
-import { deepClone, omitUndefined } from "../utils/misc.js";
+import { omitUndefined } from "../utils/misc.js";
 import { expandConfigVariables } from "./config-interpolation.js";
 import { loadTypeSpecConfigForPath, validateConfigPathsAbsolute } from "./config-loader.js";
 import { EmitterOptions, TypeSpecConfig } from "./types.js";
@@ -164,7 +164,7 @@ function mergeOptions(
   base: Record<string, Record<string, unknown>> | undefined,
   overrides: Record<string, Record<string, unknown>> | undefined,
 ): Record<string, EmitterOptions> {
-  const configuredEmitters: Record<string, Record<string, unknown>> = deepClone(base ?? {});
+  const configuredEmitters: Record<string, Record<string, unknown>> = structuredClone(base ?? {});
   function isObject(item: unknown): item is Record<string, unknown> {
     return item && typeof item === "object" && (!Array.isArray(item) as any);
   }

--- a/packages/compiler/src/server/client-config-provider.ts
+++ b/packages/compiler/src/server/client-config-provider.ts
@@ -1,5 +1,4 @@
 import { Connection } from "vscode-languageserver/node.js";
-import { deepClone } from "../utils/misc.js";
 import { ServerHost } from "./types.js";
 
 interface LSPConfig {
@@ -33,14 +32,14 @@ export function createClientConfigProvider(): ClientConfigProvider {
     try {
       const configs = await connection.workspace.getConfiguration("typespec");
       // Transform the raw configuration to match our Config interface
-      config = deepClone(configs);
+      config = structuredClone(configs);
 
       host.log({ level: "debug", message: "vscode settings loaded", detail: config });
 
       connection.onDidChangeConfiguration(async (params) => {
         if (params.settings) {
           const newConfigs = params.settings?.typespec;
-          config = deepClone(newConfigs);
+          config = structuredClone(newConfigs);
         }
 
         host.log({ level: "debug", message: "Configuration changed", detail: params.settings });

--- a/packages/compiler/src/server/compile-service.ts
+++ b/packages/compiler/src/server/compile-service.ts
@@ -15,7 +15,7 @@ import { CompilerOptions } from "../core/options.js";
 import { parse } from "../core/parser.js";
 import { getBaseFileName, getDirectoryPath } from "../core/path-utils.js";
 import type { CompilerHost, TypeSpecScriptNode } from "../core/types.js";
-import { deepClone, distinctArray } from "../utils/misc.js";
+import { distinctArray } from "../utils/misc.js";
 import { getLocationInYamlScript } from "../yaml/diagnostics.js";
 import { parseYaml } from "../yaml/parser.js";
 import { ClientConfigProvider } from "./client-config-provider.js";
@@ -145,7 +145,7 @@ export function createCompileService({
       cwd: getDirectoryPath(path),
     });
     // we need to keep the optionsFromConfig unchanged which will be returned in CompileResult
-    const clone = deepClone(optionsFromConfig);
+    const clone = structuredClone(optionsFromConfig);
     const options: CompilerOptions = {
       ...clone,
       ...serverOptions,
@@ -296,14 +296,14 @@ export function createCompileService({
       return { ...defaultConfig, projectRoot: getDirectoryPath(mainFile) };
     }
 
+    // JSON round-trip intentionally strips non-serializable values (functions) from the config
     const cached = await fileSystemCache.get(configPath);
-    const deepCopy = (obj: any) => JSON.parse(JSON.stringify(obj));
     if (cached?.data) {
-      return deepCopy(cached.data);
+      return JSON.parse(JSON.stringify(cached.data));
     }
 
     const config = await loadTypeSpecConfigFile(compilerHost, configPath);
-    return deepCopy(config);
+    return JSON.parse(JSON.stringify(config));
   }
 
   async function getScript(

--- a/packages/compiler/src/utils/index.ts
+++ b/packages/compiler/src/utils/index.ts
@@ -4,5 +4,6 @@
 // ---------------------------------------
 export { createPerfReporter, perf } from "../core/perf.js";
 export { DuplicateTracker } from "./duplicate-tracker.js";
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { Queue, TwoLevelMap, createRekeyableMap, deepClone, deepEquals } from "./misc.js";
 export { useStateMap, useStateSet } from "./state-accessor.js";

--- a/packages/compiler/src/utils/misc.ts
+++ b/packages/compiler/src/utils/misc.ts
@@ -31,9 +31,12 @@ export function deepFreeze<T>(value: T): T {
  *
  * Does not support cycles. Intended to be used only on plain data that can
  * be directly represented in JSON.
+ *
+ * @deprecated Use `structuredClone` instead.
  */
 export function deepClone<T>(value: T): T {
   if (Array.isArray(value)) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return value.map(deepClone) as any;
   }
 
@@ -44,6 +47,7 @@ export function deepClone<T>(value: T): T {
   if (typeof value === "object") {
     const obj: any = {};
     for (const prop in value) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       obj[prop] = deepClone(value[prop]);
     }
     return obj;

--- a/packages/http-specs/specs/type/property/additional-properties/mockapi.ts
+++ b/packages/http-specs/specs/type/property/additional-properties/mockapi.ts
@@ -120,7 +120,7 @@ function createServerTests(url: string, value: unknown) {
         status: 204,
       },
       handler: (req: MockRequest) => {
-        const expectedBody = JSON.parse(JSON.stringify(value));
+        const expectedBody = structuredClone(value);
         req.expect.coercedBodyEquals(expectedBody);
         return {
           status: 204,

--- a/packages/http/src/auth.ts
+++ b/packages/http/src/auth.ts
@@ -1,5 +1,5 @@
 import { Operation, Program } from "@typespec/compiler";
-import { deepClone, deepEquals } from "@typespec/compiler/utils";
+import { deepEquals } from "@typespec/compiler/utils";
 import { getAuthentication } from "./decorators.js";
 import {
   Authentication,
@@ -130,7 +130,7 @@ function mergeOAuthScopes<Flows extends OAuth2Flow[]>(
   scheme1: Oauth2Auth<Flows>,
   scheme2: Oauth2Auth<Flows>,
 ): Oauth2Auth<Flows> {
-  const flows = deepClone(scheme1.flows);
+  const flows = structuredClone(scheme1.flows);
   flows.forEach((flow1, i) => {
     const flow2 = scheme2.flows[i];
     const scopes = Array.from(new Set(flow1.scopes.concat(flow2.scopes)));
@@ -145,7 +145,7 @@ function mergeOAuthScopes<Flows extends OAuth2Flow[]>(
 function ignoreScopes<Flows extends OAuth2Flow[]>(
   scheme: Omit<Oauth2Auth<Flows>, "model">,
 ): Omit<Oauth2Auth<Flows>, "model"> {
-  const flows: Flows = deepClone(scheme.flows);
+  const flows: Flows = structuredClone(scheme.flows);
   flows.forEach((flow) => {
     flow.scopes = [];
   });


### PR DESCRIPTION
Replace the custom deepClone utility and JSON.parse(JSON.stringify(...)) patterns with structuredClone.

## Changes
- Replaced all internal deepClone() calls with structuredClone()
- Replaced JSON.parse(JSON.stringify(...)) deep copy patterns with structuredClone()
- Deprecated the public deepClone export with @deprecated JSDoc tag (kept for backward compat)
- Cleaned up unused imports