### PR TITLE
fix(http-client-python): do not precompute Model class as XML deserializer

### DIFF
--- a/.chronus/changes/fix-http-client-python-xml-model-precomputation-2026-6-4-0-0-0.md
+++ b/.chronus/changes/fix-http-client-python-xml-model-precomputation-2026-6-4-0-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix XML deserialization regression where a downstream customization that subclassed a generated Model and re-annotated a nested Model field with a strict subclass would cause the generated parent class's `_init_from_xml` to call `CustomModel(<ET.Element>)` directly and raise. The precomputed XML field plan no longer hard-codes the Model class as the deserializer, deferring to the generic `_deserialize` path that tolerates such customizations.

--- a/packages/http-client-python/generator/pygen/codegen/templates/model_base.py.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/model_base.py.jinja2
@@ -761,30 +761,6 @@ def _xml_deser_enum_or_str(enum_cls, value):
         return text
 
 
-def _extract_xml_model_type(rf_type):
-    """Extract the concrete Model class from a resolved rf._type partial chain.
-
-    Unwraps ``Optional[Model]`` and ``_deserialize_model(Model, ...)``
-    wrappers.  Only handles Model and Optional[Model] — other composite
-    types (List, Dict, Union, etc.) return None and fall through to the
-    generic ``_deserialize`` path at runtime.
-    """
-    if rf_type is None:
-        return None
-    if isinstance(rf_type, type) and _is_model(rf_type):
-        return rf_type
-    if not isinstance(rf_type, functools.partial):
-        return None
-    func = rf_type.func
-    args = rf_type.args
-    if func is _deserialize_with_optional and args:
-        return _extract_xml_model_type(args[0])
-    if func is _deserialize_model and args:
-        cls = args[0]
-        return cls if isinstance(cls, type) and _is_model(cls) else None
-    return None
-
-
 def _build_xml_field_plan(  # pylint: disable=docstring-missing-return, docstring-missing-rtype, unused-variable
     cls, attr_to_rest_field: dict
 ) -> list:
@@ -795,11 +771,16 @@ def _build_xml_field_plan(  # pylint: disable=docstring-missing-return, docstrin
 
     kind: 0=wrapped, 1=attribute, 2=unwrapped, 3=text
 
-    For Model and Optional[Model] fields that lack a scalar
-    ``_deserializer``, this function precomputes the Model class as the
-    deserializer so ``_init_from_xml`` can call ``ModelClass(element)``
-    directly instead of going through the expensive
-    ``_get_deserialize_callable_from_annotation`` chain at runtime.
+    Only scalar ``rest_field(deserializer=...)`` callables are precomputed
+    as ``deser``.  Model and Optional[Model] fields are *not* precomputed:
+    a downstream customization may subclass a generated Model and
+    re-annotate a nested field with a strict subclass, which would
+    populate the shared ``_RestField._type`` from that custom annotation.
+    Precomputing the Model class as the deserializer here would then make
+    ``_init_from_xml`` invoke ``CustomModel(<ET.Element>)`` directly on
+    the parent (generated) class, which can raise if the customization
+    enforces a strict ``__init__`` signature.  Falling back to the
+    generic ``_deserialize`` path keeps that customization safe.
     """
     model_meta = getattr(cls, "_xml", {})
     model_ns = model_meta.get("ns") or model_meta.get("namespace")
@@ -815,13 +796,6 @@ def _build_xml_field_plan(  # pylint: disable=docstring-missing-return, docstrin
             xml_name = "{" + xml_ns + "}" + xml_name
 
         is_optional = rf._is_optional
-
-        # For Model / Optional[Model] fields without a scalar deserializer,
-        # precompute the Model class as the deserializer.
-        if deser is None and rf._type is not None:
-            model_cls = _extract_xml_model_type(rf._type)
-            if model_cls is not None:
-                deser = model_cls
 
         if prop_meta.get("attribute", False):
             plan.append((rf._rest_name, xml_name, 1, deser, rf._type, is_optional, None))

--- a/packages/http-client-python/tests/unit/test_model_base_xml_serialization.py
+++ b/packages/http-client-python/tests/unit/test_model_base_xml_serialization.py
@@ -706,6 +706,75 @@ class TestXmlDeserialization:
         assert result.blobs.blob_items is None
         assert result.next_marker == ""
 
+    def test_customized_subclass_does_not_break_generated_xml_deserialization(self):
+        """Regression test: a downstream customized subclass that re-annotates a Model
+        field must not corrupt the parent (generated) class's XML deserialization.
+
+        When a customization (such as
+        ``azure.storage.fileshare._models.Metrics`` in azure-sdk-for-python)
+        subclasses a generated model and re-annotates a nested Model field
+        to a strict custom class, instantiating the customized subclass
+        populates the *shared* ``_RestField._type`` (via ``Model.__new__``)
+        from the custom annotation.  Previously, ``_build_xml_field_plan``
+        would then precompute that custom Model class as the deserializer
+        for the *generated* class too, and ``_init_from_xml`` would invoke
+        ``CustomChild(<ET.Element>)`` directly — which raises if the custom
+        ``__init__`` enforces a strict signature.
+        """
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+            <Metrics>
+                <Enabled>true</Enabled>
+                <RetentionPolicy>
+                    <Enabled>true</Enabled>
+                    <Days>5</Days>
+                </RetentionPolicy>
+            </Metrics>"""
+
+        class RetentionPolicy(Model):
+            enabled: bool = rest_field(name="Enabled", xml={"name": "Enabled"})
+            days: Optional[int] = rest_field(name="Days", xml={"name": "Days"})
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            _xml = {"name": "RetentionPolicy"}
+
+        class Metrics(Model):
+            enabled: bool = rest_field(name="Enabled", xml={"name": "Enabled"})
+            retention_policy: Optional[RetentionPolicy] = rest_field(
+                name="RetentionPolicy", xml={"name": "RetentionPolicy"}
+            )
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            _xml = {"name": "Metrics"}
+
+        class CustomRetentionPolicy(RetentionPolicy):
+            def __init__(self, enabled: bool = False, days: Optional[int] = None) -> None:
+                if enabled and days is None:
+                    raise ValueError("If policy is enabled, 'days' must be specified.")
+                super().__init__(enabled=enabled, days=days)
+
+        class CustomMetrics(Metrics):
+            # Re-annotating with the custom subclass is what triggers the
+            # shared _RestField._type to be resolved against CustomRetentionPolicy.
+            retention_policy: CustomRetentionPolicy = CustomRetentionPolicy()  # noqa: F811
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+        # Instantiate the customized subclass FIRST so that the shared
+        # ``_RestField`` for ``retention_policy`` on the parent Metrics gets
+        # its ``_type`` populated from the custom annotation.
+        CustomMetrics()
+
+        # Deserializing into the parent (generated-style) Metrics class
+        # must NOT invoke ``CustomRetentionPolicy(<ET.Element>)``.
+        result = _deserialize_xml(Metrics, xml)
+        assert result.enabled is True
+        assert result.retention_policy is not None
+
     def test_enumeration_results_blobs_unwrapped(self):
         """Test what happens when the blobs field itself is declared with unwrapped=True."""
         # When a non-list model field uses unwrapped=True, the matching XML elements are collected


### PR DESCRIPTION
Regression from #10698. 

When the customized class is instantiated first, `Model.__new__` walks the MRO and sets `rf._type` from the last-wins annotation (the custom class). The `_RestField` is shared with the generated parent, so the parent's `rf._type` ends up pointing at `partial(_deserialize_model, CustomRetentionPolicy)`. `_build_xml_field_plan` extracts that and stores `CustomRetentionPolicy` as the precomputed `deser` for the generated parent's field plan. `_init_from_xml` then calls `CustomRetentionPolicy(<ET.Element>)` directly, the element is bound positionally to `enabled` (truthy), `days` is None, and you get the `ValueError`.

Before #10698 the same path went through `_deserialize` -> `_deserialize_default`, whose `except Exception: pass` swallowed the ValueError and returned the raw `ET.Element` for the consumer's `_from_generated` shim to handle.

Fix: stop precomputing Model and `Optional[Model]` fields in `_build_xml_field_plan`. Scalar `rest_field(deserializer=...)` callables are still precomputed. Model fields fall back to `_deserialize(rf._type, item)` like before. Also removed the now-unused `_extract_xml_model_type` helper.

Added a regression test that reproduces the pattern. It fails on current code and passes with the fix. Two existing tests that were also broken by the same precomputation (`test_polymorphic_deserialization`, `test_enumeration_results_blobs_unwrapped`) start passing as a side effect. All 375 unit tests pass after regen.
