### PR TITLE
[openapi3] add `enum-mode` option for annotated enums in 3.1+

### DIFF
--- a/.chronus/changes/openapi3-annotated-enums-2026-6-4-14-25-0.md
+++ b/.chronus/changes/openapi3-annotated-enums-2026-6-4-14-25-0.md
@@ -1,0 +1,14 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Add `enum-mode` emitter option for OpenAPI 3.1+. When set to `"annotated"`, enums are emitted using the [annotated enumerations](https://spec.openapis.org/oas/v3.1.1.html#annotated-enumerations) pattern (`oneOf` of single-`const` subschemas with `title`/`description` from `@summary`/`@doc` on each member). The default `"enum"` preserves the existing flat `enum: [...]` output. The option has no effect on OpenAPI 3.0.
+
+```yaml
+options:
+  "@typespec/openapi3":
+    enum-mode: annotated
+    openapi-versions: ["3.1.0"]
+```

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -3,6 +3,7 @@ import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/c
 export type FileType = "yaml" | "json";
 export type OpenAPIVersion = "3.0.0" | "3.1.0" | "3.2.0";
 export type ExperimentalParameterExamplesStrategy = "data" | "serialized";
+export type EnumMode = "enum" | "annotated";
 export interface OpenAPI3EmitterOptions {
   /**
    * If the content should be serialized as YAML or JSON. Can be a single value or an array to emit multiple file types.
@@ -82,6 +83,17 @@ export interface OpenAPI3EmitterOptions {
    * @default false
    */
   "seal-object-schemas"?: boolean;
+
+  /**
+   * How to render `enum` types in the emitted schema. Only applies to OpenAPI 3.1+
+   * (ignored for OpenAPI 3.0). Options are:
+   *  - `enum`: Render as `{ type, enum: [...] }`. Per-member `@doc`/`@summary` are dropped.
+   *  - `annotated`: Render as `{ oneOf: [{ type, const, title?, description? }, ...] }`
+   *    following the OpenAPI 3.1 [annotated enumerations](https://spec.openapis.org/oas/v3.1.1.html#annotated-enumerations)
+   *    pattern. Preserves per-member annotations but some tooling may not recognize it as an enum.
+   * @default "enum"
+   */
+  "enum-mode"?: EnumMode;
 
   /**
    * Determines how to emit examples on parameters.
@@ -238,6 +250,20 @@ const EmitterOptionsSchema: JSONSchemaType<OpenAPI3EmitterOptions> = {
         "If true, then for models emitted as object schemas we default `additionalProperties` to false for",
         "OpenAPI 3.0, and `unevaluatedProperties` to false for OpenAPI 3.1, if not explicitly specified elsewhere.",
         "Default: `false`",
+      ].join("\n"),
+    },
+    "enum-mode": {
+      type: "string",
+      enum: ["enum", "annotated"],
+      nullable: true,
+      default: "enum",
+      description: [
+        "How to render `enum` types in the emitted schema. Only applies to OpenAPI 3.1+ (ignored for OpenAPI 3.0).",
+        " - `enum`: Render as `{ type, enum: [...] }`. Per-member `@doc`/`@summary` are dropped.",
+        " - `annotated`: Render as `{ oneOf: [{ type, const, title?, description? }, ...] }` per the OpenAPI 3.1 annotated enumerations pattern.",
+        "   Preserves per-member annotations but some tooling may not recognize it as an enum.",
+        "",
+        "Default: `enum`",
       ].join("\n"),
     },
     "experimental-parameter-examples": {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -86,6 +86,7 @@ import { getExampleOrExamples, OperationExamples, resolveOperationExamples } fro
 import { JsonSchemaModule, resolveJsonSchemaModule } from "./json-schema.js";
 import {
   createDiagnostic,
+  EnumMode,
   FileType,
   OpenAPI3EmitterOptions,
   OpenAPIVersion,
@@ -229,6 +230,7 @@ export function resolveOptions(
     outputFile: resolvePath(context.emitterOutputDir, specDir, outputFile),
     openapiVersions,
     sealObjectSchemas: resolvedOptions["seal-object-schemas"],
+    enumMode: resolvedOptions["enum-mode"] ?? "enum",
     parameterExamplesStrategy: resolvedOptions["experimental-parameter-examples"],
     operationIdStrategy: resolveOperationIdStrategy(resolvedOptions["operation-id-strategy"]),
   };
@@ -270,6 +272,7 @@ export interface ResolvedOpenAPI3EmitterOptions {
   includeXTypeSpecName: "inline-only" | "never";
   safeintStrategy: "double-int" | "int64";
   sealObjectSchemas: boolean;
+  enumMode: EnumMode;
   parameterExamplesStrategy?: "data" | "serialized";
   operationIdStrategy: { kind: OperationIdStrategy; separator: string };
 }

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -12,9 +12,11 @@ import {
   compilerAssert,
   Enum,
   getDiscriminatedUnion,
+  getDoc,
   getExamples,
   getMaxValueExclusive,
   getMinValueExclusive,
+  getSummary,
   IntrinsicScalarName,
   IntrinsicType,
   Model,
@@ -181,6 +183,27 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
     if (en.members.size === 0) {
       reportDiagnostic(program, { code: "empty-enum", target: en });
       return {};
+    }
+
+    if (this._options.enumMode === "annotated") {
+      const oneOf: OpenAPISchema3_1[] = [];
+      for (const member of en.members.values()) {
+        const value = member.value ?? member.name;
+        const subschema: OpenAPISchema3_1 = {
+          type: typeof value === "number" ? "number" : "string",
+          const: value,
+        };
+        const title = getSummary(program, member);
+        if (title) {
+          subschema.title = title;
+        }
+        const description = getDoc(program, member);
+        if (description) {
+          subschema.description = description;
+        }
+        oneOf.push(subschema);
+      }
+      return this.applyConstraints(en, { oneOf });
     }
 
     const enumTypes = new Set<JsonType>();

--- a/packages/openapi3/test/enums.test.ts
+++ b/packages/openapi3/test/enums.test.ts
@@ -1,6 +1,6 @@
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual, strictEqual } from "assert";
-import { it } from "vitest";
+import { describe, it } from "vitest";
 import { supportedVersions, worksFor } from "./works-for.js";
 
 worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel }) => {
@@ -45,6 +45,113 @@ worksFor(["3.1.0"], ({ oapiForModel }) => {
     deepStrictEqual(res.schemas.PetType, {
       type: ["string", "number"],
       enum: ["dog", 1],
+    });
+  });
+});
+
+worksFor(["3.1.0", "3.2.0"], ({ oapiForModel }) => {
+  describe("enum-mode: annotated", () => {
+    it("emits oneOf with const and per-member descriptions", async () => {
+      const res = await oapiForModel(
+        "PetType",
+        `
+        enum PetType {
+          /** A four-legged friend */
+          Dog: "dog",
+          /** A whiskered companion */
+          Cat: "cat",
+        }
+        `,
+        { "enum-mode": "annotated" },
+      );
+
+      deepStrictEqual(res.schemas.PetType, {
+        oneOf: [
+          { type: "string", const: "dog", description: "A four-legged friend" },
+          { type: "string", const: "cat", description: "A whiskered companion" },
+        ],
+      });
+    });
+
+    it("uses @summary as title on members", async () => {
+      const res = await oapiForModel(
+        "Priority",
+        `
+        enum Priority {
+          @summary("Low priority")
+          Low: 1,
+          @summary("High priority")
+          High: 10,
+        }
+        `,
+        { "enum-mode": "annotated" },
+      );
+
+      deepStrictEqual(res.schemas.Priority, {
+        oneOf: [
+          { type: "number", const: 1, title: "Low priority" },
+          { type: "number", const: 10, title: "High priority" },
+        ],
+      });
+    });
+
+    it("omits title/description when member has no annotations", async () => {
+      const res = await oapiForModel(
+        "PetType",
+        `enum PetType { Dog: "dog", Cat: "cat" }`,
+        { "enum-mode": "annotated" },
+      );
+
+      deepStrictEqual(res.schemas.PetType, {
+        oneOf: [
+          { type: "string", const: "dog" },
+          { type: "string", const: "cat" },
+        ],
+      });
+    });
+
+    it("preserves enum-level description on wrapping schema", async () => {
+      const res = await oapiForModel(
+        "PetType",
+        `
+        /** Kinds of pets */
+        enum PetType {
+          /** A four-legged friend */
+          Dog: "dog",
+          Cat: "cat",
+        }
+        `,
+        { "enum-mode": "annotated" },
+      );
+
+      deepStrictEqual(res.schemas.PetType, {
+        description: "Kinds of pets",
+        oneOf: [
+          { type: "string", const: "dog", description: "A four-legged friend" },
+          { type: "string", const: "cat" },
+        ],
+      });
+    });
+  });
+});
+
+worksFor(["3.0.0"], ({ oapiForModel }) => {
+  it("ignores enum-mode: annotated and still emits flat enum", async () => {
+    const res = await oapiForModel(
+      "PetType",
+      `
+      enum PetType {
+        /** A four-legged friend */
+        Dog: "dog",
+        Cat: "cat",
+      }
+      `,
+      { "enum-mode": "annotated" },
+    );
+
+    deepStrictEqual(res.schemas.PetType, {
+      type: "string",
+      enum: ["dog", "cat"],
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #5721

Adds an opt-in `enum-mode` emitter option to `@typespec/openapi3`. When set to `"annotated"`, enums are rendered using the OpenAPI 3.1 [annotated enumerations](https://spec.openapis.org/oas/v3.1.1.html#annotated-enumerations) pattern — a `oneOf` of single-`const` subschemas with per-member `title`/`description` pulled from `@summary`/`@doc`:

```yaml
PetType:
  oneOf:
    - type: string
      const: dog
      description: A four-legged friend
    - type: string
      const: cat
```

The default `"enum"` preserves today's flat `enum: [...]` output. The option is silently ignored for OpenAPI 3.0 since `const` annotated enums are a 3.1 construct. 3.2 inherits the 3.1 emitter and so picks the behavior up automatically.

## Test plan

- [x] `pnpm -F @typespec/openapi3 build` — clean
- [x] `pnpm -F @typespec/openapi3 test` — 2532 tests pass, including 5 new cases:
  - String enum with `@doc` → `description` on each subschema
  - Numeric enum with `@summary` → `title` on each subschema
  - Unannotated members → bare `{type, const}` subschemas
  - Enum-level `@doc` still applied to the wrapping schema
  - OpenAPI 3.0 + `enum-mode: annotated` → option ignored (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)