### PR TITLE
feat(compiler): Support multi-file assertions in applyCodeFix rule tester

### DIFF
--- a/.chronus/changes/apply-code-fix-multi-file-2026-6-5-9-3-53.md
+++ b/.chronus/changes/apply-code-fix-multi-file-2026-6-5-9-3-53.md
@@ -1,0 +1,19 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+`ApplyCodeFixExpect.toEqual` now accepts `Record<string, string>` to assert on multiple files after a code fix is applied. This enables testing code fixes that write to a different file (e.g., adding augment decorators to a `client.tsp`).
+
+```ts
+await ruleTester
+  .expect({
+    "main.tsp": `import "./client.tsp";\nmodel Foo { name: string; }`,
+    "client.tsp": ``,
+  })
+  .applyCodeFix("add-client-override")
+  .toEqual({
+    "client.tsp": `@@override(Foo.name, "clientName");\n`,
+  });
+```

--- a/packages/compiler/src/testing/rule-tester.ts
+++ b/packages/compiler/src/testing/rule-tester.ts
@@ -4,6 +4,7 @@ import { createDiagnosticCollector } from "../core/diagnostics.js";
 import { createLinterRuleContext } from "../core/linter.js";
 import { navigateProgram } from "../core/semantic-walker.js";
 import {
+  CodeFix,
   CompilerHost,
   Diagnostic,
   DiagnosticMessages,
@@ -35,7 +36,36 @@ export interface LinterRuleTestExpect<T extends Record<string, Entity> = any> {
 }
 
 export interface ApplyCodeFixExpect {
-  toEqual(code: string): Promise<void>;
+  /**
+   * Assert the content of the file(s) after the code fix is applied.
+   * @param code Expected content. Pass a `string` for single-file assertions (main.tsp),
+   * or a `Record<string, string>` to assert on specific files (partial match — only the
+   * specified files are checked).
+   *
+   * @example Single file
+   *
+   * ```ts
+   * await ruleTester
+   *   .expect(`model Foo { name: string; }`)
+   *   .applyCodeFix("rename-model")
+   *   .toEqual(`model Bar { name: string; }`);
+   * ```
+   *
+   * @example Multiple files (e.g. code fix writes augment decorators to a separate file)
+   *
+   * ```ts
+   * await ruleTester
+   *   .expect({
+   *     "main.tsp": `import "./client.tsp";\nmodel Foo { name: string; }`,
+   *     "client.tsp": ``,
+   *   })
+   *   .applyCodeFix("add-client-override")
+   *   .toEqual({
+   *     "client.tsp": `@@override(Foo.name, "clientName");\n`,
+   *   });
+   * ```
+   */
+  toEqual(code: string | Record<string, string>): Promise<void>;
 }
 
 export function createLinterRuleTester(
@@ -85,10 +115,19 @@ export function createLinterRuleTester(
     function applyCodeFix(fixId: string) {
       return { toEqual };
 
-      async function toEqual(expectedCode: string) {
+      async function toEqual(expectedCode: string | Record<string, string>) {
         const [_, diagnostics] = await compileAndDiagnose(code);
         const codefix = diagnostics[0].codefixes?.find((x) => x.id === fixId);
         ok(codefix, `Codefix with id "${fixId}" not found.`);
+
+        if (typeof expectedCode === "string") {
+          await assertSingleFileCodeFix(codefix, expectedCode);
+        } else {
+          await assertMultiFileCodeFix(codefix, expectedCode);
+        }
+      }
+
+      async function assertSingleFileCodeFix(codefix: CodeFix, expectedCode: string) {
         let content: string | undefined;
         const host: CompilerHost = {
           ...runner.program.host,
@@ -103,6 +142,41 @@ export function createLinterRuleTester(
         const fs = "keys" in runner.fs ? runner.fs : runner.fs.fs;
         const offset = fs.get(resolveVirtualPath("./main.tsp"))?.indexOf(code as any);
         strictEqual(trimBlankLines(content.slice(offset)), trimBlankLines(expectedCode));
+      }
+
+      async function assertMultiFileCodeFix(
+        codefix: CodeFix,
+        expectedFiles: Record<string, string>,
+      ) {
+        const writtenFiles = new Map<string, string>();
+        const host: CompilerHost = {
+          ...runner.program.host,
+          writeFile: (name, newContent) => {
+            writtenFiles.set(name, newContent);
+            return Promise.resolve();
+          },
+        };
+        await applyCodeFixReal(host, codefix);
+
+        ok(writtenFiles.size > 0, "No content was written to the host.");
+        const fs = "keys" in runner.fs ? runner.fs : runner.fs.fs;
+        for (const [filename, expected] of Object.entries(expectedFiles)) {
+          const virtualPath = resolveVirtualPath(filename);
+          const written = writtenFiles.get(virtualPath);
+          ok(
+            written !== undefined,
+            `Expected file "${filename}" to be written by the code fix but it was not. Written files: ${[...writtenFiles.keys()].join(", ")}`,
+          );
+          const inputCode =
+            typeof code === "string" ? code : (code as Record<string, any>)[filename];
+          const originalContent = fs.get(virtualPath);
+          const offset =
+            typeof inputCode === "string" && originalContent
+              ? originalContent.indexOf(inputCode)
+              : undefined;
+          const actual = offset !== undefined && offset >= 0 ? written.slice(offset) : written;
+          strictEqual(trimBlankLines(actual), trimBlankLines(expected));
+        }
       }
     }
   }

--- a/packages/compiler/test/testing/rule-tester-codefix.test.ts
+++ b/packages/compiler/test/testing/rule-tester-codefix.test.ts
@@ -37,8 +37,7 @@ async function createCodeFixRuleTester(
                 {
                   id: fixId,
                   label: "Test fix",
-                  fix: (fixContext) =>
-                    createFix({ model, fixContext, program: context.program }),
+                  fix: (fixContext) => createFix({ model, fixContext, program: context.program }),
                 },
               ],
             });
@@ -103,4 +102,3 @@ it("toEqual with Record asserts code fix that modifies both the original and a n
       "client.tsp": `@@override(Foo, "ClientFoo");\n`,
     });
 });
-

--- a/packages/compiler/test/testing/rule-tester-codefix.test.ts
+++ b/packages/compiler/test/testing/rule-tester-codefix.test.ts
@@ -1,0 +1,104 @@
+import { it } from "vitest";
+import { getSourceLocation } from "../../src/core/diagnostics.js";
+import { createLinterRule } from "../../src/core/library.js";
+import type { Program } from "../../src/core/program.js";
+import { createSourceFile } from "../../src/core/source-file.js";
+import { CodeFixContext, CodeFixEdit, Model, SyntaxKind } from "../../src/core/types.js";
+import { createLinterRuleTester } from "../../src/testing/rule-tester.js";
+import { resolveVirtualPath } from "../../src/testing/test-utils.js";
+import { Tester } from "../tester.js";
+
+interface CodeFixTestContext {
+  model: Model;
+  fixContext: CodeFixContext;
+  program: Program;
+}
+
+/**
+ * Creates a rule tester with a rule that triggers on a model named "Foo"
+ * and applies the given code fix function.
+ */
+async function createCodeFixRuleTester(
+  createFix: (context: CodeFixTestContext) => CodeFixEdit | CodeFixEdit[],
+  fixId = "test-fix",
+) {
+  const rule = createLinterRule({
+    name: "test-codefix-rule",
+    severity: "warning",
+    description: "Test rule.",
+    messages: { default: "Fix needed." },
+    create(context) {
+      return {
+        model: (model: Model) => {
+          if (model.name === "Foo" && model.node?.kind === SyntaxKind.ModelStatement) {
+            context.reportDiagnostic({
+              target: model,
+              codefixes: [
+                {
+                  id: fixId,
+                  label: "Test fix",
+                  fix: (fixContext) =>
+                    createFix({ model, fixContext, program: context.program }),
+                },
+              ],
+            });
+          }
+        },
+      };
+    },
+  });
+
+  return createLinterRuleTester(await Tester.createInstance(), rule, "@typespec/compiler");
+}
+it("toEqual with string asserts single-file code fix on main.tsp", async () => {
+  const tester = await createCodeFixRuleTester(({ model, fixContext }) => {
+    return fixContext.replaceText(getSourceLocation(model.node!.id), "Bar");
+  });
+
+  await tester
+    .expect(`model Foo { name: string; }`)
+    .applyCodeFix("test-fix")
+    .toEqual(`model Bar { name: string; }`);
+});
+
+it("toEqual with Record asserts code fix that writes to a different file", async () => {
+  const tester = await createCodeFixRuleTester(({ fixContext, program }) => {
+    const clientFile = program.sourceFiles.get(resolveVirtualPath("client.tsp"))!.file;
+    return fixContext.appendText(
+      { file: clientFile, pos: clientFile.text.length },
+      `\n@@override(Foo, "ClientFoo");\n`,
+    );
+  });
+
+  await tester
+    .expect({
+      "main.tsp": `import "./client.tsp";\nmodel Foo { name: string; }`,
+      "client.tsp": ``,
+    })
+    .applyCodeFix("test-fix")
+    .toEqual({
+      "client.tsp": `\n@@override(Foo, "ClientFoo");\n`,
+    });
+});
+
+it("toEqual with Record asserts code fix that modifies both the original and a new file", async () => {
+  const tester = await createCodeFixRuleTester(({ model, fixContext }) => {
+    const mainFile = getSourceLocation(model.node!).file;
+    const clientFile = createSourceFile("", resolveVirtualPath("client.tsp"));
+    return [
+      fixContext.prependText({ file: mainFile, pos: 0 }, `import "./client.tsp";\n`),
+      fixContext.appendText({ file: clientFile, pos: 0 }, `@@override(Foo, "ClientFoo");\n`),
+    ];
+  });
+
+  await tester
+    .expect({
+      "main.tsp": `model Foo { name: string; }`,
+    })
+    .applyCodeFix("test-fix")
+    .toEqual({
+      "main.tsp": `import "./client.tsp";\nmodel Foo { name: string; }`,
+      "client.tsp": `@@override(Foo, "ClientFoo");\n`,
+    });
+});
+

--- a/packages/compiler/test/testing/rule-tester-codefix.test.ts
+++ b/packages/compiler/test/testing/rule-tester-codefix.test.ts
@@ -52,7 +52,9 @@ async function createCodeFixRuleTester(
 }
 it("toEqual with string asserts single-file code fix on main.tsp", async () => {
   const tester = await createCodeFixRuleTester(({ model, fixContext }) => {
-    return fixContext.replaceText(getSourceLocation(model.node!.id), "Bar");
+    const node = model.node!;
+    if (node.kind !== SyntaxKind.ModelStatement) throw new Error("unexpected");
+    return fixContext.replaceText(getSourceLocation(node.id), "Bar");
   });
 
   await tester


### PR DESCRIPTION
## Summary

`ApplyCodeFixExpect.toEqual` now accepts `Record<string, string>` to assert on multiple files after a code fix is applied. This enables testing code fixes that write to a different file (e.g., adding augment decorators to a `client.tsp`).

## Changes

- Overloaded `toEqual` to accept `string | Record<string, string>`
- Single-file (`string`): existing behavior unchanged
- Multi-file (`Record<string, string>`): captures all `writeFile` calls, asserts only on specified files (partial match)
- Supports code fixes that create new files not in the original input

## Example

```ts
await ruleTester
  .expect({
    "main.tsp": `import "./client.tsp";\nmodel Foo { name: string; }`,
    "client.tsp": ``,
  })
  .applyCodeFix("add-client-override")
  .toEqual({
    "client.tsp": `@@override(Foo.name, "clientName");\n`,
  });
```
