### PR TITLE
docs(http-client-csharp): document plugins option path resolution with examples

### DIFF
--- a/.chronus/changes/docs-csharp-plugins-examples-2026-06-05-13-04-24.md
+++ b/.chronus/changes/docs-csharp-plugins-examples-2026-06-05-13-04-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Document that the `plugins` emitter option accepts absolute paths or paths relative to `emitter-output-dir`, with examples

--- a/.chronus/changes/docs-csharp-plugins-examples-2026-06-05-13-04-24.md
+++ b/.chronus/changes/docs-csharp-plugins-examples-2026-06-05-13-04-24.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/http-client-csharp"
----
-
-Document that the `plugins` emitter option accepts absolute paths or paths relative to `emitter-output-dir`, with examples

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -120,7 +120,17 @@ export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = 
       nullable: true,
       description:
         "Paths to generator plugin assemblies (DLLs) or directories containing plugin assemblies. " +
-        "Each plugin must contain a class that extends GeneratorPlugin.",
+        "Each plugin must contain a class that extends `GeneratorPlugin`. " +
+        "Paths may be absolute or relative to the resolved `emitter-output-dir`. " +
+        "For example, to load plugins that live in a `codegen` folder under the output directory:\n\n" +
+        "```yaml\n" +
+        "options:\n" +
+        '  "@typespec/http-client-csharp":\n' +
+        "    plugins:\n" +
+        '      - "codegen/MyPlugin.dll" # file relative to emitter-output-dir\n' +
+        '      - "codegen" # directory containing plugin assemblies\n' +
+        '      - "/abs/path/to/MyPlugin.dll" # absolute path used as-is\n' +
+        "```",
     },
     license: {
       type: "object",

--- a/packages/http-client-csharp/readme.md
+++ b/packages/http-client-csharp/readme.md
@@ -129,7 +129,16 @@ Allows emitter authors to specify the path to a custom emitter package, allowing
 
 **Type:** `array`
 
-Paths to generator plugin assemblies (DLLs) or directories containing plugin assemblies. Each plugin must contain a class that extends GeneratorPlugin.
+Paths to generator plugin assemblies (DLLs) or directories containing plugin assemblies. Each plugin must contain a class that extends `GeneratorPlugin`. Paths may be absolute or relative to the resolved `emitter-output-dir`. For example, to load plugins that live in a `codegen` folder under the output directory:
+
+```yaml
+options:
+  "@typespec/http-client-csharp":
+    plugins:
+      - "codegen/MyPlugin.dll" # file relative to emitter-output-dir
+      - "codegen" # directory containing plugin assemblies
+      - "/abs/path/to/MyPlugin.dll" # absolute path used as-is
+```
 
 ### `license`
 

--- a/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
@@ -112,7 +112,16 @@ Allows emitter authors to specify the path to a custom emitter package, allowing
 
 **Type:** `array`
 
-Paths to generator plugin assemblies (DLLs) or directories containing plugin assemblies. Each plugin must contain a class that extends GeneratorPlugin.
+Paths to generator plugin assemblies (DLLs) or directories containing plugin assemblies. Each plugin must contain a class that extends `GeneratorPlugin`. Paths may be absolute or relative to the resolved `emitter-output-dir`. For example, to load plugins that live in a `codegen` folder under the output directory:
+
+```yaml
+options:
+  "@typespec/http-client-csharp":
+    plugins:
+      - "codegen/MyPlugin.dll" # file relative to emitter-output-dir
+      - "codegen" # directory containing plugin assemblies
+      - "/abs/path/to/MyPlugin.dll" # absolute path used as-is
+```
 
 ### `license`
 


### PR DESCRIPTION
## Description

The `plugins` emitter option for `@typespec/http-client-csharp` resolves each path against the resolved `emitter-output-dir` (see `emitter.ts` -> `resolvePath(outputFolder, p)`). This means:

- Absolute plugin paths are used as-is.
- Relative plugin paths (e.g. a `codegen` subfolder under the output directory) are anchored to `emitter-output-dir`.

This was not documented. This PR expands the `plugins` option description with that behavior and a YAML example, and regenerates the reference docs (`readme.md` and the website reference `emitter.md`).

## Changes

- Updated the `plugins` option `description` in `emitter/src/options.ts` to explain path resolution and show examples.
- Regenerated docs via `pnpm regen-docs`.