### PR TITLE
perf(http-client-csharp): avoid Roslyn simplifier for type names

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/TestData/ModelSerializationExtensionsDefinitionTests/ValidateGetFirstPropertyName.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/TestData/ModelSerializationExtensionsDefinitionTests/ValidateGetFirstPropertyName.cs
@@ -37,7 +37,7 @@ namespace Sample
 #else
             key = global::System.Text.Encoding.UTF8.GetString(local.Slice(0, bytesConsumed).ToArray());
 #endif
-            bytesConsumed += (jsonPath.Length - local.Length);
+            (bytesConsumed += (jsonPath.Length - local.Length));
             return key;
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/TestData/ModelSerializationExtensionsDefinitionTests/ValidateGetFirstPropertyName.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/TestData/ModelSerializationExtensionsDefinitionTests/ValidateGetFirstPropertyName.cs
@@ -37,7 +37,7 @@ namespace Sample
 #else
             key = global::System.Text.Encoding.UTF8.GetString(local.Slice(0, bytesConsumed).ToArray());
 #endif
-            (bytesConsumed += (jsonPath.Length - local.Length));
+            bytesConsumed += (jsonPath.Length - local.Length);
             return key;
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/GeneratedCodeWorkspaceNameResolverBenchmark.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/GeneratedCodeWorkspaceNameResolverBenchmark.cs
@@ -17,8 +17,6 @@ namespace Microsoft.TypeSpec.Generator.Perf
     public class GeneratedCodeWorkspaceNameResolverBenchmark
     {
         private TypeProvider[] _providers = [];
-        private CSharpTypeNameResolver _typeNameResolver = CSharpTypeNameResolver.Disabled;
-
         [Params(100)]
         public int ModelCount { get; set; }
 
@@ -55,20 +53,19 @@ namespace Microsoft.TypeSpec.Generator.Perf
             }
 
             _providers = [.. providers];
-            _typeNameResolver = CSharpTypeNameResolver.Create(_providers);
         }
 
         [Benchmark(Baseline = true)]
         public Task<int> LegacyWriterWithRoslynSimplifier()
-            => WriteAndPostProcessAsync(CSharpTypeNameResolver.Disabled);
+            => WriteAndPostProcessAsync(resolveTypeNames: false);
 
         [Benchmark]
         public Task<int> OptimizedWriterWithoutRoslynSimplifier()
-            => WriteAndPostProcessAsync(_typeNameResolver);
+            => WriteAndPostProcessAsync(resolveTypeNames: true);
 
-        private async Task<int> WriteAndPostProcessAsync(CSharpTypeNameResolver typeNameResolver)
+        private async Task<int> WriteAndPostProcessAsync(bool resolveTypeNames)
         {
-            CodeModelGenerator.Instance.TypeNameResolver = typeNameResolver;
+            CodeModelGenerator.Instance.ShouldResolveTypeNames = resolveTypeNames;
 
             var workspace = await GeneratedCodeWorkspace.Create(isCustomCodeProject: false);
             foreach (var provider in _providers)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/GeneratedCodeWorkspaceNameResolverBenchmark.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/GeneratedCodeWorkspaceNameResolverBenchmark.cs
@@ -13,7 +13,6 @@ using Microsoft.TypeSpec.Generator.Tests.Common;
 
 namespace Microsoft.TypeSpec.Generator.Perf
 {
-    [InProcess]
     public class GeneratedCodeWorkspaceNameResolverBenchmark
     {
         private TypeProvider[] _providers = [];

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/GeneratedCodeWorkspaceNameResolverBenchmark.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/GeneratedCodeWorkspaceNameResolverBenchmark.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.SourceInput;
+using Microsoft.TypeSpec.Generator.Tests.Common;
+
+namespace Microsoft.TypeSpec.Generator.Perf
+{
+    [InProcess]
+    public class GeneratedCodeWorkspaceNameResolverBenchmark
+    {
+        private TypeProvider[] _providers = [];
+        private CSharpTypeNameResolver _typeNameResolver = CSharpTypeNameResolver.Disabled;
+
+        [Params(100)]
+        public int ModelCount { get; set; }
+
+        [Params(10)]
+        public int PropertyCount { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var outputPath = Path.Combine(Path.GetTempPath(), "Microsoft.TypeSpec.Generator.Perf", nameof(GeneratedCodeWorkspaceNameResolverBenchmark));
+            Directory.CreateDirectory(outputPath);
+
+            var inputModels = new List<InputModelType>(ModelCount);
+            for (int i = 0; i < ModelCount; i++)
+            {
+                inputModels.Add(CreateModel(i));
+            }
+
+            var generator = new BenchmarkCodeModelGenerator(new GeneratorContext(Configuration.Load(
+                outputPath,
+                """
+                {
+                    "package-name": "Benchmark"
+                }
+                """)),
+                InputFactory.Namespace("Benchmark", models: [.. inputModels]));
+            generator.SourceInputModel = new SourceInputModel(null, null);
+            CodeModelGenerator.Instance = generator;
+
+            var providers = new List<TypeProvider>(ModelCount);
+            foreach (var inputModel in inputModels)
+            {
+                providers.Add(new ModelProvider(inputModel));
+            }
+
+            _providers = [.. providers];
+            _typeNameResolver = CSharpTypeNameResolver.Create(_providers);
+        }
+
+        [Benchmark(Baseline = true)]
+        public Task<int> LegacyWriterWithRoslynSimplifier()
+            => WriteAndPostProcessAsync(CSharpTypeNameResolver.Disabled);
+
+        [Benchmark]
+        public Task<int> OptimizedWriterWithoutRoslynSimplifier()
+            => WriteAndPostProcessAsync(_typeNameResolver);
+
+        private async Task<int> WriteAndPostProcessAsync(CSharpTypeNameResolver typeNameResolver)
+        {
+            CodeModelGenerator.Instance.TypeNameResolver = typeNameResolver;
+
+            var workspace = await GeneratedCodeWorkspace.Create(isCustomCodeProject: false);
+            foreach (var provider in _providers)
+            {
+                await workspace.AddGeneratedFile(new TypeProviderWriter(provider).Write());
+            }
+
+            var totalLength = 0;
+            await foreach (var (_, text) in workspace.GetGeneratedFilesAsync())
+            {
+                totalLength += text.Length;
+            }
+
+            return totalLength;
+        }
+
+        private InputModelType CreateModel(int modelIndex)
+        {
+            var properties = new List<InputModelProperty>(PropertyCount);
+            for (int i = 0; i < PropertyCount; i++)
+            {
+                properties.Add(InputFactory.Property($"property{i}", GetPropertyType(i), isRequired: true));
+            }
+
+            return InputFactory.Model($"BenchmarkModel{modelIndex}", properties: properties);
+        }
+
+        private static InputType GetPropertyType(int propertyIndex)
+            => (propertyIndex % 4) switch
+            {
+                0 => InputPrimitiveType.String,
+                1 => InputPrimitiveType.Int32,
+                2 => InputFactory.Array(InputPrimitiveType.String),
+                _ => InputFactory.Dictionary(InputPrimitiveType.Int32),
+            };
+
+        private sealed class BenchmarkCodeModelGenerator : CodeModelGenerator
+        {
+            private readonly InputLibrary _inputLibrary;
+
+            public BenchmarkCodeModelGenerator(GeneratorContext context, InputNamespace inputNamespace)
+                : base(context)
+            {
+                _inputLibrary = new BenchmarkInputLibrary(inputNamespace);
+            }
+
+            public override InputLibrary InputLibrary => _inputLibrary;
+        }
+
+        private sealed class BenchmarkInputLibrary : InputLibrary
+        {
+            private readonly InputNamespace _inputNamespace;
+
+            public BenchmarkInputLibrary(InputNamespace inputNamespace)
+            {
+                _inputNamespace = inputNamespace;
+            }
+
+            public override InputNamespace InputNamespace => _inputNamespace;
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
@@ -89,7 +89,12 @@ namespace Microsoft.TypeSpec.Generator
             {
                 // Ensure back-compatibility processing is done after all visitors have run
                 outputType.ProcessTypeForBackCompatibility();
+            }
 
+            CodeModelGenerator.Instance.TypeNameResolver = CSharpTypeNameResolver.Create(output.TypeProviders);
+
+            foreach (var outputType in output.TypeProviders)
+            {
                 var writer = CodeModelGenerator.Instance.GetWriter(outputType);
                 generateFilesTasks.Add(generatedCodeWorkspace.AddGeneratedFile(writer.Write()));
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
@@ -91,7 +91,7 @@ namespace Microsoft.TypeSpec.Generator
                 outputType.ProcessTypeForBackCompatibility();
             }
 
-            CodeModelGenerator.Instance.TypeNameResolver = CSharpTypeNameResolver.Create(output.TypeProviders);
+            CodeModelGenerator.Instance.ShouldResolveTypeNames = true;
 
             foreach (var outputType in output.TypeProviders)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CodeModelGenerator.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CodeModelGenerator.cs
@@ -95,6 +95,8 @@ namespace Microsoft.TypeSpec.Generator
         public virtual OutputLibrary OutputLibrary { get; } = new();
         public virtual InputLibrary InputLibrary => _inputLibrary;
         public virtual TypeProviderWriter GetWriter(TypeProvider provider) => new(provider);
+        internal CSharpTypeNameResolver TypeNameResolver { get; set; } = CSharpTypeNameResolver.Disabled;
+        internal bool ShouldSkipRoslynSimplifier => TypeNameResolver.IsEnabled && Rewriters.Count == 0;
         public IReadOnlyList<MetadataReference> AdditionalMetadataReferences => _additionalMetadataReferences;
 
         public IReadOnlyList<string> SharedSourceDirectories => _sharedSourceDirectories;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CodeModelGenerator.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CodeModelGenerator.cs
@@ -95,8 +95,8 @@ namespace Microsoft.TypeSpec.Generator
         public virtual OutputLibrary OutputLibrary { get; } = new();
         public virtual InputLibrary InputLibrary => _inputLibrary;
         public virtual TypeProviderWriter GetWriter(TypeProvider provider) => new(provider);
-        internal CSharpTypeNameResolver TypeNameResolver { get; set; } = CSharpTypeNameResolver.Disabled;
-        internal bool ShouldSkipRoslynSimplifier => TypeNameResolver.IsEnabled && Rewriters.Count == 0;
+        internal bool ShouldResolveTypeNames { get; set; }
+        internal bool ShouldSkipRoslynSimplifier => ShouldResolveTypeNames && Rewriters.Count == 0;
         public IReadOnlyList<MetadataReference> AdditionalMetadataReferences => _additionalMetadataReferences;
 
         public IReadOnlyList<string> SharedSourceDirectories => _sharedSourceDirectories;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             {
                 writer.Append($" = ");
             }
-            Value.WriteNested(writer);
+            Value.Write(writer);
         }
 
         private MethodBodyStatement? _terminated;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
@@ -15,9 +15,12 @@ namespace Microsoft.TypeSpec.Generator.Expressions
     {
         public ValueExpression Variable { get; private set; } = Variable;
         public ValueExpression Value { get; private set; } = Value;
+
+        internal override ExpressionPrecedence Precedence => ExpressionPrecedence.Assignment;
+
         internal override void Write(CodeWriter writer)
         {
-            Variable.Write(writer);
+            Variable.WriteInContext(writer, Precedence);
             if (UseNullCoalesce)
             {
                 writer.Append($" ??= ");
@@ -26,7 +29,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             {
                 writer.Append($" = ");
             }
-            Value.Write(writer);
+            Value.WriteInContext(writer, Precedence);
         }
 
         private MethodBodyStatement? _terminated;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
@@ -16,11 +16,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         public ValueExpression Variable { get; private set; } = Variable;
         public ValueExpression Value { get; private set; } = Value;
 
-        internal override ExpressionPrecedence Precedence => ExpressionPrecedence.Assignment;
-
         internal override void Write(CodeWriter writer)
         {
-            Variable.WriteInContext(writer, Precedence);
+            Variable.WriteNested(writer);
             if (UseNullCoalesce)
             {
                 writer.Append($" ??= ");
@@ -29,7 +27,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             {
                 writer.Append($" = ");
             }
-            Value.WriteInContext(writer, Precedence);
+            Value.WriteNested(writer);
         }
 
         private MethodBodyStatement? _terminated;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/AssignmentExpression.cs
@@ -16,6 +16,8 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         public ValueExpression Variable { get; private set; } = Variable;
         public ValueExpression Value { get; private set; } = Value;
 
+        internal override bool ShouldParenthesize => true;
+
         internal override void Write(CodeWriter writer)
         {
             Variable.WriteNested(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
@@ -5,15 +5,45 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 {
     public sealed record BinaryOperatorExpression(string Operator, ValueExpression Left, ValueExpression Right) : ValueExpression
     {
+        internal override ExpressionPrecedence Precedence => GetPrecedence(Operator);
+
         internal override void Write(CodeWriter writer)
         {
-            writer.AppendRaw("(");
-            Left.Write(writer);
+            if (!writer.UseExpressionPrecedence)
+            {
+                writer.AppendRaw("(");
+                Left.Write(writer);
+                writer.AppendRawIf(" ", !Left.IsEmptyExpression());
+                writer.AppendRaw(Operator);
+                writer.AppendRawIf(" ", !Right.IsEmptyExpression());
+                Right.Write(writer);
+                writer.AppendRaw(")");
+                return;
+            }
+
+            Left.WriteInContext(writer, Precedence);
             writer.AppendRawIf(" ", !Left.IsEmptyExpression());
             writer.AppendRaw(Operator);
             writer.AppendRawIf(" ", !Right.IsEmptyExpression());
-            Right.Write(writer);
-            writer.AppendRaw(")");
+            Right.WriteInContext(writer, Precedence, parenthesizeOnEqualPrecedence: true);
         }
+
+        private static ExpressionPrecedence GetPrecedence(string @operator)
+            => @operator switch
+            {
+                "*" or "/" or "%" => ExpressionPrecedence.Multiplicative,
+                "+" or "-" => ExpressionPrecedence.Additive,
+                "<<" or ">>" => ExpressionPrecedence.Shift,
+                "<" or ">" or "<=" or ">=" or "is" or "is not" => ExpressionPrecedence.Relational,
+                "==" or "!=" => ExpressionPrecedence.Equality,
+                "&" => ExpressionPrecedence.LogicalAnd,
+                "^" => ExpressionPrecedence.LogicalXor,
+                "|" => ExpressionPrecedence.LogicalOr,
+                "&&" or "and" => ExpressionPrecedence.ConditionalAnd,
+                "||" or "or" => ExpressionPrecedence.ConditionalOr,
+                "??" => ExpressionPrecedence.NullCoalescing,
+                _ when @operator.EndsWith("=") => ExpressionPrecedence.Assignment,
+                _ => ExpressionPrecedence.Primary
+            };
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
@@ -5,45 +5,13 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 {
     public sealed record BinaryOperatorExpression(string Operator, ValueExpression Left, ValueExpression Right) : ValueExpression
     {
-        internal override ExpressionPrecedence Precedence => GetPrecedence(Operator);
-
         internal override void Write(CodeWriter writer)
         {
-            if (!writer.UseExpressionPrecedence)
-            {
-                writer.AppendRaw("(");
-                Left.Write(writer);
-                writer.AppendRawIf(" ", !Left.IsEmptyExpression());
-                writer.AppendRaw(Operator);
-                writer.AppendRawIf(" ", !Right.IsEmptyExpression());
-                Right.Write(writer);
-                writer.AppendRaw(")");
-                return;
-            }
-
-            Left.WriteInContext(writer, Precedence);
+            Left.WriteNested(writer);
             writer.AppendRawIf(" ", !Left.IsEmptyExpression());
             writer.AppendRaw(Operator);
             writer.AppendRawIf(" ", !Right.IsEmptyExpression());
-            Right.WriteInContext(writer, Precedence, parenthesizeOnEqualPrecedence: true);
+            Right.WriteNested(writer);
         }
-
-        private static ExpressionPrecedence GetPrecedence(string @operator)
-            => @operator switch
-            {
-                "*" or "/" or "%" => ExpressionPrecedence.Multiplicative,
-                "+" or "-" => ExpressionPrecedence.Additive,
-                "<<" or ">>" => ExpressionPrecedence.Shift,
-                "<" or ">" or "<=" or ">=" or "is" or "is not" => ExpressionPrecedence.Relational,
-                "==" or "!=" => ExpressionPrecedence.Equality,
-                "&" => ExpressionPrecedence.LogicalAnd,
-                "^" => ExpressionPrecedence.LogicalXor,
-                "|" => ExpressionPrecedence.LogicalOr,
-                "&&" or "and" => ExpressionPrecedence.ConditionalAnd,
-                "||" or "or" => ExpressionPrecedence.ConditionalOr,
-                "??" => ExpressionPrecedence.NullCoalescing,
-                _ when @operator.EndsWith("=") => ExpressionPrecedence.Assignment,
-                _ => ExpressionPrecedence.Primary
-            };
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
@@ -8,12 +8,32 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         internal override void Write(CodeWriter writer)
         {
             writer.AppendRaw("(");
+            WriteCore(writer);
+            writer.AppendRaw(")");
+        }
+
+        internal override void WriteAsStatement(CodeWriter writer)
+        {
+            if (IsCompoundAssignmentOperator(Operator))
+            {
+                WriteCore(writer);
+            }
+            else
+            {
+                base.WriteAsStatement(writer);
+            }
+        }
+
+        private void WriteCore(CodeWriter writer)
+        {
             Left.Write(writer);
             writer.AppendRawIf(" ", !Left.IsEmptyExpression());
             writer.AppendRaw(Operator);
             writer.AppendRawIf(" ", !Right.IsEmptyExpression());
             Right.Write(writer);
-            writer.AppendRaw(")");
         }
+
+        private static bool IsCompoundAssignmentOperator(string @operator)
+            => @operator.EndsWith("=") && @operator is not "==" and not "!=" and not "<=" and not ">=";
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
@@ -8,32 +8,12 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         internal override void Write(CodeWriter writer)
         {
             writer.AppendRaw("(");
-            WriteCore(writer);
-            writer.AppendRaw(")");
-        }
-
-        internal override void WriteAsStatement(CodeWriter writer)
-        {
-            if (IsCompoundAssignmentOperator(Operator))
-            {
-                WriteCore(writer);
-            }
-            else
-            {
-                base.WriteAsStatement(writer);
-            }
-        }
-
-        private void WriteCore(CodeWriter writer)
-        {
             Left.Write(writer);
             writer.AppendRawIf(" ", !Left.IsEmptyExpression());
             writer.AppendRaw(Operator);
             writer.AppendRawIf(" ", !Right.IsEmptyExpression());
             Right.Write(writer);
+            writer.AppendRaw(")");
         }
-
-        private static bool IsCompoundAssignmentOperator(string @operator)
-            => @operator.EndsWith("=") && @operator is not "==" and not "!=" and not "<=" and not ">=";
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/BinaryOperatorExpression.cs
@@ -5,6 +5,8 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 {
     public sealed record BinaryOperatorExpression(string Operator, ValueExpression Left, ValueExpression Right) : ValueExpression
     {
+        internal override bool ShouldParenthesize => true;
+
         internal override void Write(CodeWriter writer)
         {
             Left.WriteNested(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/CastExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/CastExpression.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             // if the parenthesis are not needed, the roslyn reducer will remove it.
             writer.AppendRaw("(");
             writer.Append($"({Type})");
-            Inner.Write(writer);
+            Inner.WriteInContext(writer, ExpressionPrecedence.Unary);
             writer.AppendRaw(")");
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/CastExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/CastExpression.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             // if the parenthesis are not needed, the roslyn reducer will remove it.
             writer.AppendRaw("(");
             writer.Append($"({Type})");
-            Inner.WriteInContext(writer, ExpressionPrecedence.Unary);
+            Inner.WriteNested(writer);
             writer.AppendRaw(")");
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/KeywordExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/KeywordExpression.cs
@@ -15,8 +15,17 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             writer.AppendRaw(Keyword);
             if (Expression is not null)
             {
-                writer.AppendRaw(" ");
-                Expression.Write(writer);
+                if (writer.UseExpressionPrecedence && Keyword is "checked" or "unchecked")
+                {
+                    writer.AppendRaw("(");
+                    Expression.Write(writer);
+                    writer.AppendRaw(")");
+                }
+                else
+                {
+                    writer.AppendRaw(" ");
+                    Expression.Write(writer);
+                }
             }
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/KeywordExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/KeywordExpression.cs
@@ -15,10 +15,10 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             writer.AppendRaw(Keyword);
             if (Expression is not null)
             {
-                if (writer.UseExpressionPrecedence && Keyword is "checked" or "unchecked")
+                if (Keyword is "checked" or "unchecked")
                 {
                     writer.AppendRaw("(");
-                    Expression.Write(writer);
+                    Expression.WriteNested(writer);
                     writer.AppendRaw(")");
                 }
                 else

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/MemberExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/MemberExpression.cs
@@ -16,7 +16,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         {
             if (Inner is not null)
             {
-                Inner.Write(writer);
+                Inner.WriteInContext(writer, ExpressionPrecedence.Primary);
                 writer.AppendRaw(".");
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/MemberExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/MemberExpression.cs
@@ -16,7 +16,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         {
             if (Inner is not null)
             {
-                Inner.WriteInContext(writer, ExpressionPrecedence.Primary);
+                Inner.WriteNested(writer);
                 writer.AppendRaw(".");
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/NullConditionalExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/NullConditionalExpression.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TypeSpec.Generator.Expressions
     {
         internal override void Write(CodeWriter writer)
         {
-            Inner.Write(writer);
+            Inner.WriteNested(writer);
             writer.AppendRaw("?");
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/TernaryConditionalExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/TernaryConditionalExpression.cs
@@ -10,11 +10,11 @@ namespace Microsoft.TypeSpec.Generator.Expressions
     {
         internal override void Write(CodeWriter writer)
         {
-            Condition.Write(writer);
+            Condition.WriteNested(writer);
             writer.AppendRaw(" ? ");
-            Consequent.Write(writer);
+            Consequent.WriteNested(writer);
             writer.AppendRaw(" : ");
-            Alternative.Write(writer);
+            Alternative.WriteNested(writer);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/TernaryConditionalExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/TernaryConditionalExpression.cs
@@ -8,6 +8,8 @@ namespace Microsoft.TypeSpec.Generator.Expressions
     /// </summary>
     public sealed record TernaryConditionalExpression(ValueExpression Condition, ValueExpression Consequent, ValueExpression Alternative) : ValueExpression
     {
+        internal override bool ShouldParenthesize => true;
+
         internal override void Write(CodeWriter writer)
         {
             Condition.WriteNested(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/UnaryOperatorExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/UnaryOperatorExpression.cs
@@ -7,12 +7,10 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 {
     public sealed record UnaryOperatorExpression(string Operator, ValueExpression Operand, bool OperandOnTheLeft) : ValueExpression
     {
-        internal override ExpressionPrecedence Precedence => OperandOnTheLeft ? ExpressionPrecedence.Primary : ExpressionPrecedence.Unary;
-
         internal override void Write(CodeWriter writer)
         {
             writer.AppendRawIf(Operator, !OperandOnTheLeft);
-            Operand.WriteInContext(writer, Precedence);
+            Operand.WriteNested(writer);
             writer.AppendRawIf(Operator, OperandOnTheLeft);
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/UnaryOperatorExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/UnaryOperatorExpression.cs
@@ -7,10 +7,12 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 {
     public sealed record UnaryOperatorExpression(string Operator, ValueExpression Operand, bool OperandOnTheLeft) : ValueExpression
     {
+        internal override ExpressionPrecedence Precedence => OperandOnTheLeft ? ExpressionPrecedence.Primary : ExpressionPrecedence.Unary;
+
         internal override void Write(CodeWriter writer)
         {
             writer.AppendRawIf(Operator, !OperandOnTheLeft);
-            Operand.Write(writer);
+            Operand.WriteInContext(writer, Precedence);
             writer.AppendRawIf(Operator, OperandOnTheLeft);
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
@@ -12,6 +12,24 @@ using Microsoft.TypeSpec.Generator.Statements;
 
 namespace Microsoft.TypeSpec.Generator.Expressions
 {
+    internal enum ExpressionPrecedence
+    {
+        Assignment = 1,
+        NullCoalescing = 2,
+        ConditionalOr = 3,
+        ConditionalAnd = 4,
+        LogicalOr = 5,
+        LogicalXor = 6,
+        LogicalAnd = 7,
+        Equality = 8,
+        Relational = 9,
+        Shift = 10,
+        Additive = 11,
+        Multiplicative = 12,
+        Unary = 13,
+        Primary = 14
+    }
+
     /// <summary>
     /// Represents a single operator or operand, or a sequence of operators or operands.
     /// </summary>
@@ -22,7 +40,33 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 
         private protected ValueExpression() { }
 
+        internal virtual ExpressionPrecedence Precedence => ExpressionPrecedence.Primary;
+
         internal virtual void Write(CodeWriter writer) { }
+
+        internal void WriteInContext(CodeWriter writer, ExpressionPrecedence parentPrecedence, bool parenthesizeOnEqualPrecedence = false)
+        {
+            if (!writer.UseExpressionPrecedence)
+            {
+                Write(writer);
+                return;
+            }
+
+            var shouldParenthesize = Precedence < parentPrecedence ||
+                (parenthesizeOnEqualPrecedence && Precedence == parentPrecedence);
+
+            if (shouldParenthesize)
+            {
+                writer.AppendRaw("(");
+            }
+
+            Write(writer);
+
+            if (shouldParenthesize)
+            {
+                writer.AppendRaw(")");
+            }
+        }
 
         internal virtual ValueExpression? Accept(LibraryVisitor visitor, MethodProvider method)
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
@@ -22,21 +22,20 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 
         private protected ValueExpression() { }
 
+        internal virtual bool ShouldParenthesize => false;
+
         internal virtual void Write(CodeWriter writer) { }
 
         internal void WriteNested(CodeWriter writer)
         {
-            var expression = this is ScopedApi scopedApi ? scopedApi.Original : this;
-            var shouldParenthesize = expression is BinaryOperatorExpression or AssignmentExpression or TernaryConditionalExpression;
-
-            if (shouldParenthesize)
+            if (ShouldParenthesize)
             {
                 writer.AppendRaw("(");
             }
 
             Write(writer);
 
-            if (shouldParenthesize)
+            if (ShouldParenthesize)
             {
                 writer.AppendRaw(")");
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
@@ -12,24 +12,6 @@ using Microsoft.TypeSpec.Generator.Statements;
 
 namespace Microsoft.TypeSpec.Generator.Expressions
 {
-    internal enum ExpressionPrecedence
-    {
-        Assignment = 1,
-        NullCoalescing = 2,
-        ConditionalOr = 3,
-        ConditionalAnd = 4,
-        LogicalOr = 5,
-        LogicalXor = 6,
-        LogicalAnd = 7,
-        Equality = 8,
-        Relational = 9,
-        Shift = 10,
-        Additive = 11,
-        Multiplicative = 12,
-        Unary = 13,
-        Primary = 14
-    }
-
     /// <summary>
     /// Represents a single operator or operand, or a sequence of operators or operands.
     /// </summary>
@@ -40,20 +22,12 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 
         private protected ValueExpression() { }
 
-        internal virtual ExpressionPrecedence Precedence => ExpressionPrecedence.Primary;
-
         internal virtual void Write(CodeWriter writer) { }
 
-        internal void WriteInContext(CodeWriter writer, ExpressionPrecedence parentPrecedence, bool parenthesizeOnEqualPrecedence = false)
+        internal void WriteNested(CodeWriter writer)
         {
-            if (!writer.UseExpressionPrecedence)
-            {
-                Write(writer);
-                return;
-            }
-
-            var shouldParenthesize = Precedence < parentPrecedence ||
-                (parenthesizeOnEqualPrecedence && Precedence == parentPrecedence);
+            var expression = this is ScopedApi scopedApi ? scopedApi.Original : this;
+            var shouldParenthesize = expression is BinaryOperatorExpression or AssignmentExpression or TernaryConditionalExpression;
 
             if (shouldParenthesize)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
@@ -24,6 +24,8 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 
         internal virtual void Write(CodeWriter writer) { }
 
+        internal virtual void WriteAsStatement(CodeWriter writer) => Write(writer);
+
         internal virtual ValueExpression? Accept(LibraryVisitor visitor, MethodProvider method)
         {
             return this;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ValueExpression.cs
@@ -24,8 +24,6 @@ namespace Microsoft.TypeSpec.Generator.Expressions
 
         internal virtual void Write(CodeWriter writer) { }
 
-        internal virtual void WriteAsStatement(CodeWriter writer) => Write(writer);
-
         internal virtual ValueExpression? Accept(LibraryVisitor visitor, MethodProvider method)
         {
             return this;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
@@ -148,7 +148,10 @@ namespace Microsoft.TypeSpec.Generator
             }
             document = document.WithSyntaxRoot(root);
 
-            document = await Simplifier.ReduceAsync(document);
+            if (!CodeModelGenerator.Instance.ShouldSkipRoslynSimplifier)
+            {
+                document = await Simplifier.ReduceAsync(document);
+            }
 
             // Reformat if any custom rewriters have been applied
             if (CodeModelGenerator.Instance.Rewriters.Count > 0)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
@@ -19,28 +19,14 @@ namespace Microsoft.TypeSpec.Generator.Primitives
         public virtual CodeFile Write()
         {
             var typeNameResolver = CodeModelGenerator.Instance.TypeNameResolver;
-            if (typeNameResolver.IsEnabled)
-            {
-                using var collector = new CodeWriter(typeNameResolver.CreateCollector(), suppressOutput: true);
-                using (collector.SetNamespace(_provider.Type.Namespace))
-                {
-                    WriteType(collector);
-                }
+            using var writer = new CodeWriter(typeNameResolver);
+            writer.CollectTypeReferences(_provider.Type.Namespace, WriteType);
 
-                using var writer = new CodeWriter(typeNameResolver.CreateResolver(collector.ReferencedTypes, _provider.Type.Namespace));
-                using (writer.SetNamespace(_provider.Type.Namespace))
-                {
-                    WriteType(writer);
-                }
-                return new CodeFile(writer.ToString(), _provider.RelativeFilePath);
-            }
-
-            using var legacyWriter = new CodeWriter();
-            using (var ns = legacyWriter.SetNamespace(_provider.Type.Namespace))
+            using (writer.SetNamespace(_provider.Type.Namespace))
             {
-                WriteType(legacyWriter);
+                WriteType(writer);
             }
-            return new CodeFile(legacyWriter.ToString(), _provider.RelativeFilePath);
+            return new CodeFile(writer.ToString(), _provider.RelativeFilePath);
         }
 
         private bool IsPublicContext(TypeProvider provider)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
@@ -18,12 +18,29 @@ namespace Microsoft.TypeSpec.Generator.Primitives
 
         public virtual CodeFile Write()
         {
-            using var writer = new CodeWriter();
-            using (var ns = writer.SetNamespace(_provider.Type.Namespace))
+            var typeNameResolver = CodeModelGenerator.Instance.TypeNameResolver;
+            if (typeNameResolver.IsEnabled)
             {
-                WriteType(writer);
+                using var collector = new CodeWriter(typeNameResolver.CreateCollector(), suppressOutput: true);
+                using (collector.SetNamespace(_provider.Type.Namespace))
+                {
+                    WriteType(collector);
+                }
+
+                using var writer = new CodeWriter(typeNameResolver.CreateResolver(collector.ReferencedTypes, _provider.Type.Namespace));
+                using (writer.SetNamespace(_provider.Type.Namespace))
+                {
+                    WriteType(writer);
+                }
+                return new CodeFile(writer.ToString(), _provider.RelativeFilePath);
             }
-            return new CodeFile(writer.ToString(), _provider.RelativeFilePath);
+
+            using var legacyWriter = new CodeWriter();
+            using (var ns = legacyWriter.SetNamespace(_provider.Type.Namespace))
+            {
+                WriteType(legacyWriter);
+            }
+            return new CodeFile(legacyWriter.ToString(), _provider.RelativeFilePath);
         }
 
         private bool IsPublicContext(TypeProvider provider)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
@@ -18,8 +18,7 @@ namespace Microsoft.TypeSpec.Generator.Primitives
 
         public virtual CodeFile Write()
         {
-            var typeNameResolver = CodeModelGenerator.Instance.TypeNameResolver;
-            using var writer = new CodeWriter(typeNameResolver);
+            using var writer = new CodeWriter(CodeModelGenerator.Instance.ShouldResolveTypeNames);
             writer.CollectTypeReferences(_provider.Type.Namespace, WriteType);
 
             using (writer.SetNamespace(_provider.Type.Namespace))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
@@ -22,6 +22,8 @@ namespace Microsoft.TypeSpec.Generator.Snippets
 
         private MethodBodyStatement? _terminated;
 
+        internal override ExpressionPrecedence Precedence => Original.Precedence;
+
         internal override void Write(CodeWriter writer)
         {
             Original.Write(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
@@ -27,6 +27,11 @@ namespace Microsoft.TypeSpec.Generator.Snippets
             Original.Write(writer);
         }
 
+        internal override void WriteAsStatement(CodeWriter writer)
+        {
+            Original.WriteAsStatement(writer);
+        }
+
         protected internal override bool IsEmptyExpression() => Original.IsEmptyExpression();
         public MethodBodyStatement Terminate() => _terminated ??= new ExpressionStatement(this);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
@@ -22,6 +22,8 @@ namespace Microsoft.TypeSpec.Generator.Snippets
 
         private MethodBodyStatement? _terminated;
 
+        internal override bool ShouldParenthesize => Original.ShouldParenthesize;
+
         internal override void Write(CodeWriter writer)
         {
             Original.Write(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
@@ -27,11 +27,6 @@ namespace Microsoft.TypeSpec.Generator.Snippets
             Original.Write(writer);
         }
 
-        internal override void WriteAsStatement(CodeWriter writer)
-        {
-            Original.WriteAsStatement(writer);
-        }
-
         protected internal override bool IsEmptyExpression() => Original.IsEmptyExpression();
         public MethodBodyStatement Terminate() => _terminated ??= new ExpressionStatement(this);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ScopedApi.cs
@@ -22,8 +22,6 @@ namespace Microsoft.TypeSpec.Generator.Snippets
 
         private MethodBodyStatement? _terminated;
 
-        internal override ExpressionPrecedence Precedence => Original.Precedence;
-
         internal override void Write(CodeWriter writer)
         {
             Original.Write(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/ExpressionStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/ExpressionStatement.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TypeSpec.Generator.Statements
 
         internal override void Write(CodeWriter writer)
         {
-            Expression.WriteAsStatement(writer);
+            Expression.Write(writer);
             writer.WriteRawLine(";");
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/ExpressionStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/ExpressionStatement.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TypeSpec.Generator.Statements
 
         internal override void Write(CodeWriter writer)
         {
-            Expression.Write(writer);
+            Expression.WriteAsStatement(writer);
             writer.WriteRawLine(";");
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
@@ -1,0 +1,368 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+
+namespace Microsoft.TypeSpec.Generator
+{
+    internal sealed class CSharpTypeNameResolver
+    {
+        private readonly KnownTypeIndex _knownTypes;
+        private readonly HashSet<CSharpType>? _referencedTypes;
+        private readonly Dictionary<string, TypeResolution>? _resolutions;
+
+        public static CSharpTypeNameResolver Disabled { get; } = new(false, new KnownTypeIndex([]), null, null);
+
+        private CSharpTypeNameResolver(
+            bool isEnabled,
+            KnownTypeIndex knownTypes,
+            HashSet<CSharpType>? referencedTypes,
+            Dictionary<string, TypeResolution>? resolutions)
+        {
+            IsEnabled = isEnabled;
+            _knownTypes = knownTypes;
+            _referencedTypes = referencedTypes;
+            _resolutions = resolutions;
+        }
+
+        public bool IsEnabled { get; }
+
+        public IReadOnlyCollection<CSharpType> ReferencedTypes => _referencedTypes ?? [];
+
+        public static CSharpTypeNameResolver Create(IEnumerable<TypeProvider> providers)
+            => new(true, new KnownTypeIndex(EnumerateProviders(providers)), null, null);
+
+        public CSharpTypeNameResolver CreateCollector()
+            => IsEnabled
+                ? new CSharpTypeNameResolver(true, _knownTypes, new HashSet<CSharpType>(), null)
+                : Disabled;
+
+        public CSharpTypeNameResolver CreateResolver(IEnumerable<CSharpType> referencedTypes, string? currentNamespace)
+            => IsEnabled
+                ? new CSharpTypeNameResolver(true, _knownTypes, null, Analyze(referencedTypes, currentNamespace))
+                : Disabled;
+
+        public void AddReference(CSharpType type)
+        {
+            if (_referencedTypes is null || !CanAnalyze(type))
+            {
+                return;
+            }
+
+            _referencedTypes.Add(type);
+        }
+
+        public bool TryResolve(CSharpType type, out string resolvedName, out string? namespaceToImport)
+        {
+            resolvedName = string.Empty;
+            namespaceToImport = null;
+
+            if (!IsEnabled || _resolutions is null || !CanAnalyze(type))
+            {
+                return false;
+            }
+
+            if (!_resolutions.TryGetValue(GetFullName(type), out var resolution))
+            {
+                return false;
+            }
+
+            resolvedName = resolution.Name;
+            namespaceToImport = resolution.NamespaceToImport;
+            return true;
+        }
+
+        private Dictionary<string, TypeResolution> Analyze(IEnumerable<CSharpType> referencedTypes, string? currentNamespace)
+        {
+            var groups = new Dictionary<string, TypeReferenceGroup>(StringComparer.Ordinal);
+
+            foreach (var type in referencedTypes)
+            {
+                if (!CanAnalyze(type))
+                {
+                    continue;
+                }
+
+                var simpleName = GetLookupName(type);
+                if (!groups.TryGetValue(simpleName, out var group))
+                {
+                    group = new TypeReferenceGroup(simpleName);
+                    groups.Add(simpleName, group);
+                }
+
+                group.Add(type);
+            }
+
+            var resolutions = new Dictionary<string, TypeResolution>(StringComparer.Ordinal);
+            foreach (var group in groups.Values)
+            {
+                var hasCurrentNamespaceShadow = _knownTypes.HasDifferentTypeInNamespace(
+                    group.SimpleName,
+                    currentNamespace,
+                    group.ReferencedFullNames);
+
+                if (group.References.Count == 1 && !hasCurrentNamespaceShadow)
+                {
+                    var type = group.References[0];
+                    var namespaceToImport = string.Equals(type.Namespace, currentNamespace, StringComparison.Ordinal)
+                        ? null
+                        : type.Namespace;
+                    resolutions[GetFullName(type)] = new TypeResolution(GetDisplayName(type), namespaceToImport);
+                    continue;
+                }
+
+                var prefixTrie = new NamespacePrefixTrie();
+                var namespaceCount = 0;
+                foreach (var type in group.References)
+                {
+                    if (prefixTrie.Add(type.Namespace))
+                    {
+                        namespaceCount++;
+                    }
+                }
+
+                namespaceCount += _knownTypes.AddNamespacesForDifferentTypes(group.SimpleName, currentNamespace, group.ReferencedFullNames, prefixTrie);
+
+                var commonPrefix = prefixTrie.GetLongestCommonPrefix(namespaceCount);
+                foreach (var type in group.References)
+                {
+                    var name = BuildQualifiedName(type, commonPrefix);
+                    var namespaceToImport = string.IsNullOrEmpty(commonPrefix) ||
+                        string.Equals(commonPrefix, currentNamespace, StringComparison.Ordinal)
+                            ? null
+                            : commonPrefix;
+                    resolutions[GetFullName(type)] = new TypeResolution(name, namespaceToImport);
+                }
+            }
+
+            return resolutions;
+        }
+
+        private static string BuildQualifiedName(CSharpType type, string commonPrefix)
+        {
+            if (string.IsNullOrEmpty(commonPrefix))
+            {
+                return $"{type.Namespace}.{GetDisplayName(type)}";
+            }
+
+            if (string.Equals(type.Namespace, commonPrefix, StringComparison.Ordinal))
+            {
+                return GetDisplayName(type);
+            }
+
+            return $"{type.Namespace.AsSpan(commonPrefix.Length + 1).ToString()}.{GetDisplayName(type)}";
+        }
+
+        private static bool CanAnalyze(CSharpType type)
+            => !string.IsNullOrEmpty(type.Namespace);
+
+        private static string GetLookupName(CSharpType type)
+            => type.DeclaringType?.Name ?? type.Name;
+
+        private static string GetDisplayName(CSharpType type)
+            => type.DeclaringType is null ? type.Name : $"{type.DeclaringType.Name}.{type.Name}";
+
+        private static string GetFullName(CSharpType type)
+            => type.DeclaringType is null
+                ? type.FullyQualifiedName
+                : $"{type.Namespace}.{type.DeclaringType.Name}.{type.Name}";
+
+        private static IEnumerable<TypeProvider> EnumerateProviders(IEnumerable<TypeProvider> providers)
+        {
+            foreach (var provider in providers)
+            {
+                yield return provider;
+
+                foreach (var serializationProvider in EnumerateProviders(provider.SerializationProviders))
+                {
+                    yield return serializationProvider;
+                }
+
+                foreach (var nestedProvider in EnumerateProviders(provider.NestedTypes))
+                {
+                    yield return nestedProvider;
+                }
+            }
+        }
+
+        private readonly record struct TypeResolution(string Name, string? NamespaceToImport);
+
+        private sealed class TypeReferenceGroup
+        {
+            private readonly HashSet<string> _fullNames = new(StringComparer.Ordinal);
+
+            public TypeReferenceGroup(string simpleName)
+            {
+                SimpleName = simpleName;
+            }
+
+            public string SimpleName { get; }
+            public List<CSharpType> References { get; } = [];
+            public IReadOnlySet<string> ReferencedFullNames => _fullNames;
+
+            public void Add(CSharpType type)
+            {
+                if (_fullNames.Add(GetFullName(type)))
+                {
+                    References.Add(type);
+                }
+            }
+        }
+
+        private sealed class KnownTypeIndex
+        {
+            private readonly Dictionary<string, List<KnownType>> _typesBySimpleName = new(StringComparer.Ordinal);
+
+            public KnownTypeIndex(IEnumerable<TypeProvider> providers)
+            {
+                foreach (var provider in providers)
+                {
+                    var type = provider.Type;
+                    if (string.IsNullOrEmpty(type.Namespace))
+                    {
+                        continue;
+                    }
+
+                    if (!_typesBySimpleName.TryGetValue(type.Name, out var knownTypes))
+                    {
+                        knownTypes = [];
+                        _typesBySimpleName.Add(type.Name, knownTypes);
+                    }
+
+                    knownTypes.Add(new KnownType(type.Namespace, GetFullName(type)));
+                }
+            }
+
+            public bool HasDifferentTypeInNamespace(string simpleName, string? namespaceName, IReadOnlySet<string> referencedFullNames)
+            {
+                if (namespaceName is null || !_typesBySimpleName.TryGetValue(simpleName, out var knownTypes))
+                {
+                    return false;
+                }
+
+                foreach (var knownType in knownTypes)
+                {
+                    if (string.Equals(knownType.Namespace, namespaceName, StringComparison.Ordinal) &&
+                        !referencedFullNames.Contains(knownType.FullName))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public int AddNamespacesForDifferentTypes(
+                string simpleName,
+                string? namespaceName,
+                IReadOnlySet<string> referencedFullNames,
+                NamespacePrefixTrie trie)
+            {
+                if (namespaceName is null || !_typesBySimpleName.TryGetValue(simpleName, out var knownTypes))
+                {
+                    return 0;
+                }
+
+                var added = 0;
+                foreach (var knownType in knownTypes)
+                {
+                    if (string.Equals(knownType.Namespace, namespaceName, StringComparison.Ordinal) &&
+                        !referencedFullNames.Contains(knownType.FullName) &&
+                        trie.Add(knownType.Namespace))
+                    {
+                        added++;
+                    }
+                }
+
+                return added;
+            }
+
+            private readonly record struct KnownType(string Namespace, string FullName);
+        }
+
+        private sealed class NamespacePrefixTrie
+        {
+            private readonly Node _root = new();
+            private readonly HashSet<string> _namespaces = new(StringComparer.Ordinal);
+
+            public bool Add(string namespaceName)
+            {
+                if (!_namespaces.Add(namespaceName))
+                {
+                    return false;
+                }
+
+                var node = _root;
+                node.Count++;
+                var start = 0;
+                while (start < namespaceName.Length)
+                {
+                    var separator = namespaceName.IndexOf('.', start);
+                    var length = separator < 0 ? namespaceName.Length - start : separator - start;
+                    var segment = namespaceName.Substring(start, length);
+                    node = node.GetOrAdd(segment);
+                    node.Count++;
+                    if (separator < 0)
+                    {
+                        break;
+                    }
+                    start = separator + 1;
+                }
+
+                return true;
+            }
+
+            public string GetLongestCommonPrefix(int expectedCount)
+            {
+                if (expectedCount <= 0)
+                {
+                    return string.Empty;
+                }
+
+                var builder = new StringBuilder();
+                var node = _root;
+                while (node.Children is { Count: 1 })
+                {
+                    using var enumerator = node.Children.GetEnumerator();
+                    enumerator.MoveNext();
+                    var child = enumerator.Current.Value;
+                    if (child.Count != expectedCount)
+                    {
+                        break;
+                    }
+
+                    if (builder.Length > 0)
+                    {
+                        builder.Append('.');
+                    }
+                    builder.Append(enumerator.Current.Key);
+                    node = child;
+                }
+
+                return builder.ToString();
+            }
+
+            private sealed class Node
+            {
+                public int Count { get; set; }
+                public Dictionary<string, Node>? Children { get; private set; }
+
+                public Node GetOrAdd(string segment)
+                {
+                    Children ??= new Dictionary<string, Node>(StringComparer.Ordinal);
+                    if (!Children.TryGetValue(segment, out var child))
+                    {
+                        child = new Node();
+                        Children.Add(segment, child);
+                    }
+
+                    return child;
+                }
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
@@ -4,34 +4,20 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.TypeSpec.Generator.Primitives;
-using Microsoft.TypeSpec.Generator.Providers;
 
 namespace Microsoft.TypeSpec.Generator
 {
     internal sealed class CSharpTypeNameResolver
     {
-        private readonly KnownTypeIndex _knownTypes;
+        private readonly Dictionary<string, TypeResolution> _resolutions;
 
-        public static CSharpTypeNameResolver Disabled { get; } = new(false, new KnownTypeIndex([]));
-
-        private CSharpTypeNameResolver(bool isEnabled, KnownTypeIndex knownTypes)
+        private CSharpTypeNameResolver(Dictionary<string, TypeResolution> resolutions)
         {
-            IsEnabled = isEnabled;
-            _knownTypes = knownTypes;
+            _resolutions = resolutions;
         }
 
-        public bool IsEnabled { get; }
-
-        public static CSharpTypeNameResolver Create(IEnumerable<TypeProvider> providers)
-            => new(true, new KnownTypeIndex(EnumerateProviders(providers)));
-
-        public Dictionary<string, TypeResolution> Analyze(IEnumerable<CSharpType> referencedTypes, string? currentNamespace)
+        public static CSharpTypeNameResolver Create(IEnumerable<CSharpType> referencedTypes, string? currentNamespace)
         {
-            if (!IsEnabled)
-            {
-                return [];
-            }
-
             var groups = new Dictionary<string, TypeReferenceGroup>(StringComparer.Ordinal);
 
             foreach (var type in referencedTypes)
@@ -54,12 +40,7 @@ namespace Microsoft.TypeSpec.Generator
             var resolutions = new Dictionary<string, TypeResolution>(StringComparer.Ordinal);
             foreach (var group in groups.Values)
             {
-                var hasCurrentNamespaceShadow = _knownTypes.HasDifferentTypeInNamespace(
-                    group.SimpleName,
-                    currentNamespace,
-                    group.ReferencedFullNames);
-
-                if (group.References.Count == 1 && !hasCurrentNamespaceShadow)
+                if (group.References.Count == 1)
                 {
                     var type = group.References[0];
                     var namespaceToImport = string.Equals(type.Namespace, currentNamespace, StringComparison.Ordinal)
@@ -75,24 +56,20 @@ namespace Microsoft.TypeSpec.Generator
                 }
             }
 
-            return resolutions;
+            return new CSharpTypeNameResolver(resolutions);
         }
 
-        public bool TryResolve(
-            CSharpType type,
-            IReadOnlyDictionary<string, TypeResolution>? resolutions,
-            out string resolvedName,
-            out string? namespaceToImport)
+        public bool TryResolve(CSharpType type, out string resolvedName, out string? namespaceToImport)
         {
             resolvedName = string.Empty;
             namespaceToImport = null;
 
-            if (!IsEnabled || resolutions is null || !CanAnalyze(type))
+            if (!CanAnalyze(type))
             {
                 return false;
             }
 
-            if (!resolutions.TryGetValue(GetFullName(type), out var resolution))
+            if (!_resolutions.TryGetValue(GetFullName(type), out var resolution))
             {
                 return false;
             }
@@ -116,38 +93,19 @@ namespace Microsoft.TypeSpec.Generator
                 ? type.FullyQualifiedName
                 : $"{type.Namespace}.{type.DeclaringType.Name}.{type.Name}";
 
-        private static IEnumerable<TypeProvider> EnumerateProviders(IEnumerable<TypeProvider> providers)
-        {
-            foreach (var provider in providers)
-            {
-                yield return provider;
-
-                foreach (var serializationProvider in EnumerateProviders(provider.SerializationProviders))
-                {
-                    yield return serializationProvider;
-                }
-
-                foreach (var nestedProvider in EnumerateProviders(provider.NestedTypes))
-                {
-                    yield return nestedProvider;
-                }
-            }
-        }
-
-        public readonly record struct TypeResolution(string Name, string? NamespaceToImport);
+        private readonly record struct TypeResolution(string Name, string? NamespaceToImport);
 
         private sealed class TypeReferenceGroup
         {
             private readonly HashSet<string> _fullNames = new(StringComparer.Ordinal);
 
+            public string SimpleName { get; }
+            public List<CSharpType> References { get; } = [];
+
             public TypeReferenceGroup(string simpleName)
             {
                 SimpleName = simpleName;
             }
-
-            public string SimpleName { get; }
-            public List<CSharpType> References { get; } = [];
-            public IReadOnlySet<string> ReferencedFullNames => _fullNames;
 
             public void Add(CSharpType type)
             {
@@ -156,52 +114,6 @@ namespace Microsoft.TypeSpec.Generator
                     References.Add(type);
                 }
             }
-        }
-
-        private sealed class KnownTypeIndex
-        {
-            private readonly Dictionary<string, List<KnownType>> _typesBySimpleName = new(StringComparer.Ordinal);
-
-            public KnownTypeIndex(IEnumerable<TypeProvider> providers)
-            {
-                foreach (var provider in providers)
-                {
-                    var type = provider.Type;
-                    if (string.IsNullOrEmpty(type.Namespace))
-                    {
-                        continue;
-                    }
-
-                    if (!_typesBySimpleName.TryGetValue(type.Name, out var knownTypes))
-                    {
-                        knownTypes = [];
-                        _typesBySimpleName.Add(type.Name, knownTypes);
-                    }
-
-                    knownTypes.Add(new KnownType(type.Namespace, GetFullName(type)));
-                }
-            }
-
-            public bool HasDifferentTypeInNamespace(string simpleName, string? namespaceName, IReadOnlySet<string> referencedFullNames)
-            {
-                if (namespaceName is null || !_typesBySimpleName.TryGetValue(simpleName, out var knownTypes))
-                {
-                    return false;
-                }
-
-                foreach (var knownType in knownTypes)
-                {
-                    if (string.Equals(knownType.Namespace, namespaceName, StringComparison.Ordinal) &&
-                        !referencedFullNames.Contains(knownType.FullName))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            private readonly record struct KnownType(string Namespace, string FullName);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
@@ -11,72 +11,27 @@ namespace Microsoft.TypeSpec.Generator
     internal sealed class CSharpTypeNameResolver
     {
         private readonly KnownTypeIndex _knownTypes;
-        private readonly HashSet<CSharpType>? _referencedTypes;
-        private readonly Dictionary<string, TypeResolution>? _resolutions;
 
-        public static CSharpTypeNameResolver Disabled { get; } = new(false, new KnownTypeIndex([]), null, null);
+        public static CSharpTypeNameResolver Disabled { get; } = new(false, new KnownTypeIndex([]));
 
-        private CSharpTypeNameResolver(
-            bool isEnabled,
-            KnownTypeIndex knownTypes,
-            HashSet<CSharpType>? referencedTypes,
-            Dictionary<string, TypeResolution>? resolutions)
+        private CSharpTypeNameResolver(bool isEnabled, KnownTypeIndex knownTypes)
         {
             IsEnabled = isEnabled;
             _knownTypes = knownTypes;
-            _referencedTypes = referencedTypes;
-            _resolutions = resolutions;
         }
 
         public bool IsEnabled { get; }
 
-        public IReadOnlyCollection<CSharpType> ReferencedTypes => _referencedTypes ?? [];
-
         public static CSharpTypeNameResolver Create(IEnumerable<TypeProvider> providers)
-            => new(true, new KnownTypeIndex(EnumerateProviders(providers)), null, null);
+            => new(true, new KnownTypeIndex(EnumerateProviders(providers)));
 
-        public CSharpTypeNameResolver CreateCollector()
-            => IsEnabled
-                ? new CSharpTypeNameResolver(true, _knownTypes, new HashSet<CSharpType>(), null)
-                : Disabled;
-
-        public CSharpTypeNameResolver CreateResolver(IEnumerable<CSharpType> referencedTypes, string? currentNamespace)
-            => IsEnabled
-                ? new CSharpTypeNameResolver(true, _knownTypes, null, Analyze(referencedTypes, currentNamespace))
-                : Disabled;
-
-        public void AddReference(CSharpType type)
+        public Dictionary<string, TypeResolution> Analyze(IEnumerable<CSharpType> referencedTypes, string? currentNamespace)
         {
-            if (_referencedTypes is null || !CanAnalyze(type))
+            if (!IsEnabled)
             {
-                return;
+                return [];
             }
 
-            _referencedTypes.Add(type);
-        }
-
-        public bool TryResolve(CSharpType type, out string resolvedName, out string? namespaceToImport)
-        {
-            resolvedName = string.Empty;
-            namespaceToImport = null;
-
-            if (!IsEnabled || _resolutions is null || !CanAnalyze(type))
-            {
-                return false;
-            }
-
-            if (!_resolutions.TryGetValue(GetFullName(type), out var resolution))
-            {
-                return false;
-            }
-
-            resolvedName = resolution.Name;
-            namespaceToImport = resolution.NamespaceToImport;
-            return true;
-        }
-
-        private Dictionary<string, TypeResolution> Analyze(IEnumerable<CSharpType> referencedTypes, string? currentNamespace)
-        {
             var groups = new Dictionary<string, TypeReferenceGroup>(StringComparer.Ordinal);
 
             foreach (var type in referencedTypes)
@@ -123,7 +78,31 @@ namespace Microsoft.TypeSpec.Generator
             return resolutions;
         }
 
-        private static bool CanAnalyze(CSharpType type)
+        public bool TryResolve(
+            CSharpType type,
+            IReadOnlyDictionary<string, TypeResolution>? resolutions,
+            out string resolvedName,
+            out string? namespaceToImport)
+        {
+            resolvedName = string.Empty;
+            namespaceToImport = null;
+
+            if (!IsEnabled || resolutions is null || !CanAnalyze(type))
+            {
+                return false;
+            }
+
+            if (!resolutions.TryGetValue(GetFullName(type), out var resolution))
+            {
+                return false;
+            }
+
+            resolvedName = resolution.Name;
+            namespaceToImport = resolution.NamespaceToImport;
+            return true;
+        }
+
+        public static bool CanAnalyze(CSharpType type)
             => !string.IsNullOrEmpty(type.Namespace);
 
         private static string GetLookupName(CSharpType type)
@@ -155,7 +134,7 @@ namespace Microsoft.TypeSpec.Generator
             }
         }
 
-        private readonly record struct TypeResolution(string Name, string? NamespaceToImport);
+        public readonly record struct TypeResolution(string Name, string? NamespaceToImport);
 
         private sealed class TypeReferenceGroup
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpTypeNameResolver.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 
@@ -115,46 +114,13 @@ namespace Microsoft.TypeSpec.Generator
                     continue;
                 }
 
-                var prefixTrie = new NamespacePrefixTrie();
-                var namespaceCount = 0;
                 foreach (var type in group.References)
                 {
-                    if (prefixTrie.Add(type.Namespace))
-                    {
-                        namespaceCount++;
-                    }
-                }
-
-                namespaceCount += _knownTypes.AddNamespacesForDifferentTypes(group.SimpleName, currentNamespace, group.ReferencedFullNames, prefixTrie);
-
-                var commonPrefix = prefixTrie.GetLongestCommonPrefix(namespaceCount);
-                foreach (var type in group.References)
-                {
-                    var name = BuildQualifiedName(type, commonPrefix);
-                    var namespaceToImport = string.IsNullOrEmpty(commonPrefix) ||
-                        string.Equals(commonPrefix, currentNamespace, StringComparison.Ordinal)
-                            ? null
-                            : commonPrefix;
-                    resolutions[GetFullName(type)] = new TypeResolution(name, namespaceToImport);
+                    resolutions[GetFullName(type)] = new TypeResolution(GetFullName(type), null);
                 }
             }
 
             return resolutions;
-        }
-
-        private static string BuildQualifiedName(CSharpType type, string commonPrefix)
-        {
-            if (string.IsNullOrEmpty(commonPrefix))
-            {
-                return $"{type.Namespace}.{GetDisplayName(type)}";
-            }
-
-            if (string.Equals(type.Namespace, commonPrefix, StringComparison.Ordinal))
-            {
-                return GetDisplayName(type);
-            }
-
-            return $"{type.Namespace.AsSpan(commonPrefix.Length + 1).ToString()}.{GetDisplayName(type)}";
         }
 
         private static bool CanAnalyze(CSharpType type)
@@ -256,113 +222,7 @@ namespace Microsoft.TypeSpec.Generator
                 return false;
             }
 
-            public int AddNamespacesForDifferentTypes(
-                string simpleName,
-                string? namespaceName,
-                IReadOnlySet<string> referencedFullNames,
-                NamespacePrefixTrie trie)
-            {
-                if (namespaceName is null || !_typesBySimpleName.TryGetValue(simpleName, out var knownTypes))
-                {
-                    return 0;
-                }
-
-                var added = 0;
-                foreach (var knownType in knownTypes)
-                {
-                    if (string.Equals(knownType.Namespace, namespaceName, StringComparison.Ordinal) &&
-                        !referencedFullNames.Contains(knownType.FullName) &&
-                        trie.Add(knownType.Namespace))
-                    {
-                        added++;
-                    }
-                }
-
-                return added;
-            }
-
             private readonly record struct KnownType(string Namespace, string FullName);
-        }
-
-        private sealed class NamespacePrefixTrie
-        {
-            private readonly Node _root = new();
-            private readonly HashSet<string> _namespaces = new(StringComparer.Ordinal);
-
-            public bool Add(string namespaceName)
-            {
-                if (!_namespaces.Add(namespaceName))
-                {
-                    return false;
-                }
-
-                var node = _root;
-                node.Count++;
-                var start = 0;
-                while (start < namespaceName.Length)
-                {
-                    var separator = namespaceName.IndexOf('.', start);
-                    var length = separator < 0 ? namespaceName.Length - start : separator - start;
-                    var segment = namespaceName.Substring(start, length);
-                    node = node.GetOrAdd(segment);
-                    node.Count++;
-                    if (separator < 0)
-                    {
-                        break;
-                    }
-                    start = separator + 1;
-                }
-
-                return true;
-            }
-
-            public string GetLongestCommonPrefix(int expectedCount)
-            {
-                if (expectedCount <= 0)
-                {
-                    return string.Empty;
-                }
-
-                var builder = new StringBuilder();
-                var node = _root;
-                while (node.Children is { Count: 1 })
-                {
-                    using var enumerator = node.Children.GetEnumerator();
-                    enumerator.MoveNext();
-                    var child = enumerator.Current.Value;
-                    if (child.Count != expectedCount)
-                    {
-                        break;
-                    }
-
-                    if (builder.Length > 0)
-                    {
-                        builder.Append('.');
-                    }
-                    builder.Append(enumerator.Current.Key);
-                    node = child;
-                }
-
-                return builder.ToString();
-            }
-
-            private sealed class Node
-            {
-                public int Count { get; set; }
-                public Dictionary<string, Node>? Children { get; private set; }
-
-                public Node GetOrAdd(string segment)
-                {
-                    Children ??= new Dictionary<string, Node>(StringComparer.Ordinal);
-                    if (!Children.TryGetValue(segment, out var child))
-                    {
-                        child = new Node();
-                        Children.Add(segment, child);
-                    }
-
-                    return child;
-                }
-            }
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -48,8 +48,6 @@ namespace Microsoft.TypeSpec.Generator
             _atBeginningOfLine = true;
         }
 
-        internal bool UseExpressionPrecedence => _resolveTypeNames;
-
         internal void CollectTypeReferences(string @namespace, Action<CodeWriter> write)
         {
             if (!_resolveTypeNames)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -48,6 +48,8 @@ namespace Microsoft.TypeSpec.Generator
             _atBeginningOfLine = true;
         }
 
+        internal bool UseExpressionPrecedence => _resolveTypeNames;
+
         internal void CollectTypeReferences(string @namespace, Action<CodeWriter> write)
         {
             if (!_resolveTypeNames)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -26,8 +26,8 @@ namespace Microsoft.TypeSpec.Generator
         private const char _space = ' ';
 
         private readonly HashSet<string> _usingNamespaces = new HashSet<string>();
-        private readonly CSharpTypeNameResolver _typeNameResolver;
-        private Dictionary<string, CSharpTypeNameResolver.TypeResolution>? _typeNameResolutions;
+        private readonly bool _resolveTypeNames;
+        private CSharpTypeNameResolver? _typeNameResolver;
         private HashSet<CSharpType>? _referencedTypes;
 
         private readonly Stack<CodeScope> _scopes;
@@ -38,9 +38,9 @@ namespace Microsoft.TypeSpec.Generator
         private bool _writingNewInstance;
         private bool _suppressOutput;
 
-        internal CodeWriter(CSharpTypeNameResolver? typeNameResolver = null)
+        internal CodeWriter(bool resolveTypeNames = false)
         {
-            _typeNameResolver = typeNameResolver ?? CSharpTypeNameResolver.Disabled;
+            _resolveTypeNames = resolveTypeNames;
             _builder = new UnsafeBufferSequence(1024);
 
             _scopes = new Stack<CodeScope>();
@@ -50,7 +50,7 @@ namespace Microsoft.TypeSpec.Generator
 
         internal void CollectTypeReferences(string @namespace, Action<CodeWriter> write)
         {
-            if (!_typeNameResolver.IsEnabled)
+            if (!_resolveTypeNames)
             {
                 return;
             }
@@ -69,7 +69,7 @@ namespace Microsoft.TypeSpec.Generator
                 _suppressOutput = false;
             }
 
-            _typeNameResolutions = _typeNameResolver.Analyze(_referencedTypes, @namespace);
+            _typeNameResolver = CSharpTypeNameResolver.Create(_referencedTypes, @namespace);
             _referencedTypes = null;
         }
 
@@ -696,7 +696,7 @@ namespace Microsoft.TypeSpec.Generator
                     _referencedTypes.Add(type);
                 }
 
-                if (_typeNameResolver.TryResolve(type, _typeNameResolutions, out var resolvedName, out var namespaceToImport))
+                if (_typeNameResolver?.TryResolve(type, out var resolvedName, out var namespaceToImport) == true)
                 {
                     if (namespaceToImport is not null)
                     {
@@ -706,7 +706,7 @@ namespace Microsoft.TypeSpec.Generator
                 }
                 else
                 {
-                    if (!_typeNameResolver.IsEnabled)
+                    if (!_resolveTypeNames)
                     {
                         UseNamespace(type.Namespace);
                         AppendFullyQualifiedType(type);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -26,6 +26,7 @@ namespace Microsoft.TypeSpec.Generator
         private const char _space = ' ';
 
         private readonly HashSet<string> _usingNamespaces = new HashSet<string>();
+        private readonly CSharpTypeNameResolver _typeNameResolver;
 
         private readonly Stack<CodeScope> _scopes;
         private string? _currentNamespace;
@@ -33,14 +34,20 @@ namespace Microsoft.TypeSpec.Generator
         private bool _atBeginningOfLine;
         private bool _writingXmlDocumentation;
         private bool _writingNewInstance;
-        internal CodeWriter()
+        private readonly bool _suppressOutput;
+
+        internal CodeWriter(CSharpTypeNameResolver? typeNameResolver = null, bool suppressOutput = false)
         {
+            _typeNameResolver = typeNameResolver ?? CSharpTypeNameResolver.Disabled;
+            _suppressOutput = suppressOutput;
             _builder = new UnsafeBufferSequence(1024);
 
             _scopes = new Stack<CodeScope>();
             _scopes.Push(new CodeScope(this, "", false, 0));
             _atBeginningOfLine = true;
         }
+
+        internal IReadOnlyCollection<CSharpType> ReferencedTypes => _typeNameResolver.ReferencedTypes;
 
         public CodeScope Scope(FormattableString line, string start = "{", string end = "}", bool newLine = true)
         {
@@ -660,14 +667,27 @@ namespace Microsoft.TypeSpec.Generator
             }
             else
             {
-                UseNamespace(type.Namespace);
-
-                AppendRaw("global::");
-                AppendRaw(type.Namespace);
-                AppendRaw(".");
-                if (type.DeclaringType is not null)
-                    AppendRaw($"{type.DeclaringType.Name}.");
-                AppendRaw(type.Name);
+                _typeNameResolver.AddReference(type);
+                if (_typeNameResolver.TryResolve(type, out var resolvedName, out var namespaceToImport))
+                {
+                    if (namespaceToImport is not null)
+                    {
+                        UseNamespace(namespaceToImport);
+                    }
+                    AppendRaw(resolvedName);
+                }
+                else
+                {
+                    if (!_typeNameResolver.IsEnabled)
+                    {
+                        UseNamespace(type.Namespace);
+                        AppendFullyQualifiedType(type);
+                    }
+                    else
+                    {
+                        AppendQualifiedType(type);
+                    }
+                }
             }
 
             if (type.Arguments.Any())
@@ -681,6 +701,7 @@ namespace Microsoft.TypeSpec.Generator
                         AppendRaw(_writingXmlDocumentation ? "," : ", ");
                     }
                 }
+
                 AppendRaw(_writingXmlDocumentation ? "}" : ">");
             }
 
@@ -689,6 +710,21 @@ namespace Microsoft.TypeSpec.Generator
             {
                 AppendRaw("?");
             }
+        }
+
+        private void AppendFullyQualifiedType(CSharpType type)
+        {
+            AppendRaw("global::");
+            AppendQualifiedType(type);
+        }
+
+        private void AppendQualifiedType(CSharpType type)
+        {
+            AppendRaw(type.Namespace);
+            AppendRaw(".");
+            if (type.DeclaringType is not null)
+                AppendRaw($"{type.DeclaringType.Name}.");
+            AppendRaw(type.Name);
         }
 
         public CodeWriter WriteLine(FormattableString formattableString)
@@ -709,6 +745,11 @@ namespace Microsoft.TypeSpec.Generator
 
         private CodeWriter AppendRawChar(char c)
         {
+            if (_suppressOutput)
+            {
+                return this;
+            }
+
             var destination = _builder.GetSpan(1);
             destination[0] = c;
             _builder.Advance(1);
@@ -720,6 +761,11 @@ namespace Microsoft.TypeSpec.Generator
         {
             if (span.Length == 0 )
                 return this;
+
+            if (_suppressOutput)
+            {
+                return this;
+            }
 
             AddSpaces(span);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -27,6 +27,8 @@ namespace Microsoft.TypeSpec.Generator
 
         private readonly HashSet<string> _usingNamespaces = new HashSet<string>();
         private readonly CSharpTypeNameResolver _typeNameResolver;
+        private Dictionary<string, CSharpTypeNameResolver.TypeResolution>? _typeNameResolutions;
+        private HashSet<CSharpType>? _referencedTypes;
 
         private readonly Stack<CodeScope> _scopes;
         private string? _currentNamespace;
@@ -34,12 +36,11 @@ namespace Microsoft.TypeSpec.Generator
         private bool _atBeginningOfLine;
         private bool _writingXmlDocumentation;
         private bool _writingNewInstance;
-        private readonly bool _suppressOutput;
+        private bool _suppressOutput;
 
-        internal CodeWriter(CSharpTypeNameResolver? typeNameResolver = null, bool suppressOutput = false)
+        internal CodeWriter(CSharpTypeNameResolver? typeNameResolver = null)
         {
             _typeNameResolver = typeNameResolver ?? CSharpTypeNameResolver.Disabled;
-            _suppressOutput = suppressOutput;
             _builder = new UnsafeBufferSequence(1024);
 
             _scopes = new Stack<CodeScope>();
@@ -47,7 +48,30 @@ namespace Microsoft.TypeSpec.Generator
             _atBeginningOfLine = true;
         }
 
-        internal IReadOnlyCollection<CSharpType> ReferencedTypes => _typeNameResolver.ReferencedTypes;
+        internal void CollectTypeReferences(string @namespace, Action<CodeWriter> write)
+        {
+            if (!_typeNameResolver.IsEnabled)
+            {
+                return;
+            }
+
+            _referencedTypes = [];
+            _suppressOutput = true;
+            try
+            {
+                using (SetNamespace(@namespace))
+                {
+                    write(this);
+                }
+            }
+            finally
+            {
+                _suppressOutput = false;
+            }
+
+            _typeNameResolutions = _typeNameResolver.Analyze(_referencedTypes, @namespace);
+            _referencedTypes = null;
+        }
 
         public CodeScope Scope(FormattableString line, string start = "{", string end = "}", bool newLine = true)
         {
@@ -667,8 +691,12 @@ namespace Microsoft.TypeSpec.Generator
             }
             else
             {
-                _typeNameResolver.AddReference(type);
-                if (_typeNameResolver.TryResolve(type, out var resolvedName, out var namespaceToImport))
+                if (_referencedTypes is not null && CSharpTypeNameResolver.CanAnalyze(type))
+                {
+                    _referencedTypes.Add(type);
+                }
+
+                if (_typeNameResolver.TryResolve(type, _typeNameResolutions, out var resolvedName, out var namespaceToImport))
                 {
                     if (namespaceToImport is not null)
                     {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Expressions/KnownValueExpressionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Expressions/KnownValueExpressionsTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Expressions
             using var writer = new CodeWriter();
             result.Write(writer);
 
-            Assert.AreEqual("(||)", writer.ToString(false));
+            Assert.AreEqual("||", writer.ToString(false));
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Expressions
             using var writer = new CodeWriter();
             result.Write(writer);
 
-            Assert.AreEqual("(&&)", writer.ToString(false));
+            Assert.AreEqual("&&", writer.ToString(false));
         }
 
         [TestCase(typeof(int))]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
@@ -187,6 +187,18 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
         }
 
         [Test]
+        public void CompoundAssignmentExpressionStatementIsNotParenthesized()
+        {
+            var x = new VariableExpression(typeof(int), "x");
+            var statement = x.AddAndAssign(Literal(1));
+
+            using var writer = new CodeWriter();
+            statement.Write(writer);
+
+            Assert.AreEqual("x += 1;\n", writer.ToString(false));
+        }
+
+        [Test]
         public void SwitchStatementWithSingleCase()
         {
             var matchExpression = ValueExpression.Empty;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
             var condition = True;
             var ifStatement = new IfStatement(condition);
 
-            using var writer = new CodeWriter();
+            using var writer = new CodeWriter(resolveTypeNames: true);
             ifStatement.Write(writer);
 
             Assert.AreEqual(Helpers.GetExpectedFromFile(), writer.ToString(false));
@@ -144,7 +144,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
 
             var ifElseStatement = new IfElseStatement(new IfStatement(condition), elseStatement);
 
-            using var writer = new CodeWriter();
+            using var writer = new CodeWriter(resolveTypeNames: true);
             ifElseStatement.Write(writer);
 
             Assert.AreEqual(Helpers.GetExpectedFromFile(), writer.ToString(false));
@@ -184,6 +184,18 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
             ifElseStatement.Write(writer);
 
             Assert.AreEqual(Helpers.GetExpectedFromFile(), writer.ToString(false));
+        }
+
+        [Test]
+        public void CompoundAssignmentExpressionStatementIsNotParenthesized()
+        {
+            var x = new VariableExpression(typeof(int), "x");
+            var statement = x.AddAndAssign(Literal(1));
+
+            using var writer = new CodeWriter(resolveTypeNames: true);
+            statement.Write(writer);
+
+            Assert.AreEqual("x += 1;\n", writer.ToString(false));
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementTests.cs
@@ -187,18 +187,6 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
         }
 
         [Test]
-        public void CompoundAssignmentExpressionStatementIsNotParenthesized()
-        {
-            var x = new VariableExpression(typeof(int), "x");
-            var statement = x.AddAndAssign(Literal(1));
-
-            using var writer = new CodeWriter();
-            statement.Write(writer);
-
-            Assert.AreEqual("x += 1;\n", writer.ToString(false));
-        }
-
-        [Test]
         public void SwitchStatementWithSingleCase()
         {
             var matchExpression = ValueExpression.Empty;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/StatementVisitorTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Statements
             var updatedMethod = method.Accept(visitor);
             Assert.IsNotNull(updatedMethod);
             var actual = updatedMethod!.BodyStatements!.ToDisplayString();
-            Assert.AreEqual("for (int index = 0; (index < 20); index++)\n{\n}\n", actual);
+            Assert.AreEqual("for (int index = 0; index < 20; index++)\n{\n}\n", actual);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/TestData/StatementTests/IfElseStatementWithMultipleElseIfs.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Statements/TestData/StatementTests/IfElseStatementWithMultipleElseIfs.cs
@@ -1,12 +1,12 @@
-if ((x == 1))
+if (x == 1)
 {
     return "first";
 }
-else if ((x == 2))
+else if (x == 2)
 {
     return "second";
 }
-else if ((x == 3))
+else if (x == 3)
 {
     return "third";
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
@@ -117,5 +117,86 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
                 ];
             }
         }
+
+        [Test]
+        public void CodeWriter_UsesSimpleTypeNamesWhenResolverIsEnabled()
+        {
+            var result = WriteWithResolver(CSharpTypeNameResolver.Create([]), writer =>
+                writer.WriteLine($"{typeof(BinaryData)} Value;"));
+
+            StringAssert.Contains("using System;\n", result);
+            StringAssert.Contains("BinaryData Value;\n", result);
+            StringAssert.DoesNotContain("global::System.BinaryData", result);
+        }
+
+        [Test]
+        public void CodeWriter_FallsBackToFullyQualifiedNameForConflictingSimpleNames()
+        {
+            var firstType = new CSharpType("Foo", "Azure.Sample", false, false, null, [], true, false);
+            var secondType = new CSharpType("Foo", "System", false, false, null, [], true, false);
+
+            var result = WriteWithResolver(CSharpTypeNameResolver.Create([]), writer =>
+            {
+                writer.WriteLine($"{firstType} first;");
+                writer.WriteLine($"{secondType} second;");
+            });
+
+            StringAssert.DoesNotContain("using Azure.Sample;\n", result);
+            StringAssert.DoesNotContain("using System;\n", result);
+            StringAssert.Contains("Azure.Sample.Foo first;\n", result);
+            StringAssert.Contains("System.Foo second;\n", result);
+            StringAssert.DoesNotContain("global::", result);
+        }
+
+        [Test]
+        public void CodeWriter_FallsBackToFullyQualifiedNameWhenCurrentNamespaceShadowsType()
+        {
+            var resolver = CSharpTypeNameResolver.Create(
+            [
+                new TestTypeProvider(name: "BinaryData", ns: "Sample.Models")
+            ]);
+
+            var result = WriteWithResolver(resolver, writer =>
+                writer.WriteLine($"{typeof(BinaryData)} Value;"));
+
+            StringAssert.DoesNotContain("using System;\n", result);
+            StringAssert.Contains("System.BinaryData Value;\n", result);
+            StringAssert.DoesNotContain("global::", result);
+        }
+
+        [Test]
+        public void CodeWriter_UsesCommonNamespacePrefixForConflictingSimpleNames()
+        {
+            var firstType = new CSharpType("Foo", "Azure.ResourceManager.Network", false, false, null, [], true, false);
+            var secondType = new CSharpType("Foo", "Azure.ResourceManager.Compute", false, false, null, [], true, false);
+
+            var result = WriteWithResolver(CSharpTypeNameResolver.Create([]), writer =>
+            {
+                writer.WriteLine($"{firstType} first;");
+                writer.WriteLine($"{secondType} second;");
+            });
+
+            StringAssert.Contains("using Azure.ResourceManager;\n", result);
+            StringAssert.Contains("Network.Foo first;\n", result);
+            StringAssert.Contains("Compute.Foo second;\n", result);
+            StringAssert.DoesNotContain("global::", result);
+        }
+
+        private static string WriteWithResolver(CSharpTypeNameResolver resolver, Action<CodeWriter> write)
+        {
+            using var collector = new CodeWriter(resolver.CreateCollector(), suppressOutput: true);
+            using (collector.SetNamespace("Sample.Models"))
+            {
+                write(collector);
+            }
+
+            using var writer = new CodeWriter(resolver.CreateResolver(collector.ReferencedTypes, "Sample.Models"));
+            using (writer.SetNamespace("Sample.Models"))
+            {
+                write(writer);
+            }
+
+            return writer.ToString();
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
         [Test]
         public void CodeWriter_UsesSimpleTypeNamesWhenResolverIsEnabled()
         {
-            var result = WriteWithResolver(CSharpTypeNameResolver.Create([]), writer =>
+            var result = WriteWithResolver(writer =>
                 writer.WriteLine($"{typeof(BinaryData)} Value;"));
 
             StringAssert.Contains("using System;\n", result);
@@ -135,7 +135,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
             var firstType = new CSharpType("Foo", "Azure.Sample", false, false, null, [], true, false);
             var secondType = new CSharpType("Foo", "System", false, false, null, [], true, false);
 
-            var result = WriteWithResolver(CSharpTypeNameResolver.Create([]), writer =>
+            var result = WriteWithResolver(writer =>
             {
                 writer.WriteLine($"{firstType} first;");
                 writer.WriteLine($"{secondType} second;");
@@ -149,18 +149,20 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
         }
 
         [Test]
-        public void CodeWriter_FallsBackToFullyQualifiedNameWhenCurrentNamespaceShadowsType()
+        public void CodeWriter_UsesFileLocalReferencesForResolution()
         {
-            var resolver = CSharpTypeNameResolver.Create(
-            [
-                new TestTypeProvider(name: "BinaryData", ns: "Sample.Models")
-            ]);
+            var usedType = new CSharpType("Foo", "A", false, false, null, [], true, false);
+            var unusedType = new CSharpType("Foo", "A.B", false, false, null, [], true, false);
 
-            var result = WriteWithResolver(resolver, writer =>
-                writer.WriteLine($"{typeof(BinaryData)} Value;"));
+            var result = WriteWithResolver(writer =>
+                writer.WriteLine($"{usedType} Value;"));
 
-            StringAssert.DoesNotContain("using System;\n", result);
-            StringAssert.Contains("System.BinaryData Value;\n", result);
+            _ = unusedType;
+            StringAssert.Contains("using A;\n", result);
+            StringAssert.Contains("Foo Value;\n", result);
+            StringAssert.DoesNotContain("using A.B;\n", result);
+            StringAssert.DoesNotContain("A.Foo", result);
+            StringAssert.DoesNotContain("A.B.Foo", result);
             StringAssert.DoesNotContain("global::", result);
         }
 
@@ -170,7 +172,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
             var firstType = new CSharpType("Foo", "Azure.ResourceManager.Network", false, false, null, [], true, false);
             var secondType = new CSharpType("Foo", "Azure.ResourceManager.Compute", false, false, null, [], true, false);
 
-            var result = WriteWithResolver(CSharpTypeNameResolver.Create([]), writer =>
+            var result = WriteWithResolver(writer =>
             {
                 writer.WriteLine($"{firstType} first;");
                 writer.WriteLine($"{secondType} second;");
@@ -182,9 +184,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
             StringAssert.DoesNotContain("global::", result);
         }
 
-        private static string WriteWithResolver(CSharpTypeNameResolver resolver, Action<CodeWriter> write)
+        private static string WriteWithResolver(Action<CodeWriter> write)
         {
-            using var writer = new CodeWriter(resolver);
+            using var writer = new CodeWriter(resolveTypeNames: true);
             writer.CollectTypeReferences("Sample.Models", write);
 
             using (writer.SetNamespace("Sample.Models"))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
@@ -184,13 +184,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
 
         private static string WriteWithResolver(CSharpTypeNameResolver resolver, Action<CodeWriter> write)
         {
-            using var collector = new CodeWriter(resolver.CreateCollector(), suppressOutput: true);
-            using (collector.SetNamespace("Sample.Models"))
-            {
-                write(collector);
-            }
+            using var writer = new CodeWriter(resolver);
+            writer.CollectTypeReferences("Sample.Models", write);
 
-            using var writer = new CodeWriter(resolver.CreateResolver(collector.ReferencedTypes, "Sample.Models"));
             using (writer.SetNamespace("Sample.Models"))
             {
                 write(writer);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/TypeProviderWriterTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
         }
 
         [Test]
-        public void CodeWriter_UsesCommonNamespacePrefixForConflictingSimpleNames()
+        public void CodeWriter_UsesFullNameForConflictingSimpleNamesWithCommonNamespacePrefix()
         {
             var firstType = new CSharpType("Foo", "Azure.ResourceManager.Network", false, false, null, [], true, false);
             var secondType = new CSharpType("Foo", "Azure.ResourceManager.Compute", false, false, null, [], true, false);
@@ -176,9 +176,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
                 writer.WriteLine($"{secondType} second;");
             });
 
-            StringAssert.Contains("using Azure.ResourceManager;\n", result);
-            StringAssert.Contains("Network.Foo first;\n", result);
-            StringAssert.Contains("Compute.Foo second;\n", result);
+            StringAssert.DoesNotContain("using Azure.ResourceManager;\n", result);
+            StringAssert.Contains("Azure.ResourceManager.Network.Foo first;\n", result);
+            StringAssert.Contains("Azure.ResourceManager.Compute.Foo second;\n", result);
             StringAssert.DoesNotContain("global::", result);
         }
 


### PR DESCRIPTION
This PR moves C# type-name simplification into the generator's write path so the common no-rewriter path can skip Roslyn `Simplifier.ReduceAsync`.

## Changes

- Collect `CSharpType` references per generated `.cs` file in `CodeWriter`.
- Resolve type names per file, using simple names when safe and full namespace-qualified names when ambiguous.
- Stop emitting `global::` in the optimized path.
- Skip Roslyn simplification when direct type-name resolution is enabled and no custom Roslyn rewriters are registered.
- Add expression parenthesization support so generated code remains valid without Roslyn simplification.
- Add `GeneratedCodeWorkspaceNameResolverBenchmark` covering writer + generated workspace post-processing.

## Performance

Benchmark: `GeneratedCodeWorkspaceNameResolverBenchmark` with 100 models and 10 properties per model.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| LegacyWriterWithRoslynSimplifier | 594.5 ms | 1.00 | 168.2 MB | 1.00 |
| OptimizedWriterWithoutRoslynSimplifier | 202.4 ms | 0.34 | 22.12 MB | 0.13 |

This benchmark shows the optimized path is about 3x faster and allocates about 13% of the legacy path for the synthetic generated-workspace scenario.

## Validation

- `dotnet build packages/http-client-csharp/generator`
- `dotnet test packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Microsoft.TypeSpec.Generator.Tests.csproj --filter FullyQualifiedName!~GeneratorHandlerTests`
- `dotnet test packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj`
- `dotnet run -c Release --framework net10.0 --filter *GeneratedCodeWorkspaceNameResolverBenchmark*` from `packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf`