### PR TITLE
Fix configured plugin loading by scanning for the built assembly

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
@@ -196,14 +196,14 @@ namespace Microsoft.TypeSpec.Generator
                 return null;
             }
 
-            return BuildPlugin(csprojFiles[0], emitter);
+            return BuildPlugin(csprojFiles[0], directory, emitter);
         }
 
         /// <summary>
-        /// Builds a plugin .csproj and returns the path to the output DLL.
-        /// The output path is constructed from the csproj properties rather than parsing build output.
+        /// Builds a plugin .csproj and returns the path to the output DLL by scanning
+        /// <paramref name="scanDirectory"/> for the built assembly.
         /// </summary>
-        internal static string? BuildPlugin(string csprojPath, Emitter emitter)
+        internal static string? BuildPlugin(string csprojPath, string scanDirectory, Emitter emitter)
         {
             emitter.Info($"Building plugin: {csprojPath}");
 
@@ -232,67 +232,75 @@ namespace Microsoft.TypeSpec.Generator
                     $"Failed to build plugin '{csprojPath}'. Exit code: {process.ExitCode}\n{stderr}");
             }
 
-            var dllPath = GetExpectedOutputPath(csprojPath);
-            if (dllPath != null && File.Exists(dllPath))
+            var dllPath = FindPluginAssembly(csprojPath, scanDirectory);
+            if (dllPath != null)
             {
                 emitter.Info($"Plugin built: {dllPath}");
                 return dllPath;
             }
 
-            emitter.Info($"Warning: Build succeeded but could not determine output DLL path for '{csprojPath}'");
+            emitter.Info($"Warning: Build succeeded but could not locate the output DLL for '{csprojPath}'");
             return null;
         }
 
         /// <summary>
-        /// Constructs the expected output DLL path from the csproj properties:
-        /// [ProjectDirectory]/bin/Release/[TargetFramework]/[AssemblyName].dll
+        /// Locates the assembly produced by building a plugin .csproj by scanning
+        /// <paramref name="scanDirectory"/> for a DLL whose name matches the project's
+        /// assembly name. Scanning is used instead of computing the output path because
+        /// the build output location varies across repositories (for example, some
+        /// redirect output to an 'artifacts' folder) and target frameworks, which makes
+        /// a computed path unreliable.
         /// </summary>
-        internal static string? GetExpectedOutputPath(string csprojPath)
+        internal static string? FindPluginAssembly(string csprojPath, string scanDirectory)
         {
-            var projectDir = Path.GetDirectoryName(csprojPath)!;
-            var projectName = Path.GetFileNameWithoutExtension(csprojPath);
+            var dllName = GetAssemblyName(csprojPath) + ".dll";
 
+            return Directory.EnumerateFiles(scanDirectory, dllName, SearchOption.AllDirectories)
+                // Skip intermediate build output under 'obj' (e.g. obj/.../ref/*.dll
+                // reference assemblies), which are metadata-only and cannot be loaded.
+                .FirstOrDefault(path => !ContainsDirectorySegment(path, "obj"));
+        }
+
+        /// <summary>
+        /// Reads the &lt;AssemblyName&gt; from the csproj, falling back to the project file name
+        /// when it is not explicitly specified.
+        /// </summary>
+        internal static string GetAssemblyName(string csprojPath)
+        {
             try
             {
                 using var stream = File.OpenRead(csprojPath);
                 var doc = XDocument.Load(stream);
 
-                var propertyGroups = doc.Descendants("PropertyGroup");
-                string? targetFramework = null;
-                string? assemblyName = null;
+                var assemblyName = doc.Descendants("PropertyGroup")
+                    .Select(pg => pg.Element("AssemblyName")?.Value)
+                    .FirstOrDefault(value => !string.IsNullOrEmpty(value));
 
-                foreach (var pg in propertyGroups)
+                if (!string.IsNullOrEmpty(assemblyName))
                 {
-                    targetFramework ??= pg.Element("TargetFramework")?.Value;
-                    assemblyName ??= pg.Element("AssemblyName")?.Value;
+                    return assemblyName!;
                 }
-
-                // For multi-targeting projects, use the first target framework
-                if (string.IsNullOrEmpty(targetFramework))
-                {
-                    foreach (var pg in propertyGroups)
-                    {
-                        var frameworks = pg.Element("TargetFrameworks")?.Value;
-                        if (!string.IsNullOrEmpty(frameworks))
-                        {
-                            targetFramework = frameworks.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
-                            break;
-                        }
-                    }
-                }
-
-                if (string.IsNullOrEmpty(targetFramework))
-                {
-                    return null;
-                }
-
-                var effectiveAssemblyName = string.IsNullOrEmpty(assemblyName) ? projectName : assemblyName;
-                return Path.Combine(projectDir, "bin", "Release", targetFramework, $"{effectiveAssemblyName}.dll");
             }
             catch
             {
-                return null;
+                // Fall back to the project file name below.
             }
+
+            return Path.GetFileNameWithoutExtension(csprojPath);
+        }
+
+        private static bool ContainsDirectorySegment(string path, string segment)
+        {
+            var dir = Path.GetDirectoryName(path);
+            while (!string.IsNullOrEmpty(dir))
+            {
+                if (string.Equals(Path.GetFileName(dir), segment, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            return false;
         }
 
         internal static IList<string> GetOrderedPluginDlls(string pluginDirectoryStart)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
@@ -624,5 +624,44 @@ namespace Redirected { public class Dummy { } }");
                 try { Directory.Delete(testDir, true); } catch { }
             }
         }
+
+        [Test]
+        public void BuildPlugin_FindsOutputForMultiTargetedProject()
+        {
+            var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
+            try
+            {
+                Directory.CreateDirectory(testDir);
+
+                // Multi-targeting (multiple frameworks) produces a separate output folder
+                // per framework. The previous path-computation logic could not reliably
+                // pick a framework; the scan should still locate a loadable assembly.
+                File.WriteAllText(Path.Combine(testDir, "MultiTarget.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>");
+
+                File.WriteAllText(Path.Combine(testDir, "Plugin.cs"), @"
+namespace MultiTarget { public class Dummy { } }");
+
+                using var emitter = new Emitter(Stream.Null);
+                var result = GeneratorHandler.BuildPlugin(
+                    Path.Combine(testDir, "MultiTarget.csproj"), testDir, emitter);
+
+                Assert.IsNotNull(result, "Should locate the DLL for a multi-targeted project");
+                Assert.IsTrue(result!.EndsWith("MultiTarget.dll", StringComparison.OrdinalIgnoreCase));
+                Assert.IsTrue(File.Exists(result), $"Built DLL should exist at {result}");
+                // The located assembly must be a real output, not an 'obj' reference assembly.
+                Assert.IsFalse(
+                    result.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                        .Contains("obj", StringComparer.OrdinalIgnoreCase),
+                    $"Should not return a metadata-only reference assembly under obj: {result}");
+            }
+            finally
+            {
+                try { Directory.Delete(testDir, true); } catch { }
+            }
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
@@ -211,6 +211,7 @@ namespace TestPlugin
                 using var emitter = new Emitter(Stream.Null);
                 var result = GeneratorHandler.BuildPlugin(
                     Path.Combine(testDir, "TestPlugin.csproj"),
+                    testDir,
                     emitter);
 
                 Assert.IsNotNull(result, "BuildPlugin should return a DLL path");
@@ -239,6 +240,7 @@ namespace TestPlugin
                 Assert.Throws<InvalidOperationException>(() =>
                     GeneratorHandler.BuildPlugin(
                         Path.Combine(testDir, "Bad.csproj"),
+                        testDir,
                         emitter));
             }
             finally
@@ -317,7 +319,7 @@ namespace TypedPlugin { public class MyType { public int Value => 42; } }");
 
                 using var emitter = new Emitter(Stream.Null);
                 var dllPath = GeneratorHandler.BuildPlugin(
-                    Path.Combine(testDir, "TypedPlugin.csproj"), emitter);
+                    Path.Combine(testDir, "TypedPlugin.csproj"), testDir, emitter);
 
                 Assert.IsNotNull(dllPath);
                 var asm = System.Reflection.Assembly.LoadFrom(dllPath!);
@@ -478,34 +480,7 @@ namespace Plugin2 { public class Dummy { } }");
             }
         }
         [Test]
-        public void GetExpectedOutputPath_ConstructsPathFromCsprojProperties()
-        {
-            var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
-            try
-            {
-                Directory.CreateDirectory(testDir);
-
-                File.WriteAllText(Path.Combine(testDir, "MyPlugin.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
-</Project>");
-
-                var result = GeneratorHandler.GetExpectedOutputPath(
-                    Path.Combine(testDir, "MyPlugin.csproj"));
-
-                Assert.IsNotNull(result);
-                var expected = Path.Combine(testDir, "bin", "Release", "net10.0", "MyPlugin.dll");
-                Assert.AreEqual(expected, result);
-            }
-            finally
-            {
-                try { Directory.Delete(testDir, true); } catch { }
-            }
-        }
-
-        [Test]
-        public void GetExpectedOutputPath_UsesAssemblyNameWhenSpecified()
+        public void GetAssemblyName_UsesAssemblyNameWhenSpecified()
         {
             var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
             try
@@ -519,12 +494,10 @@ namespace Plugin2 { public class Dummy { } }");
   </PropertyGroup>
 </Project>");
 
-                var result = GeneratorHandler.GetExpectedOutputPath(
+                var result = GeneratorHandler.GetAssemblyName(
                     Path.Combine(testDir, "MyPlugin.csproj"));
 
-                Assert.IsNotNull(result);
-                var expected = Path.Combine(testDir, "bin", "Release", "net10.0", "CustomName.dll");
-                Assert.AreEqual(expected, result);
+                Assert.AreEqual("CustomName", result);
             }
             finally
             {
@@ -533,22 +506,23 @@ namespace Plugin2 { public class Dummy { } }");
         }
 
         [Test]
-        public void GetExpectedOutputPath_ReturnsNullWhenNoTargetFramework()
+        public void GetAssemblyName_FallsBackToProjectFileName()
         {
             var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
             try
             {
                 Directory.CreateDirectory(testDir);
 
-                File.WriteAllText(Path.Combine(testDir, "Bad.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+                File.WriteAllText(Path.Combine(testDir, "MyPlugin.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 </Project>");
 
-                var result = GeneratorHandler.GetExpectedOutputPath(
-                    Path.Combine(testDir, "Bad.csproj"));
+                var result = GeneratorHandler.GetAssemblyName(
+                    Path.Combine(testDir, "MyPlugin.csproj"));
 
-                Assert.IsNull(result);
+                Assert.AreEqual("MyPlugin", result);
             }
             finally
             {
@@ -557,7 +531,7 @@ namespace Plugin2 { public class Dummy { } }");
         }
 
         [Test]
-        public void GetExpectedOutputPath_ReturnsNullForInvalidXml()
+        public void GetAssemblyName_FallsBackToProjectFileNameForInvalidXml()
         {
             var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
             try
@@ -566,10 +540,10 @@ namespace Plugin2 { public class Dummy { } }");
 
                 File.WriteAllText(Path.Combine(testDir, "Bad.csproj"), "not valid xml");
 
-                var result = GeneratorHandler.GetExpectedOutputPath(
+                var result = GeneratorHandler.GetAssemblyName(
                     Path.Combine(testDir, "Bad.csproj"));
 
-                Assert.IsNull(result);
+                Assert.AreEqual("Bad", result);
             }
             finally
             {
@@ -578,25 +552,72 @@ namespace Plugin2 { public class Dummy { } }");
         }
 
         [Test]
-        public void GetExpectedOutputPath_UsesFirstTargetFrameworkFromMultiTargeting()
+        public void FindPluginAssembly_LocatesDllAndIgnoresIntermediateObjOutput()
         {
             var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
             try
             {
                 Directory.CreateDirectory(testDir);
 
-                File.WriteAllText(Path.Combine(testDir, "MultiTarget.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+                File.WriteAllText(Path.Combine(testDir, "MyPlugin.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>CustomName</AssemblyName>
   </PropertyGroup>
 </Project>");
 
-                var result = GeneratorHandler.GetExpectedOutputPath(
-                    Path.Combine(testDir, "MultiTarget.csproj"));
+                // A reference assembly under 'obj' must be ignored (metadata-only).
+                var objRefDir = Path.Combine(testDir, "obj", "Release", "net10.0", "ref");
+                Directory.CreateDirectory(objRefDir);
+                File.WriteAllText(Path.Combine(objRefDir, "CustomName.dll"), "ref");
 
-                Assert.IsNotNull(result);
-                var expected = Path.Combine(testDir, "bin", "Release", "net8.0", "MultiTarget.dll");
+                // The real output may live in a non-default location.
+                var outDir = Path.Combine(testDir, "custom-out", "Release", "net10.0");
+                Directory.CreateDirectory(outDir);
+                var expected = Path.Combine(outDir, "CustomName.dll");
+                File.WriteAllText(expected, "real");
+
+                var result = GeneratorHandler.FindPluginAssembly(
+                    Path.Combine(testDir, "MyPlugin.csproj"), testDir);
+
                 Assert.AreEqual(expected, result);
+            }
+            finally
+            {
+                try { Directory.Delete(testDir, true); } catch { }
+            }
+        }
+
+        [Test]
+        public void BuildPlugin_FindsOutputWhenRedirectedToCustomLocation()
+        {
+            var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
+            try
+            {
+                Directory.CreateDirectory(testDir);
+
+                // Use <TargetFrameworks> (plural) and redirect build output to a custom
+                // folder, mirroring repositories that send output to an 'artifacts'-style
+                // location. The previous path-computation logic failed in this scenario.
+                File.WriteAllText(Path.Combine(testDir, "Redirected.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <BaseOutputPath>$(MSBuildProjectDirectory)\artifacts-bin\</BaseOutputPath>
+  </PropertyGroup>
+</Project>");
+
+                File.WriteAllText(Path.Combine(testDir, "Plugin.cs"), @"
+namespace Redirected { public class Dummy { } }");
+
+                using var emitter = new Emitter(Stream.Null);
+                var result = GeneratorHandler.BuildPlugin(
+                    Path.Combine(testDir, "Redirected.csproj"), testDir, emitter);
+
+                Assert.IsNotNull(result, "Should locate the DLL even when output is redirected");
+                Assert.IsTrue(result!.EndsWith("Redirected.dll", StringComparison.OrdinalIgnoreCase));
+                Assert.IsTrue(File.Exists(result), $"Built DLL should exist at {result}");
+                StringAssert.Contains("artifacts-bin", result,
+                    "DLL should be located in the redirected output folder");
             }
             finally
             {


### PR DESCRIPTION
## Problem

When a codegen plugin is declared via the `plugins` list in `tspconfig.yaml` (the configured-plugin path), the plugin builds successfully but is silently never loaded. The plugin only works when declared in `emitter-package.json`.

### Root cause

`GeneratorHandler` computed the built plugin DLL path as `bin/Release/<tfm>/<AssemblyName>.dll` (`GetExpectedOutputPath`). This is unreliable:

1. Plugin projects that use `<TargetFrameworks>` (plural, often via an MSBuild variable like `$(RequiredTargetFrameworks)`) have no single computable `<tfm>`.
2. Repositories commonly redirect build output. For example, `azure-sdk-for-net` redirects to `artifacts/bin/<Project>/<Config>/<tfm>/` rather than the project-local `bin/`.

In both cases `File.Exists` returns false, `BuildPlugin` returns `null`, and the plugin is silently skipped. The `emitter-package.json` (npm-dependency) path worked because it scans `dist` recursively.

## Fix

Replace the computed-path logic with a recursive scan of the plugin directory for `<AssemblyName>.dll`, mirroring the npm-dependency plugin path. Reference assemblies under `obj/` (metadata-only, not loadable) are excluded. This is robust to output redirection and multi-targeting.

## Tests

Updated `GeneratorHandlerTests` with scan-based tests, including a regression test (`BuildPlugin_FindsOutputWhenRedirectedToCustomLocation`) that uses `<TargetFrameworks>` plural plus a redirected `<BaseOutputPath>` and asserts the DLL is still located. All 22 tests pass.
