### PR TITLE
fix(http-client-csharp): strip [Experimental] attribute when internalizing types

### DIFF
--- a/.github/instructions/http-client-csharp.instructions.md
+++ b/.github/instructions/http-client-csharp.instructions.md
@@ -26,3 +26,4 @@ applyTo: "packages/http-client-csharp/**/*"
 - Regenerate all generated libraries by running `eng/scripts/Generate.ps1`.
 - Ensure all unit tests are passing.
 - Do not comment out or delete any existing tests.
+- StyleCop runs as part of the generator build (warnings are treated as errors). Before committing C# changes, run the StyleCop check locally by building the generator with `dotnet build packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Microsoft.TypeSpec.Generator.csproj` (or `npm run build:generator`) and ensure it reports `0 Warning(s)` and `0 Error(s)`.

--- a/.github/instructions/http-client-csharp.instructions.md
+++ b/.github/instructions/http-client-csharp.instructions.md
@@ -26,4 +26,3 @@ applyTo: "packages/http-client-csharp/**/*"
 - Regenerate all generated libraries by running `eng/scripts/Generate.ps1`.
 - Ensure all unit tests are passing.
 - Do not comment out or delete any existing tests.
-- StyleCop runs as part of the generator build (warnings are treated as errors). Before committing C# changes, run the StyleCop check locally by building the generator with `dotnet build packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Microsoft.TypeSpec.Generator.csproj` (or `npm run build:generator`) and ensure it reports `0 Warning(s)` and `0 Error(s)`.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/PostProcessor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/PostProcessor.cs
@@ -156,6 +156,12 @@ namespace Microsoft.TypeSpec.Generator
                 project = MarkInternal(project, model, documentId);
             }
 
+            if (nodesToInternalize.Count > 0)
+            {
+                CodeModelGenerator.Instance.Emitter.Info(
+                    $"Internalized {nodesToInternalize.Count} unreferenced public type(s).");
+            }
+
             var modelNamesToRemove =
                 nodesToInternalize.Keys.Select(item => item.Identifier.Text);
             project = await RemoveMethodsFromModelFactoryAsync(project, definitions, modelNamesToRemove.ToHashSet());
@@ -336,13 +342,89 @@ namespace Microsoft.TypeSpec.Generator
 
         private Project MarkInternal(Project project, BaseTypeDeclarationSyntax declarationNode, DocumentId documentId)
         {
+            CodeModelGenerator.Instance.Emitter.Debug(
+                $"Internalizing unreferenced public type '{declarationNode.Identifier.Text}'.");
+
             var newNode = ChangeModifier(declarationNode, SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword);
+            // The [Experimental] attribute is a public-API stability signal that is meaningless on a type that is
+            // being internalized, so strip it to avoid emitting it (and its use-site diagnostics) on internal types.
+            newNode = RemoveExperimentalAttribute(newNode, declarationNode.Identifier.Text);
             var tree = declarationNode.SyntaxTree;
             var document = project.GetDocument(documentId)!;
             var newRoot = tree.GetRoot().ReplaceNode(declarationNode, newNode)
                 .WithAdditionalAnnotations(Simplifier.Annotation);
             document = document.WithSyntaxRoot(newRoot);
             return document.Project;
+        }
+
+        private static readonly string[] _experimentalAttributeNames = ["Experimental", "ExperimentalAttribute"];
+
+        /// <summary>
+        /// Removes any <c>[Experimental]</c> (<see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>)
+        /// attribute from <paramref name="declarationNode"/>. The declaration's leading trivia (such as documentation
+        /// comments and indentation) is re-attached to the resulting first token so that the surrounding formatting and
+        /// any documentation comment are preserved even when the attribute that carried them is removed.
+        /// </summary>
+        private static BaseTypeDeclarationSyntax RemoveExperimentalAttribute(
+            BaseTypeDeclarationSyntax declarationNode,
+            string typeName)
+        {
+            if (declarationNode.AttributeLists.Count == 0)
+                return declarationNode;
+
+            var newAttributeLists = new List<AttributeListSyntax>();
+            bool removed = false;
+
+            foreach (var attributeList in declarationNode.AttributeLists)
+            {
+                var keptAttributes = attributeList.Attributes
+                    .Where(attribute => !IsExperimentalAttribute(attribute))
+                    .ToList();
+
+                if (keptAttributes.Count == attributeList.Attributes.Count)
+                {
+                    // Nothing removed from this list.
+                    newAttributeLists.Add(attributeList);
+                }
+                else if (keptAttributes.Count > 0)
+                {
+                    // Keep the remaining (non-experimental) attributes in this list.
+                    removed = true;
+                    newAttributeLists.Add(attributeList.WithAttributes(SyntaxFactory.SeparatedList(keptAttributes)));
+                }
+                else
+                {
+                    // The entire list only contained experimental attributes and is dropped.
+                    removed = true;
+                }
+            }
+
+            if (!removed)
+                return declarationNode;
+
+            CodeModelGenerator.Instance.Emitter.Debug(
+                $"Removed [Experimental] attribute from '{typeName}' while internalizing it.");
+
+            // Preserve the original leading trivia (e.g. documentation comments and indentation) by re-attaching it to
+            // whatever token now leads the declaration. This keeps the doc comment even when it was attached to the
+            // attribute list that was removed.
+            var originalLeadingTrivia = declarationNode.GetLeadingTrivia();
+            var newNode = declarationNode.WithAttributeLists(SyntaxFactory.List(newAttributeLists));
+            var firstToken = newNode.GetFirstToken();
+
+            return newNode.ReplaceToken(firstToken, firstToken.WithLeadingTrivia(originalLeadingTrivia));
+        }
+
+        private static bool IsExperimentalAttribute(AttributeSyntax attribute)
+        {
+            var name = attribute.Name switch
+            {
+                QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+                IdentifierNameSyntax identifier => identifier.Identifier.Text,
+                _ => attribute.Name.ToString()
+            };
+
+            return Array.IndexOf(_experimentalAttributeNames, name) >= 0;
         }
 
         private async Task<Project> RemoveModelsAsync(Project project,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/PostProcessor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/PostProcessor.cs
@@ -20,6 +20,8 @@ namespace Microsoft.TypeSpec.Generator
         private readonly HashSet<string> _typesToKeep;
         private INamedTypeSymbol? _modelFactorySymbol;
 
+        private static readonly string[] _experimentalAttributeNames = ["Experimental", "ExperimentalAttribute"];
+
         public PostProcessor(
             HashSet<string> typesToKeep,
             string? modelFactoryFullName = null,
@@ -357,8 +359,6 @@ namespace Microsoft.TypeSpec.Generator
             return document.Project;
         }
 
-        private static readonly string[] _experimentalAttributeNames = ["Experimental", "ExperimentalAttribute"];
-
         /// <summary>
         /// Removes any <c>[Experimental]</c> (<see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>)
         /// attribute from <paramref name="declarationNode"/>. The declaration's leading trivia (such as documentation
@@ -370,7 +370,9 @@ namespace Microsoft.TypeSpec.Generator
             string typeName)
         {
             if (declarationNode.AttributeLists.Count == 0)
+            {
                 return declarationNode;
+            }
 
             var newAttributeLists = new List<AttributeListSyntax>();
             bool removed = false;
@@ -400,7 +402,9 @@ namespace Microsoft.TypeSpec.Generator
             }
 
             if (!removed)
+            {
                 return declarationNode;
+            }
 
             CodeModelGenerator.Instance.Emitter.Debug(
                 $"Removed [Experimental] attribute from '{typeName}' while internalizing it.");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/PostProcessorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/PostProcessorTests.cs
@@ -3,10 +3,12 @@
 
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
@@ -288,6 +290,100 @@ namespace Microsoft.TypeSpec.Generator.Tests.PostProcessing
 
             Assert.AreEqual(Helpers.GetExpectedFromFile().TrimEnd(), output, "The output should match the expected content.");
         }
+
+        [Test]
+        public async Task RemovesExperimentalAttributeWhenInternalizing()
+        {
+            MockHelpers.LoadMockGenerator();
+            var workspace = new AdhocWorkspace();
+            var projectInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    name: "TestProj",
+                    assemblyName: "TestProj",
+                    language: LanguageNames.CSharp)
+                .WithMetadataReferences(new[]
+                {
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(ExperimentalAttribute).Assembly.Location)
+                });
+
+            var project = workspace.AddProject(projectInfo);
+            var folder = Helpers.GetAssetFileOrDirectoryPath(false);
+            const string rootFileName = "ExperimentalInternalizeRoot.cs";
+            string[] modelFileNames =
+            [
+                "ReferencedModel.cs",
+                "UnreferencedModel.cs",
+                "UnreferencedWithOtherAttribute.cs",
+                "UnreferencedWithCombinedAttributes.cs"
+            ];
+            foreach (var fileName in modelFileNames)
+            {
+                project = project.AddDocument(
+                    fileName,
+                    File.ReadAllText(Path.Join(folder, fileName))).Project;
+            }
+            project = project.AddDocument(
+                rootFileName,
+                File.ReadAllText(Path.Join(folder, rootFileName))).Project;
+            var postProcessor = new TestPostProcessor(rootFileName);
+
+            var resultProject = await postProcessor.InternalizeAsync(project);
+
+            var referencedModel = await GetSingleClassAsync(resultProject, "ReferencedModel.cs", "ReferencedModel");
+            var unreferencedModel = await GetSingleClassAsync(resultProject, "UnreferencedModel.cs", "UnreferencedModel");
+            var unreferencedWithOther = await GetSingleClassAsync(resultProject, "UnreferencedWithOtherAttribute.cs", "UnreferencedWithOtherAttribute");
+            var unreferencedWithCombined = await GetSingleClassAsync(resultProject, "UnreferencedWithCombinedAttributes.cs", "UnreferencedWithCombinedAttributes");
+
+            // The referenced model stays public and keeps its [Experimental] attribute.
+            Assert.IsTrue(referencedModel.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)));
+            Assert.IsTrue(HasExperimentalAttribute(referencedModel), "Referenced (public) model should keep [Experimental].");
+
+            // The unreferenced model is internalized and loses its [Experimental] attribute.
+            Assert.IsTrue(unreferencedModel.Modifiers.Any(m => m.IsKind(SyntaxKind.InternalKeyword)));
+            Assert.IsFalse(unreferencedModel.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)));
+            Assert.IsFalse(HasExperimentalAttribute(unreferencedModel), "Internalized model should not keep [Experimental].");
+
+            // The documentation comment on the internalized type is preserved.
+            Assert.IsTrue(
+                unreferencedModel.GetLeadingTrivia().ToFullString().Contains("not referenced"),
+                "Doc comment of the internalized type should be preserved.");
+
+            // An internalized type with another attribute in a separate list keeps the other attribute.
+            Assert.IsTrue(unreferencedWithOther.Modifiers.Any(m => m.IsKind(SyntaxKind.InternalKeyword)));
+            Assert.IsFalse(HasExperimentalAttribute(unreferencedWithOther), "Internalized model should not keep [Experimental].");
+            Assert.IsTrue(HasAttribute(unreferencedWithOther, "Serializable"), "Other attributes should be preserved.");
+            Assert.IsTrue(
+                unreferencedWithOther.GetLeadingTrivia().ToFullString().Contains("must be preserved"),
+                "Doc comment should be preserved when only one of several attribute lists is removed.");
+
+            // An internalized type with the experimental attribute combined in a single list keeps the others.
+            Assert.IsTrue(unreferencedWithCombined.Modifiers.Any(m => m.IsKind(SyntaxKind.InternalKeyword)));
+            Assert.IsFalse(HasExperimentalAttribute(unreferencedWithCombined), "Internalized model should not keep [Experimental].");
+            Assert.IsTrue(HasAttribute(unreferencedWithCombined, "Serializable"), "Other attributes in the same list should be preserved.");
+        }
+
+        private static async Task<ClassDeclarationSyntax> GetSingleClassAsync(Project project, string fileName, string className)
+        {
+            var doc = project.Documents.Single(d => d.Name == fileName);
+            var root = await doc.GetSyntaxRootAsync();
+            return ((CompilationUnitSyntax)root!)
+                .DescendantNodes()
+                .OfType<ClassDeclarationSyntax>()
+                .Single(t => t.Identifier.Text == className);
+        }
+
+        private static bool HasAttribute(BaseTypeDeclarationSyntax type, string attributeName)
+            => type.AttributeLists
+                .SelectMany(list => list.Attributes)
+                .Any(attr => attr.Name.ToString() == attributeName);
+
+
+        private static bool HasExperimentalAttribute(BaseTypeDeclarationSyntax type)
+            => type.AttributeLists
+                .SelectMany(list => list.Attributes)
+                .Any(attr => attr.Name.ToString() is "Experimental" or "ExperimentalAttribute");
 
         private class TestPostProcessor : PostProcessor
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/ExperimentalInternalizeRoot.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/ExperimentalInternalizeRoot.cs
@@ -1,0 +1,7 @@
+namespace Sample
+{
+    public class ExperimentalInternalizeRoot
+    {
+        public ReferencedModel Model { get; set; }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/ReferencedModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/ReferencedModel.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sample
+{
+    /// <summary>
+    /// A model that is referenced from a root type and therefore stays public.
+    /// </summary>
+    [Experimental("EXP001")]
+    public class ReferencedModel
+    {
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/UnreferencedModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/UnreferencedModel.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sample
+{
+    /// <summary>
+    /// A model that is not referenced from any root type and is internalized.
+    /// </summary>
+    [Experimental("EXP001")]
+    public class UnreferencedModel
+    {
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/UnreferencedWithCombinedAttributes.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/UnreferencedWithCombinedAttributes.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sample
+{
+    /// <summary>
+    /// An unreferenced model with the experimental attribute combined in a single list.
+    /// </summary>
+    [Serializable, Experimental("EXP001")]
+    public class UnreferencedWithCombinedAttributes
+    {
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/UnreferencedWithOtherAttribute.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/PostProcessing/TestData/PostProcessorTests/RemovesExperimentalAttributeWhenInternalizing/UnreferencedWithOtherAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sample
+{
+    /// <summary>
+    /// An unreferenced model that carries another attribute which must be preserved.
+    /// </summary>
+    [Serializable]
+    [Experimental("EXP001")]
+    public class UnreferencedWithOtherAttribute
+    {
+    }
+}


### PR DESCRIPTION
## Problem

Public types are tagged with `[Experimental]` during the visitor phase (`CSharpGen` runs visitors before `PostProcessAsync`). The post-processor later internalizes types that are not reachable from the public API surface, but `MarkInternal` only changed the `public` -> `internal` modifier token and left the already-written `[Experimental]` attribute in place. The result was a public-API stability attribute on `internal` types (e.g. `InternalProjectsClientOptions` and various model-factory internals), which is meaningless on non-public types and produces spurious diff churn.

## Fix

`MarkInternal` now also strips the `[Experimental]` (`System.Diagnostics.CodeAnalysis.ExperimentalAttribute`) attribute when internalizing a type:

- Matches both `Experimental` and `ExperimentalAttribute`, including qualified names.
- Preserves other attributes (e.g. trims a combined `[Serializable, Experimental]` list down to `[Serializable]`).
- Re-attaches the declaration's original leading trivia so documentation comments and indentation are preserved (the internalize pass is not reformatted afterward).

### Logging

- `Debug`: `Internalizing unreferenced public type '<name>'.`
- `Debug`: `Removed [Experimental] attribute from '<name>' while internalizing it.`
- `Info`: `Internalized N unreferenced public type(s).`

## Tests

New `PostProcessorTests.RemovesExperimentalAttributeWhenInternalizing` covering:
- referenced (public) type keeps `[Experimental]`;
- unreferenced type is internalized and loses `[Experimental]`, doc comment preserved;
- other attribute preserved when in a separate list;
- other attribute preserved when combined in the same list.

Full `Microsoft.TypeSpec.Generator` suite passes (1526 passed, 0 failed).