### PR TITLE
fix(http-client-csharp): bump pinned cop release to v2026.6.10.1

### DIFF
--- a/.github/instructions/http-client-csharp.instructions.md
+++ b/.github/instructions/http-client-csharp.instructions.md
@@ -26,3 +26,4 @@ applyTo: "packages/http-client-csharp/**/*"
 - Regenerate all generated libraries by running `eng/scripts/Generate.ps1`.
 - Ensure all unit tests are passing.
 - Do not comment out or delete any existing tests.
+- Run the Cop static-analysis checks locally with `npm run cop` (which invokes `eng/scripts/Invoke-Cop.ps1`). This downloads the pinned Agent Cop release and runs the rules under `cop-checks/` against the generator, failing on any violation. Ensure it reports `cop checks passed.` before committing C# changes.

--- a/packages/http-client-csharp/eng/scripts/Invoke-Cop.ps1
+++ b/packages/http-client-csharp/eng/scripts/Invoke-Cop.ps1
@@ -38,7 +38,7 @@ param(
     # Pinned cop release. Bump deliberately after verifying the cop-checks/ rules
     # still run against the new release (cop can make breaking API changes
     # between releases). Pass "latest" to test against the newest release.
-    [string] $Version = "v2026.6.9.1"
+    [string] $Version = "v2026.6.10.1"
 )
 
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
Bumps the pinned Agent Cop release used by `eng/scripts/Invoke-Cop.ps1` from `v2026.6.9.1` to the latest release `v2026.6.10.1`.

Verified locally against a clean `main` checkout: the new binary downloads, providers seed at the matching tag, and the `cop-checks/` rules run clean (`cop checks passed.`).