### PR TITLE
[DO NOT MERGE]feat(compiler): prefer client.tsp over main.tsp when no entrypoint configured

### DIFF
--- a/.chronus/changes/prefer-client-tsp-entrypoint-2026-6-10-15-15-0.md
+++ b/.chronus/changes/prefer-client-tsp-entrypoint-2026-6-10-15-15-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Default entrypoint resolution now prefers `client.tsp` over `main.tsp` when a project's `tspconfig.yaml` does not explicitly set `entrypoint` and a sibling `client.tsp` exists. This matches the convention used by `tsp-client` and allows augment decorators in `client.tsp` (e.g. `@@clientName`) to participate in compilation and linting without needing to add `imports: - ./client.tsp` to `tspconfig.yaml`.

--- a/packages/compiler/src/core/entrypoint-resolution.ts
+++ b/packages/compiler/src/core/entrypoint-resolution.ts
@@ -36,7 +36,7 @@ export async function resolveTypeSpecEntrypointForDir(
   // Check for project tspconfig first
   const config = await loadTypeSpecConfigForPath(host, dir, false, false);
   if (config.kind === "project") {
-    const entrypoint = config.entrypoint ?? "main.tsp";
+    const entrypoint = config.entrypoint ?? (await resolveDefaultEntrypoint(host, dir));
     return resolvePath(dir, entrypoint);
   }
 
@@ -49,5 +49,11 @@ export async function resolveTypeSpecEntrypointForDir(
     return resolvePath(dir, tspMain);
   }
 
-  return resolvePath(dir, "main.tsp");
+  return resolvePath(dir, await resolveDefaultEntrypoint(host, dir));
+}
+
+async function resolveDefaultEntrypoint(host: CompilerHost, dir: string): Promise<string> {
+  const clientTspPath = resolvePath(dir, "client.tsp");
+  const stat = await doIO(host.stat, clientTspPath, () => {}, { allowFileNotFound: true });
+  return stat?.isFile() ? "client.tsp" : "main.tsp";
 }

--- a/packages/compiler/src/server/entrypoint-resolver.ts
+++ b/packages/compiler/src/server/entrypoint-resolver.ts
@@ -24,14 +24,15 @@ export async function resolveEntrypointFile(
   let dir = isFilePath ? getDirectoryPath(path) : path;
 
   if (!entrypoints) {
-    entrypoints = ["main.tsp"];
+    entrypoints = ["client.tsp", "main.tsp"];
   }
 
   while (true) {
     // Check for project tspconfig first (highest priority)
     const config = await loadTypeSpecConfigForPath(host, dir, false, false);
     if (config.kind === "project") {
-      const entrypoint = config.entrypoint ?? "main.tsp";
+      const entrypoint =
+        config.entrypoint ?? ((await existingFile(dir, "client.tsp")) ? "client.tsp" : "main.tsp");
       const candidate = await existingFile(dir, entrypoint);
       logDebug({
         level: "debug",

--- a/packages/compiler/test/server/entrypoint-resolver.test.ts
+++ b/packages/compiler/test/server/entrypoint-resolver.test.ts
@@ -70,6 +70,13 @@ describe("entrypoint resolution", () => {
     const resultForUndefined = await resolveEntrypoint(files, "project/src/file.tsp", undefined);
     expect(resultForUndefined).toBe(resolveVirtualPath("project/main.tsp"));
   });
+
+  it("prefers client.tsp over main.tsp in default fallback when both exist", async () => {
+    const files = { "project/main.tsp": "", "project/client.tsp": "" };
+
+    const result = await resolveEntrypoint(files, "project/src/file.tsp");
+    expect(result).toBe(resolveVirtualPath("project/client.tsp"));
+  });
 });
 
 describe("project tspconfig entrypoint resolution", () => {
@@ -104,6 +111,18 @@ describe("project tspconfig entrypoint resolution", () => {
       "project/src/doc.tsp",
     );
     expect(result).toBe(resolveVirtualPath("project/main.tsp"));
+  });
+
+  it("defaults to client.tsp when kind is project, no entrypoint specified, and client.tsp exists", async () => {
+    const result = await resolveEntrypoint(
+      {
+        "project/tspconfig.yaml": "kind: project\n",
+        "project/main.tsp": "",
+        "project/client.tsp": "",
+      },
+      "project/src/doc.tsp",
+    );
+    expect(result).toBe(resolveVirtualPath("project/client.tsp"));
   });
 
   it("project tspconfig stops the walk even if entrypoint file doesn't exist", async () => {


### PR DESCRIPTION
## Summary

When resolving the default entrypoint and no entrypoint is explicitly set (via tspconfig.yaml `entrypoint` or package.json `tspMain`), prefer `client.tsp` over `main.tsp` when a sibling `client.tsp` exists.

This matches the convention already used by `tsp-client` and allows augment decorators in `client.tsp` (e.g. `@@clientName`) to participate in compilation and linting without requiring `imports: - ./client.tsp` in tspconfig.yaml.

## Motivation

Linter rules that emit codefixes targeting `client.tsp` (e.g. https://github.com/Azure/typespec-azure/pull/4541) currently have two options to ensure the augmented decorators participate in the compile/lint pass:

1. Mutate `tspconfig.yaml` to add `imports: - ./client.tsp`.
2. Require the user to add that import line manually.

Both are awkward. `tsp-client` already solves this by treating `client.tsp` as the entrypoint when present. This change brings the same convention to the core compiler/language server so that:

- Linter rules that write into `client.tsp` Just Work without YAML editing.
- The dependency direction stays natural: `client.tsp imports main.tsp` (client depends on service, not the other way around).

## Behavior

Resolution order is unchanged except for the implicit default:

- If `tspconfig.yaml` explicitly sets `entrypoint`, that wins.
- If `package.json` sets `tspMain`, that wins.
- Otherwise: prefer `client.tsp` if it exists in the project root, else `main.tsp`.

Both the CLI entrypoint resolver (`core/entrypoint-resolution.ts`) and the language-server entrypoint resolver (`server/entrypoint-resolver.ts`) are updated.

## Caveat

For augments in `client.tsp` to reference types defined in `main.tsp`, `client.tsp` must `import './main.tsp'`. This matches the existing tsp-client convention and is already the standard pattern.

## Tests

- 2 new tests added in `test/server/entrypoint-resolver.test.ts`.
- Verified end-to-end with a scratch project: both resolvers pick `client.tsp` over `main.tsp` when both exist, and compilation succeeds when `client.tsp` imports `main.tsp`.
- All 765 existing compiler server tests pass.
