### PR TITLE
[python] Use specific exception types in status code range mock_api tests

### DIFF
--- a/.chronus/changes/fix-test-case-for-response-error-2026-6-16-0-0-0.md
+++ b/.chronus/changes/fix-test-case-for-response-error-2026-6-16-0-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-python"
+---
+
+Use specific exception types in status code range mock_api tests for sync and async

--- a/packages/http-client-python/generator/pygen/codegen/models/utils.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/utils.py
@@ -44,10 +44,6 @@ class NamespaceType(str, Enum):
 
 LOCALS_LENGTH_LIMIT = 25
 
-REQUEST_BUILDER_BODY_VARIABLES_LENGTH = (
-    6  # how many body variables are present in a request builder
-)
+REQUEST_BUILDER_BODY_VARIABLES_LENGTH = 6  # how many body variables are present in a request builder
 
-OPERATION_BODY_VARIABLES_LENGTH = (
-    14  # how many body variables are present in an operation
-)
+OPERATION_BODY_VARIABLES_LENGTH = 14  # how many body variables are present in an operation

--- a/packages/http-client-python/tests/mock_api/shared/asynctests/test_response_status_code_range_async.py
+++ b/packages/http-client-python/tests/mock_api/shared/asynctests/test_response_status_code_range_async.py
@@ -16,8 +16,8 @@ async def client():
 
 
 @pytest.mark.asyncio
-async def test_error_response_status_code_in_range(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+async def test_error_response_status_code_in_range(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.HttpResponseError) as exc_info:
         await client.error_response_status_code_in_range()
 
     error = exc_info.value.model
@@ -28,8 +28,8 @@ async def test_error_response_status_code_in_range(client: StatusCodeRangeClient
 
 
 @pytest.mark.asyncio
-async def test_error_response_status_code_404(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+async def test_error_response_status_code_404(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.ResourceNotFoundError) as exc_info:
         await client.error_response_status_code404()
 
     error = exc_info.value.model

--- a/packages/http-client-python/tests/mock_api/shared/test_response_status_code_range.py
+++ b/packages/http-client-python/tests/mock_api/shared/test_response_status_code_range.py
@@ -14,8 +14,8 @@ def client():
         yield client
 
 
-def test_error_response_status_code_in_range(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+def test_error_response_status_code_in_range(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.HttpResponseError) as exc_info:
         client.error_response_status_code_in_range()
 
     error = exc_info.value.model
@@ -25,8 +25,8 @@ def test_error_response_status_code_in_range(client: StatusCodeRangeClient):
     assert exc_info.value.response.status_code == 494
 
 
-def test_error_response_status_code_404(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+def test_error_response_status_code_404(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.ResourceNotFoundError) as exc_info:
         client.error_response_status_code404()
 
     error = exc_info.value.model


### PR DESCRIPTION
## Description

Use specific exception types in the status code range mock_api tests instead of the generic `Exception`, for both sync and async variants.

- `test_error_response_status_code_in_range` now asserts on `core_library.exceptions.HttpResponseError`
- `test_error_response_status_code_404` now asserts on `core_library.exceptions.ResourceNotFoundError`
- Applied consistently to both the sync test and its async counterpart

A changelog entry was added under `.chronus/changes`.