### PR TITLE
fix(http-client-java): handle null LRO error response bodies

### DIFF
--- a/.chronus/changes/fix-http-client-java-lro-empty-body-2026-6-17-15-59-00.md
+++ b/.chronus/changes/fix-http-client-java-lro-empty-body-2026-6-17-15-59-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+Fix null LRO error response body handling in generated management clients.

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentServiceClientTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentServiceClientTemplate.java
@@ -134,7 +134,7 @@ public class FluentServiceClientTemplate extends ServiceClientTemplate {
                         code.line("this.statusCode = statusCode;");
                         code.line("this.httpHeaders = httpHeaders;");
                         code.line(
-                            "this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);");
+                            "this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);");
                     });
 
                 block.publicMethod("int getStatusCode()", code -> code.methodReturn("statusCode"));

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentServiceClientTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentServiceClientTemplate.java
@@ -133,6 +133,8 @@ public class FluentServiceClientTemplate extends ServiceClientTemplate {
                         code.line("super(null);");
                         code.line("this.statusCode = statusCode;");
                         code.line("this.httpHeaders = httpHeaders;");
+                        // Use an empty array so body accessors still work when the poller surfaces an error without a
+                        // response body.
                         code.line(
                             "this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);");
                     });

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/test/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentServiceClientTemplateTests.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/test/java/com/microsoft/typespec/http/client/generator/mgmt/template/FluentServiceClientTemplateTests.java
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.typespec.http.client.generator.mgmt.template;
+
+import com.microsoft.typespec.http.client.generator.core.model.javamodel.JavaFile;
+import com.microsoft.typespec.http.client.generator.mgmt.TestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class FluentServiceClientTemplateTests {
+
+    @BeforeAll
+    public static void ensurePlugin() {
+        new TestUtils.MockFluentGen();
+    }
+
+    @Test
+    public void writesEmptyByteArrayForNullLroErrorBody() {
+        JavaFile javaFile = new JavaFile("ProgramEnrollmentManagementClientImpl.java");
+
+        javaFile.publicFinalClass("ProgramEnrollmentManagementClientImpl",
+            classBlock -> FluentServiceClientTemplate.getInstance().writeAdditionalClassBlock(classBlock));
+
+        String output = javaFile.getContents().toString();
+
+        Assertions.assertTrue(output.contains(
+            "this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);"));
+        Assertions.assertFalse(output.contains(
+            "this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);"));
+    }
+}

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/implementation/CommonPropertiesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/commonproperties/implementation/CommonPropertiesClientImpl.java
@@ -304,7 +304,7 @@ public final class CommonPropertiesClientImpl implements CommonPropertiesClient 
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/largeheader/implementation/LargeHeaderClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/largeheader/implementation/LargeHeaderClientImpl.java
@@ -272,7 +272,7 @@ public final class LargeHeaderClientImpl implements LargeHeaderClient {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/managementgroup/implementation/ManagementGroupClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/managementgroup/implementation/ManagementGroupClientImpl.java
@@ -256,7 +256,7 @@ public final class ManagementGroupClientImpl implements ManagementGroupClient {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/methodsubscriptionid/implementation/MethodSubscriptionIdClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/methodsubscriptionid/implementation/MethodSubscriptionIdClientImpl.java
@@ -346,7 +346,7 @@ public final class MethodSubscriptionIdClientImpl implements MethodSubscriptionI
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/multiservice/combined/implementation/CombinedImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/multiservice/combined/implementation/CombinedImpl.java
@@ -273,7 +273,7 @@ public final class CombinedImpl implements Combined {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/multiservicesharedmodels/combined/implementation/CombinedImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/multiservicesharedmodels/combined/implementation/CombinedImpl.java
@@ -273,7 +273,7 @@ public final class CombinedImpl implements Combined {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/nonresource/implementation/NonResourceClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/nonresource/implementation/NonResourceClientImpl.java
@@ -272,7 +272,7 @@ public final class NonResourceClientImpl implements NonResourceClient {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/implementation/OperationTemplatesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/operationtemplates/implementation/OperationTemplatesClientImpl.java
@@ -336,7 +336,7 @@ public final class OperationTemplatesClientImpl implements OperationTemplatesCli
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/ResourcesClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/azure/resourcemanager/resources/implementation/ResourcesClientImpl.java
@@ -336,7 +336,7 @@ public final class ResourcesClientImpl implements ResourcesClient {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armcustomization/implementation/ArmCustomizationClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armcustomization/implementation/ArmCustomizationClientImpl.java
@@ -272,7 +272,7 @@ public final class ArmCustomizationClientImpl implements ArmCustomizationClient 
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armlegacy/implementation/ArmLegacyClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armlegacy/implementation/ArmLegacyClientImpl.java
@@ -272,7 +272,7 @@ public final class ArmLegacyClientImpl implements ArmLegacyClient {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/ArmClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armresourceprovider/implementation/ArmClientImpl.java
@@ -400,7 +400,7 @@ public final class ArmClientImpl implements ArmClient {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/implementation/ArmResourceProviderManagementClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armstreamstyleserialization/implementation/ArmResourceProviderManagementClientImpl.java
@@ -336,7 +336,7 @@ public final class ArmResourceProviderManagementClientImpl implements ArmResourc
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armversioned/implementation/ArmVersionedClientImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/armversioned/implementation/ArmVersionedClientImpl.java
@@ -252,7 +252,7 @@ public final class ArmVersionedClientImpl implements ArmVersionedClient {
             super(null);
             this.statusCode = statusCode;
             this.httpHeaders = httpHeaders;
-            this.responseBody = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+            this.responseBody = responseBody == null ? new byte[0] : responseBody.getBytes(StandardCharsets.UTF_8);
         }
 
         public int getStatusCode() {


### PR DESCRIPTION
downstream https://github.com/Azure/azure-sdk-for-java/pull/49537

## Summary
- default generated management LRO error response bodies to an empty byte array when the service returns no body
- add a management template test covering the generated HttpResponseImpl output
- regenerate the affected management test clients and add a changelog entry