### PR TITLE
Fix C# generator base model recursion

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -96,7 +96,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Process each output-library provider recursively to discover types from methods and properties.
             foreach (var provider in contextEligibleOutputProviders)
             {
-                CollectBuildableTypeProvidersRecursive(provider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                if (ImplementsModelReaderWriter(provider))
+                {
+                    buildableProviders.Add(provider);
+                }
+
+                CollectBuildableTypeProvidersRecursive(provider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
 
             return (buildableTypes, buildableProviders);
@@ -123,7 +128,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         /// </summary>
         private void CollectBuildableTypeProvidersRecursive(
             TypeProvider currentProvider,
-            HashSet<TypeProvider> contextEligibleOutputProviders,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
             HashSet<TypeProvider> buildableProviders,
@@ -135,23 +139,15 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 return;
             }
 
-            // Only add providers that the output library asked this context to build; base providers outside
-            // that set are still traversed for their properties but do not get standalone context entries.
-            if (contextEligibleOutputProviders.Contains(currentProvider) && ImplementsModelReaderWriter(currentProvider))
-            {
-                buildableProviders.Add(currentProvider);
-            }
-
             // Process all providers to discover types from methods and properties
             if (currentProvider is not null)
             {
-                CollectBuildableTypesRecursiveCore(currentProvider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypesRecursiveCore(currentProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
         }
 
         private void CollectBuildableTypesRecursiveCore(
             TypeProvider provider,
-            HashSet<TypeProvider> contextEligibleOutputProviders,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
             HashSet<TypeProvider> buildableProviders,
@@ -188,9 +184,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             if (provider is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
             {
-                // Base-model traversal can visit providers that were not in the initial output-library
-                // set, so the recursive call still needs the context eligibility filter.
-                CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
             else
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -183,7 +183,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             if (provider is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
             {
                 // For base model types, we need to process their properties as well, but we don't need to add the base model type itself
-                CollectBuildableTypesRecursiveCore(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                if (visitedTypeProviders.Add(modelProvider.BaseModelProvider))
+                {
+                    CollectBuildableTypesRecursiveCore(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                }
             }
             else
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -87,14 +87,16 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var buildableProviders = new HashSet<TypeProvider>(s_typeProviderNameComparer);
             var buildableTypes = new HashSet<CSharpType>(s_cSharpTypeNameComparer);
 
-            // Process all providers from the output library to discover types from methods and properties
+            // Process all providers from the output library to discover types from methods and properties.
             var providers = ScmCodeModelGenerator.Instance.OutputLibrary.TypeProviders;
-            var outputLibraryProviders = new HashSet<TypeProvider>(providers, s_typeProviderNameComparer);
+            // Base-model traversal can encounter equivalent provider instances that are not reference-equal to
+            // the output-library roots, so keep the root set name-comparable when deciding context eligibility.
+            var contextEligibleOutputProviders = new HashSet<TypeProvider>(providers, s_typeProviderNameComparer);
 
             // Process each provider recursively
             foreach (var provider in providers)
             {
-                CollectBuildableTypeProvidersRecursive(provider, outputLibraryProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypeProvidersRecursive(provider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
 
             return (buildableTypes, buildableProviders);
@@ -121,7 +123,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         /// </summary>
         private void CollectBuildableTypeProvidersRecursive(
             TypeProvider currentProvider,
-            HashSet<TypeProvider> outputLibraryProviders,
+            HashSet<TypeProvider> contextEligibleOutputProviders,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
             HashSet<TypeProvider> buildableProviders,
@@ -133,8 +135,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 return;
             }
 
-            // Only add to buildableProviders if it implements MRW and belongs to the output library.
-            if (outputLibraryProviders.Contains(currentProvider) && ImplementsModelReaderWriter(currentProvider))
+            // Only add providers that the output library asked this context to build; base providers outside
+            // that set are still traversed for their properties but do not get standalone context entries.
+            if (contextEligibleOutputProviders.Contains(currentProvider) && ImplementsModelReaderWriter(currentProvider))
             {
                 buildableProviders.Add(currentProvider);
             }
@@ -142,13 +145,13 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Process all providers to discover types from methods and properties
             if (currentProvider is not null)
             {
-                CollectBuildableTypesRecursiveCore(currentProvider, outputLibraryProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypesRecursiveCore(currentProvider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
         }
 
         private void CollectBuildableTypesRecursiveCore(
             TypeProvider provider,
-            HashSet<TypeProvider> outputLibraryProviders,
+            HashSet<TypeProvider> contextEligibleOutputProviders,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
             HashSet<TypeProvider> buildableProviders,
@@ -185,7 +188,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             if (provider is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
             {
-                CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, outputLibraryProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
             else
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -89,11 +89,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             // Process all providers from the output library to discover types from methods and properties
             var providers = ScmCodeModelGenerator.Instance.OutputLibrary.TypeProviders;
+            var outputLibraryProviders = new HashSet<TypeProvider>(providers, s_typeProviderNameComparer);
 
             // Process each provider recursively
             foreach (var provider in providers)
             {
-                CollectBuildableTypeProvidersRecursive(provider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypeProvidersRecursive(provider, outputLibraryProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
 
             return (buildableTypes, buildableProviders);
@@ -120,6 +121,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         /// </summary>
         private void CollectBuildableTypeProvidersRecursive(
             TypeProvider currentProvider,
+            HashSet<TypeProvider> outputLibraryProviders,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
             HashSet<TypeProvider> buildableProviders,
@@ -131,8 +133,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 return;
             }
 
-            // Only add to buildableProviders if it implements MRW
-            if (ImplementsModelReaderWriter(currentProvider))
+            // Only add to buildableProviders if it implements MRW and belongs to the output library.
+            if (outputLibraryProviders.Contains(currentProvider) && ImplementsModelReaderWriter(currentProvider))
             {
                 buildableProviders.Add(currentProvider);
             }
@@ -140,12 +142,13 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Process all providers to discover types from methods and properties
             if (currentProvider is not null)
             {
-                CollectBuildableTypesRecursiveCore(currentProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypesRecursiveCore(currentProvider, outputLibraryProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
         }
 
         private void CollectBuildableTypesRecursiveCore(
             TypeProvider provider,
+            HashSet<TypeProvider> outputLibraryProviders,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
             HashSet<TypeProvider> buildableProviders,
@@ -182,11 +185,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             if (provider is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
             {
-                // For base model types, we need to process their properties as well, but we don't need to add the base model type itself
-                if (visitedTypeProviders.Add(modelProvider.BaseModelProvider))
-                {
-                    CollectBuildableTypesRecursiveCore(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
-                }
+                CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, outputLibraryProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
             else
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -96,6 +96,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Process each output-library provider recursively to discover types from methods and properties.
             foreach (var provider in contextEligibleOutputProviders)
             {
+                // Only output-library providers get standalone context entries.
                 if (ImplementsModelReaderWriter(provider))
                 {
                     buildableProviders.Add(provider);
@@ -184,6 +185,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             if (provider is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
             {
+                // Traverse base model properties for discoverable types, but do not add the base model
+                // itself as a context entry unless it was in the output-library seed set.
                 CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
             else

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -87,14 +87,14 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var buildableProviders = new HashSet<TypeProvider>(s_typeProviderNameComparer);
             var buildableTypes = new HashSet<CSharpType>(s_cSharpTypeNameComparer);
 
-            // Process all providers from the output library to discover types from methods and properties.
-            var providers = ScmCodeModelGenerator.Instance.OutputLibrary.TypeProviders;
             // Base-model traversal can encounter equivalent provider instances that are not reference-equal to
-            // the output-library roots, so keep the root set name-comparable when deciding context eligibility.
-            var contextEligibleOutputProviders = new HashSet<TypeProvider>(providers, s_typeProviderNameComparer);
+            // the output-library roots, so keep the output-library provider set name-comparable.
+            var contextEligibleOutputProviders = new HashSet<TypeProvider>(
+                ScmCodeModelGenerator.Instance.OutputLibrary.TypeProviders,
+                s_typeProviderNameComparer);
 
-            // Process each provider recursively
-            foreach (var provider in providers)
+            // Process each output-library provider recursively to discover types from methods and properties.
+            foreach (var provider in contextEligibleOutputProviders)
             {
                 CollectBuildableTypeProvidersRecursive(provider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -188,6 +188,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             if (provider is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
             {
+                // Base-model traversal can visit providers that were not in the initial output-library
+                // set, so the recursive call still needs the context eligibility filter.
                 CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, contextEligibleOutputProviders, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
             else

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -291,10 +291,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType);
             var modifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static |
                             MethodSignatureModifiers.Explicit | MethodSignatureModifiers.Operator;
-            if (HasBaseExplicitFromClientResult())
-            {
-                modifiers |= MethodSignatureModifiers.New;
-            }
             // using PipelineResponse response = result.GetRawResponse();
             var response = result.ToApi<ClientResponseApi>();
             MethodBodyStatement responseDeclaration;
@@ -352,25 +348,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     ScmCodeModelGenerator.Instance.TypeFactory.RequestContentApi.ToExpression().Create(model)
                 },
                 this);
-        }
-
-        private bool HasBaseExplicitFromClientResult()
-            => EnumerateBaseModelProviders()
-                .SelectMany(provider => provider.SerializationProviders)
-                .OfType<MrwSerializationTypeDefinition>()
-                .SelectMany(provider => provider.Methods)
-                .Any(IsExplicitFromClientResultMethod);
-
-        private static bool IsExplicitFromClientResultMethod(MethodProvider method)
-        {
-            if (method.Signature.Parameters is not [var parameter]
-                || !parameter.Type.AreNamesEqual(ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType))
-            {
-                return false;
-            }
-
-            return method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator)
-                && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Explicit);
         }
 
         private MethodProvider BuildToBinaryContentMethod()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -291,6 +291,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType);
             var modifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static |
                             MethodSignatureModifiers.Explicit | MethodSignatureModifiers.Operator;
+            if (HasBaseExplicitFromClientResult())
+            {
+                modifiers |= MethodSignatureModifiers.New;
+            }
             // using PipelineResponse response = result.GetRawResponse();
             var response = result.ToApi<ClientResponseApi>();
             MethodBodyStatement responseDeclaration;
@@ -348,6 +352,25 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     ScmCodeModelGenerator.Instance.TypeFactory.RequestContentApi.ToExpression().Create(model)
                 },
                 this);
+        }
+
+        private bool HasBaseExplicitFromClientResult()
+            => EnumerateBaseModelProviders()
+                .SelectMany(provider => provider.SerializationProviders)
+                .OfType<MrwSerializationTypeDefinition>()
+                .SelectMany(provider => provider.Methods)
+                .Any(IsExplicitFromClientResultMethod);
+
+        private static bool IsExplicitFromClientResultMethod(MethodProvider method)
+        {
+            if (method.Signature.Parameters is not [var parameter]
+                || !parameter.Type.AreNamesEqual(ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType))
+            {
+                return false;
+            }
+
+            return method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator)
+                && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Explicit);
         }
 
         private MethodProvider BuildToBinaryContentMethod()
@@ -1114,8 +1137,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var rawBinaryData = _rawDataField;
             if (rawBinaryData == null)
             {
-                var baseModelProvider = _model.BaseModelProvider;
-                while (baseModelProvider != null)
+                foreach (var baseModelProvider in EnumerateBaseModelProviders())
                 {
                     var field = baseModelProvider.Fields.FirstOrDefault(f => f.Name == AdditionalPropertiesHelper.AdditionalBinaryDataPropsFieldName);
                     if (field != null)
@@ -1123,7 +1145,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         rawBinaryData = field;
                         break;
                     }
-                    baseModelProvider = baseModelProvider.BaseModelProvider;
                 }
             }
 
@@ -1737,8 +1758,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             if (isDynamicModelWithNonDynamicBase)
             {
-                var baseModelProvider = _model.BaseModelProvider;
-                while (baseModelProvider != null)
+                foreach (var baseModelProvider in EnumerateBaseModelProviders())
                 {
                     foreach (var property in baseModelProvider.CanonicalView.Properties)
                     {
@@ -1759,8 +1779,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
                         propertyStatements.Add(CreateWritePropertyStatement(field.WireInfo, field.Type, field.Name, field, field.WireInfo?.SerializationFormat));
                     }
-
-                    baseModelProvider = baseModelProvider.BaseModelProvider;
                 }
             }
 
@@ -2575,21 +2593,20 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             PropertyProvider? property = _model.Properties.FirstOrDefault(
                 p => p.BackingField?.Name == AdditionalPropertiesHelper.AdditionalBinaryDataPropsFieldName);
             // search in the base model if the property is not found in the current model
-            return property ?? _model.BaseModelProvider?.Properties.FirstOrDefault(
-                p => p.BackingField?.Name == AdditionalPropertiesHelper.AdditionalBinaryDataPropsFieldName);
+            return property ?? EnumerateBaseModelProviders()
+                .SelectMany(m => m.Properties)
+                .FirstOrDefault(p => p.BackingField?.Name == AdditionalPropertiesHelper.AdditionalBinaryDataPropsFieldName);
         }
 
         private MethodProvider? FindCustomHookMethod(string hookName)
         {
-            var model = _model;
-            while (model != null)
+            foreach (var model in EnumerateModelAndBaseModelProviders())
             {
                 var method = model.CanonicalView.Methods.FirstOrDefault(m => m.Signature.Name == hookName);
                 if (method != null)
                 {
                     return method;
                 }
-                model = model.BaseModelProvider;
             }
             return null;
         }
@@ -2636,9 +2653,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             List<AttributeStatement> serializationAttributes = _model.CustomCodeView?.Attributes
                 .Where(a => a.Type.Name == CodeGenAttributes.CodeGenSerializationAttributeName)
                 .ToList() ?? [];
-            var baseModelProvider = _model.BaseModelProvider;
 
-            while (baseModelProvider != null)
+            foreach (var baseModelProvider in EnumerateBaseModelProviders())
             {
                 var customCodeView = baseModelProvider.CustomCodeView;
                 if (customCodeView != null)
@@ -2647,10 +2663,31 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         .AddRange(customCodeView.Attributes
                         .Where(a => a.Type.Name == CodeGenAttributes.CodeGenSerializationAttributeName));
                 }
-                baseModelProvider = baseModelProvider.BaseModelProvider;
             }
 
             return serializationAttributes;
+        }
+
+        private IEnumerable<ModelProvider> EnumerateModelAndBaseModelProviders()
+        {
+            var visited = new HashSet<ModelProvider>();
+            var model = _model;
+            while (model != null && visited.Add(model))
+            {
+                yield return model;
+                model = model.BaseModelProvider;
+            }
+        }
+
+        private IEnumerable<ModelProvider> EnumerateBaseModelProviders()
+        {
+            var visited = new HashSet<ModelProvider> { _model };
+            var model = _model.BaseModelProvider;
+            while (model != null && visited.Add(model))
+            {
+                yield return model;
+                model = model.BaseModelProvider;
+            }
         }
 
         private static bool TypeRequiresNullCheckInSerialization(CSharpType type)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -2647,6 +2647,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         private IEnumerable<ModelProvider> EnumerateModelAndBaseModelProviders()
         {
+            // Custom code can create base-model cycles; stop at the first repeated provider.
             var visited = new HashSet<ModelProvider>();
             var model = _model;
             while (model != null && visited.Add(model))
@@ -2658,6 +2659,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         private IEnumerable<ModelProvider> EnumerateBaseModelProviders()
         {
+            // Custom code can create base-model cycles; include the current model in the visited set so
+            // a cycle back to it is not yielded as one of its own bases.
             var visited = new HashSet<ModelProvider> { _model };
             var model = _model.BaseModelProvider;
             while (model != null && visited.Add(model))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -190,6 +190,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
                 if (_buildingRawDataField)
                 {
+                    // BuildRawDataField walks base models and can re-enter this property when custom
+                    // base models form a cycle.
                     return null;
                 }
 
@@ -673,6 +675,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private IEnumerable<ModelProvider> EnumerateBaseModelProviders()
         {
+            // Custom code can create base-model cycles; include this model in the visited set so a cycle
+            // back to it is not yielded as one of its own bases.
             HashSet<ModelProvider> visited = [this];
             var model = BaseModelProvider;
             while (model != null && visited.Add(model))
@@ -1027,6 +1031,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private bool HasBaseModelProviderCycle()
         {
+            // FullConstructor reads the base constructor signature. If the custom base chain loops back
+            // to this model, skip that read rather than recursively building this constructor again.
             HashSet<ModelProvider> visited = [this];
             var modelProvider = BaseModelProvider;
             while (modelProvider != null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -59,6 +59,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private readonly Type _additionalPropsUnknownType = typeof(BinaryData);
         private Lazy<bool> _useObjectAdditionalProperties;
         private FieldProvider? _rawDataField;
+        private bool _buildingRawDataField;
         private List<FieldProvider>? _additionalPropertyFields;
         private List<PropertyProvider>? _additionalPropertyProperties;
         private ModelProvider? _baseModelProvider;
@@ -178,7 +179,31 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _fullConstructor = null;
         }
 
-        protected FieldProvider? RawDataField => _rawDataField ??= BuildRawDataField();
+        protected FieldProvider? RawDataField
+        {
+            get
+            {
+                if (_rawDataField is not null)
+                {
+                    return _rawDataField;
+                }
+
+                if (_buildingRawDataField)
+                {
+                    return null;
+                }
+
+                _buildingRawDataField = true;
+                try
+                {
+                    return _rawDataField = BuildRawDataField();
+                }
+                finally
+                {
+                    _buildingRawDataField = false;
+                }
+            }
+        }
         protected virtual bool ShouldSkipDerivedModelProperties => false;
         /// <summary>
         /// Gets whether derived models should skip overriding serialization methods from this base model.
@@ -648,8 +673,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private IEnumerable<ModelProvider> EnumerateBaseModelProviders()
         {
+            HashSet<ModelProvider> visited = [this];
             var model = BaseModelProvider;
-            while (model != null)
+            while (model != null && visited.Add(model))
             {
                 yield return model;
                 model = model.BaseModelProvider;
@@ -859,9 +885,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private IEnumerable<PropertyProvider> GetAllBasePropertiesForConstructorInitialization(bool includeAllHierarchyDiscriminator = false)
         {
             var properties = new Stack<List<PropertyProvider>>();
-            var modelProvider = BaseModelProvider;
             bool isDirectBase = true;
-            while (modelProvider != null)
+            foreach (var modelProvider in EnumerateBaseModelProviders())
             {
                 properties.Push([]);
                 foreach (var property in modelProvider.CanonicalView.Properties)
@@ -880,7 +905,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     }
                 }
 
-                modelProvider = modelProvider.BaseModelProvider;
                 isDirectBase = false;
             }
 
@@ -891,15 +915,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private IEnumerable<FieldProvider> GetAllBaseFieldsForConstructorInitialization()
         {
             var fields = new Stack<List<FieldProvider>>();
-            var modelProvider = BaseModelProvider;
-            while (modelProvider != null)
+            foreach (var modelProvider in EnumerateBaseModelProviders())
             {
                 fields.Push([]);
                 foreach (var field in modelProvider.CanonicalView.Fields)
                 {
                     fields.Peek().Add(field);
                 }
-                modelProvider = modelProvider.BaseModelProvider;
             }
 
             return fields.SelectMany(l => l);
@@ -918,7 +940,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 baseProperties = GetAllBasePropertiesForConstructorInitialization(includeDiscriminatorParameter);
                 baseFields = GetAllBaseFieldsForConstructorInitialization();
             }
-            else if (BaseModelProvider?.FullConstructor.Signature != null)
+            else if (BaseModelProvider is not null && !HasBaseModelProviderCycle())
             {
                 baseParameters.AddRange(BaseModelProvider.FullConstructor.Signature.Parameters);
             }
@@ -1001,6 +1023,23 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             return (constructorParameters, constructorInitializer);
+        }
+
+        private bool HasBaseModelProviderCycle()
+        {
+            HashSet<ModelProvider> visited = [this];
+            var modelProvider = BaseModelProvider;
+            while (modelProvider != null)
+            {
+                if (!visited.Add(modelProvider))
+                {
+                    return true;
+                }
+
+                modelProvider = modelProvider.BaseModelProvider;
+            }
+
+            return false;
         }
 
         private ValueExpression? EnsureDiscriminatorValueExpression()
@@ -1300,14 +1339,12 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             // check if there is a raw data field on any of the base models, if so, we do not have to have one here.
-            var baseModelProvider = BaseModelProvider;
-            while (baseModelProvider != null)
+            foreach (var baseModelProvider in EnumerateBaseModelProviders())
             {
                 if (baseModelProvider.RawDataField != null)
                 {
                     return null;
                 }
-                baseModelProvider = baseModelProvider.BaseModelProvider;
             }
 
             var modifiers = FieldModifiers.Private;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -525,6 +525,49 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             protected override CSharpType? BuildBaseType() => _redirectedBaseType;
         }
 
+        // Regression: custom code (such as an inheritable system base model) can produce a base
+        // ModelProvider chain that cycles back on itself. Base-model traversal during constructor,
+        // field, and raw-data discovery must terminate instead of recursing infinitely.
+        [Test]
+        public void BaseModelProviderCycleDoesNotRecurseInfinitely()
+        {
+            var inputA = InputFactory.Model(
+                "ModelA",
+                usage: InputModelTypeUsage.Input | InputModelTypeUsage.Json | InputModelTypeUsage.Output,
+                properties: [InputFactory.Property("aProp", InputPrimitiveType.String, isRequired: true)]);
+            var inputB = InputFactory.Model(
+                "ModelB",
+                usage: InputModelTypeUsage.Input | InputModelTypeUsage.Json | InputModelTypeUsage.Output,
+                properties: [InputFactory.Property("bProp", InputPrimitiveType.String, isRequired: true)]);
+            MockHelpers.LoadMockGenerator(inputModelTypes: [inputA, inputB]);
+
+            var modelA = new CyclicBaseModelProvider(inputA);
+            var modelB = new CyclicBaseModelProvider(inputB);
+
+            // Wire the base-model providers into a cycle: A -> B -> A.
+            modelA.CyclicBase = modelB;
+            modelB.CyclicBase = modelA;
+
+            Assert.AreSame(modelB, modelA.BaseModelProvider);
+            Assert.AreSame(modelA, modelB.BaseModelProvider);
+
+            // Each of these walks the base-model chain and previously stack-overflowed on a cycle.
+            Assert.DoesNotThrow(() => _ = modelA.FullConstructor);
+            Assert.DoesNotThrow(() => _ = modelA.Constructors);
+            Assert.DoesNotThrow(() => _ = modelA.Fields);
+        }
+
+        private sealed class CyclicBaseModelProvider : ModelProvider
+        {
+            public CyclicBaseModelProvider(InputModelType inputModel) : base(inputModel)
+            {
+            }
+
+            public ModelProvider? CyclicBase { get; set; }
+
+            protected override ModelProvider? BuildBaseModelProvider() => CyclicBase;
+        }
+
         [Test]
         public void BuildModelAsStruct()
         {


### PR DESCRIPTION
Fixes C# generator recursion when a customized/base model provider chain cycles through an inheritable system model.

Changes:
- Make MTG model base-provider traversal cycle-safe for properties, constructor initialization, fields, raw data fields, and full constructor discovery.
- Make ClientModel MRW serialization base traversal cycle-safe.
- Make ModelReaderWriter context collection avoid revisiting base model providers.
- Emit `new` on explicit response conversion operators from ClientModel when a base model already exposes the same conversion.

Validation:
- `dotnet build packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Microsoft.TypeSpec.Generator.ClientModel.csproj -v:minimal`
- Consumed locally from azure-sdk-for-net mgmt generator; StorageCache regen completes in ~48s.