### PR TITLE
[skip chg] Publish missing emitter-framework 0.18.0 changes

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request' && 
+      !contains(github.event.pull_request.title, '[skip chg]') &&
       !startsWith(github.head_ref, 'publish/') &&
       !startsWith(github.head_ref, 'dependabot/') &&
       !startsWith(github.head_ref, 'backmerge/') &&

--- a/packages/emitter-framework/CHANGELOG.md
+++ b/packages/emitter-framework/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - @typespec/emitter-framework
 
+## 0.18.0
+
+### Features
+
+- [#10372](https://github.com/microsoft/typespec/pull/10372) [csharp] Export new utilities from `@typespec/emitter-framework/csharp`: `getDocComments`, `getNullableUnionInnerType`, `efRefkey`, and `declarationRefkeys`
+- [#10372](https://github.com/microsoft/typespec/pull/10372) [csharp] `EnumDeclaration` now emits the doc comments of the TypeSpec enum
+
+
 ## 0.17.0
 
 ### Features

--- a/packages/emitter-framework/package.json
+++ b/packages/emitter-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/emitter-framework",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
fix #11020

## Why

[#10372](https://github.com/microsoft/typespec/pull/10372) (Http-server-csharp alloy rewrite) changed the public API of `@typespec/emitter-framework` but did **not** add a changelog entry, so the package was never versioned/published — it remains at `0.17.0` on npm while the API has moved on.

## What

- Bump `@typespec/emitter-framework` `0.17.0` → `0.18.0`.
- Add the `0.18.0` section to `CHANGELOG.md` describing the public API changes from #10372:
  - New `@typespec/emitter-framework/csharp` exports: `getDocComments`, `getNullableUnionInnerType`, `efRefkey`, `declarationRefkeys`.
  - C# `EnumDeclaration` now emits the TypeSpec enum's doc comments.
  - `development` export conditions added to all entrypoints.
- Update the `Consistency` workflow's **Check Changes** job to skip when the PR title contains `[skip chg]` (this PR intentionally has no `.chronus/changes` entry, since the version/changelog are applied manually).