### PR TITLE
bypass pyproject setting like license

### DIFF
--- a/.chronus/changes/mismatch-2026-5-19-9-54-46.md
+++ b/.chronus/changes/mismatch-2026-5-19-9-54-46.md
@@ -1,7 +1,7 @@
 ---
 changeKind: internal
 packages:
-  - typespec-vs
+  - "@typespec/http-client-python"
 ---
 
 Preserve transformed `keep-pyproject-fields` emitter options when building Python generator command arguments.

--- a/.chronus/changes/mismatch-2026-5-19-9-54-46.md
+++ b/.chronus/changes/mismatch-2026-5-19-9-54-46.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - typespec-vs
+---
+
+Preserve transformed `keep-pyproject-fields` emitter options when building Python generator command arguments.

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -220,7 +220,7 @@ async function onEmitMain(context: EmitContext<PythonEmitterOptions>) {
   }
 
   for (const [key, value] of Object.entries(resolvedOptions)) {
-    if (key === "license") continue; // skip license since it is passed in codeModel
+    if (key === "license" || key === "keep-pyproject-fields") continue; // skip license + keep-pyproject-fields since it is passed in codeModel
     commandArgs[key] = value;
   }
   if (resolvedOptions["generate-packaging-files"]) {


### PR DESCRIPTION
bypassing the pyproject setting will prevent from undefined getting set on the pyproject toml entries