### PR TITLE
Ignore modifications to META-INF metadata.json files

### DIFF
--- a/.chronus/changes/IgnoreGeneratedMetadataInDiffCheck-2026-5-19-20-15-30.md
+++ b/.chronus/changes/IgnoreGeneratedMetadataInDiffCheck-2026-5-19-20-15-30.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@typespec/http-client-java"
+---
+
+Ignore modifications to META-INF metadata.json files

--- a/packages/http-client-java/eng/scripts/Check-GitChanges.ps1
+++ b/packages/http-client-java/eng/scripts/Check-GitChanges.ps1
@@ -13,6 +13,7 @@ Set-ConsoleEncoding
 $diffExcludes = @(
     "$packageRoot/package.json"
     "$packageRoot/package-lock.json"
+    "*/src/main/resources/META-INF/*_metadata*.json"
 ) | ForEach-Object { "`":(exclude)$_`"" } | Join-String -Separator ' '
 
 Invoke-LoggedCommand "git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code -- $diffExcludes" -IgnoreExitCode


### PR DESCRIPTION
Ignore modification to META-INF `metadata.json` files that are consumed downstream when comparing APIs across languages. Some properties such as `crossLanguageVersion` are based on a file hash which may change without changing the generated result. These files also don't need to be checked in diffing as if they're different the source code will generally be different.