### PR TITLE
docs: rename scalar initializers to scalar constructors

### DIFF
--- a/website/src/content/docs/docs/language-basics/scalars.md
+++ b/website/src/content/docs/docs/language-basics/scalars.md
@@ -29,9 +29,9 @@ Scalars can also support template parameters. These template parameters are prim
 scalar Unreal<Type extends valueof string>;
 ```
 
-## Scalar initializers
+## Scalar constructors
 
-Scalars can be declared with an initializer for creating specific scalar values based on other values. For example:
+Scalars can be declared with a constructor for creating specific scalar values based on other values. For example:
 
 ```typespec
 scalar ipv4 extends string {
@@ -41,11 +41,11 @@ scalar ipv4 extends string {
 const homeIp = ipv4.fromInt(2130706433);
 ```
 
-Initializers do not have any runtime code associated with them. Instead, they merely record the scalar initializer invoked along with the arguments passed so that emitters can construct the proper value when needed.
+Constructors do not have any runtime code associated with them. Instead, they merely record the scalar constructor invoked along with the arguments passed so that emitters can construct the proper value when needed.
 
-### Date/time initializers
+### Date/time constructors
 
-The built-in date and time scalars provide initializers for common use cases:
+The built-in date and time scalars provide constructors for common use cases:
 
 #### `fromISO`: create from ISO 8601 string
 
@@ -59,7 +59,7 @@ const period = duration.fromISO("P1Y1D");
 
 #### `now`: current date/time
 
-The `now()` initializer indicates that the current date or time should be used. Emitters interpret this as the appropriate runtime value (e.g., database `CURRENT_TIMESTAMP`, JavaScript `Date.now()`, etc.).
+The `now()` constructor indicates that the current date or time should be used. Emitters interpret this as the appropriate runtime value (e.g., database `CURRENT_TIMESTAMP`, JavaScript `Date.now()`, etc.).
 
 ```typespec
 model Record {

--- a/website/src/content/docs/docs/language-basics/values.md
+++ b/website/src/content/docs/docs/language-basics/values.md
@@ -11,7 +11,7 @@ Values cannot be used as types, and types cannot be used as values, they are com
 
 ## Value kinds
 
-There are four kinds of values: objects, arrays, scalars, and null. These values can be created with object values, array values, scalar values and initializers, and the null literal respectively. Additionally, values can result from referencing enum members and union variants.
+There are four kinds of values: objects, arrays, scalars, and null. These values can be created with object values, array values, scalar values and constructors, and the null literal respectively. Additionally, values can result from referencing enum members and union variants.
 
 ### Object values
 
@@ -56,7 +56,7 @@ const exampleTags2: Tags = #["TypeSpec", "JSON", "OpenAPI"]; // error
 
 ### Scalar values
 
-There are two ways to create scalar values: with a literal syntax like `"string value"`, and with a scalar initializer like `utcDateTime.fromISO("2020-12-01T12:00:00Z")`.
+There are two ways to create scalar values: with a literal syntax like `"string value"`, and with a scalar constructor like `utcDateTime.fromISO("2020-12-01T12:00:00Z")`.
 
 #### Scalar literals
 
@@ -74,16 +74,16 @@ extern dec setNumberTypeOrValue(target: unknown, color: numeric | (valueof numer
 model A {}
 ```
 
-#### Scalar initializers
+#### Scalar constructors
 
-Scalar initializers create scalar values by calling an initializer with one or more values. Scalar initializers for types extended from `numeric`, `string`, and `boolean` are called by adding parenthesis after the scalar reference:
+Scalar constructors create scalar values by calling a constructor with one or more values. Scalar constructors for types extended from `numeric`, `string`, and `boolean` are called by adding parenthesis after the scalar reference:
 
 ```typespec
 const n = int8(100);
 const s = string("hello");
 ```
 
-Any scalar can additionally be declared with named initializers that take one or more value parameters. For example, `utcDateTime` provides a `fromISO` initializer that takes an ISO string. Named scalars can be declared like so:
+Any scalar can additionally be declared with named constructors that take one or more value parameters. For example, `utcDateTime` provides a `fromISO` constructor that takes an ISO string. Named constructors can be declared like so:
 
 ```typespec
 scalar ipv4 extends string {


### PR DESCRIPTION
Update documentation to use 'scalar constructors' terminology which matches the compiler code (ScalarConstructor) and JS API.

closes #11023 