### PR TITLE
Fix emitter crash when an extensible enum was @@alternateType'd to be in an external package.

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/EnumProvider/EnumProviderSerializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/EnumProvider/EnumProviderSerializationTests.cs
@@ -106,6 +106,30 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.EnumProvider
             }
         }
 
+        // Regression test for the "Not an enum type" crash, guarding the original crash site.
+        //
+        // An enum mapped to an existing external type (via @alternateType, surfaced as
+        // InputType.External) must be skipped during library generation rather than emitted.
+        // Otherwise building the OutputLibrary reaches EnsureBuilt -> BuildSerializationProviders ->
+        // ScmTypeFactory.CreateExtensibleEnumSerializations, which calls CSharpType.UnderlyingEnumType
+        // on the resolved external (non-enum) type and throws InvalidOperationException("Not an enum type").
+        // System.Uri stands in for an external extensible-enum struct such as OpenAI's ResponseToolKind.
+        [Test]
+        public void ExternalExtensibleEnum_NotEmittedFromOutputLibrary()
+        {
+            var externalEnum = InputFactory.StringEnum(
+                "ExternalToolType",
+                [("value1", "value1"), ("value2", "value2")],
+                isExtensible: true,
+                external: new InputExternalTypeMetadata("System.Uri", null, null));
+
+            MockHelpers.LoadMockGenerator(inputEnums: () => [externalEnum]);
+
+            // Building the library must not throw, and the external enum must not be generated.
+            var providers = ScmCodeModelGenerator.Instance.OutputLibrary.TypeProviders;
+            Assert.IsEmpty(providers.OfType<Generator.Providers.EnumProvider>().Where(e => e.Name == "ExternalToolType"));
+        }
+
         [TestCaseSource(nameof(ValidateTypes), [true])]
         public void ValidateToSerialMethodsExtensible(InputEnumType inputEnum)
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -253,6 +253,18 @@ namespace Microsoft.TypeSpec.Generator
             if (EnumCache.TryGetValue(enumCacheKey, out var enumProvider))
                 return enumProvider;
 
+            // An enum marked as external maps to a type that already exists in a framework or
+            // referenced assembly, so it must not be generated. Unlike models there is no derived-type
+            // scenario for enums, so we simply skip generation; callers use the resolved external
+            // CSharpType produced by CreateCSharpType (which short-circuits on InputType.External)
+            // instead of a generated provider. This is handled here, before the overridable
+            // CreateEnumCore, so all generators share the behavior and mirror CreateExternalModel.
+            if (enumType.External != null)
+            {
+                EnumCache.TryAdd(enumCacheKey, null);
+                return null;
+            }
+
             enumProvider = CreateEnumCore(enumType, declaringType);
 
             foreach (var visitor in Visitors)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
@@ -340,6 +340,45 @@ namespace Microsoft.TypeSpec.Generator.Tests
             Assert.IsTrue(enumProvider!.IsExtensible);
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CreateEnum_ExternalEnum_ReturnsNull(bool isExtensible)
+        {
+            // An enum mapped to an existing external type (via @alternateType, surfaced as
+            // InputType.External) must not be generated -- it mirrors CreateExternalModel for models.
+            // Previously a provider was produced and threw "Not an enum type" while building its
+            // serialization (ScmTypeFactory.CreateExtensibleEnumSerializations -> UnderlyingEnumType).
+            var input = InputFactory.StringEnum(
+                "ExternalToolType",
+                [("value1", "value1"), ("value2", "value2")],
+                usage: InputModelTypeUsage.Input,
+                isExtensible: isExtensible,
+                external: new InputExternalTypeMetadata("System.Uri", null, null));
+
+            var enumProvider = CodeModelGenerator.Instance.TypeFactory.CreateEnum(input);
+
+            Assert.IsNull(enumProvider);
+        }
+
+        [Test]
+        public void CreateCSharpType_ExternalEnum_ResolvesToExternalFrameworkType()
+        {
+            // Although no provider is generated for an external enum, references to it must still
+            // resolve to the external framework type so consumers (properties, parameters) compile.
+            var input = InputFactory.StringEnum(
+                "ExternalToolType",
+                [("value1", "value1"), ("value2", "value2")],
+                usage: InputModelTypeUsage.Input,
+                isExtensible: true,
+                external: new InputExternalTypeMetadata("System.Uri", null, null));
+
+            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(input);
+
+            Assert.IsNotNull(type);
+            Assert.IsTrue(type!.IsFrameworkType);
+            Assert.AreEqual(typeof(Uri), type.FrameworkType);
+        }
+
         [Test]
         public void CreateCSharpType_SelfReferencingModel_DoesNotThrow()
         {


### PR DESCRIPTION
Fix emitter crash when an extensible enum was @@alternateType'd to be in an external package.

Also add unit level testing.