### PR TITLE
Make C# back-compat aware of ApiCompat baseline files

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/CSharpGen.cs
@@ -59,7 +59,8 @@ namespace Microsoft.TypeSpec.Generator
 
             CodeModelGenerator.Instance.SourceInputModel = new SourceInputModel(
                 await customCodeWorkspace.GetCompilationAsync(),
-                await GeneratedCodeWorkspace.LoadBaselineContract());
+                await GeneratedCodeWorkspace.LoadBaselineContract(),
+                GeneratedCodeWorkspace.LoadApiCompatBaseline());
 
             GeneratedCodeWorkspace generatedCodeWorkspace = await GeneratedCodeWorkspace.Create(isCustomCodeProject: false);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/EmitterRpc/BackCompatibilityChangeCategory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/EmitterRpc/BackCompatibilityChangeCategory.cs
@@ -42,5 +42,8 @@ namespace Microsoft.TypeSpec.Generator.EmitterRpc
 
         /// <summary>A back-compat overload of a client method was added because new optional non-body parameter(s) were introduced relative to the last contract.</summary>
         SvcMethodNewOptionalParameterOverloadAdded,
+
+        /// <summary>A back-compat change was skipped because the removal was accepted in the ApiCompat baseline.</summary>
+        BaselineAcceptedRemovalSkipped,
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/EmitterRpc/Emitter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/EmitterRpc/Emitter.cs
@@ -181,6 +181,7 @@ namespace Microsoft.TypeSpec.Generator.EmitterRpc
             BackCompatibilityChangeCategory.ModelFactoryMethodAdded => "Model Factory Method Added For Back-Compat",
             BackCompatibilityChangeCategory.ModelFactoryMethodSkipped => "Model Factory Method Back-Compat Skipped",
             BackCompatibilityChangeCategory.SvcMethodNewOptionalParameterOverloadAdded => "Method Back-Compat Overload Added For New Optional Parameter",
+            BackCompatibilityChangeCategory.BaselineAcceptedRemovalSkipped => "Back-Compat Skipped For ApiCompat Baseline Accepted Removal",
             _ => category.ToString(),
         };
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Utilities;
 using NuGet.Configuration;
 
@@ -362,6 +363,32 @@ namespace Microsoft.TypeSpec.Generator
                         $"Added metadata reference: {refPackageName} from {resolvedAssemblyPath}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Locates and parses the ApiCompat baseline (suppression) file for the current library, if
+        /// present. The file is expected at <c>eng/apicompatbaselines/&lt;AssemblyName&gt;.txt</c>
+        /// relative to a repository root discovered by walking up from the project directory.
+        /// Returns <see cref="ApiCompatBaseline.Empty"/> when no baseline file is found.
+        /// </summary>
+        internal static ApiCompatBaseline LoadApiCompatBaseline()
+        {
+            var packageName = CodeModelGenerator.Instance.TypeFactory.PrimaryNamespace;
+            var directory = new DirectoryInfo(CodeModelGenerator.Instance.Configuration.ProjectDirectory);
+
+            while (directory != null)
+            {
+                var candidate = Path.Combine(directory.FullName, "eng", "apicompatbaselines", $"{packageName}.txt");
+                if (File.Exists(candidate))
+                {
+                    CodeModelGenerator.Instance.Emitter.Debug($"Loading ApiCompat baseline from {candidate}");
+                    return ApiCompatBaseline.FromFile(candidate);
+                }
+
+                directory = directory.Parent;
+            }
+
+            return ApiCompatBaseline.Empty;
         }
 
         internal static async Task<Compilation?> LoadBaselineContract()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -123,8 +123,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
                         previousMethod.Signature.Name,
                         previousMethod.Signature.Parameters.Count) == true)
                 {
-                    CodeModelGenerator.Instance.Emitter.Debug(
-                        $"Skipping back-compat shim for '{Type.FullyQualifiedName}.{previousMethod.Signature.Name}'; removal is accepted in the ApiCompat baseline.");
+                    CodeModelGenerator.Instance.Emitter.Info(
+                        $"Skipping back-compat shim for '{Type.FullyQualifiedName}.{previousMethod.Signature.Name}'; removal is accepted in the ApiCompat baseline.",
+                        BackCompatibilityChangeCategory.BaselineAcceptedRemovalSkipped);
                     continue;
                 }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -116,6 +116,18 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     continue;
                 }
 
+                // If the removal of this factory method has already been accepted in the ApiCompat
+                // baseline, honor that decision and do not resurrect a compatibility shim for it.
+                if (CodeModelGenerator.Instance.SourceInputModel?.ApiCompatBaseline.IsMemberSuppressed(
+                        Type.FullyQualifiedName,
+                        previousMethod.Signature.Name,
+                        previousMethod.Signature.Parameters.Count) == true)
+                {
+                    CodeModelGenerator.Instance.Emitter.Debug(
+                        $"Skipping back-compat shim for '{Type.FullyQualifiedName}.{previousMethod.Signature.Name}'; removal is accepted in the ApiCompat baseline.");
+                    continue;
+                }
+
                 List<MethodSignature> currentOverloads = [];
                 bool foundCompatibleOverload = false;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -593,10 +593,22 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     LastContractPropertiesMap.TryGetValue(outputProperty.Name, out var lastContractPropertyType) &&
                     !lastContractPropertyType.Equals(outputProperty.Type))
                 {
-                    outputProperty.Type = lastContractPropertyType.ApplyInputSpecProperty(property);
-                    CodeModelGenerator.Instance.Emitter.Info(
-                        $"Changed property '{Name}.{outputProperty.Name}' type to '{lastContractPropertyType}' to match last contract.",
-                        BackCompatibilityChangeCategory.PropertyTypePreserved);
+                    // If the previous property type (or a type nested in it) has been intentionally
+                    // removed and that removal is accepted in the ApiCompat baseline, preserving it
+                    // would reference a now-deleted type. Honor the baseline and allow the new type.
+                    if (CodeModelGenerator.Instance.SourceInputModel?.ApiCompatBaseline.ReferencesSuppressedType(lastContractPropertyType) == true)
+                    {
+                        CodeModelGenerator.Instance.Emitter.Info(
+                            $"Allowing property '{Name}.{outputProperty.Name}' type change to '{outputProperty.Type}'; previous type '{lastContractPropertyType}' is an accepted removal in the ApiCompat baseline.",
+                            BackCompatibilityChangeCategory.BaselineAcceptedRemovalSkipped);
+                    }
+                    else
+                    {
+                        outputProperty.Type = lastContractPropertyType.ApplyInputSpecProperty(property);
+                        CodeModelGenerator.Instance.Emitter.Info(
+                            $"Changed property '{Name}.{outputProperty.Name}' type to '{lastContractPropertyType}' to match last contract.",
+                            BackCompatibilityChangeCategory.PropertyTypePreserved);
+                    }
                 }
 
                 if (!isDiscriminator)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.TypeSpec.Generator.SourceInput
+{
+    /// <summary>
+    /// Represents the set of intentional, already-accepted breaking changes recorded in an
+    /// <c>ApiCompat</c> baseline (suppression) file (for example the files under
+    /// <c>eng/apicompatbaselines/&lt;AssemblyName&gt;.txt</c>).
+    /// <para>
+    /// The backward-compatibility system resurrects any public member that exists in the previous
+    /// contract (<see cref="SourceInputModel.LastContract"/>) but is missing from the current
+    /// generation. When such a removal has already been reviewed and accepted via an ApiCompat
+    /// baseline, the generator must honor that decision and <b>not</b> regenerate a compatibility
+    /// shim for the removed member -- otherwise it would re-introduce the intentionally removed API
+    /// (and may reference types that no longer exist). This type lets the back-compat code recognize
+    /// those accepted removals.
+    /// </para>
+    /// </summary>
+    public sealed class ApiCompatBaseline
+    {
+        private const string TypesMustExist = "TypesMustExist";
+        private const string MembersMustExist = "MembersMustExist";
+
+        private readonly HashSet<string> _suppressedTypes;
+        private readonly HashSet<MemberKey> _suppressedMembers;
+
+        private ApiCompatBaseline(HashSet<string> suppressedTypes, HashSet<MemberKey> suppressedMembers)
+        {
+            _suppressedTypes = suppressedTypes;
+            _suppressedMembers = suppressedMembers;
+        }
+
+        /// <summary>
+        /// An empty baseline that suppresses nothing. Used when no baseline file is present.
+        /// </summary>
+        public static ApiCompatBaseline Empty { get; } =
+            new(new HashSet<string>(StringComparer.Ordinal), new HashSet<MemberKey>());
+
+        /// <summary>
+        /// Gets a value indicating whether this baseline contains any suppressions.
+        /// </summary>
+        public bool IsEmpty => _suppressedTypes.Count == 0 && _suppressedMembers.Count == 0;
+
+        /// <summary>
+        /// Parses an ApiCompat baseline file from disk. Returns <see cref="Empty"/> when the file
+        /// does not exist.
+        /// </summary>
+        public static ApiCompatBaseline FromFile(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            {
+                return Empty;
+            }
+
+            return Parse(File.ReadAllLines(path));
+        }
+
+        /// <summary>
+        /// Parses the contents of an ApiCompat baseline file.
+        /// </summary>
+        public static ApiCompatBaseline Parse(IEnumerable<string> lines)
+        {
+            var suppressedTypes = new HashSet<string>(StringComparer.Ordinal);
+            var suppressedMembers = new HashSet<MemberKey>();
+
+            foreach (var rawLine in lines)
+            {
+                var line = rawLine?.Trim();
+                if (string.IsNullOrEmpty(line))
+                {
+                    continue;
+                }
+
+                var separatorIndex = line!.IndexOf(':');
+                if (separatorIndex < 0)
+                {
+                    continue;
+                }
+
+                var ruleId = line.Substring(0, separatorIndex).Trim();
+                var message = line.Substring(separatorIndex + 1).Trim();
+
+                // The element of interest is the first single-quoted token in the message.
+                if (!TryExtractQuoted(message, out var quoted))
+                {
+                    continue;
+                }
+
+                switch (ruleId)
+                {
+                    case TypesMustExist:
+                        suppressedTypes.Add(quoted);
+                        break;
+                    case MembersMustExist:
+                        if (TryParseMember(quoted, out var memberKey))
+                        {
+                            suppressedMembers.Add(memberKey);
+                        }
+                        break;
+                    // Other rule ids (e.g. CannotRemoveAttribute) do not describe a removed
+                    // member/type that the back-compat system would resurrect, so they are ignored.
+                    default:
+                        break;
+                }
+            }
+
+            return new ApiCompatBaseline(suppressedTypes, suppressedMembers);
+        }
+
+        /// <summary>
+        /// Determines whether the removal of the type with the given fully-qualified name has been
+        /// accepted in the baseline.
+        /// </summary>
+        public bool IsTypeSuppressed(string typeFullName)
+            => !string.IsNullOrEmpty(typeFullName) && _suppressedTypes.Contains(typeFullName);
+
+        /// <summary>
+        /// Determines whether the removal of a member has been accepted in the baseline. Matching is
+        /// performed on the declaring type's fully-qualified name, the member name, and the parameter
+        /// count, which is sufficient to identify the removed member without depending on the exact
+        /// textual format of parameter types. The removal of the declaring type itself (recorded as a
+        /// <c>TypesMustExist</c> suppression) also implies all of its members are suppressed.
+        /// </summary>
+        public bool IsMemberSuppressed(string declaringTypeFullName, string memberName, int parameterCount)
+        {
+            if (string.IsNullOrEmpty(declaringTypeFullName) || string.IsNullOrEmpty(memberName))
+            {
+                return false;
+            }
+
+            if (_suppressedTypes.Contains(declaringTypeFullName))
+            {
+                return true;
+            }
+
+            return _suppressedMembers.Contains(new MemberKey(declaringTypeFullName, memberName, parameterCount));
+        }
+
+        private static bool TryExtractQuoted(string message, out string value)
+        {
+            value = string.Empty;
+            var start = message.IndexOf('\'');
+            if (start < 0)
+            {
+                return false;
+            }
+
+            var end = message.IndexOf('\'', start + 1);
+            if (end <= start)
+            {
+                return false;
+            }
+
+            value = message.Substring(start + 1, end - start - 1);
+            return value.Length > 0;
+        }
+
+        // Parses an ApiCompat member signature of the form:
+        //   [modifiers] ReturnType Namespace.DeclaringType.MemberName(ParamType, ...)
+        // for example:
+        //   public Ns.Result Ns.Factory.Make(Ns.Kind, System.String)
+        //   public void Ns.Record..ctor(Ns.Kind, System.String)
+        //   public Ns.Kind Ns.Record.Prop.get()
+        private static bool TryParseMember(string signature, out MemberKey memberKey)
+        {
+            memberKey = default;
+
+            var parenIndex = signature.IndexOf('(');
+            if (parenIndex < 0 || !signature.EndsWith(")", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var beforeParen = signature.Substring(0, parenIndex).TrimEnd();
+            // The fully-qualified member path is the last whitespace-delimited token (the tokens
+            // before it are access modifiers and the return type).
+            var lastSpace = beforeParen.LastIndexOf(' ');
+            var memberPath = lastSpace >= 0 ? beforeParen.Substring(lastSpace + 1) : beforeParen;
+            if (memberPath.Length == 0)
+            {
+                return false;
+            }
+
+            string declaringTypeFullName;
+            string memberName;
+
+            // Constructors are rendered as "DeclaringType..ctor".
+            var ctorIndex = memberPath.IndexOf("..", StringComparison.Ordinal);
+            if (ctorIndex > 0)
+            {
+                declaringTypeFullName = memberPath.Substring(0, ctorIndex);
+                memberName = memberPath.Substring(ctorIndex + 1); // ".ctor" / ".cctor"
+            }
+            else
+            {
+                var lastDot = memberPath.LastIndexOf('.');
+                if (lastDot <= 0 || lastDot == memberPath.Length - 1)
+                {
+                    return false;
+                }
+
+                declaringTypeFullName = memberPath.Substring(0, lastDot);
+                memberName = memberPath.Substring(lastDot + 1);
+
+                // Property/event accessors are rendered as "DeclaringType.Member.get"/".set"; collapse
+                // them onto the owning member so the suppression matches the accessor's owner.
+                if (memberName is "get" or "set" or "add" or "remove")
+                {
+                    var ownerDot = declaringTypeFullName.LastIndexOf('.');
+                    if (ownerDot > 0)
+                    {
+                        memberName = declaringTypeFullName.Substring(ownerDot + 1);
+                        declaringTypeFullName = declaringTypeFullName.Substring(0, ownerDot);
+                    }
+                }
+            }
+
+            var parameterCount = CountParameters(signature.Substring(parenIndex + 1, signature.Length - parenIndex - 2));
+            memberKey = new MemberKey(declaringTypeFullName, memberName, parameterCount);
+            return true;
+        }
+
+        private static int CountParameters(string parameterList)
+        {
+            var trimmed = parameterList.Trim();
+            if (trimmed.Length == 0)
+            {
+                return 0;
+            }
+
+            // Count top-level commas (ignoring those nested inside generic argument lists).
+            var count = 1;
+            var depth = 0;
+            foreach (var c in trimmed)
+            {
+                switch (c)
+                {
+                    case '<':
+                        depth++;
+                        break;
+                    case '>':
+                        depth--;
+                        break;
+                    case ',':
+                        if (depth == 0)
+                        {
+                            count++;
+                        }
+                        break;
+                }
+            }
+
+            return count;
+        }
+
+        private readonly struct MemberKey : IEquatable<MemberKey>
+        {
+            private readonly string _declaringTypeFullName;
+            private readonly string _memberName;
+            private readonly int _parameterCount;
+
+            public MemberKey(string declaringTypeFullName, string memberName, int parameterCount)
+            {
+                _declaringTypeFullName = declaringTypeFullName;
+                _memberName = memberName;
+                _parameterCount = parameterCount;
+            }
+
+            public bool Equals(MemberKey other)
+                => string.Equals(_declaringTypeFullName, other._declaringTypeFullName, StringComparison.Ordinal)
+                   && string.Equals(_memberName, other._memberName, StringComparison.Ordinal)
+                   && _parameterCount == other._parameterCount;
+
+            public override bool Equals(object? obj) => obj is MemberKey other && Equals(other);
+
+            public override int GetHashCode()
+                => HashCode.Combine(_declaringTypeFullName, _memberName, _parameterCount);
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.TypeSpec.Generator.Primitives;
 
 namespace Microsoft.TypeSpec.Generator.SourceInput
 {
@@ -140,6 +141,36 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
             }
 
             return _suppressedMembers.Contains(new MemberKey(declaringTypeFullName, memberName, parameterCount));
+        }
+
+        /// <summary>
+        /// Determines whether the given type, or any of its generic argument types, refers to a type
+        /// whose removal has been accepted in the baseline (a <c>TypesMustExist</c> suppression). This
+        /// is used by the back-compat code to recognize when a previously-published type can no longer
+        /// be referenced (for example when preserving a property's previous type would point at a type
+        /// that has been intentionally removed).
+        /// </summary>
+        public bool ReferencesSuppressedType(CSharpType? type)
+        {
+            if (type is null || _suppressedTypes.Count == 0)
+            {
+                return false;
+            }
+
+            if (IsTypeSuppressed(type.FullyQualifiedName))
+            {
+                return true;
+            }
+
+            foreach (var argument in type.Arguments)
+            {
+                if (ReferencesSuppressedType(argument))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool TryExtractQuoted(string message, out string value)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
@@ -226,7 +226,7 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
             if (ctorIndex > 0)
             {
                 declaringTypeFullName = memberPath.Substring(0, ctorIndex);
-                memberName = memberPath.Substring(ctorIndex + 1); // ".ctor" / ".cctor"
+                memberName = memberPath.Substring(ctorIndex + 1); // ".ctor"
             }
             else
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.TypeSpec.Generator.Primitives;
 
 namespace Microsoft.TypeSpec.Generator.SourceInput

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
@@ -14,12 +14,25 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
         public Compilation? Customization { get; }
         public Compilation? LastContract { get; }
 
+        /// <summary>
+        /// The set of intentional, already-accepted breaking changes recorded in the ApiCompat
+        /// baseline file for this library. The backward-compatibility system consults this to avoid
+        /// regenerating compatibility shims for members whose removal has already been accepted.
+        /// </summary>
+        public ApiCompatBaseline ApiCompatBaseline { get; }
+
         private readonly Lazy<IReadOnlyDictionary<string, INamedTypeSymbol>> _nameMap;
 
         public SourceInputModel(Compilation? customization, Compilation? lastContract)
+            : this(customization, lastContract, ApiCompatBaseline.Empty)
+        {
+        }
+
+        public SourceInputModel(Compilation? customization, Compilation? lastContract, ApiCompatBaseline apiCompatBaseline)
         {
             Customization = customization;
             LastContract = lastContract;
+            ApiCompatBaseline = apiCompatBaseline ?? ApiCompatBaseline.Empty;
 
             _nameMap = new(PopulateNameMap);
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 
@@ -377,6 +378,39 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             Assert.AreEqual(
                 "return new global::Sample.Models.PublicModel1(stringProp, default, default, default, additionalBinaryDataProperties: null);\n",
                 result);
+        }
+
+        [Test]
+        public async Task BackCompatibility_SuppressedByApiCompatBaselineNotRegenerated()
+        {
+            // The previous contract contains a "PublicModel1OldName" factory method that no longer
+            // exists in the current contract. Normally a back-compat shim would be regenerated, but
+            // here the removal has been accepted in the ApiCompat baseline, so it must be skipped.
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "MembersMustExist : Member 'public Sample.Models.PublicModel1 Sample.Namespace.SampleNamespaceModelFactory.PublicModel1OldName(System.String)' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: ModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(method: "BackCompatibility_NoCurrentOverloadFound"),
+                apiCompatBaseline: baseline)).Object;
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            Assert.AreEqual("SampleNamespaceModelFactory", modelFactory.Name);
+
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            var methods = modelFactory.Methods;
+
+            // The suppressed back-compat method should NOT have been regenerated.
+            var backwardCompatibilityMethod = methods
+                .FirstOrDefault(m => m.Signature.Name == "PublicModel1OldName");
+            Assert.IsNull(backwardCompatibilityMethod);
+
+            // No extra back-compat method beyond the current factory methods.
+            Assert.AreEqual(ModelList.Length - ModelList.Where(m => m.Access == "internal").Count(), methods.Count);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -9,7 +9,6 @@ using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
-using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 
@@ -386,10 +385,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             // The previous contract contains a "PublicModel1OldName" factory method that no longer
             // exists in the current contract. Normally a back-compat shim would be regenerated, but
             // here the removal has been accepted in the ApiCompat baseline, so it must be skipped.
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "MembersMustExist : Member 'public Sample.Models.PublicModel1 Sample.Namespace.SampleNamespaceModelFactory.PublicModel1OldName(System.String)' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile();
 
             _instance = (await MockHelpers.LoadMockGeneratorAsync(
                 inputNamespaceName: "Sample.Namespace",

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_SuppressedByApiCompatBaselineNotRegenerated.txt
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_SuppressedByApiCompatBaselineNotRegenerated.txt
@@ -1,0 +1,1 @@
+MembersMustExist : Member 'public Sample.Models.PublicModel1 Sample.Namespace.SampleNamespaceModelFactory.PublicModel1OldName(System.String)' does not exist in the implementation but it does exist in the contract.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Statements;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using Microsoft.TypeSpec.Generator.Utilities;
@@ -1326,6 +1327,41 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             // Spec type (non-nullable int) is preserved because there is no last contract to compare to.
             Assert.IsTrue(countProperty!.Type.Equals(typeof(int)));
             Assert.IsFalse(countProperty.Type.IsNullable);
+        }
+
+        [Test]
+        public async Task BackCompat_PropertyTypeChangeAllowedWhenPreviousTypeSuppressed()
+        {
+            // The last contract has `string Count { get; set; }` and the new spec says int. Normally
+            // the generator preserves the last contract's `string` type. Here the previous type has
+            // been intentionally removed and that removal is accepted in the ApiCompat baseline, so the
+            // generator must allow the property to take its current (spec) type instead of preserving
+            // a now-removed type.
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            var inputModel = InputFactory.Model(
+                "MockInputModel",
+                properties:
+                [
+                    InputFactory.Property("count", InputPrimitiveType.Int32, isRequired: true),
+                ]);
+
+            await MockHelpers.LoadMockGeneratorAsync(
+                inputModelTypes: [inputModel],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(method: "BackCompat_ScalarPropertyTypeOverriddenWhenTypeNameDiffers"),
+                apiCompatBaseline: baseline);
+
+            var modelProvider = CodeModelGenerator.Instance.OutputLibrary.TypeProviders.SingleOrDefault(t => t.Name == "MockInputModel") as ModelProvider;
+            Assert.IsNotNull(modelProvider);
+
+            var countProperty = modelProvider!.Properties.FirstOrDefault(p => p.Name == "Count");
+            Assert.IsNotNull(countProperty);
+            // The previous `string` type is a baseline-accepted removal, so the current spec type
+            // (int) is kept rather than being reverted to `string`.
+            Assert.IsTrue(countProperty!.Type.Equals(typeof(int)));
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
-using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Statements;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using Microsoft.TypeSpec.Generator.Utilities;
@@ -1337,10 +1336,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             // been intentionally removed and that removal is accepted in the ApiCompat baseline, so the
             // generator must allow the property to take its current (spec) type instead of preserving
             // a now-removed type.
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile();
 
             var inputModel = InputFactory.Model(
                 "MockInputModel",

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_PropertyTypeChangeAllowedWhenPreviousTypeSuppressed.txt
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_PropertyTypeChangeAllowedWhenPreviousTypeSuppressed.txt
@@ -1,0 +1,1 @@
+TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.SourceInput;
 using NUnit.Framework;
 
@@ -124,6 +126,41 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
             });
 
             Assert.IsTrue(baseline.IsEmpty);
+        }
+
+        [Test]
+        public void ReferencesSuppressedTypeMatchesDirectType()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.ReferencesSuppressedType(new CSharpType(typeof(string))));
+            Assert.IsFalse(baseline.ReferencesSuppressedType(new CSharpType(typeof(int))));
+        }
+
+        [Test]
+        public void ReferencesSuppressedTypeMatchesNestedGenericArgument()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            // IList<string> -- the suppressed type is nested as a generic argument.
+            var listOfString = new CSharpType(typeof(IList<>), new CSharpType(typeof(string)));
+            Assert.IsTrue(baseline.ReferencesSuppressedType(listOfString));
+
+            var listOfInt = new CSharpType(typeof(IList<>), new CSharpType(typeof(int)));
+            Assert.IsFalse(baseline.ReferencesSuppressedType(listOfInt));
+        }
+
+        [Test]
+        public void ReferencesSuppressedTypeReturnsFalseForNullOrEmptyBaseline()
+        {
+            Assert.IsFalse(ApiCompatBaseline.Empty.ReferencesSuppressedType(new CSharpType(typeof(string))));
+            Assert.IsFalse(ApiCompatBaseline.Empty.ReferencesSuppressedType(null));
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.SourceInput;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
+{
+    public class ApiCompatBaselineTests
+    {
+        [Test]
+        public void EmptyBaselineSuppressesNothing()
+        {
+            var baseline = ApiCompatBaseline.Empty;
+
+            Assert.IsTrue(baseline.IsEmpty);
+            Assert.IsFalse(baseline.IsTypeSuppressed("Some.Type"));
+            Assert.IsFalse(baseline.IsMemberSuppressed("Some.Type", "Member", 0));
+        }
+
+        [Test]
+        public void ParsesTypesMustExist()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "TypesMustExist : Type 'Azure.AI.Projects.Agents.ProjectsAgentProtocol' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol"));
+            Assert.IsFalse(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.SomethingElse"));
+        }
+
+        [Test]
+        public void TypeSuppressionImpliesAllMembersSuppressed()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "TypesMustExist : Type 'Azure.AI.Projects.Agents.ProjectsAgentProtocol' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.IsMemberSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol", "AnyMember", 3));
+        }
+
+        [Test]
+        public void ParsesMembersMustExistMethod()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "MembersMustExist : Member 'public Azure.AI.Projects.Agents.ProtocolVersionRecord Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ProtocolVersionRecord(Azure.AI.Projects.Agents.ProjectsAgentProtocol, System.String)' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.IsMemberSuppressed(
+                "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
+                "ProtocolVersionRecord",
+                2));
+            // Different arity should not match.
+            Assert.IsFalse(baseline.IsMemberSuppressed(
+                "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
+                "ProtocolVersionRecord",
+                1));
+            // Different declaring type should not match.
+            Assert.IsFalse(baseline.IsMemberSuppressed(
+                "Azure.AI.Projects.Agents.OtherFactory",
+                "ProtocolVersionRecord",
+                2));
+        }
+
+        [Test]
+        public void ParsesParameterlessMember()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "MembersMustExist : Member 'public System.Void Ns.Foo.Reset()' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Reset", 0));
+        }
+
+        [Test]
+        public void ParsesConstructor()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "MembersMustExist : Member 'public Ns.Foo..ctor(Ns.Kind, System.String)' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", ".ctor", 2));
+        }
+
+        [Test]
+        public void ParsesPropertyAccessorOntoOwner()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "MembersMustExist : Member 'public Ns.Kind Ns.Foo.Kind.get()' does not exist in the implementation but it does exist in the contract.",
+                "MembersMustExist : Member 'public System.Void Ns.Foo.Kind.set(Ns.Kind)' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 0));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 1));
+        }
+
+        [Test]
+        public void CountsGenericParametersAsSingleArgument()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "MembersMustExist : Member 'public System.Void Ns.Foo.Configure(System.Collections.Generic.IDictionary<System.String, System.Int32>, System.String)' does not exist in the implementation but it does exist in the contract.",
+            });
+
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Configure", 2));
+        }
+
+        [Test]
+        public void IgnoresUnknownRulesAndMalformedLines()
+        {
+            var baseline = ApiCompatBaseline.Parse(new[]
+            {
+                "CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.ExperimentalAttribute' exists on 'Ns.Foo' in the contract but not the implementation.",
+                "this line has no colon and should be ignored",
+                "",
+                "   ",
+                "MembersMustExist : Member with no quotes should be ignored",
+            });
+
+            Assert.IsTrue(baseline.IsEmpty);
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.SourceInput;
+using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
@@ -23,10 +24,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesTypesMustExist()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "TypesMustExist : Type 'Azure.AI.Projects.Agents.ProjectsAgentProtocol' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
 
             Assert.IsTrue(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol"));
             Assert.IsFalse(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.SomethingElse"));
@@ -35,10 +33,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void TypeSuppressionImpliesAllMembersSuppressed()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "TypesMustExist : Type 'Azure.AI.Projects.Agents.ProjectsAgentProtocol' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol", "AnyMember", 3));
         }
@@ -46,10 +41,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesMembersMustExistMethod()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "MembersMustExist : Member 'public Azure.AI.Projects.Agents.ProtocolVersionRecord Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ProtocolVersionRecord(Azure.AI.Projects.Agents.ProjectsAgentProtocol, System.String)' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed(
                 "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
@@ -70,10 +62,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesParameterlessMember()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "MembersMustExist : Member 'public System.Void Ns.Foo.Reset()' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Reset", 0));
         }
@@ -81,10 +70,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesConstructor()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "MembersMustExist : Member 'public Ns.Foo..ctor(Ns.Kind, System.String)' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", ".ctor", 2));
         }
@@ -92,11 +78,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesPropertyAccessorOntoOwner()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "MembersMustExist : Member 'public Ns.Kind Ns.Foo.Kind.get()' does not exist in the implementation but it does exist in the contract.",
-                "MembersMustExist : Member 'public System.Void Ns.Foo.Kind.set(Ns.Kind)' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 0));
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 1));
@@ -105,10 +87,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void CountsGenericParametersAsSingleArgument()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "MembersMustExist : Member 'public System.Void Ns.Foo.Configure(System.Collections.Generic.IDictionary<System.String, System.Int32>, System.String)' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Configure", 2));
         }
@@ -116,14 +95,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IgnoresUnknownRulesAndMalformedLines()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.ExperimentalAttribute' exists on 'Ns.Foo' in the contract but not the implementation.",
-                "this line has no colon and should be ignored",
-                "",
-                "   ",
-                "MembersMustExist : Member with no quotes should be ignored",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile();
 
             Assert.IsTrue(baseline.IsEmpty);
         }
@@ -131,10 +103,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ReferencesSuppressedTypeMatchesDirectType()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "SuppressedString");
 
             Assert.IsTrue(baseline.ReferencesSuppressedType(new CSharpType(typeof(string))));
             Assert.IsFalse(baseline.ReferencesSuppressedType(new CSharpType(typeof(int))));
@@ -143,10 +112,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ReferencesSuppressedTypeMatchesNestedGenericArgument()
         {
-            var baseline = ApiCompatBaseline.Parse(new[]
-            {
-                "TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.",
-            });
+            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "SuppressedString");
 
             // IList<string> -- the suppressed type is nested as a generic argument.
             var listOfString = new CSharpType(typeof(IList<>), new CSharpType(typeof(string)));

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/Baseline.txt
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/Baseline.txt
@@ -1,0 +1,8 @@
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.ExperimentalAttribute' exists on 'Azure.AI.Projects.Agents.HostedAgentDefinition' in the contract but not the implementation.
+TypesMustExist : Type 'Azure.AI.Projects.Agents.ProjectsAgentProtocol' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Azure.AI.Projects.Agents.ProtocolVersionRecord Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ProtocolVersionRecord(Azure.AI.Projects.Agents.ProjectsAgentProtocol, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public System.Void Ns.Foo.Reset()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Ns.Foo..ctor(Ns.Kind, System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Ns.Kind Ns.Foo.Kind.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public System.Void Ns.Foo.Kind.set(Ns.Kind)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public System.Void Ns.Foo.Configure(System.Collections.Generic.IDictionary<System.String, System.Int32>, System.String)' does not exist in the implementation but it does exist in the contract.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/IgnoresUnknownRulesAndMalformedLines.txt
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/IgnoresUnknownRulesAndMalformedLines.txt
@@ -1,0 +1,5 @@
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.ExperimentalAttribute' exists on 'Ns.Foo' in the contract but not the implementation.
+this line has no colon and should be ignored
+
+   
+MembersMustExist : Member with no quotes should be ignored

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/SuppressedString.txt
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/SuppressedString.txt
@@ -1,0 +1,1 @@
+TypesMustExist : Type 'System.String' does not exist in the implementation but it does exist in the contract.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/MockHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TestHelpers/MockHelpers.cs
@@ -41,7 +41,8 @@ namespace Microsoft.TypeSpec.Generator.Tests
             IEnumerable<string>? typesToKeep = null,
             bool includeXmlDocs = false,
             string? inputNamespaceName = null,
-            string? outputPath = null)
+            string? outputPath = null,
+            ApiCompatBaseline? apiCompatBaseline = null)
         {
             var mockGenerator = LoadMockGenerator(
                 createCSharpTypeCore,
@@ -63,7 +64,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
             var compilationResult = compilation == null ? null : await compilation();
             var lastContractCompilationResult = lastContractCompilation == null ? null : await lastContractCompilation();
 
-            var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(compilationResult, lastContractCompilationResult)) { CallBase = true };
+            var sourceInputModel = new Mock<SourceInputModel>(() => new SourceInputModel(compilationResult, lastContractCompilationResult, apiCompatBaseline ?? ApiCompatBaseline.Empty)) { CallBase = true };
             mockGenerator.Setup(p => p.SourceInputModel).Returns(sourceInputModel.Object);
 
             return mockGenerator;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/Helpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/Helpers.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.TypeSpec.Generator.SourceInput;
 using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Common
@@ -25,16 +26,30 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
             return File.ReadAllText(GetAssetFileOrDirectoryPath(true, parameters, method, filePath));
         }
 
-        public static string GetAssetFileOrDirectoryPath(
-            bool isFile,
+        /// <summary>
+        /// Loads an <see cref="ApiCompatBaseline"/> from a <c>.txt</c> baseline asset file located at
+        /// <c>TestData/&lt;CallingClass&gt;/&lt;method&gt;.txt</c> next to the calling test.
+        /// </summary>
+        public static ApiCompatBaseline GetApiCompatBaselineFromFile(
             string? parameters = null,
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "")
         {
+            return ApiCompatBaseline.FromFile(
+                GetAssetFileOrDirectoryPath(true, parameters, method, filePath, fileExtension: ".txt"));
+        }
+
+        public static string GetAssetFileOrDirectoryPath(
+            bool isFile,
+            string? parameters = null,
+            [CallerMemberName] string method = "",
+            [CallerFilePath] string filePath = "",
+            string fileExtension = ".cs")
+        {
 
             var callingClass =  Path.GetFileName(filePath).Split('.').First();
             var paramString = parameters is null ? string.Empty : $"({parameters})";
-            var extName = isFile ? ".cs" : string.Empty;
+            var extName = isFile ? fileExtension : string.Empty;
 
             return Path.Combine(Path.GetDirectoryName(filePath)!, "TestData", callingClass, $"{method}{paramString}{extName}");
         }

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -38,6 +38,15 @@ When generating code, the generator can optionally receive a compiled assembly f
 2. Compares the generated types against the types in the last contract
 3. Automatically generates compatibility methods, properties, or enum members where differences are detected
 
+### ApiCompat Baseline Awareness
+
+Sometimes a breaking change (such as removing a model or a model factory method) is intentional and has already been reviewed and accepted. In the Azure SDK, such accepted breaking changes are recorded in an [ApiCompat](https://github.com/dotnet/sdk/tree/main/src/Compatibility) baseline (suppression) file, conventionally located at `eng/apicompatbaselines/<AssemblyName>.txt`.
+
+Without awareness of these files, the back-compat system would resurrect every member present in the last contract — re-introducing the very API that was intentionally removed (and potentially referencing types that no longer exist). To prevent this, the generator discovers the baseline file by walking up from the project directory and parses its `TypesMustExist` and `MembersMustExist` suppressions. Before regenerating a compatibility shim for a removed member, the back-compat code checks whether the removal has been accepted in the baseline (matched by declaring-type full name, member name, and parameter count) and, if so, skips it.
+
+> [!NOTE]
+> Baseline awareness is currently wired into the model factory back-compat path (`ModelFactoryProvider`). The other back-compat consumers (`ClientProvider`, `ModelProvider` constructors/properties, the enum providers, and `RestClientProvider`) can be made baseline-aware in the same way as a follow-up.
+
 ## Supported Scenarios
 
 ### Model Factory Methods

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -42,10 +42,13 @@ When generating code, the generator can optionally receive a compiled assembly f
 
 Sometimes a breaking change (such as removing a model or a model factory method) is intentional and has already been reviewed and accepted. In the Azure SDK, such accepted breaking changes are recorded in an [ApiCompat](https://github.com/dotnet/sdk/tree/main/src/Compatibility) baseline (suppression) file, conventionally located at `eng/apicompatbaselines/<AssemblyName>.txt`.
 
-Without awareness of these files, the back-compat system would resurrect every member present in the last contract — re-introducing the very API that was intentionally removed (and potentially referencing types that no longer exist). To prevent this, the generator discovers the baseline file by walking up from the project directory and parses its `TypesMustExist` and `MembersMustExist` suppressions. Before regenerating a compatibility shim for a removed member, the back-compat code checks whether the removal has been accepted in the baseline (matched by declaring-type full name, member name, and parameter count) and, if so, skips it.
+Without awareness of these files, the back-compat system would resurrect every member present in the last contract — re-introducing the very API that was intentionally removed (and potentially referencing types that no longer exist). To prevent this, the generator discovers the baseline file by walking up from the project directory and parses its `TypesMustExist` and `MembersMustExist` suppressions. The back-compat code then consults the baseline in two ways:
+
+- **Skipping resurrected members:** before regenerating a compatibility shim for a removed member, it checks whether the removal has been accepted in the baseline (matched by declaring-type full name, member name, and parameter count) and, if so, skips it.
+- **Allowing property type changes:** the back-compat system normally preserves a property's previous (last-contract) type to avoid a breaking change. When that previous type — or a type nested within it (e.g. the element type of a collection) — has itself been intentionally removed and accepted in the baseline, preserving it would reference a now-deleted type. In that case the generator allows the property to take its current (spec) type instead.
 
 > [!NOTE]
-> Baseline awareness is currently wired into the model factory back-compat path (`ModelFactoryProvider`). The other back-compat consumers (`ClientProvider`, `ModelProvider` constructors/properties, the enum providers, and `RestClientProvider`) can be made baseline-aware in the same way as a follow-up.
+> Baseline awareness is currently wired into the model factory back-compat path (`ModelFactoryProvider`) and the model property type-preservation path (`ModelProvider`). The other back-compat consumers (`ModelProvider` constructors, the enum providers, `ClientProvider`, and `RestClientProvider`) can be made baseline-aware in the same way as a follow-up.
 
 ## Supported Scenarios
 


### PR DESCRIPTION
## Problem

The backward-compatibility system uses `LastContractView` to keep generated APIs source-compatible with the previous version: it resurrects removed public members and preserves a property's previous type. But when a breaking change has **already been accepted** in an [ApiCompat](https://github.com/dotnet/sdk/tree/main/src/Compatibility) baseline (suppression) file — conventionally `eng/apicompatbaselines/<AssemblyName>.txt` in the Azure SDK — that back-compat behavior fights the accepted decision: it re-introduces intentionally-removed API and can reference types that no longer exist.

Example baseline entries:

```
TypesMustExist : Type 'Azure.AI.Projects.Agents.ProjectsAgentProtocol' does not exist in the implementation but it does exist in the contract.
MembersMustExist : Member 'public Azure.AI.Projects.Agents.ProtocolVersionRecord Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ProtocolVersionRecord(Azure.AI.Projects.Agents.ProjectsAgentProtocol, System.String)' does not exist in the implementation but it does exist in the contract.
```

## Fix

- Add `ApiCompatBaseline` (`Microsoft.TypeSpec.Generator.SourceInput`): a tolerant parser for ApiCompat baseline files that understands `TypesMustExist` and `MembersMustExist` suppressions. Member matching uses declaring-type full name + member name + parameter count (arity), avoiding brittle parameter-type string comparisons. Type suppression implies all of its members are suppressed.
- Discover the baseline file by walking up from the project directory to `eng/apicompatbaselines/<PrimaryNamespace>.txt` (`GeneratedCodeWorkspace.LoadApiCompatBaseline`), expose the parsed baseline on `SourceInputModel`, and wire loading into `CSharpGen`.
- **Skip resurrected members** in the model factory back-compat path (`ModelFactoryProvider.BuildMethodsForBackCompatibility`): a removed factory method whose removal is accepted in the baseline is not regenerated.
- **Allow property type changes** in `ModelProvider.BuildProperties`: the generator normally reverts a property to its previous (last-contract) type to avoid a breaking change. When that previous type — or a type nested within it (e.g. a collection element type) — is an accepted baseline removal, preserving it would reference a now-deleted type, so the current (spec) type is kept instead. Added `ApiCompatBaseline.ReferencesSuppressedType` (recurses into generic arguments) and a `BaselineAcceptedRemovalSkipped` change category.

The remaining back-compat consumers (`ModelProvider` constructors, the enum providers, `ClientProvider`, and `RestClientProvider`) can be made baseline-aware the same way as a follow-up; this is documented in `docs/backward-compatibility.md`.

## Tests

- `ApiCompatBaselineTests` — parser coverage (types, methods, constructors, property accessors, generic-arg arity, unknown/malformed lines) and `ReferencesSuppressedType` (direct + nested generic argument).
- `ModelFactoryProviderTests.BackCompatibility_SuppressedByApiCompatBaselineNotRegenerated` — a baselined factory method is **not** regenerated.
- `ModelProviderTests.BackCompat_PropertyTypeChangeAllowedWhenPreviousTypeSuppressed` — a property whose previous type is a baseline-accepted removal takes its current spec type.
- Full `Microsoft.TypeSpec.Generator.Tests` suite passes (1552 tests).
