### PR TITLE
Fix MRW context base model discovery

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -187,7 +187,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 // Traverse base model properties for discoverable types, but do not add the base model
                 // itself as a context entry unless it was in the output-library seed set.
-                CollectBuildableTypeProvidersRecursive(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypesRecursiveCore(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
             }
             else
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -84,6 +84,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         {
             var visitedTypes = new HashSet<CSharpType>(s_cSharpTypeNameComparer);
             var visitedTypeProviders = new HashSet<TypeProvider>(s_typeProviderNameComparer);
+            var visitedBaseProviders = new HashSet<TypeProvider>(ReferenceEqualityComparer.Instance);
             var buildableProviders = new HashSet<TypeProvider>(s_typeProviderNameComparer);
             var buildableTypes = new HashSet<CSharpType>(s_cSharpTypeNameComparer);
 
@@ -102,7 +103,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     buildableProviders.Add(provider);
                 }
 
-                CollectBuildableTypeProvidersRecursive(provider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypeProvidersRecursive(provider, visitedTypes, visitedTypeProviders, visitedBaseProviders, buildableProviders, buildableTypes);
             }
 
             return (buildableTypes, buildableProviders);
@@ -131,6 +132,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             TypeProvider currentProvider,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
+            HashSet<TypeProvider> visitedBaseProviders,
             HashSet<TypeProvider> buildableProviders,
             HashSet<CSharpType> buildableTypes)
         {
@@ -143,7 +145,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Process all providers to discover types from methods and properties
             if (currentProvider is not null)
             {
-                CollectBuildableTypesRecursiveCore(currentProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                CollectBuildableTypesRecursiveCore(currentProvider, visitedTypes, visitedTypeProviders, visitedBaseProviders, buildableProviders, buildableTypes);
             }
         }
 
@@ -151,6 +153,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             TypeProvider provider,
             HashSet<CSharpType> visitedTypes,
             HashSet<TypeProvider> visitedTypeProviders,
+            HashSet<TypeProvider> visitedBaseProviders,
             HashSet<TypeProvider> buildableProviders,
             HashSet<CSharpType> buildableTypes)
         {
@@ -187,7 +190,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 // Traverse base model properties for discoverable types, but do not add the base model
                 // itself as a context entry unless it was in the output-library seed set.
-                CollectBuildableTypesRecursiveCore(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, buildableProviders, buildableTypes);
+                if (visitedBaseProviders.Add(modelProvider.BaseModelProvider))
+                {
+                    CollectBuildableTypesRecursiveCore(modelProvider.BaseModelProvider, visitedTypes, visitedTypeProviders, visitedBaseProviders, buildableProviders, buildableTypes);
+                }
             }
             else
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
@@ -781,6 +781,31 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
         }
 
         [Test]
+        public void ValidateDuplicateBaseProviderNameStillDiscoversFrameworkTypes()
+        {
+            var rootBaseInputModel = InputFactory.Model("SharedBaseModel", properties: []);
+            var derivedInputModel = InputFactory.Model("DerivedModel", properties: []);
+            var rootBaseProvider = new DuplicateBaseProvider(rootBaseInputModel, includeFrameworkProperty: false);
+            var derivedBaseProvider = new DuplicateBaseProvider(rootBaseInputModel, includeFrameworkProperty: true);
+            var outputLibrary = new TestOutputLibrary(
+            [
+                rootBaseProvider,
+                new DuplicateDerivedProvider(derivedInputModel, derivedBaseProvider)
+            ]);
+            var mockGenerator = MockHelpers.LoadMockGenerator(createOutputLibrary: () => outputLibrary);
+
+            var contextDefinition = new ModelReaderWriterContextDefinition();
+            var buildableAttributes = contextDefinition.Attributes
+                .Where(a => a.Type.IsFrameworkType && a.Type.FrameworkType == typeof(ModelReaderWriterBuildableAttribute))
+                .Select(a => a.Arguments.First().ToDisplayString())
+                .ToList();
+
+            Assert.IsTrue(
+                buildableAttributes.Contains("typeof(global::Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions.ModelReaderWriterContextDefinitionTests.FrameworkModelWithMRW)"),
+                "Framework MRW types from a derived model's base provider must be discovered even when an output-library provider with the same type name was already visited.");
+        }
+
+        [Test]
         public void ValidateObsoleteFrameworkTypeHasAttributeSuppression()
         {
             // Create a model with a property that references an obsolete framework type
@@ -1077,6 +1102,51 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
             {
                 throw new NotImplementedException();
             }
+        }
+
+        private class DuplicateBaseProvider : ModelProvider
+        {
+            private readonly bool _includeFrameworkProperty;
+
+            public DuplicateBaseProvider(InputModelType inputModelType, bool includeFrameworkProperty) : base(inputModelType)
+            {
+                _includeFrameworkProperty = includeFrameworkProperty;
+            }
+
+            protected override string BuildName() => "SharedBaseModel";
+
+            protected internal override PropertyProvider[] BuildProperties()
+            {
+                if (!_includeFrameworkProperty)
+                {
+                    return [];
+                }
+
+                return
+                [
+                    new PropertyProvider(
+                        null,
+                        MethodSignatureModifiers.Public,
+                        new CSharpType(typeof(FrameworkModelWithMRW)),
+                        "FrameworkProperty",
+                        new AutoPropertyBody(false),
+                        this)
+                ];
+            }
+        }
+
+        private class DuplicateDerivedProvider : ModelProvider
+        {
+            private readonly ModelProvider _baseProvider;
+
+            public DuplicateDerivedProvider(InputModelType inputModelType, ModelProvider baseProvider) : base(inputModelType)
+            {
+                _baseProvider = baseProvider;
+            }
+
+            protected override ModelProvider? BuildBaseModelProvider() => _baseProvider;
+
+            protected override string BuildName() => "DerivedModel";
         }
 
         public class FrameworkTypeImplementingOtherFrameworkType : ComplexFrameworkType

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
@@ -806,6 +806,29 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
         }
 
         [Test]
+        public void ValidateCyclicBaseProviderTraversalStops()
+        {
+            var baseInputModel = InputFactory.Model("BaseModel", properties: []);
+            var derivedInputModel = InputFactory.Model("DerivedModel", properties: []);
+            var baseProviderA = new CyclicBaseProvider(baseInputModel, includeFrameworkProperty: false);
+            var baseProviderB = new CyclicBaseProvider(baseInputModel, includeFrameworkProperty: true);
+            baseProviderA.BaseProvider = baseProviderB;
+            baseProviderB.BaseProvider = baseProviderA;
+            var outputLibrary = new TestOutputLibrary([new DuplicateDerivedProvider(derivedInputModel, baseProviderA)]);
+            var mockGenerator = MockHelpers.LoadMockGenerator(createOutputLibrary: () => outputLibrary);
+
+            var contextDefinition = new ModelReaderWriterContextDefinition();
+            var buildableAttributes = contextDefinition.Attributes
+                .Where(a => a.Type.IsFrameworkType && a.Type.FrameworkType == typeof(ModelReaderWriterBuildableAttribute))
+                .Select(a => a.Arguments.First().ToDisplayString())
+                .ToList();
+
+            Assert.IsTrue(
+                buildableAttributes.Contains("typeof(global::Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions.ModelReaderWriterContextDefinitionTests.FrameworkModelWithMRW)"),
+                "Framework MRW types from cyclic base providers should be discovered before the cycle is stopped.");
+        }
+
+        [Test]
         public void ValidateObsoleteFrameworkTypeHasAttributeSuppression()
         {
             // Create a model with a property that references an obsolete framework type
@@ -1147,6 +1170,17 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
             protected override ModelProvider? BuildBaseModelProvider() => _baseProvider;
 
             protected override string BuildName() => "DerivedModel";
+        }
+
+        private class CyclicBaseProvider : DuplicateBaseProvider
+        {
+            public CyclicBaseProvider(InputModelType inputModelType, bool includeFrameworkProperty) : base(inputModelType, includeFrameworkProperty)
+            {
+            }
+
+            public ModelProvider? BaseProvider { get; set; }
+
+            protected override ModelProvider? BuildBaseModelProvider() => BaseProvider;
         }
 
         public class FrameworkTypeImplementingOtherFrameworkType : ComplexFrameworkType


### PR DESCRIPTION
## Description
Fixes `ModelReaderWriterContextDefinition` so recursive base-model traversal still discovers framework model reader/writer types when an equivalent provider name was already visited from the output library roots.

This prevents context attributes such as `ModelReaderWriterBuildable` from being dropped for framework MRW types referenced through base provider properties.

## Validation
- `dotnet test Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj --filter FullyQualifiedName~ModelReaderWriterContextDefinitionTests.ValidateDuplicateBaseProviderNameStillDiscoversFrameworkTypes --no-restore`
- `dotnet test Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj --no-restore`
- `git diff --check`