### PR TITLE
fix(http-client-csharp): correct return type namespace and parameter names in partial method customization

### DIFF
--- a/.chronus/changes/fix-partial-method-customization-return-type-2026-06-23-10-27-11.md
+++ b/.chronus/changes/fix-partial-method-customization-return-type-2026-06-23-10-27-11.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@typespec/http-client-csharp"
----
-
-Fix partial method customization emitting return types without a namespace (`global::.TypeName`) and appending `0` to parameter names. The generated partial implementation now uses the generator's resolved return type and parameter types instead of the customer's parsed declaration types.

--- a/.chronus/changes/fix-partial-method-customization-return-type-2026-06-23-10-27-11.md
+++ b/.chronus/changes/fix-partial-method-customization-return-type-2026-06-23-10-27-11.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Fix partial method customization emitting return types without a namespace (`global::.TypeName`) and appending `0` to parameter names. The generated partial implementation now uses the generator's resolved return type and parameter types instead of the customer's parsed declaration types.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -180,7 +180,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 }
                 convenienceBodyParameters = bodyParams;
 
-                methodSignature = PartialMethodCustomization.BuildPartialSignature(customSignature, renamedSignatureParameters);
+                methodSignature = PartialMethodCustomization.BuildPartialSignature(
+                    customSignature,
+                    renamedSignatureParameters,
+                    GetResponseType(ServiceMethod.Operation.Responses, true, isAsync, out _));
             }
             else
             {
@@ -1077,12 +1080,18 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             if (customSignature != null)
             {
                 // Partial methods cannot have optional parameters in the implementation.
+                // Clone from the generator's parameters (resolved types/metadata) while taking the
+                // customer's names, rather than from the customer's parsed parameters whose types
+                // may be unresolved error types (which render with no namespace).
                 var requiredCustomParameters = PartialMethodCustomization.RenameAndCloneParameters(
-                    customSignature.Parameters,
+                    parameters,
                     customSignature.Parameters,
                     removeDefaults: true).ToArray();
 
-                methodSignature = PartialMethodCustomization.BuildPartialSignature(customSignature, requiredCustomParameters);
+                methodSignature = PartialMethodCustomization.BuildPartialSignature(
+                    customSignature,
+                    requiredCustomParameters,
+                    GetResponseType(ServiceMethod.Operation.Responses, false, isAsync, out _));
 
                 bodyParameters = requiredCustomParameters;
                 // Re-resolve the request options parameter from the customized parameter list so the

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PartialMethodCustomization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PartialMethodCustomization.cs
@@ -159,16 +159,22 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         /// <summary>
         /// Builds a <see cref="MethodSignature"/> for a partial method implementation using
-        /// <paramref name="customSignature"/> (modifiers, name, return type, attributes, and
-        /// other signature metadata) and the supplied <paramref name="implementationParameters"/>.
+        /// <paramref name="customSignature"/> (modifiers, name, attributes, and other signature
+        /// metadata) and the supplied <paramref name="implementationParameters"/>.
         /// The result has <see cref="MethodSignatureModifiers.Partial"/> applied.
         /// </summary>
         /// <param name="customSignature">The customer's partial declaration signature.</param>
         /// <param name="implementationParameters">The parameters to use for the implementation.
         /// Must all be required (no default values) per the C# partial method rules.</param>
+        /// <param name="returnType">The return type the implementation should use. Pass the
+        /// generator's own return type rather than relying on the customer's parsed declaration:
+        /// the customer's declaration may reference not-yet-generated types, which Roslyn surfaces
+        /// as error types with no namespace (producing malformed <c>global::.TypeName</c> output).
+        /// When <c>null</c>, the customer's parsed return type is used as a fallback.</param>
         public static MethodSignature BuildPartialSignature(
             MethodSignature customSignature,
-            IReadOnlyList<ParameterProvider> implementationParameters)
+            IReadOnlyList<ParameterProvider> implementationParameters,
+            CSharpType? returnType = null)
         {
             if (customSignature is null)
             {
@@ -184,7 +190,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 customSignature.Name,
                 customSignature.Description,
                 customSignature.Modifiers | MethodSignatureModifiers.Partial,
-                customSignature.ReturnType,
+                returnType ?? customSignature.ReturnType,
                 customSignature.ReturnDescription,
                 implementationParameters,
                 customSignature.Attributes,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PartialMethodCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PartialMethodCustomizationTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Providers
+{
+    public class PartialMethodCustomizationTests
+    {
+        // A type whose namespace is empty, mimicking what Roslyn produces for an unresolved
+        // (not-yet-generated) type referenced from a customer's partial declaration.
+        private static CSharpType UnresolvedType(string name) =>
+            new CSharpType(name, string.Empty, isValueType: false, isNullable: false, declaringType: null, args: [], isPublic: true, isStruct: false);
+
+        // A type that carries a proper namespace, mimicking the generator's resolved type.
+        private static CSharpType ResolvedType(string name, string ns) =>
+            new CSharpType(name, ns, isValueType: false, isNullable: false, declaringType: null, args: [], isPublic: true, isStruct: false);
+
+        [Test]
+        public void BuildPartialSignature_UsesGeneratorReturnType()
+        {
+            var customReturnType = UnresolvedType("MyModel");
+            var generatorReturnType = ResolvedType("MyModel", "Sample.Models");
+
+            var customSignature = new MethodSignature(
+                "DoStuff",
+                $"",
+                MethodSignatureModifiers.Public,
+                customReturnType,
+                $"",
+                []);
+
+            var result = PartialMethodCustomization.BuildPartialSignature(
+                customSignature,
+                [],
+                generatorReturnType);
+
+            Assert.IsTrue(result.Modifiers.HasFlag(MethodSignatureModifiers.Partial));
+            // The return type should come from the generator (with its namespace), not from the
+            // customer's parsed declaration (which has no namespace).
+            Assert.AreEqual("Sample.Models", result.ReturnType!.Namespace);
+            Assert.AreEqual("MyModel", result.ReturnType.Name);
+        }
+
+        [Test]
+        public void BuildPartialSignature_FallsBackToCustomReturnTypeWhenNull()
+        {
+            var customReturnType = ResolvedType("MyModel", "Sample.Models");
+            var customSignature = new MethodSignature(
+                "DoStuff",
+                $"",
+                MethodSignatureModifiers.Public,
+                customReturnType,
+                $"",
+                []);
+
+            var result = PartialMethodCustomization.BuildPartialSignature(customSignature, []);
+
+            Assert.AreSame(customReturnType, result.ReturnType);
+        }
+
+        [Test]
+        public void RenameAndCloneParameters_KeepsGeneratorTypesAndCustomNames()
+        {
+            // Generator parameter: resolved type + generator name.
+            var generatorParam = new ParameterProvider("content", $"", ResolvedType("ExecuteContent", "Sample.Models"));
+            // Custom parameter: unresolved type (empty namespace) + customer-chosen name.
+            var customParam = new ParameterProvider("body", $"", UnresolvedType("ExecuteContent"));
+
+            IReadOnlyList<ParameterProvider> result = PartialMethodCustomization.RenameAndCloneParameters(
+                [generatorParam],
+                [customParam],
+                removeDefaults: true);
+
+            Assert.AreEqual(1, result.Count);
+            // Name comes from the customer's declaration.
+            Assert.AreEqual("body", result[0].Name);
+            // Type (and its namespace) comes from the generator, not the unresolved custom type.
+            Assert.AreEqual("Sample.Models", result[0].Type.Namespace);
+            Assert.AreEqual("ExecuteContent", result[0].Type.Name);
+        }
+    }
+}


### PR DESCRIPTION
Fixes two bugs in the C# emitter's partial method customization feature, observed in [Azure/azure-sdk-for-net#59749](https://github.com/Azure/azure-sdk-for-net/pull/59749):

1. **Missing namespace on return types** — generated partial implementations rendered return types as global::.DeallocateResourceOperationResult (empty namespace). The implementation signature was built from the customer's *parsed* partial declaration, whose return type references not-yet-generated models. Roslyn surfaces those as error types with an empty namespace, which CodeWriter.AppendType writes as global::.TypeName.
2. **`0` appended to parameter names** — e.g. `resourceGroupResource0`. This happens when the method signature and body reference different `ParameterProvider` instances that share the same name, triggering the writer's disambiguation.

## Fix
- `BuildPartialSignature` now accepts an optional `CSharpType? returnType` and uses `returnType ?? customSignature.ReturnType`, so callers can supply the generator's resolved return type instead of the customer's parsed (unresolved) one.
- `ScmMethodProviderCollection` (convenience + protocol paths) now pass the generator's resolved return type (`GetResponseType(...)`) and clone parameters from the generator's resolved parameters while taking the customer's names. The protocol body shares the same renamed parameter instances as the signature, preventing the `0` suffix.

## Tests
- Added `PartialMethodCustomizationTests` (3 tests) verifying the generator return type is used, the null fallback, and that cloned parameters keep generator types with custom names.
- Existing `ClientProviderCustomizationTests` (18 tests) still pass.

Note: the management generator (in azure-sdk-for-net) is the actual consumer producing the buggy output; these shared helpers now enable correct usage, and this repo's data-plane paths are correct.