### PR TITLE
Enforce braces on all control-flow bodies in the C# emitter (cop)

### DIFF
--- a/packages/http-client-csharp/cop-checks/braces.cop
+++ b/packages/http-client-csharp/cop-checks/braces.cop
@@ -1,34 +1,33 @@
-# Rule: enforce braces on inline control-flow statements in the C# emitter.
+# Rule: enforce braces on every control-flow body in the C# emitter.
 #
-# Flags `if` / `else` / `else if` / `for` / `foreach` / `while` whose body is
-# written inline on the same line as the header without a `{ ... }` block, e.g.:
+# Flags `if` / `else` / `else if` / `for` / `foreach` / `while` whose body is not
+# wrapped in a `{ ... }` block, whether the body is written inline or on its own
+# line, e.g.:
 #
-#     if (a) DoX();              -> violation
-#     if (x is null) throw ...;  -> violation (guard clause without braces)
+#     if (a) DoX();              -> violation (inline body)
+#     if (x is null) throw ...;  -> violation (inline guard clause)
+#     if (x is null)             -> violation (Allman guard clause)
+#         return;
 #     for (...) Step();          -> violation
 #     while (a) Tick();          -> violation
 #     else Two();                -> violation
-#     else if (a) DoY();         -> violation (inner `if` body is inline)
+#     else if (a) DoY();         -> violation (inner `if` body is unbraced)
 #
-# These are allowed (body is a brace-delimited block, or an Allman header whose
-# unbraced body sits on its own line):
+# These are allowed (body is a brace-delimited block):
 #
 #     if (a) { ... }
-#     if (a)                     # Allman: brace on the next line
+#     if (a)
 #     {
 #         ...
 #     }
-#     else if (a) { ... }        # `else if` chains are idiomatic
-#     if (x is null)             # Allman guard clause: body on the next line
-#         return;
+#     else if (a) { ... }        # `else if` chains are idiomatic when braced
 #
 # The rule is driven by the code provider's structural parse rather than line
 # text: a control-flow statement exposes `Braced` (true only when its body is a
-# `{ ... }` block) and `Children` (its body statements). A violation is an
-# unbraced control-flow statement whose body statement starts on the *same* line
-# as the header -- i.e. an inline body. Compared with the previous line-text
-# heuristic, keying on the structural model removes the false positives on
-# multi-line conditions and recognizes `else if` chains correctly.
+# `{ ... }` block) and `Children` (its body statements). A violation is any
+# unbraced control-flow statement. Keying on the structural model removes the
+# false positives on multi-line conditions and recognizes `else if` chains
+# correctly.
 #
 # An `else if` is modeled as an `else` whose body is the inner (braced or
 # unbraced) `if`, so the `else` itself reports `Braced == false`. That is
@@ -44,14 +43,9 @@ import code
 # statement kind does not poison the result with a null.
 predicate hasChildIf(Statement) => Statement.Children:where((c) => c.Kind == 'if').Count > 0
 
-# True when a body statement starts on the same line as the control-flow header,
-# i.e. the body is written inline rather than as a block or on its own line.
-predicate hasInlineBody(Statement) => Statement.Children:where((c) => c.Line == Statement.Line).Count > 0
-
-# A control-flow statement (if / else / for / foreach / while) with an unbraced
-# inline body, excluding the idiomatic `else if` chain header.
+# A control-flow statement (if / else / for / foreach / while) whose body is not a
+# brace-delimited block, excluding the idiomatic `else if` chain header.
 predicate missingBraces(Statement) =>
     Statement:isControlFlow
     && !Statement.Braced
     && !(Statement.Kind == 'else' && Statement:hasChildIf)
-    && Statement:hasInlineBody

--- a/packages/http-client-csharp/cop-checks/braces.cop
+++ b/packages/http-client-csharp/cop-checks/braces.cop
@@ -1,49 +1,57 @@
-# Rule: enforce braces on control-flow statements in the C# emitter.
+# Rule: enforce braces on inline control-flow statements in the C# emitter.
 #
 # Flags `if` / `else` / `else if` / `for` / `foreach` / `while` whose body is
-# written inline on the same line without a `{ ... }` block, e.g.:
+# written inline on the same line as the header without a `{ ... }` block, e.g.:
 #
 #     if (a) DoX();              -> violation
 #     if (x is null) throw ...;  -> violation (guard clause without braces)
 #     for (...) Step();          -> violation
 #     while (a) Tick();          -> violation
 #     else Two();                -> violation
+#     else if (a) DoY();         -> violation (inner `if` body is inline)
 #
-# These are allowed (body is a brace-delimited block, Allman or K&R):
+# These are allowed (body is a brace-delimited block, or an Allman header whose
+# unbraced body sits on its own line):
 #
 #     if (a) { ... }
 #     if (a)                     # Allman: brace on the next line
 #     {
 #         ...
 #     }
+#     else if (a) { ... }        # `else if` chains are idiomatic
+#     if (x is null)             # Allman guard clause: body on the next line
+#         return;
 #
-# A line is reported when it is a control-flow header that also contains an
-# inline body terminated by `;` and introduces no `{` block. Keying on a
-# trailing `;` avoids false positives on multi-line conditions whose first
-# line ends in an operator (e.g. `if (a &&`), which are not complete headers.
+# The rule is driven by the code provider's structural parse rather than line
+# text: a control-flow statement exposes `Braced` (true only when its body is a
+# `{ ... }` block) and `Children` (its body statements). A violation is an
+# unbraced control-flow statement whose body statement starts on the *same* line
+# as the header -- i.e. an inline body. Compared with the previous line-text
+# heuristic, keying on the structural model removes the false positives on
+# multi-line conditions and recognizes `else if` chains correctly.
 #
-# Known limitation: an unbraced body written on a *separate* line (Allman
-# header followed by a single unbraced statement) is not detected, because the
-# header line is indistinguishable from a valid Allman braced header.
+# An `else if` is modeled as an `else` whose body is the inner (braced or
+# unbraced) `if`, so the `else` itself reports `Braced == false`. That is
+# idiomatic C#, so the `else` is excluded; the inner `if` is still checked on its
+# own, so `else if (a) DoY();` is reported via that inner `if`.
 #
 # Predicates only; the runnable command/test live in main.cop.
 
 import code
 
-# A control-flow header whose condition closes on this line.
-predicate isControlHeader(Line) => Line.Text:matches('^\s*(else\s+)?(if|for|foreach|while)\s*\(.*\)')
+# True when the statement has a direct child `if` -- i.e. it is the `else` of an
+# `else if` chain. `where` is used instead of `any` so a child that carries no
+# statement kind does not poison the result with a null.
+predicate hasChildIf(Statement) => Statement.Children:where((c) => c.Kind == 'if').Count > 0
 
-# An `else` that is not `else if`.
-predicate isElseHeader(Line) => Line.Text:matches('^\s*else\b') && !Line.Text:matches('^\s*else\s+if\b')
+# True when a body statement starts on the same line as the control-flow header,
+# i.e. the body is written inline rather than as a block or on its own line.
+predicate hasInlineBody(Statement) => Statement.Children:where((c) => c.Line == Statement.Line).Count > 0
 
-# The line introduces a `{ ... }` block.
-predicate hasBrace(Line) => Line.Text:matches('\{')
-
-# The line ends with a `;`-terminated statement (the inline body), optionally
-# followed by a trailing line comment.
-predicate hasInlineBody(Line) => Line.Text:matches(';\s*(//.*)?$')
-
-predicate missingBraces(Line) =>
-    !Line:hasBrace
-    && Line:hasInlineBody
-    && (Line:isControlHeader || Line:isElseHeader)
+# A control-flow statement (if / else / for / foreach / while) with an unbraced
+# inline body, excluding the idiomatic `else if` chain header.
+predicate missingBraces(Statement) =>
+    Statement:isControlFlow
+    && !Statement.Braced
+    && !(Statement.Kind == 'else' && Statement:hasChildIf)
+    && Statement:hasInlineBody

--- a/packages/http-client-csharp/cop-checks/main.cop
+++ b/packages/http-client-csharp/cop-checks/main.cop
@@ -2,7 +2,7 @@
 #
 # Each rule's detection logic (predicates) lives in its own file:
 #
-#     braces.cop          -> inline control-flow statements must use braces
+#     braces.cop          -> control-flow statements must use braces
 #     snippet-factory.cop -> expressions must be created via the Snippet factory
 #
 # This file wires those predicates to the C# codebase and exposes one runnable
@@ -18,9 +18,9 @@ import csharp
 let cb : Codebase = provider('csharp')
 
 # Rule: braces.cop
-command CHECK-BRACES = foreach cb.Statements:missingBraces => '{error:@red} {item.File.Path}:{item.Line}: missing braces on inline {item.Kind} statement'
+command CHECK-BRACES = foreach cb.Statements:missingBraces => '{error:@red} {item.File.Path}:{item.Line}: missing braces on {item.Kind} statement'
 
-test no-missing-braces = assert(cb.Statements:missingBraces.Count == 0, 'inline control-flow statements must use braces')
+test no-missing-braces = assert(cb.Statements:missingBraces.Count == 0, 'control-flow statements must use braces')
 
 # Rule: snippet-factory.cop
 command CHECK-SNIPPETS = foreach cb.Lines:usesCtorOverSnippet => '{error:@red} {item.File.Path}:{item.Number}: use the Snippet factory instead of constructing the expression directly -> {item.Text}'

--- a/packages/http-client-csharp/cop-checks/main.cop
+++ b/packages/http-client-csharp/cop-checks/main.cop
@@ -2,7 +2,7 @@
 #
 # Each rule's detection logic (predicates) lives in its own file:
 #
-#     braces.cop          -> control-flow statements must use braces
+#     braces.cop          -> inline control-flow statements must use braces
 #     snippet-factory.cop -> expressions must be created via the Snippet factory
 #
 # This file wires those predicates to the C# codebase and exposes one runnable
@@ -18,9 +18,9 @@ import csharp
 let cb : Codebase = provider('csharp')
 
 # Rule: braces.cop
-command CHECK-BRACES = foreach cb.Lines:missingBraces => '{error:@red} {item.File.Path}:{item.Number}: missing braces -> {item.Text}'
+command CHECK-BRACES = foreach cb.Statements:missingBraces => '{error:@red} {item.File.Path}:{item.Line}: missing braces on inline {item.Kind} statement'
 
-test no-missing-braces = assert(cb.Lines:missingBraces.Count == 0, 'control-flow statements must use braces')
+test no-missing-braces = assert(cb.Statements:missingBraces.Count == 0, 'inline control-flow statements must use braces')
 
 # Rule: snippet-factory.cop
 command CHECK-SNIPPETS = foreach cb.Lines:usesCtorOverSnippet => '{error:@red} {item.File.Path}:{item.Number}: use the Snippet factory instead of constructing the expression directly -> {item.Text}'

--- a/packages/http-client-csharp/eng/scripts/Invoke-Cop.ps1
+++ b/packages/http-client-csharp/eng/scripts/Invoke-Cop.ps1
@@ -38,7 +38,7 @@ param(
     # Pinned cop release. Bump deliberately after verifying the cop-checks/ rules
     # still run against the new release (cop can make breaking API changes
     # between releases). Pass "latest" to test against the newest release.
-    [string] $Version = "v2026.6.10.1"
+    [string] $Version = "v2026.6.23.2"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel.StubLibrary/src/StubLibraryVisitor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel.StubLibrary/src/StubLibraryVisitor.cs
@@ -21,7 +21,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.StubLibrary
             if (!type.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public) &&
                 !type.Name.StartsWith("Unknown", StringComparison.Ordinal) &&
                 !type.Name.Equals("MultiPartFormDataBinaryContent", StringComparison.Ordinal))
+            {
                 return null;
+            }
 
             type.Update(xmlDocs: XmlDocProvider.Empty);
             return type;
@@ -48,7 +50,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.StubLibrary
                 !IsParameterlessInternalCtorOnMrwSerializationType(constructor) &&
                 !IsInternalClientConstructor(constructor) &&
                 (constructor.EnclosingType is not ModelProvider model || model.DerivedModels.Count == 0))
+            {
                 return null;
+            }
 
             constructor.Update(
                 bodyStatements: null,
@@ -61,7 +65,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.StubLibrary
         private static bool IsInternalClientConstructor(ConstructorProvider constructor)
         {
             if (!constructor.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal))
+            {
                 return false;
+            }
 
             return constructor.EnclosingType is ClientProvider;
         }
@@ -69,10 +75,14 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.StubLibrary
         private static bool IsParameterlessInternalCtorOnMrwSerializationType(ConstructorProvider constructor)
         {
             if (constructor.Signature.Parameters.Count != 0)
+            {
                 return false;
+            }
 
             if (!constructor.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal))
+            {
                 return false;
+            }
 
             return constructor.EnclosingType is MrwSerializationTypeDefinition;
         }
@@ -101,7 +111,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.StubLibrary
         protected override MethodProvider? VisitMethod(MethodProvider method)
         {
             if (method.Signature.ExplicitInterface is null && !IsEffectivelyPublic(method.Signature.Modifiers))
+            {
                 return null;
+            }
 
             method.Signature.Update(modifiers: method.Signature.Modifiers & ~MethodSignatureModifiers.Async);
 
@@ -116,7 +128,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.StubLibrary
         protected override PropertyProvider? VisitProperty(PropertyProvider property)
         {
             if (!property.IsDiscriminator && !IsEffectivelyPublic(property.Modifiers))
+            {
                 return null;
+            }
 
             var propertyBody = new ExpressionPropertyBody(_throwNull, property.Body.HasSetter ? _throwNull : null);
 
@@ -130,10 +144,14 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.StubLibrary
         private bool IsEffectivelyPublic(MethodSignatureModifiers modifiers)
         {
             if (modifiers.HasFlag(MethodSignatureModifiers.Public))
+            {
                 return true;
+            }
 
             if (modifiers.HasFlag(MethodSignatureModifiers.Protected) && !modifiers.HasFlag(MethodSignatureModifiers.Private))
+            {
                 return true;
+            }
 
             return false;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/FixedEnumSerializationProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/FixedEnumSerializationProvider.cs
@@ -49,7 +49,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // fixed enum with int based types, we do not write a method for serialization because it was embedded in the definition
             bool isIntValueType = _enumProvider.EnumUnderlyingType.Equals(typeof(int)) || _enumProvider.EnumUnderlyingType.Equals(typeof(long));
             if (!_enumType.IsExtensible && isIntValueType)
+            {
                 return false;
+            }
 
             // otherwise we need a serialization method with the name of `ToSerial{UnderlyingTypeName}`
             return true;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -327,7 +327,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             if (!type.IsFrameworkType || type.IsEnum || type.IsLiteral)
+            {
                 return false;
+            }
 
             return type.FrameworkType.GetInterfaces().Any(i => i.Name == "IPersistableModel`1" || i.Name == "IJsonModel`1");
         }
@@ -346,7 +348,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private static string RemovePeriods(string input)
         {
             if (string.IsNullOrEmpty(input))
+            {
                 return input;
+            }
 
             Span<char> buffer = stackalloc char[input.Length];
             int index = 0;
@@ -354,7 +358,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             foreach (char c in input)
             {
                 if (c != '.')
+                {
                     buffer[index++] = c;
+                }
             }
 
             return buffer.Slice(0, index).ToString();
@@ -363,7 +369,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private static bool ImplementsModelReaderWriter(Type type)
         {
             if (type.IsEnum || type.IsValueType)
+            {
                 return false;
+            }
 
             return type.GetInterfaces().Any(i => i.Name == "IPersistableModel`1" || i.Name == "IJsonModel`1");
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.Dynamic.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.Dynamic.cs
@@ -505,7 +505,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private static bool IsDirectDynamicListProperty(PropertyProvider property)
         {
             if (!property.Type.IsList && !property.Type.IsArray)
+            {
                 return false;
+            }
+
             return ScmCodeModelGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(
                 property.Type.ElementType,
                 out var provider) &&

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -1881,7 +1881,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 (IsNonNullableValueType(propertyType) || (propertyIsRequired && !propertyIsNullable)))
             {
                 if (patchCheck == null)
+                {
                     return writePropertySerializationStatement;
+                }
 
                 return (propertyType.IsList || propertyType.IsArray)
                     ? CreateConditionalPatchSerializationStatement(jsonSerializedName, null, writePropertySerializationStatement, writePropertySerializationStatement)
@@ -2208,18 +2210,24 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 if (valueType.IsStruct) // extensible enum
                 {
                     if (valueType.UnderlyingEnumType.Equals(typeof(string)))
+                    {
                         return utf8JsonWriter.WriteStringValue(value.Invoke(nameof(ToString)));
+                    }
 
                     return utf8JsonWriter.WriteNumberValue(value.Invoke($"ToSerial{valueType.UnderlyingEnumType.Name}"));
                 }
                 else // fixed enum
                 {
                     if (valueType.UnderlyingEnumType.Equals(typeof(int)))
+                    {
                         // when the fixed enum is implemented as int, we cast to the value
                         return utf8JsonWriter.WriteNumberValue(value.CastTo(valueType.UnderlyingEnumType));
+                    }
 
                     if (valueType.UnderlyingEnumType.Equals(typeof(string)))
+                    {
                         return utf8JsonWriter.WriteStringValue(value.Invoke($"ToSerial{valueType.UnderlyingEnumType.Name}"));
+                    }
 
                     return utf8JsonWriter.WriteNumberValue(value.Invoke($"ToSerial{valueType.UnderlyingEnumType.Name}"));
                 }
@@ -2227,7 +2235,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             // Handle non-enum types
             if (!valueType.IsFrameworkType)
+            {
                 return utf8JsonWriter.WriteObjectValue(value.As(valueType), options: mrwOptionsParameter);
+            }
 
             // Handle framework types
             var frameworkType = valueType.FrameworkType;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -469,7 +469,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             foreach (var inputParameter in operation.Parameters)
             {
                 if (inputParameter is not InputQueryParameter inputQueryParameter)
+                {
                     continue;
+                }
 
                 var queryStatement = BuildQueryParameterStatement(uri, inputQueryParameter, paramMap, operation, isNextLinkRequest);
                 if (queryStatement != null)
@@ -993,7 +995,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             foreach (var response in operation.Responses)
             {
                 if (response.IsErrorResponse)
+                {
                     continue;
+                }
 
                 foreach (var statusCode in response.StatusCodes)
                 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -278,7 +278,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             foreach (var parameter in convenienceMethodParameters)
             {
                 if (parameter.SpreadSource != null)
+                {
                     continue;
+                }
 
                 if (parameter.Location == ParameterLocation.Body)
                 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
@@ -408,7 +408,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
                 {
                     // Map string property to a framework type that implements MRW
                     if (input == InputPrimitiveType.String)
+                    {
                         return new CSharpType(typeof(FrameworkModelWithMRW));
+                    }
+
                     return ScmCodeModelGenerator.Instance.TypeFactory.CreateCSharpType(input)!;
                 },
                 createCSharpTypeCoreFallback: input => input == InputPrimitiveType.String);
@@ -448,7 +451,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
                 createModelCore: input =>
                 {
                     if (input.Name == "NonMRWModel")
+                    {
                         return new NonMRWModelProvider(input);
+                    }
+
                     return new ModelProvider(input);
                 });
 
@@ -562,7 +568,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
                 createCSharpTypeCore: input =>
                 {
                     if (input == InputPrimitiveType.String)
+                    {
                         return new CSharpType(typeof(ComplexFrameworkType));
+                    }
+
                     return ScmCodeModelGenerator.Instance.TypeFactory.CreateCSharpType(input)!;
                 },
                 createCSharpTypeCoreFallback: input => input == InputPrimitiveType.String);
@@ -684,7 +693,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
                 createCSharpTypeCore: input =>
                 {
                     if (input == InputPrimitiveType.String)
+                    {
                         return new CSharpType(typeof(NestedFrameworkType));
+                    }
+
                     return ScmCodeModelGenerator.Instance.TypeFactory.CreateCSharpType(input)!;
                 });
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/SystemObjectModelSerializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/SystemObjectModelSerializationTests.cs
@@ -40,7 +40,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 createModelCore: (model) =>
                 {
                     if (model.Name == "Resource")
+                    {
                         return systemBase;
+                    }
+
                     return new ModelProvider(model);
                 },
                 createSerializationsCore: (inputType, typeProvider) =>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
@@ -636,7 +636,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientPro
                 foreach (var response in inputOperation.Responses)
                 {
                     if (response.IsErrorResponse)
+                    {
                         continue;
+                    }
+
                     expectedStatusCodes.AddRange(response.StatusCodes);
                 }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -58,11 +58,15 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
                     // grow the first word length when this letter follows by two other upper case letters
                     // this happens in OSProfile, where OS is the first word
                     if (i + 2 < name.Length && char.IsUpper(name[i + 1]) && (char.IsUpper(name[i + 2]) || IsWordSeparator(name[i + 2], preserveUnderscores)))
+                    {
                         firstWordLength++;
+                    }
                     // grow the first word length when this letter follows by another upper case letter and an end of the string
                     // this happens when the string only has one word, like OS, DNS
                     if (i + 2 == name.Length && char.IsUpper(name[i + 1]))
+                    {
                         firstWordLength++;
+                    }
                 }
 
                 if (upperCase)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputLongRunningServiceMetadata.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputLongRunningServiceMetadata.cs
@@ -28,10 +28,14 @@ namespace Microsoft.TypeSpec.Generator.Input
             get
             {
                 if (FinalResponse.BodyType is null)
+                {
                     return null;
+                }
 
                 if (ResultPath is null)
+                {
                     return FinalResponse.BodyType;
+                }
 
                 var rawResponseType = (InputModelType)FinalResponse.BodyType;
                 return rawResponseType.Properties.FirstOrDefault(p => p is InputModelProperty modelProperty && modelProperty.SerializationOptions?.Json?.Name == ResultPath)!.Type;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
@@ -94,7 +94,9 @@ namespace Microsoft.TypeSpec.Generator.Input
             internal set
             {
                 if (value is null || DiscriminatorProperty == null || DiscriminatorValue == UnknownDiscriminatorValue)
+                {
                     return;
+                }
 
                 _discriminatedSubtypes = new Dictionary<string, InputModelType>(value);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputType.cs
@@ -54,7 +54,10 @@ namespace Microsoft.TypeSpec.Generator.Input
         public InputType WithNullable(bool isNullable)
         {
             if (isNullable)
+            {
                 return new InputNullableType(this);
+            }
+
             return this;
         }
         public InputType GetImplementType() => this switch

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/Examples/TypeSpecInputExampleValueConverter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/Serialization/Examples/TypeSpecInputExampleValueConverter.cs
@@ -131,17 +131,30 @@ namespace Microsoft.TypeSpec.Generator.Input
                     case JsonValueKind.Number:
                         var rawText = rawValue.Value.GetRawText();
                         if (int.TryParse(rawText, out var int32Value))
+                        {
                             return InputExampleValue.Value(type, int32Value);
+                        }
                         else if (long.TryParse(rawText, out var int64Value))
+                        {
                             return InputExampleValue.Value(type, int64Value);
+                        }
                         else if (float.TryParse(rawText, out var floatValue))
+                        {
                             return InputExampleValue.Value(type, floatValue);
+                        }
                         else if (double.TryParse(rawText, out var doubleValue))
+                        {
                             return InputExampleValue.Value(type, doubleValue);
+                        }
                         else if (decimal.TryParse(rawText, out var decimalValue))
+                        {
                             return InputExampleValue.Value(type, decimalValue);
+                        }
                         else
+                        {
                             return InputExampleValue.Value(type, null);
+                        }
+
                     case JsonValueKind.Array:
                         var length = rawValue.Value.GetArrayLength();
                         var values = new List<InputExampleValue>(length);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/InputNamespaceTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/InputNamespaceTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
-using System.Text.Json;
 
 namespace Microsoft.TypeSpec.Generator.Input.Tests
 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputExampleConverterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputExampleConverterTests.cs
@@ -1,5 +1,5 @@
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/MethodProviderBenchmark.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/MethodProviderBenchmark.cs
@@ -72,10 +72,15 @@ namespace Microsoft.TypeSpec.Generator.Perf
                 foreach (var parameter in Signature.Parameters)
                 {
                     if (parameter.Validation == ParameterValidationType.None)
+                    {
                         continue;
+                    }
 
                     if (!paramHash.ContainsKey(parameter.Validation))
+                    {
                         paramHash[parameter.Validation] = new List<ParameterProvider>();
+                    }
+
                     paramHash[parameter.Validation].Add(parameter);
                 }
             }
@@ -85,13 +90,18 @@ namespace Microsoft.TypeSpec.Generator.Perf
         private MethodBodyStatement GetStatementsWithHash(MethodBodyStatement bodyStatements, Dictionary<ParameterValidationType, List<ParameterProvider>>? paramHash)
         {
             if (paramHash is null)
+            {
                 return bodyStatements;
+            }
 
             int count = 0;
             foreach (var kvp in paramHash)
             {
                 if (kvp.Key == ParameterValidationType.None)
+                {
                     continue;
+                }
+
                 count += kvp.Value.Count;
             }
 
@@ -132,7 +142,9 @@ namespace Microsoft.TypeSpec.Generator.Perf
                 }
             }
             if (wroteValidation)
+            {
                 statements.Add(MethodBodyStatement.EmptyLine);
+            }
 
             statements.Add(original);
             return statements;
@@ -150,7 +162,9 @@ namespace Microsoft.TypeSpec.Generator.Perf
                 }
             }
             if (wroteValidation)
+            {
                 yield return MethodBodyStatement.EmptyLine;
+            }
         }
 
         private IReadOnlyList<MethodBodyStatement> GetValidationStatements()
@@ -166,7 +180,10 @@ namespace Microsoft.TypeSpec.Generator.Perf
                 }
             }
             if (wroteValidation)
+            {
                 statements.Add(MethodBodyStatement.EmptyLine);
+            }
+
             return statements;
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/ModelReaderWriterContextDefinitionBenchmark.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/perf/ModelReaderWriterContextDefinitionBenchmark.cs
@@ -90,7 +90,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Perf
         private static InputModelType? GetRecursiveNestedModel(int modelNumber, int simplePropertyCount, int nestingLevel)
         {
             if (nestingLevel <= 0)
+            {
                 return null;
+            }
 
             var nestedModel = GetRecursiveNestedModel(modelNumber, simplePropertyCount, nestingLevel - 1);
             return InputFactory.Model(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Configuration.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Configuration.cs
@@ -206,7 +206,9 @@ namespace Microsoft.TypeSpec.Generator
         private static string? ReadStringOption(JsonElement root, string option)
         {
             if (root.TryGetProperty(option, out JsonElement value))
+            {
                 return value.GetString();
+            }
 
             return null;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ArrayInitializerExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/ArrayInitializerExpression.cs
@@ -27,7 +27,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
                 {
                     Elements[i].Write(writer);
                     if (i < Elements.Count - 1)
+                    {
                         writer.AppendRaw(", ");
+                    }
                 }
                 writer.AppendRaw(" }");
             }
@@ -40,9 +42,13 @@ namespace Microsoft.TypeSpec.Generator.Expressions
                     {
                         Elements[i].Write(writer);
                         if (i < Elements.Count - 1)
+                        {
                             writer.WriteRawLine(",");
+                        }
                         else
+                        {
                             writer.WriteLine();
+                        }
                     }
                 }
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/CollectionInitializerExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/CollectionInitializerExpression.cs
@@ -16,7 +16,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             {
                 Items[i].Write(writer);
                 if (i < Items.Length - 1)
+                {
                     writer.AppendRaw(", ");
+                }
             }
             writer.AppendRaw(" }");
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FormattableStringExpression.cs
@@ -55,7 +55,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             foreach (var (_, isLiteral) in StringExtensions.GetFormattableStringFormatParts(format))
             {
                 if (!isLiteral)
+                {
                     count++;
+                }
             }
 
             if (count != args.Count)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FuncExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/FuncExpression.cs
@@ -39,7 +39,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
                             writer.AppendRaw("_");
                         }
                         if (i < Parameters.Count - 1)
+                        {
                             writer.AppendRaw(", ");
+                        }
                     }
                     writer.AppendRaw(")");
                 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/InvokeMethodExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/InvokeMethodExpression.cs
@@ -95,7 +95,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         internal override void Write(CodeWriter writer)
         {
             if (ExtensionType is not null)
+            {
                 writer.UseNamespace(ExtensionType.Namespace);
+            }
 
             writer.AppendRawIf("await ", CallAsAsync);
             if (InstanceReference != null && !ReferenceEquals(InstanceReference, Static()))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/LiteralExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/LiteralExpression.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.CodeAnalysis.CSharp;
 using System;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.TypeSpec.Generator.Expressions
 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/SwitchExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/SwitchExpression.cs
@@ -23,7 +23,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
                     {
                         Cases[i].Write(writer);
                         if (i < Cases.Length - 1)
+                        {
                             writer.WriteRawLine(",");
+                        }
                     }
                 }
                 writer.WriteLine();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/TypeReferenceExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/TypeReferenceExpression.cs
@@ -25,7 +25,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
         internal static TypeReferenceExpression FromType(CSharpType? type)
         {
             if (type is null)
+            {
                 return _nullType;
+            }
 
             if (!_typeCache.TryGetValue(type, out var result))
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/WhereExpression.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Expressions/WhereExpression.cs
@@ -21,7 +21,9 @@ namespace Microsoft.TypeSpec.Generator.Expressions
             {
                 Constraints[i].Write(writer);
                 if (i < Constraints.Count - 1)
+                {
                     writer.AppendRaw(", ");
+                }
             }
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/OutputLibrary.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/OutputLibrary.cs
@@ -27,7 +27,10 @@ namespace Microsoft.TypeSpec.Generator
             foreach (var inputEnum in input.Enums)
             {
                 if (inputEnum.Usage.HasFlag(InputModelTypeUsage.ApiVersionEnum))
+                {
                     continue;
+                }
+
                 var outputEnum = CodeModelGenerator.Instance.TypeFactory.CreateEnum(inputEnum);
 
                 // If there is a custom code view for a fixed enum, then we should not emit the generated enum as the custom code will have

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 using Microsoft.CodeAnalysis;
-using MSBuildProjectCollection = Microsoft.Build.Evaluation.ProjectCollection;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
@@ -18,6 +17,7 @@ using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Utilities;
 using NuGet.Configuration;
+using MSBuildProjectCollection = Microsoft.Build.Evaluation.ProjectCollection;
 
 namespace Microsoft.TypeSpec.Generator
 {
@@ -249,7 +249,9 @@ namespace Microsoft.TypeSpec.Generator
             foreach (string sourceFile in Directory.GetFiles(directory, "*.cs", SearchOption.AllDirectories))
             {
                 if (skipPredicate != null && skipPredicate(sourceFile))
+                {
                     continue;
+                }
 
                 project = project.AddDocument(sourceFile, File.ReadAllText(sourceFile), folders ?? Array.Empty<string>(), sourceFile).Project;
             }
@@ -370,12 +372,16 @@ namespace Microsoft.TypeSpec.Generator
             string projectFilePath = Path.GetFullPath(Path.Combine(CodeModelGenerator.Instance.Configuration.ProjectDirectory, $"{packageName}.csproj"));
 
             if (!File.Exists(projectFilePath))
+            {
                 return null;
+            }
 
             var projectRoot = ProjectRootElement.Open(projectFilePath);
             var baselineVersion = projectRoot.Properties.SingleOrDefault(p => p.Name == ApiCompatPropertyName)?.Value;
             if (baselineVersion == null)
+            {
                 return null;
+            }
 
             var targetFrameworksValue = projectRoot.Properties
                 .FirstOrDefault(p => p.Name == TargetFrameworkPropertyName || p.Name == TargetFrameworksPropertyName)?.Value;
@@ -394,7 +400,9 @@ namespace Microsoft.TypeSpec.Generator
                 foreach (var preferredTargetFramework in NugetPackageDownloader.PreferredDotNetFrameworkVersions)
                 {
                     if (parsedTargetFrameworks != null && !parsedTargetFrameworks.Contains(preferredTargetFramework))
+                    {
                         continue;
+                    }
 
                     nugetFolderPathToAssembly = Path.Combine(
                         nugetGlobalPackageFolder,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/PostProcessor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/PostProcessor.cs
@@ -127,7 +127,9 @@ namespace Microsoft.TypeSpec.Generator
         {
             var compilation = await project.GetCompilationAsync();
             if (compilation == null)
+            {
                 return project;
+            }
 
             // first get all the declared symbols
             var definitions = await GetTypeSymbolsAsync(compilation, project, true);
@@ -169,7 +171,9 @@ namespace Microsoft.TypeSpec.Generator
         {
             var modelFactorySymbol = definitions.ModelFactorySymbol;
             if (modelFactorySymbol == null)
+            {
                 return project;
+            }
 
             var nodesToRemove = new List<SyntaxNode>();
 
@@ -203,7 +207,9 @@ namespace Microsoft.TypeSpec.Generator
 
             // maybe this is possible, for instance, we could be adding the customization all entries previously inside the generated model factory so that the generated model factory is empty and removed.
             if (modelFactoryGeneratedDocument == null)
+            {
                 return project;
+            }
 
             var root = await modelFactoryGeneratedDocument.GetSyntaxRootAsync();
             Debug.Assert(root is not null);
@@ -234,7 +240,9 @@ namespace Microsoft.TypeSpec.Generator
         {
             var compilation = await project.GetCompilationAsync();
             if (compilation == null)
+            {
                 return project;
+            }
 
             // find all the declarations, including non-public declared
             var definitions = await GetTypeSymbolsAsync(compilation, project, false);
@@ -247,7 +255,9 @@ namespace Microsoft.TypeSpec.Generator
             // include model factory as a root symbol when doing the remove pass so that we are sure to include any internal
             // helpers that are required by the model factory.
             if (_modelFactorySymbol != null)
+            {
                 rootSymbols.Add(_modelFactorySymbol);
+            }
             // traverse the map to determine the declarations that we are about to remove, starting from root nodes
             var referencedSymbols = VisitSymbolsFromRootAsync(rootSymbols, referenceMap);
 
@@ -276,7 +286,10 @@ namespace Microsoft.TypeSpec.Generator
         {
             var baseType = symbol.BaseType;
             if (baseType == null || baseType.SpecialType == SpecialType.System_Object)
+            {
                 return symbol;
+            }
+
             return GetBase(baseType);
         }
 
@@ -313,7 +326,10 @@ namespace Microsoft.TypeSpec.Generator
             {
                 var definition = queue.Dequeue();
                 if (visited.Contains(definition))
+                {
                     continue;
+                }
+
                 visited.Add(definition);
                 // add this definition to the result
                 yield return definition;
@@ -329,7 +345,9 @@ namespace Microsoft.TypeSpec.Generator
             IReadOnlyDictionary<T, IEnumerable<T>> referenceMap) where T : notnull
         {
             if (referenceMap.TryGetValue(definition, out var references))
+            {
                 return references;
+            }
 
             return Enumerable.Empty<T>();
         }
@@ -356,7 +374,9 @@ namespace Microsoft.TypeSpec.Generator
                 var document = project.GetDocument(model.SyntaxTree);
                 Debug.Assert(document != null);
                 if (!documents.ContainsKey(document))
+                {
                     documents.Add(document, new HashSet<BaseTypeDeclarationSyntax>());
+                }
 
                 documents[document].Add(model);
             }
@@ -380,7 +400,9 @@ namespace Microsoft.TypeSpec.Generator
 
             // skip this if there is nothing to replace
             if (originalTokenInList == default)
+            {
                 return memberDeclaration;
+            }
 
             var newToken =
                 SyntaxFactory.Token(originalTokenInList.LeadingTrivia, to, originalTokenInList.TrailingTrivia);
@@ -394,7 +416,10 @@ namespace Microsoft.TypeSpec.Generator
             var tree = models.First().SyntaxTree;
             var document = project.GetDocument(tree);
             if (document == null)
+            {
                 return project;
+            }
+
             var root = await tree.GetRootAsync();
             root = root.RemoveNodes(models, SyntaxRemoveOptions.KeepNoTrivia);
 
@@ -439,7 +464,9 @@ namespace Microsoft.TypeSpec.Generator
             var model = await document.GetSemanticModelAsync();
 
             if (root is not CompilationUnitSyntax cu || model == null)
+            {
                 return solution;
+            }
 
             var invalidUsings = cu.Usings
                 .Where(u =>
@@ -466,7 +493,9 @@ namespace Microsoft.TypeSpec.Generator
             var model = await document.GetSemanticModelAsync();
 
             if (root is not CompilationUnitSyntax cu || model == null)
+            {
                 return solution;
+            }
 
             var attributes = cu.DescendantNodes().OfType<AttributeListSyntax>();
             var firstAttribute = attributes.FirstOrDefault();
@@ -542,7 +571,10 @@ namespace Microsoft.TypeSpec.Generator
                 {
                     var document = project.GetDocument(declarationNode.SyntaxTree);
                     if (document == null)
+                    {
                         continue;
+                    }
+
                     if (await IsRootDocument(document))
                     {
                         result.Add(symbol);
@@ -569,7 +601,9 @@ namespace Microsoft.TypeSpec.Generator
         private static bool ShouldKeepType(SyntaxNode? root, HashSet<string> typesToKeep)
         {
             if (root is null)
+            {
                 return false;
+            }
 
             // use `BaseTypeDeclarationSyntax` to also include enums because `EnumDeclarationSyntax` extends `BaseTypeDeclarationSyntax`
             // `ClassDeclarationSyntax` and `StructDeclarationSyntax` both inherit `TypeDeclarationSyntax`
@@ -619,9 +653,14 @@ namespace Microsoft.TypeSpec.Generator
             {
                 TList newList;
                 if (collectionConstructor == null)
+                {
                     newList = new TList();
+                }
                 else
+                {
                     newList = collectionConstructor();
+                }
+
                 newList.Add(value);
                 dictionary.Add(key, newList);
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/ReferenceMapBuilder.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/ReferenceMapBuilder.cs
@@ -50,7 +50,9 @@ namespace Microsoft.TypeSpec.Generator
         {
             // only add to reference when myself is public
             if (symbol.DeclaredAccessibility != Accessibility.Public)
+            {
                 return;
+            }
 
             // process myself, adding base and generic arguments
             AddTypeSymbol(symbol, symbol, referenceMap);
@@ -70,7 +72,9 @@ namespace Microsoft.TypeSpec.Generator
             {
                 // only go through the public members
                 if (member.DeclaredAccessibility != Accessibility.Public)
+                {
                     continue;
+                }
 
                 switch (member)
                 {
@@ -109,15 +113,21 @@ namespace Microsoft.TypeSpec.Generator
         private async Task ProcessExtensionSymbol(INamedTypeSymbol extensionClassSymbol, ReferenceMap referenceMap, IReadOnlyDictionary<Document, HashSet<INamedTypeSymbol>> documentCache)
         {
             if (!extensionClassSymbol.IsStatic)
+            {
                 return;
+            }
 
             foreach (var member in extensionClassSymbol.GetMembers())
             {
                 if (member is not IMethodSymbol methodSymbol)
+                {
                     continue;
+                }
 
                 if (!methodSymbol.IsExtensionMethod)
+                {
                     continue;
+                }
 
                 foreach (var reference in await SymbolFinder.FindReferencesAsync(member, _project.Solution))
                 {
@@ -134,12 +144,16 @@ namespace Microsoft.TypeSpec.Generator
                 // if this is an extension method, we add it to the reference map of the type it is extending to pretend that this class is a part of that type
                 // handle the first method above
                 if (methodSymbol.Parameters.FirstOrDefault()?.Type is INamedTypeSymbol typeSymbol)
+                {
                     referenceMap.AddInList(typeSymbol, extensionClassSymbol);
+                }
 
                 // we also add the return type into the reference map of the extension class to cover both cases
                 // handle the second method above
                 if (methodSymbol.ReturnType is INamedTypeSymbol returnTypeSymbol)
+                {
                     referenceMap.AddInList(returnTypeSymbol, extensionClassSymbol);
+                }
             }
         }
 
@@ -151,7 +165,9 @@ namespace Microsoft.TypeSpec.Generator
 
                 // skip this reference if it comes from a document that does not define any symbol
                 if (!documentCache.TryGetValue(document, out var candidateReferenceSymbols))
+                {
                     continue;
+                }
 
                 if (candidateReferenceSymbols.Count == 1)
                 {
@@ -164,7 +180,9 @@ namespace Microsoft.TypeSpec.Generator
                     // customized code might have this issue
                     var root = await document.GetSyntaxRootAsync();
                     if (root == null)
+                    {
                         continue;
+                    }
                     // get the node of this reference
                     var node = root.FindNode(location.Location.SourceSpan);
                     var owner = GetOwnerTypeOfReference(node);
@@ -178,7 +196,9 @@ namespace Microsoft.TypeSpec.Generator
                         var ownerSymbol = semanticModel.GetDeclaredSymbol(owner);
 
                         if (ownerSymbol == null)
+                        {
                             continue;
+                        }
                         // add it to the map
                         referenceMap.AddInList(ownerSymbol, symbol);
                     }
@@ -195,9 +215,14 @@ namespace Microsoft.TypeSpec.Generator
         private void AddTypeSymbol(ITypeSymbol keySymbol, ITypeSymbol? valueSymbol, ReferenceMap referenceMap)
         {
             if (keySymbol is not INamedTypeSymbol keyTypeSymbol)
+            {
                 return;
+            }
+
             if (valueSymbol is not INamedTypeSymbol valueTypeSymbol)
+            {
                 return;
+            }
             // add the class and all its partial classes to the map
             // this will make all the partial classes are referencing each other in the reference map
             // when we make the travesal over the reference map, we will not only remove one of the partial class, instead we will either keep all the partial classes (if at least one of them has references), or remove all of them (if none of them has references)
@@ -267,7 +292,9 @@ namespace Microsoft.TypeSpec.Generator
             while (current != null)
             {
                 if (current is BaseTypeDeclarationSyntax declarationNode)
+                {
                     return declarationNode;
+                }
 
                 current = current.Parent;
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
@@ -470,9 +470,15 @@ namespace Microsoft.TypeSpec.Generator.Primitives
         public sealed override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
+            {
                 return false;
+            }
+
             if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
+
             return obj is CSharpType csType && Equals(csType, ignoreNullable: false);
         }
 
@@ -513,7 +519,9 @@ namespace Microsoft.TypeSpec.Generator.Primitives
         {
             // we cache the hashcode since `CSharpType` is meant to be immutable.
             if (_hashCode != null)
+            {
                 return _hashCode.Value;
+            }
 
             var hashCode = new HashCode();
             foreach (var arg in Arguments)
@@ -583,15 +591,21 @@ namespace Microsoft.TypeSpec.Generator.Primitives
             }
 
             if (!IsNameMatch(other))
+            {
                 return false;
+            }
 
             if (Arguments.Count != other.Arguments.Count)
+            {
                 return false;
+            }
 
             for (int i = 0; i < Arguments.Count; i++)
             {
                 if (!Arguments[i].AreNamesEqual(other.Arguments[i]))
+                {
                     return false;
+                }
             }
 
             return true;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CodeWriterDeclaration.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CodeWriterDeclaration.cs
@@ -38,7 +38,9 @@ namespace Microsoft.TypeSpec.Generator.Primitives
         internal string GetActualName(CodeWriter.CodeScope scope)
         {
             if (!_actualNames.TryGetValue(scope, out var actualName))
+            {
                 throw new InvalidOperationException($"Declaration {RequestedName} is not initialized");
+            }
 
             return actualName;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/TypeProviderWriter.cs
@@ -105,22 +105,34 @@ namespace Microsoft.TypeSpec.Generator.Primitives
                 WriteFields(writer);
 
                 if (sectionWritten && _provider.Constructors.Any())
+                {
                     writer.WriteLine();
+                }
+
                 WriteConstructors(writer);
                 sectionWritten |= _provider.Constructors.Any();
 
                 if (sectionWritten && _provider.Properties.Any())
+                {
                     writer.WriteLine();
+                }
+
                 WriteProperties(writer);
                 sectionWritten |= _provider.Properties.Any();
 
                 if (sectionWritten && _provider.Methods.Any())
+                {
                     writer.WriteLine();
+                }
+
                 WriteMethods(writer);
                 sectionWritten |= _provider.Methods.Any();
 
                 if (sectionWritten = _provider.NestedTypes.Any())
+                {
                     writer.WriteLine();
+                }
+
                 WriteNestedTypes(writer);
             }
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ApiVersionEnumProvider.cs
@@ -282,7 +282,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private static char? ExtractApiVersionSeparator(string version)
         {
             if (string.IsNullOrEmpty(version))
+            {
                 return null;
+            }
 
             char[] versionSeparators = ['-', '.', '_', '/'];
             int separatorIndex = version.IndexOfAny(versionSeparators);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -54,7 +54,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 var modelProvider = CodeModelGenerator.Instance.TypeFactory.CreateModel(model);
 
                 if (modelProvider is null)
+                {
                     continue;
+                }
 
                 var typeToInstantiate = GetModelToInstantiateForFactoryMethod(modelProvider);
                 if (typeToInstantiate is null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -325,7 +325,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
             foreach (var property in _inputModel.Properties)
             {
                 if (IsDiscriminator(property))
+                {
                     continue;
+                }
 
                 var derivedProperty = InputDerivedProperties.FirstOrDefault(p => p.Value.ContainsKey(property.Name)).Value?[property.Name];
                 if (derivedProperty is not null)
@@ -659,9 +661,15 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private static bool DomainEqual(InputProperty baseProperty, InputProperty derivedProperty)
         {
             if (baseProperty.Type.Name != derivedProperty.Type.Name)
+            {
                 return false;
+            }
+
             if (baseProperty.IsRequired != derivedProperty.IsRequired)
+            {
                 return false;
+            }
+
             var baseNullable = baseProperty.Type is InputNullableType;
             return baseNullable ? derivedProperty.Type is InputNullableType : derivedProperty.Type is not InputNullableType;
         }
@@ -997,7 +1005,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
                 // only add the raw data field if it has not already been added as a parameter for BinaryData additional properties
                 if (RawDataField != null && !SupportsBinaryDataAdditionalProperties)
+                {
                     constructorParameters.Add(RawDataField.AsParameter);
+                }
             }
 
             return (constructorParameters, constructorInitializer);
@@ -1222,12 +1232,16 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var wireInfo = property?.WireInfo ?? field?.WireInfo;
             // skip those non-spec properties
             if (wireInfo == null)
+            {
                 return;
+            }
 
             // skip if this is an overload / new of a base property
             // also skip if the base was required or the derived property is not required
             if (property?.BaseProperty is not null && (!isPrimaryConstructor || wireInfo.IsRequired == false || property.BaseProperty.WireInfo?.IsRequired == true))
+            {
                 return;
+            }
 
             ValueExpression assignee = property != null
                 ? property.BackingField is null ? property : property.BackingField

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -228,7 +228,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
             foreach (var constructorSymbol in _namedTypeSymbol.Constructors)
             {
                 if (constructorSymbol.IsImplicitlyDeclared)
+                {
                     continue;
+                }
 
                 var initializer = ExtractConstructorInitializer(constructorSymbol);
                 var signature = new ConstructorSignature(
@@ -249,11 +251,15 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 // skip property accessors
                 if (methodSymbol.AssociatedSymbol is IPropertySymbol)
+                {
                     continue;
+                }
 
                 // skip constructors
                 if (methodSymbol.MethodKind == MethodKind.Constructor)
+                {
                     continue;
+                }
 
                 var modifiers = GetAccessModifier(methodSymbol.DeclaredAccessibility);
 
@@ -540,16 +546,22 @@ namespace Microsoft.TypeSpec.Generator.Providers
             // Get the first syntax reference for the constructor
             var syntaxReference = constructorSymbol.DeclaringSyntaxReferences.FirstOrDefault();
             if (syntaxReference == null)
+            {
                 return null;
+            }
 
             // Get the syntax node and cast to constructor declaration
             var syntaxNode = syntaxReference.GetSyntax();
             if (syntaxNode is not ConstructorDeclarationSyntax constructorSyntax)
+            {
                 return null;
+            }
 
             // Check if there's an initializer
             if (constructorSyntax.Initializer == null)
+            {
                 return null;
+            }
 
             // Determine if it's 'this' or 'base'
             var isBase = constructorSyntax.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -256,26 +256,38 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private ParameterValidationType GetParameterValidation()
         {
             if (Field is not null && !Field.Type.IsNullable)
+            {
                 return ParameterValidationType.AssertNotNull;
+            }
 
             if (Property is null || Property.WireInfo is null)
+            {
                 return ParameterValidationType.None;
+            }
 
             // We do not validate a parameter when it is a value type (struct or int, etc)
             if (Property.Type.IsValueType)
+            {
                 return ParameterValidationType.None;
+            }
 
             // or it is readonly
             if (Property.WireInfo.IsReadOnly)
+            {
                 return ParameterValidationType.None;
+            }
 
             // or it is optional
             if (!Property.WireInfo.IsRequired)
+            {
                 return ParameterValidationType.None;
+            }
 
             // or it is nullable
             if (Property.Type.IsNullable)
+            {
                 return ParameterValidationType.None;
+            }
 
             return ParameterValidationType.AssertNotNull;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -238,7 +238,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private ValueExpression? GetPropertyInitializationValue(CSharpType propertyType, InputProperty inputProperty)
         {
             if (!inputProperty.IsRequired)
+            {
                 return null;
+            }
 
             if (propertyType.IsLiteral)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Shared/MethodSignatureHelper.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Shared/MethodSignatureHelper.cs
@@ -82,9 +82,14 @@ namespace Microsoft.TypeSpec.Generator
             public bool Equals(ParameterProvider? x, ParameterProvider? y)
             {
                 if (ReferenceEquals(x, y))
+                {
                     return true;
+                }
+
                 if (x is null || y is null)
+                {
                     return false;
+                }
 
                 return x.Type.AreNamesEqual(y.Type)
                     && x.Name.ToVariableName() == y.Name.ToVariableName()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/CSharpTypeSnippets.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/CSharpTypeSnippets.cs
@@ -46,7 +46,9 @@ namespace Microsoft.TypeSpec.Generator.Snippets
         public static ValueExpression ToSerial(this CSharpType type, ParameterProvider param)
         {
             if (!type.IsEnum)
+            {
                 throw new InvalidOperationException($"Can't call ToSerial on non-enum type {type.Name}");
+            }
 
             ValueExpression variable = param.Field is null ? param : param.Field;
             ValueExpression invokeVariable = variable;
@@ -61,7 +63,9 @@ namespace Microsoft.TypeSpec.Generator.Snippets
         public static ValueExpression ToSerial(this CSharpType type, ValueExpression variable)
         {
             if (!type.IsEnum)
+            {
                 throw new InvalidOperationException($"Can't call ToSerial on non-enum type {type.Name}");
+            }
 
             if (type.IsStruct) //extensible
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/CodeGenAttributes.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/CodeGenAttributes.cs
@@ -29,7 +29,9 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
         {
             name = null;
             if (attributeData.AttributeClass?.Name != CodeGenMemberAttributeName)
+            {
                 return false;
+            }
 
             name = attributeData.ConstructorArguments.FirstOrDefault().Value as string;
             return name != null;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/DeclareLocalFunctionStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/DeclareLocalFunctionStatement.cs
@@ -39,7 +39,9 @@ namespace Microsoft.TypeSpec.Generator.Statements
             {
                 writer.Append($"{Parameters[i].Type} {Parameters[i].Name}, ");
                 if (i < Parameters.Count - 1)
+                {
                     writer.AppendRaw(", ");
+                }
             }
             writer.AppendRaw(")");
             if (BodyExpression is not null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocExceptionStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocExceptionStatement.cs
@@ -51,7 +51,9 @@ namespace Microsoft.TypeSpec.Generator.Statements
                     writer.Append($", <paramref name=\"{Parameters[i].AsVariable().Declaration}\"/>");
                 }
                 if (Parameters.Count > 1)
+                {
                     writer.Append($" or <paramref name=\"{Parameters[Parameters.Count - 1].AsVariable().Declaration}\"/>");
+                }
             }
 
             writer.WriteLine($" {_reason} </exception>");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocStatement.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Statements/XmlDocStatement.cs
@@ -57,7 +57,9 @@ namespace Microsoft.TypeSpec.Generator.Statements
         private static object?[] EscapeArguments(object?[] objects)
         {
             if (objects is null)
+            {
                 return Array.Empty<object?>();
+            }
 
             object?[] args = new object?[objects.Length];
             for (int i = 0; i < objects.Length; i++)
@@ -158,7 +160,9 @@ namespace Microsoft.TypeSpec.Generator.Statements
         public static string EscapeLine(string s)
         {
             if (string.IsNullOrEmpty(s))
+            {
                 return s;
+            }
 
             var span = s.AsSpan();
             Dictionary<int, string> replacements = new Dictionary<int, string>();
@@ -253,12 +257,17 @@ namespace Microsoft.TypeSpec.Generator.Statements
         {
             escapeLength = 0;
             if (span.Length < i + escapedChar.Length)
+            {
                 return false;
+            }
 
             var slice = span.Slice(i, escapedChar.Length);
             var isMatch = slice.Equals(escapedChar.AsSpan(), StringComparison.Ordinal);
             if (isMatch)
+            {
                 escapeLength = slice.Length;
+            }
+
             return isMatch;
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -175,7 +175,9 @@ namespace Microsoft.TypeSpec.Generator
         public ModelProvider? CreateModel(InputModelType model)
         {
             if (InputTypeToModelProvider.TryGetValue(model, out var modelProvider))
+            {
                 return modelProvider;
+            }
 
             // Add sentinel before construction to prevent re-entrant creation of the same model
             // (e.g., when BuildBaseModelProvider triggers CreateModel for all input models).
@@ -227,7 +229,9 @@ namespace Microsoft.TypeSpec.Generator
         {
             var enumCacheKey = new EnumCacheKey(enumType, declaringType);
             if (EnumCache.TryGetValue(enumCacheKey, out var enumProvider))
+            {
                 return enumProvider;
+            }
 
             enumProvider = CreateEnumCore(enumType, declaringType);
 
@@ -340,7 +344,9 @@ namespace Microsoft.TypeSpec.Generator
         public PropertyProvider? CreateProperty(InputProperty property, TypeProvider enclosingType)
         {
             if (PropertyCache.TryGetValue(property, out var propertyProvider))
+            {
                 return propertyProvider;
+            }
 
             propertyProvider = CreatePropertyCore(property, enclosingType);
             PropertyCache.Add(property, propertyProvider);
@@ -466,7 +472,9 @@ namespace Microsoft.TypeSpec.Generator
         public IReadOnlyList<TypeProvider> CreateSerializations(InputType inputType, TypeProvider typeProvider)
         {
             if (SerializationsCache.TryGetValue(inputType, out var serializations))
+            {
                 return serializations;
+            }
 
             serializations = CreateSerializationsCore(inputType, typeProvider);
             SerializationsCache.Add(inputType, serializations);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/DocHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/DocHelpers.cs
@@ -41,7 +41,9 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         internal static string ConvertMarkdownToXml(string markdown)
         {
             if (string.IsNullOrEmpty(markdown))
+            {
                 return markdown;
+            }
 
             var lines = markdown.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             var result = new StringBuilder();
@@ -123,7 +125,9 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         private static void AppendList(StringBuilder result, string listType, List<string> items)
         {
             if (items.Count == 0)
+            {
                 return;
+            }
 
             if (result.Length > 0)
             {
@@ -145,7 +149,9 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         private static string ConvertInlineMarkdown(string text)
         {
             if (string.IsNullOrEmpty(text))
+            {
                 return text;
+            }
 
             // Handle ***bold italic*** (must be done before ** and *)
             text = BoldItalicRegex.Replace(text, "<b><i>$1</i></b>");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/MethodProviderHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/MethodProviderHelpers.cs
@@ -21,10 +21,15 @@ namespace Microsoft.TypeSpec.Generator
                 foreach (var parameter in signature.Parameters)
                 {
                     if (parameter.Validation == ParameterValidationType.None)
+                    {
                         continue;
+                    }
 
                     if (!paramHash.ContainsKey(parameter.Validation))
+                    {
                         paramHash[parameter.Validation] = new List<ParameterProvider>();
+                    }
+
                     paramHash[parameter.Validation].Add(parameter);
                 }
             }
@@ -34,18 +39,25 @@ namespace Microsoft.TypeSpec.Generator
         public static MethodBodyStatement GetBodyStatementWithValidation(IEnumerable<ParameterProvider> parameters, MethodBodyStatement bodyStatements, Dictionary<ParameterValidationType, List<ParameterProvider>>? paramHash)
         {
             if (paramHash is null || bodyStatements == MethodBodyStatement.Empty)
+            {
                 return bodyStatements;
+            }
 
             int count = 0;
             foreach (var kvp in paramHash)
             {
                 if (kvp.Key == ParameterValidationType.None)
+                {
                     continue;
+                }
+
                 count += kvp.Value.Count;
             }
 
             if (count == 0)
+            {
                 return bodyStatements;
+            }
 
             MethodBodyStatement[] statements = new MethodBodyStatement[count + 2];
             int index = 0;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageDownloader.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageDownloader.cs
@@ -1,24 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Versioning;
-using System;
-using System.Net.Http;
-using System.Net;
-using System.Threading.Tasks;
-using System.Threading;
-using NuGet.Protocol.Core.Types;
-using System.Collections.Generic;
-using System.Linq;
-using NuGet.Protocol;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
-using NuGet.Packaging;
-using System.IO;
-using System.Diagnostics.CodeAnalysis;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
 using NuGet.Repositories;
+using NuGet.Versioning;
 using ILogger = NuGet.Common.ILogger;
 using PackageArchiveDownloader = NuGet.Protocol.LocalPackageArchiveDownloader;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/TypeSymbolExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/TypeSymbolExtensions.cs
@@ -20,7 +20,10 @@ namespace Microsoft.TypeSpec.Generator
             if (type.IsValueType && type.IsNullable)
             {
                 if (symbol.ConstructedFrom.SpecialType != SpecialType.System_Nullable_T)
+                {
                     return false;
+                }
+
                 return IsSameType((INamedTypeSymbol)symbol.TypeArguments.Single(), type.WithNullable(false));
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpProjectWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CSharpProjectWriter.cs
@@ -169,7 +169,9 @@ public class CSharpProjectWriter
         {
             // only include those CSProjProperty types
             if (property.PropertyType != typeof(CSProjProperty))
+            {
                 continue;
+            }
             // invoke the WriteElementIfNotNull method on each of them
             var value = (CSProjProperty?)property.GetValue(this);
             WriteElementIfNotNull(writer, property.Name, value);
@@ -180,7 +182,9 @@ public class CSharpProjectWriter
     private void WriteElementIfNotNull(XmlWriter writer, string name, CSProjProperty? property)
     {
         if (property == null)
+        {
             return;
+        }
 
         if (property.Comment != null)
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Writers/CodeWriter.cs
@@ -288,7 +288,9 @@ namespace Microsoft.TypeSpec.Generator
         internal void WriteXmlDocsNoScope(XmlDocProvider? docs)
         {
             if (CodeModelGenerator.Instance.Configuration.DisableXmlDocs || docs is null)
+            {
                 return;
+            }
 
             if (docs.Inherit is not null)
             {
@@ -628,7 +630,9 @@ namespace Microsoft.TypeSpec.Generator
                     }
 
                     if (i < arguments.Count - 1)
+                    {
                         AppendRaw(",");
+                    }
                 }
             }
         }
@@ -666,7 +670,10 @@ namespace Microsoft.TypeSpec.Generator
                 AppendRaw(type.Namespace);
                 AppendRaw(".");
                 if (type.DeclaringType is not null)
+                {
                     AppendRaw($"{type.DeclaringType.Name}.");
+                }
+
                 AppendRaw(type.Name);
             }
 
@@ -719,7 +726,9 @@ namespace Microsoft.TypeSpec.Generator
         private CodeWriter AppendRaw(ReadOnlySpan<char> span)
         {
             if (span.Length == 0 )
+            {
                 return this;
+            }
 
             AddSpaces(span);
 
@@ -741,7 +750,9 @@ namespace Microsoft.TypeSpec.Generator
 
             int spaces = _atBeginningOfLine ? (_scopes.Peek().Depth) * 4 : 0;
             if (spaces == 0)
+            {
                 return;
+            }
 
             var destination = _builder.GetSpan(spaces);
             destination.Slice(0, spaces).Fill(_space);
@@ -954,7 +965,9 @@ namespace Microsoft.TypeSpec.Generator
             var reader = _builder.ExtractReader();
             var totalLength = reader.Length;
             if (totalLength == 0)
+            {
                 return string.Empty;
+            }
 
             var builder = new StringBuilder((int)totalLength);
             IEnumerable<string> namespaces = _usingNamespaces

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/GeneratedCodeWorkspaceTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/GeneratedCodeWorkspaceTests.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Build.Construction;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.TypeSpec.Generator.Tests.Common;
-using NUnit.Framework;
 using System;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.TypeSpec.Generator.Tests.Common;
+using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests
 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/ApiVersionEnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/ApiVersionEnumProviderTests.cs
@@ -2,15 +2,15 @@
 // Licensed under the MIT License.
 
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Tests.Common;
-using NUnit.Framework;
-using System.Threading.Tasks;
 using Moq;
 using Moq.Protected;
-using Microsoft.TypeSpec.Generator.Expressions;
+using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Providers.EnumProviders
 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
@@ -6,11 +6,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
-using Microsoft.TypeSpec.Generator.Utilities;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Tests.Common;
+using Microsoft.TypeSpec.Generator.Utilities;
 using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Providers

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/FieldProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/FieldProviderTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -40,7 +40,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             foreach (var model in models)
             {
                 if (!model!.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public))
+                {
                     continue; //skip internal models
+                }
 
                 Assert.IsNotNull(model, "Null ModelProvider found");
                 var method = modelFactory.Methods.FirstOrDefault(m => m.Signature.Name == model!.Name);
@@ -63,7 +65,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             foreach (var model in models)
             {
                 if (!model!.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public))
+                {
                     continue; //skip internal models
+                }
 
                 Assert.IsNotNull(model, "Null ModelProvider found");
                 var method = modelFactory.Methods.FirstOrDefault(m => m.Signature.Name == model!.Name);
@@ -86,7 +90,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             foreach (var model in models)
             {
                 if (!model!.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public))
+                {
                     continue; //skip internal models
+                }
 
                 Assert.IsNotNull(model, "Null ModelProvider found");
                 var method = modelFactory.Methods.FirstOrDefault(m => m.Signature.Name == model!.Name);
@@ -108,7 +114,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             foreach (var model in models)
             {
                 if (!model!.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public))
+                {
                     continue; //skip internal models
+                }
 
                 Assert.IsNotNull(model, "Null ModelProvider found");
                 var method = modelFactory.Methods.FirstOrDefault(m => m.Signature.Name == model!.Name);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/SystemObjectModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/SystemObjectModelProviderTests.cs
@@ -83,7 +83,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
                 createModelCore: (model) =>
                 {
                     if (model.Name == "Resource")
+                    {
                         return new SystemObjectModelProvider(systemType, model);
+                    }
+
                     return new ModelProvider(model);
                 });
 
@@ -119,7 +122,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
                 createModelCore: (model) =>
                 {
                     if (model.Name == "Resource")
+                    {
                         return new SystemObjectModelProvider(systemType, model);
+                    }
+
                     return new ModelProvider(model);
                 });
 
@@ -158,7 +164,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
                 createModelCore: (model) =>
                 {
                     if (model.Name == "Resource")
+                    {
                         return new SystemObjectModelProvider(systemType, model);
+                    }
+
                     return new ModelProvider(model);
                 });
 
@@ -229,7 +238,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
                 createModelCore: (model) =>
                 {
                     if (model.Name == "Resource")
+                    {
                         return new SystemObjectModelProvider(systemType, model);
+                    }
+
                     return new ModelProvider(model);
                 });
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
@@ -372,7 +372,9 @@ namespace Microsoft.TypeSpec.Generator.Tests
             protected internal override EnumProvider? PreVisitEnum(InputEnumType enumType, EnumProvider? type)
             {
                 if (type == null)
+                {
                     return type;
+                }
 
                 // Create a new enum provider with modified namespace
                 // replace ".Models" with ".SomeOtherNamespace"

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/NugetPackageDownloaderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/NugetPackageDownloaderTests.cs
@@ -3,22 +3,22 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.TypeSpec.Generator.Tests.TestHelpers;
 using Microsoft.TypeSpec.Generator.Utilities;
 using Moq;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Repositories;
+using NuGet.RuntimeModel;
 using NuGet.Versioning;
 using NUnit.Framework;
-using Microsoft.TypeSpec.Generator.Tests.TestHelpers;
-using NuGet.Common;
-using System.IO;
-using NuGet.Repositories;
-using NuGet.Packaging;
-using NuGet.RuntimeModel;
 
 namespace Microsoft.TypeSpec.Generator.Tests.Utilities
 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/CodeWriterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Writers/CodeWriterTests.cs
@@ -515,7 +515,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Writers
             foreach (var bit in Enum.GetValues<TypeSignatureModifiers>())
             {
                 if (bit == TypeSignatureModifiers.None)
+                {
                     continue;
+                }
 
                 var expected = bit.ToString().ToLower();
                 if (modifiers.HasFlag(bit))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/ModelTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/ModelTests.cs
@@ -26,7 +26,10 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
         {
             var modelInstance = Activator.CreateInstance(typeof(T), true);
             if (modelInstance is null)
+            {
                 throw new Exception($"Unable to create a model instance of {typeof(T).Name}");
+            }
+
             return (T)modelInstance;
         }
 
@@ -70,7 +73,9 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
             var expectedSerializedString = GetExpectedResult(format);
 
             if (AssertFailures(strategy, format, serviceResponse, options))
+            {
                 return;
+            }
 
             T model = (T)strategy.Read(serviceResponse, ModelInstance, options);
 

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Authentication/OAuth2/OAuth2TestHelper.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Authentication/OAuth2/OAuth2TestHelper.cs
@@ -2,19 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
-using System.ClientModel.Primitives;
+using System.Buffers;
 using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.Net.Http.Headers;
+using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Buffers;
-using System.IO;
-using System.Net;
-using System.Reflection;
-using System.Text;
 using NUnit.Framework;
 
 namespace TestProjects.Spector.Tests.Http.Authentication.OAuth2
@@ -275,7 +275,10 @@ namespace TestProjects.Spector.Tests.Http.Authentication.OAuth2
                             int bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationTokenSource.Token).ConfigureAwait(false);
 #pragma warning restore // ReadAsync(Memory<>) overload is not available in all targets
                             if (bytesRead == 0)
+                            {
                                 break;
+                            }
+
                             await destination.WriteAsync(new ReadOnlyMemory<byte>(buffer, 0, bytesRead), cancellationTokenSource.Token).ConfigureAwait(false);
                         }
                     }

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Authentication/OAuth2/OAuth2Tests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Authentication/OAuth2/OAuth2Tests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
-using System.Threading.Tasks;
-using Authentication.OAuth2;
 using System.ClientModel;
-using static TestProjects.Spector.Tests.Http.Authentication.OAuth2.OAuth2TestHelper;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Authentication.OAuth2;
+using NUnit.Framework;
+using static TestProjects.Spector.Tests.Http.Authentication.OAuth2.OAuth2TestHelper;
 
 namespace TestProjects.Spector.Tests.Http.Authentication.Oauth2
 {

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Client/Structure/TwoOperationGroup/TwoOperationGroupTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Client/Structure/TwoOperationGroup/TwoOperationGroupTests.cs
@@ -5,8 +5,8 @@ extern alias ClientStructureTwoOperationGroup;
 using System.ClientModel;
 using System.Linq;
 using System.Threading.Tasks;
-using ClientStructureTwoOperationGroup::Client.Structure.TwoOperationGroup;
 using ClientStructureTwoOperationGroup::Client.Structure.Service;
+using ClientStructureTwoOperationGroup::Client.Structure.TwoOperationGroup;
 using NUnit.Framework;
 
 namespace TestProjects.Spector.Tests.Http.Client.Structure.TwoOperationGroup

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/Spread/SpreadTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/Spread/SpreadTests.cs
@@ -154,7 +154,9 @@ namespace TestProjects.Spector.Tests.Http.Parameters.Spread
         private static void ValidateConvenienceMethodParameters(MethodInfo method, IEnumerable<(Type ParameterType, string Name, bool IsRequired)> expected)
         {
             if (IsProtocolMethod(method))
+            {
                 return;
+            }
 
             expected = expected.Append((typeof(CancellationToken), "cancellationToken", false));
 

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Resiliency/SrvDriven/V2/SrvDrivenV2Tests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Resiliency/SrvDriven/V2/SrvDrivenV2Tests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-extern alias SrvDrivenV2;
 extern alias SrvDrivenV1;
+extern alias SrvDrivenV2;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SrvDrivenV2::Resiliency.ServiceDriven;

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Server/Endpoint/NotDefined/NotDefinedTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Server/Endpoint/NotDefined/NotDefinedTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Server.Endpoint.NotDefined;
-using System.Threading.Tasks;
 
 namespace TestProjects.Spector.Tests.Http.Server.Endpoint.NotDefined
 {

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Server/Path/Single/SingleTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Server/Path/Single/SingleTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Server.Path.Single;
-using System.Threading.Tasks;
 
 namespace TestProjects.Spector.Tests.Http.Server.Path.Single
 {

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialHeaders/Repeatability/RepeatabilityTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialHeaders/Repeatability/RepeatabilityTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
-using SpecialHeaders.Repeatability;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Linq;
+using NUnit.Framework;
+using SpecialHeaders.Repeatability;
 
 namespace TestProjects.Spector.Tests.Http.SpecialHeaders.Repeatability
 {

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Operations.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Operations.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
-using SpecialWords;
 using NUnit.Framework;
+using SpecialWords;
 
 namespace TestProjects.Spector.Tests.Http.SpecialWords
 {

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Parameters.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Parameters.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
-using SpecialWords;
 using NUnit.Framework;
+using SpecialWords;
 
 namespace TestProjects.Spector.Tests.Http.SpecialWords
 {

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Infrastructure/TestServerBase.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Infrastructure/TestServerBase.cs
@@ -97,7 +97,9 @@ namespace TestProjects.Spector.Tests
         public void Dispose()
         {
             if (_process is not null)
+            {
                 Stop(_process);
+            }
 
             _process?.Dispose();
             Client?.Dispose();

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/SpectorTestBase.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/SpectorTestBase.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
 using System;
+using System.Threading.Tasks;
 
 namespace TestProjects.Spector.Tests
 {


### PR DESCRIPTION
Upgrades the C# emitter `braces.cop` cop rule to use the cop library's new structural braces support, and extends it to enforce braces on **every** control-flow body.

## Changes
- **`cop-checks/braces.cop`** — replaced the previous line-text regex heuristic with the code provider's structural parse (`Statement.Braced` / `Statement.Children` / `isControlFlow`). Flags any unbraced `if` / `else` / `for` / `foreach` / `while` body, whether written inline or on its own line (Allman). Idiomatic `else if` chains (an unbraced `else` whose child is an `if`) are excluded, while the inner `if` is still checked.
- **`cop-checks/main.cop`** — wires the predicate to `cb.Statements` with an updated violation message.
- **`eng/scripts/Invoke-Cop.ps1`** — bumped the pinned cop release `v2026.6.10.1` → `v2026.6.23.2` (structural braces support).
- **179 existing violations fixed** across 77 `.cs` files by adding braces via the Roslyn IDE0011 add-braces fixer (`dotnet format style`).

## Validation
- `npm run cop` reports `cop checks passed.` (0 violations).
- `dotnet build Microsoft.TypeSpec.Generator.sln -c Release` succeeds with 0 warnings / 0 errors (StyleCop clean).