### PR TITLE
Allow C# api-version map option

### DIFF
--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -42,7 +42,7 @@ export interface CSharpEmitterOptions {
  * The JSON schema for the CSharp emitter options.
  * @beta
  */
-export const CSharpEmitterOptionsSchema = {
+export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = {
   type: "object",
   additionalProperties: false,
   properties: {
@@ -161,7 +161,7 @@ export const CSharpEmitterOptionsSchema = {
     },
   },
   required: [],
-} as unknown as JSONSchemaType<CSharpEmitterOptions>;
+};
 
 /**
  * The default options for the CSharp emitter.

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -1,4 +1,7 @@
-import { CreateSdkContextOptions } from "@azure-tools/typespec-client-generator-core";
+import {
+  CreateSdkContextOptions,
+  UnbrandedSdkEmitterOptions,
+} from "@azure-tools/typespec-client-generator-core";
 import { EmitContext, JSONSchemaType } from "@typespec/compiler";
 import { _defaultGeneratorName } from "./constants.js";
 import { DYNAMIC_MODEL_DECORATOR_PATTERN } from "./lib/decorators.js";
@@ -43,23 +46,7 @@ export const CSharpEmitterOptionsSchema = {
   type: "object",
   additionalProperties: false,
   properties: {
-    "api-version": {
-      oneOf: [
-        {
-          type: "string",
-          nullable: true,
-        },
-        {
-          type: "object",
-          additionalProperties: { type: "string" },
-          required: [],
-          nullable: true,
-        },
-      ],
-      description:
-        "For TypeSpec files using the [`@versioned`](https://typespec.io/docs/libraries/versioning/reference/decorators/#@TypeSpec.Versioning.versioned) decorator, " +
-        "set this option to the version that should be used to generate against. For multi-service packages, provide a map from service namespace full name to version.",
-    } as JSONSchemaType<ApiVersionSelection>,
+    ...UnbrandedSdkEmitterOptions["api-version"],
     "generate-protocol-methods": {
       type: "boolean",
       nullable: true,

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -46,7 +46,7 @@ export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = 
   type: "object",
   additionalProperties: false,
   properties: {
-    ...UnbrandedSdkEmitterOptions["api-version"],
+    "api-version": UnbrandedSdkEmitterOptions["api-version"]["api-version"],
     "generate-protocol-methods": {
       type: "boolean",
       nullable: true,

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -46,7 +46,7 @@ export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = 
   type: "object",
   additionalProperties: false,
   properties: {
-    "api-version": UnbrandedSdkEmitterOptions["api-version"]["api-version"],
+    ...UnbrandedSdkEmitterOptions["api-version"],
     "generate-protocol-methods": {
       type: "boolean",
       nullable: true,

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -8,8 +8,10 @@ import { LoggerLevel } from "./lib/logger-level.js";
  * The emitter options for the CSharp emitter.
  * @beta
  */
+export type ApiVersionSelection = string | Record<string, string>;
+
 export interface CSharpEmitterOptions {
-  "api-version"?: string;
+  "api-version"?: ApiVersionSelection;
   "unreferenced-types-handling"?: "removeOrInternalize" | "internalize" | "keepAll";
   "new-project"?: boolean;
   "save-inputs"?: boolean;
@@ -37,17 +39,27 @@ export interface CSharpEmitterOptions {
  * The JSON schema for the CSharp emitter options.
  * @beta
  */
-export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = {
+export const CSharpEmitterOptionsSchema = {
   type: "object",
   additionalProperties: false,
   properties: {
     "api-version": {
-      type: "string",
-      nullable: true,
+      oneOf: [
+        {
+          type: "string",
+          nullable: true,
+        },
+        {
+          type: "object",
+          additionalProperties: { type: "string" },
+          required: [],
+          nullable: true,
+        },
+      ],
       description:
         "For TypeSpec files using the [`@versioned`](https://typespec.io/docs/libraries/versioning/reference/decorators/#@TypeSpec.Versioning.versioned) decorator, " +
-        "set this option to the version that should be used to generate against.",
-    },
+        "set this option to the version that should be used to generate against. For multi-service packages, provide a map from service namespace full name to version.",
+    } as JSONSchemaType<ApiVersionSelection>,
     "generate-protocol-methods": {
       type: "boolean",
       nullable: true,
@@ -162,7 +174,7 @@ export const CSharpEmitterOptionsSchema: JSONSchemaType<CSharpEmitterOptions> = 
     },
   },
   required: [],
-};
+} as unknown as JSONSchemaType<CSharpEmitterOptions>;
 
 /**
  * The default options for the CSharp emitter.

--- a/packages/http-client-csharp/emitter/src/options.ts
+++ b/packages/http-client-csharp/emitter/src/options.ts
@@ -11,7 +11,7 @@ import { LoggerLevel } from "./lib/logger-level.js";
  * The emitter options for the CSharp emitter.
  * @beta
  */
-export type ApiVersionSelection = string | Record<string, string>;
+type ApiVersionSelection = string | Record<string, string>;
 
 export interface CSharpEmitterOptions {
   "api-version"?: ApiVersionSelection;

--- a/packages/http-client-csharp/emitter/test/Unit/emitter.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/emitter.test.ts
@@ -43,16 +43,21 @@ describe("$onEmit tests", () => {
         }),
       };
     });
-    vi.mock("@azure-tools/typespec-client-generator-core", () => ({
-      createSdkContext: vi.fn().mockImplementation(async (...args) => {
-        return {
-          sdkPackage: {},
-          emitContext: args[0],
-          program: args[0].program,
-          diagnostics: [],
-        };
-      }),
-    }));
+    vi.mock("@azure-tools/typespec-client-generator-core", async (importOriginal) => {
+      const actual =
+        await importOriginal<typeof import("@azure-tools/typespec-client-generator-core")>();
+      return {
+        ...actual,
+        createSdkContext: vi.fn().mockImplementation(async (...args) => {
+          return {
+            sdkPackage: {},
+            emitContext: args[0],
+            program: args[0].program,
+            diagnostics: [],
+          };
+        }),
+      };
+    });
 
     vi.mock("../../src/lib/exec-utils.js", () => ({
       execCSharpGenerator: vi.fn(),

--- a/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -1,7 +1,7 @@
 vi.resetModules();
 
-import { EmitContext, Program } from "@typespec/compiler";
 import { UnbrandedSdkEmitterOptions } from "@azure-tools/typespec-client-generator-core";
+import { EmitContext, Program } from "@typespec/compiler";
 import { ok, strictEqual } from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createConfiguration } from "../../src/emitter.js";

--- a/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -1,6 +1,7 @@
 vi.resetModules();
 
 import { EmitContext, Program } from "@typespec/compiler";
+import { UnbrandedSdkEmitterOptions } from "@azure-tools/typespec-client-generator-core";
 import { ok, strictEqual } from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createConfiguration } from "../../src/emitter.js";
@@ -189,21 +190,12 @@ describe("Configuration tests", async () => {
   });
 
   it("api-version schema accepts a string or namespace-to-version map", () => {
-    const schema = CSharpEmitterOptionsSchema.properties["api-version"] as {
+    const schema = CSharpEmitterOptionsSchema.properties["api-version"];
+    const tcgcSchema = UnbrandedSdkEmitterOptions["api-version"]["api-version"] as {
       oneOf?: unknown[];
     };
 
-    expect(schema.oneOf).toEqual([
-      {
-        type: "string",
-        nullable: true,
-      },
-      {
-        type: "object",
-        additionalProperties: { type: "string" },
-        required: [],
-        nullable: true,
-      },
-    ]);
+    expect(schema).toBe(tcgcSchema);
+    expect(tcgcSchema.oneOf).toBeDefined();
   });
 });

--- a/packages/http-client-csharp/emitter/test/Unit/options.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/options.test.ts
@@ -4,7 +4,7 @@ import { EmitContext, Program } from "@typespec/compiler";
 import { ok, strictEqual } from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createConfiguration } from "../../src/emitter.js";
-import { CSharpEmitterOptions } from "../../src/options.js";
+import { CSharpEmitterOptions, CSharpEmitterOptionsSchema } from "../../src/options.js";
 import {
   createCSharpSdkContext,
   createEmitterContext,
@@ -186,5 +186,24 @@ describe("Configuration tests", async () => {
     const config = createConfiguration(options, "namespace", sdkContext);
 
     expect(config["plugins"]).toBeUndefined();
+  });
+
+  it("api-version schema accepts a string or namespace-to-version map", () => {
+    const schema = CSharpEmitterOptionsSchema.properties["api-version"] as {
+      oneOf?: unknown[];
+    };
+
+    expect(schema.oneOf).toEqual([
+      {
+        type: "string",
+        nullable: true,
+      },
+      {
+        type: "object",
+        additionalProperties: { type: "string" },
+        required: [],
+        nullable: true,
+      },
+    ]);
   });
 });

--- a/packages/http-client-csharp/package-lock.json
+++ b/packages/http-client-csharp/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
         "@azure-tools/typespec-azure-core": "0.69.0",
-        "@azure-tools/typespec-client-generator-core": "0.69.0",
+        "@azure-tools/typespec-client-generator-core": "0.69.1",
         "@microsoft/api-extractor": "^7.52.2",
         "@types/node": "~22.12.0",
         "@typespec/compiler": "1.13.0",
@@ -39,7 +39,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.69.1 <0.70.0 || ~0.70.0-0",
         "@typespec/compiler": "^1.13.0",
         "@typespec/http": "^1.13.0",
         "@typespec/openapi": "^1.13.0",
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.69.0.tgz",
-      "integrity": "sha512-ro8zzOeiN/74r0wM19R77gzLtbfjIFgKgr1Rusii/vhCfJIoVC7IcqLxhbJl0RVkjyhRFKt4GCRAw4iurnrDnw==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.69.1.tgz",
+      "integrity": "sha512-v84ZTh9lffTyjUSfMzZMDPv+fHjXJO/LpYT+V73Zco9YL8fC6o7ou2hvSlWTnMW2KIIrymdM3AyXONxSIZUEBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -59,7 +59,7 @@
   ],
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
-    "@azure-tools/typespec-client-generator-core": ">=0.69.0 <0.70.0 || ~0.70.0-0",
+    "@azure-tools/typespec-client-generator-core": ">=0.69.1 <0.70.0 || ~0.70.0-0",
     "@typespec/compiler": "^1.13.0",
     "@typespec/http": "^1.13.0",
     "@typespec/openapi": "^1.13.0",
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.42",
     "@azure-tools/typespec-azure-core": "0.69.0",
-    "@azure-tools/typespec-client-generator-core": "0.69.0",
+    "@azure-tools/typespec-client-generator-core": "0.69.1",
     "@microsoft/api-extractor": "^7.52.2",
     "@types/node": "~22.12.0",
     "@typespec/compiler": "1.13.0",

--- a/packages/http-client-csharp/readme.md
+++ b/packages/http-client-csharp/readme.md
@@ -55,9 +55,14 @@ See [Configuring output directory for more info](https://typespec.io/docs/handbo
 
 ### `api-version`
 
-**Type:** `string | Record<string, string>`
+**Type:** `string | object`
 
-For TypeSpec files using the [`@versioned`](https://typespec.io/docs/libraries/versioning/reference/decorators/#@TypeSpec.Versioning.versioned) decorator, set this option to the version that should be used to generate against. For multi-service packages, provide a map from service namespace full name to version.
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+
+**Options:**
+
+- `string`
+- `object`
 
 ### `generate-protocol-methods`
 

--- a/packages/http-client-csharp/readme.md
+++ b/packages/http-client-csharp/readme.md
@@ -55,9 +55,9 @@ See [Configuring output directory for more info](https://typespec.io/docs/handbo
 
 ### `api-version`
 
-**Type:** `string`
+**Type:** `string | Record<string, string>`
 
-For TypeSpec files using the [`@versioned`](https://typespec.io/docs/libraries/versioning/reference/decorators/#@TypeSpec.Versioning.versioned) decorator, set this option to the version that should be used to generate against.
+For TypeSpec files using the [`@versioned`](https://typespec.io/docs/libraries/versioning/reference/decorators/#@TypeSpec.Versioning.versioned) decorator, set this option to the version that should be used to generate against. For multi-service packages, provide a map from service namespace full name to version.
 
 ### `generate-protocol-methods`
 

--- a/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
@@ -38,9 +38,14 @@ See [Configuring output directory for more info](https://typespec.io/docs/handbo
 
 ### `api-version`
 
-**Type:** `string`
+**Type:** `string | object`
 
-For TypeSpec files using the [`@versioned`](https://typespec.io/docs/libraries/versioning/reference/decorators/#@TypeSpec.Versioning.versioned) decorator, set this option to the version that should be used to generate against.
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+
+**Options:**
+
+- `string`
+- `object`
 
 ### `generate-protocol-methods`
 


### PR DESCRIPTION
## Summary
- Reuse TCGC's exported api-version option schema in the C# emitter so it accepts either a string or a namespace-to-version map.
- Bump the C# emitter's TCGC dependency to 0.69.1, where that schema shape is exposed.
- Update the option schema test and README documentation.

## Validation
- npm run build
- npm run test:emitter -- --run emitter/test/Unit/options.test.ts