### PR TITLE
Skip model-factory generation for externally-linked types

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -488,6 +488,16 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         private static ModelProvider? GetModelToInstantiateForFactoryMethod(ModelProvider modelProvider)
         {
+            // Externally-linked models are reused from another shipped package (e.g. the OpenAI .NET
+            // SDK), so this library does not own or emit their constructors. Their real constructor
+            // surface (accessibility and parameter set) is unknown here; emitting a
+            // `new ExternalType(...)` mocking factory produces calls that may be inaccessible
+            // (protected/internal) or have a non-matching arity. Skip factory generation for them.
+            if (modelProvider.IsExternal)
+            {
+                return null;
+            }
+
             var fullConstructor = modelProvider.FullConstructor;
             if (modelProvider.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Internal)
                 || fullConstructor.Signature.Parameters.Any(p => !p.Type.IsPublic && !IsEnumDiscriminator(p)))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -77,6 +77,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         public bool IsUnknownDiscriminatorModel => _inputModel.IsUnknownDiscriminatorModel;
 
+        // Whether this model is reused from another shipped package (linked via an `external` block)
+        // rather than emitted by this library. Such a type's constructor surface is owned elsewhere.
+        internal bool IsExternal => _inputModel.External is not null;
+
         public string? DiscriminatorValue => _inputModel.DiscriminatorValue;
 
         private ValueExpression? _discriminatorValueExpression;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -33,6 +33,26 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         }
 
         [Test]
+        public void SkipExternalModels()
+        {
+            var external = new InputExternalTypeMetadata("OpenAI.Responses.ResponseTool", "OpenAI", "2.11.0");
+            var externalModel = InputFactory.Model("ExternalTool", external: external);
+            var localModel = InputFactory.Model("LocalThing");
+            var instance = MockHelpers.LoadMockGenerator(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: [externalModel, localModel]).Object;
+
+            var modelFactory = instance.OutputLibrary.ModelFactory.Value;
+
+            Assert.IsNull(
+                modelFactory.Methods.FirstOrDefault(m => m.Signature.Name == "ExternalTool"),
+                "Externally-linked models must not get a model factory method.");
+            Assert.IsNotNull(
+                modelFactory.Methods.FirstOrDefault(m => m.Signature.Name == "LocalThing"),
+                "Local models must still get a model factory method.");
+        }
+
+        [Test]
         public void ListParamShape()
         {
             var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;


### PR DESCRIPTION
 Problem

  ModelFactoryProvider  emits a mocking factory method — and a  new T(...)  call — for every model, including  types that are externally linked to another shipped package via an external block (e.g. types reused from the OpenAI .NET SDK). The generator only knows the external type's identity/package/version, not its real constructor surface, so it synthesizes a constructor call from the input model's properties and assumes it's callable. When the external package's actual constructor is protected / internal , or has a different parameter set, the generated code does not compile.

 Observed downstream in  Azure.AI.Extensions.OpenAI  (reuses OpenAI.Responses.*  types):

 • CS0122 —  new ResponseTool(ResponseToolKind)  is  protected internal in the OpenAI SDK.
 • CS1729 —  new ResponseItem(kind, id, agentReference, responseId) : no 4-arg ctor exists (OpenAI exposes only 1-    and 3-arg ctors).

 Fix

Skip factory generation for externally-linked models. A library does not own or emit constructors for types it reuses from another package, so it must not construct them in its model factory.

 •  Providers/ModelProvider.cs : add internal bool IsExternal => _inputModel.External is not null; 
 •  Providers/ModelFactoryProvider.cs : guard at the top of  GetModelToInstantiateForFactoryMethod  returns null     when  modelProvider.IsExternal . This single chokepoint feeds both the main and back-compat loops, which    already handle a null  return.

 Local/Azure subtypes that merely derive from an external base are unaffected (their own External is null), so their factory methods are retained.

 Tests

 Added  ModelFactoryProviderTests.SkipExternalModels : an externally-linked model produces no factory method; a local model still does.

 Validation

 • Core generator builds clean;  ModelFactoryProviderTests  24/24 pass.
 • End-to-end: regenerated  Azure.AI.Extensions.OpenAI  with the patched generator — the     ResponseTool / ResponseItem  factory methods are gone and the package build reports 0 CS0122 / 0 CS1729    (remaining errors are an unrelated pre-existing CS0144 issue).