### PR TITLE
Fix formatter regression for union as named template argument

### DIFF
--- a/.chronus/changes/fix-named-union-template-arg-format-2026-6-25-9-50-0.md
+++ b/.chronus/changes/fix-named-union-template-arg-format-2026-6-25-9-50-0.md
@@ -1,5 +1,5 @@
 ---
-changeKind: fix
+changeKind: internal
 packages:
   - "@typespec/compiler"
 ---

--- a/.chronus/changes/fix-named-union-template-arg-format-2026-6-25-9-50-0.md
+++ b/.chronus/changes/fix-named-union-template-arg-format-2026-6-25-9-50-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix formatter regression where a `union` used as a named template argument lost its leading `|` indentation

--- a/packages/compiler/src/formatter/print/printer.ts
+++ b/packages/compiler/src/formatter/print/printer.ts
@@ -1446,7 +1446,15 @@ export function printUnion(
 function isInMultiTemplateArgumentList(path: AstPath<Node>): boolean {
   // A `TemplateArgument` only ever lives in `TypeReference.arguments`, so the
   // owning `TypeReference` is always the next node ancestor.
-  if (path.getParentNode()?.kind !== SyntaxKind.TemplateArgument) {
+  const argument = path.getParentNode();
+  if (argument?.kind !== SyntaxKind.TemplateArgument) {
+    return false;
+  }
+  // Named arguments (`Name = <union>`) print the union after `Name = `, so the
+  // argument list's line break + indent does not apply to the union variants.
+  // The union must therefore provide its own line break + indent like a
+  // standalone union. https://github.com/microsoft/typespec/issues/11092
+  if (argument.name !== undefined) {
     return false;
   }
   const reference = path.getParentNode(1);

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -2018,6 +2018,29 @@ model Picked
       });
     });
 
+    // Regression test for https://github.com/microsoft/typespec/issues/11092
+    it("keeps leading | and indent for a union used as a named template argument", async () => {
+      await assertFormat({
+        code: `
+model Test<A, TakesALongUnion> {}
+
+alias Alias = Test<A = "Some long value", TakesALongUnion = string | int32 | int64 | "Some very long string that split line">;
+`,
+        expected: `
+model Test<A, TakesALongUnion> {}
+
+alias Alias = Test<
+  A = "Some long value",
+  TakesALongUnion =
+    | string
+    | int32
+    | int64
+    | "Some very long string that split line"
+>;
+`,
+      });
+    });
+
     // Regression test for https://github.com/microsoft/typespec/issues/11009
     it("keeps the variant alignment so a nested template argument stays indented", async () => {
       await assertFormat({


### PR DESCRIPTION
Fixes #11092

## Problem

PR #11010 fixed a blank-line / over-indent issue when a `union` expression is used as one of several **positional** template arguments. That fix made `printUnion` suppress its own leading line + indent when the union is a direct argument of a multi-argument template reference (the surrounding argument list already supplies them).

This regressed the **named** template argument case (`Name = <union>`). For a named argument the union is printed *after* `Name = `, so the argument list's line break / indent does **not** apply to the union variants. Suppressing the union's own break + indent collapsed the variants:

```tsp
alias Alias = Test<
  A = "Some long value",
  TakesALongUnion = | string
  | int32
  | int64
  | "Some very long string that split line"
>;
```

## Fix

`isInMultiTemplateArgumentList` now returns `false` when the parent `TemplateArgument` has a `name`. Named-argument unions fall back to the standalone behavior (their own leading `line` + `| ` + indent):

```tsp
alias Alias = Test<
  A = "Some long value",
  TakesALongUnion =
    | string
    | int32
    | int64
    | "Some very long string that split line"
>;
```

The single-argument case and the positional multi-argument case (#11009) are unchanged.

## Tests

- Added a regression test for the named-union multi-argument case (#11092).
- Existing #11009 positional tests still pass; full formatter suite (216 tests) passes.
- `prettier --check "**/*.tsp"` clean; compiler builds.