### PR TITLE
[http-client-csharp] Fix sub-client endpoint type when root endpoint is a hostname string

### DIFF
--- a/.chronus/changes/fix-subclient-endpoint-uri-type-2026-6-25-9-45-0.md
+++ b/.chronus/changes/fix-subclient-endpoint-uri-type-2026-6-25-9-45-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Fix sub-client constructor to accept the endpoint as a `Uri` when the root client takes the endpoint as a hostname `string`. Previously the sub-client's `_endpoint` field was typed `Uri` while its constructor parameter (and the value passed by the parent) was a `string`, producing generated code that did not compile (CS0029/CS1503).

--- a/.chronus/changes/fix-subclient-endpoint-uri-type-2026-6-25-9-45-0.md
+++ b/.chronus/changes/fix-subclient-endpoint-uri-type-2026-6-25-9-45-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@typespec/http-client-csharp"
----
-
-Fix sub-client constructor to accept the endpoint as a `Uri` when the root client takes the endpoint as a hostname `string`. Previously the sub-client's `_endpoint` field was typed `Uri` while its constructor parameter (and the value passed by the parent) was a `string`, producing generated code that did not compile (CS0029/CS1503).

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -46,6 +46,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         internal InputClient InputClient => _inputClient;
         private readonly InputAuth? _inputAuth;
         private readonly ParameterProvider _endpointParameter;
+        private readonly ParameterProvider _subClientEndpointParameter;
         /// <summary>
         /// This field is not one of the fields in this client, but the field in my parent client to get myself.
         /// </summary>
@@ -104,6 +105,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             _inputClient = inputClient;
             _inputAuth = ScmCodeModelGenerator.Instance.InputLibrary.InputNamespace.Auth;
             _endpointParameter = BuildClientEndpointParameter();
+            _subClientEndpointParameter = BuildSubClientEndpointParameter();
             _publicCtorDescription = $"Initializes a new instance of {Name}.";
             ClientOptions = _inputClient.Parent is null ? ClientOptionsProvider.CreateClientOptionsProvider(_inputClient, this) : null;
             ClientOptionsParameter = ClientOptions != null ? ScmKnownParameters.ClientOptions(ClientOptions.Type) : null;
@@ -311,7 +313,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
             // Auth credentials are NOT included here — the parent passes its authenticated
             // pipeline, so the sub-client doesn't need separate credential parameters.
-            subClientParameters.Add(_endpointParameter);
+            subClientParameters.Add(_subClientEndpointParameter);
             subClientParameters.AddRange(ClientParameters);
 
             return subClientParameters;
@@ -573,7 +575,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
                 if (_canBeInitializedByParent)
                 {
-                    List<MethodBodyStatement> body = new(3) { EndpointField.Assign(_endpointParameter).Terminate() };
+                    List<MethodBodyStatement> body = new(3) { EndpointField.Assign(_subClientEndpointParameter).Terminate() };
                     foreach (var p in _subClientInternalConstructorParams.Value)
                     {
                         var assignment = p.Field?.Assign(p).Terminate() ?? p.Property?.Assign(p).Terminate();
@@ -1436,6 +1438,31 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 KnownParameters.Endpoint.Description,
                 KnownParameters.Endpoint.Type,
                 initializationValue: initializationValue)
+            {
+                Validation = ParameterValidationType.AssertNotNull
+            };
+        }
+
+        /// <summary>
+        /// Builds the endpoint parameter used by the internal constructor that a parent client uses
+        /// to initialize this sub-client. The sub-client receives the already-resolved endpoint
+        /// <see cref="Uri"/> from its parent (the parent's <c>_endpoint</c> field) and assigns it
+        /// directly to its own <see cref="Uri"/>-typed <c>_endpoint</c> field. The server URL template
+        /// is only expanded on the root client, so when the public/root endpoint parameter is a string
+        /// hostname the sub-client must instead accept a <see cref="Uri"/> parameter to avoid a type
+        /// mismatch between the parameter and both the field and the argument passed by the parent.
+        /// </summary>
+        private ParameterProvider BuildSubClientEndpointParameter()
+        {
+            if (!_endpointParameter.Type.Equals(typeof(string)))
+            {
+                return _endpointParameter;
+            }
+
+            return new(
+                KnownParameters.Endpoint.Name,
+                KnownParameters.Endpoint.Description,
+                KnownParameters.Endpoint.Type)
             {
                 Validation = ParameterValidationType.AssertNotNull
             };

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
@@ -849,6 +849,52 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
             Assert.IsNotNull(mockingConstructor);
         }
 
+        // Regression test: when the root client takes the endpoint as a hostname string and expands
+        // a server URL template into a Uri, the sub-client must receive that already-resolved Uri from
+        // its parent. The sub-client's internal (parent-initialized) constructor must therefore declare
+        // the endpoint parameter as Uri to match the Uri _endpoint field and the Uri argument the parent
+        // passes, otherwise the generated code fails to compile (CS0029/CS1503).
+        [Test]
+        public void TestBuildConstructors_ForSubClient_StringHostnameEndpoint_UsesUriEndpointParameter()
+        {
+            var endpointParameter = InputFactory.EndpointParameter(
+                KnownParameters.Endpoint.Name,
+                InputPrimitiveType.String,
+                serverUrlTemplate: "https://{endpoint}",
+                scope: InputParameterScope.Client,
+                isEndpoint: true);
+            var parentClient = InputFactory.Client("ParentClient", parameters: [endpointParameter]);
+            var subClient = InputFactory.Client(
+                "SubClient",
+                parent: parentClient,
+                parameters: [endpointParameter],
+                initializedBy: InputClientInitializedBy.Parent);
+
+            MockHelpers.LoadMockGenerator(
+                auth: () => new(new InputApiKeyAuth("mock", null), null),
+                clients: () => [parentClient]);
+
+            var clientProvider = new ClientProvider(subClient);
+            Assert.IsNotNull(clientProvider);
+
+            // The endpoint field is always Uri.
+            var endpointField = clientProvider.Fields.FirstOrDefault(f => f.Name == "_endpoint");
+            Assert.IsNotNull(endpointField, "Sub-client should have an _endpoint field");
+            Assert.AreEqual(new CSharpType(typeof(Uri)), endpointField!.Type, "_endpoint field should be Uri");
+
+            // The internal constructor used by the parent takes the pipeline as its first parameter.
+            var internalConstructor = clientProvider.Constructors.FirstOrDefault(
+                c => c.Signature?.Modifiers == MethodSignatureModifiers.Internal
+                    && c.Signature.Parameters.Any(p => p.Name == "pipeline"));
+            Assert.IsNotNull(internalConstructor, "Sub-client should have an internal parent-initialization constructor");
+
+            var endpointCtorParam = internalConstructor!.Signature.Parameters
+                .FirstOrDefault(p => p.Name == KnownParameters.Endpoint.Name);
+            Assert.IsNotNull(endpointCtorParam, "Sub-client internal constructor should have an endpoint parameter");
+            Assert.AreEqual(new CSharpType(typeof(Uri)), endpointCtorParam!.Type,
+                "Sub-client internal constructor endpoint parameter should be Uri, not string");
+        }
+
         [Test]
         public void TestBuildConstructors_ForSubClient_InitializedByBoth_HasBothConstructors()
         {


### PR DESCRIPTION
## Summary

Fixes generated C# (`@typespec/http-client-csharp`) that does not compile when the root client takes the endpoint as a hostname `string` and the service has sub-clients initialized by their parent.

This was reported for the `Azure.IoT.DeviceUpdate` data-plane SDK after its Swagger → TypeSpec migration. The server is declared as a hostname string:

```typespec
@server("https://{endpoint}", "", { endpoint: string })
```

## Root cause

- The generated `_endpoint` field is always a `Uri`.
- A parent client converts the hostname `string` into a `Uri` and passes that `Uri _endpoint` to each of its sub-clients.
- But the sub-client's internal (parent-initialized) constructor reused the **root/public** endpoint parameter, which for a hostname server URL template is a `string`.

This produced two compile errors in the generated sub-client:

```csharp
private readonly Uri _endpoint;

internal DeviceUpdate(ClientPipeline pipeline, string endpoint, string instanceId)
{
    _endpoint = endpoint; // CS0029: cannot convert string to Uri
}
// ...and the parent call `new DeviceUpdate(_pipeline, _endpoint, ...)` passes Uri to a string param → CS1503
```

The template is expanded into a `Uri` only on the root client, so only the root (and individually-initialized sub-client public constructors) should accept the hostname `string`.

## Fix

Sub-clients now use a dedicated `Uri` endpoint parameter for the parent-initialized internal constructor (`BuildSubClientEndpointParameter`). This matches the `Uri _endpoint` field and the `Uri` argument the parent passes. When the endpoint parameter is already a `Uri` (e.g. the server is declared with `url`), behavior is unchanged. The string-hostname handling — template expansion on the root, and `string`-accepting public constructors on individually-initialized sub-clients — is preserved.

## Validation

- `Microsoft.TypeSpec.Generator.ClientModel` test suite — **1439/1439 pass**.
- Added regression test `TestBuildConstructors_ForSubClient_StringHostnameEndpoint_UsesUriEndpointParameter`, which builds a root client with a `https://{endpoint}` server URL template and a parent-initialized sub-client and asserts the sub-client's internal constructor endpoint parameter (and `_endpoint` field) are `Uri`.

## Notes

The same DeviceUpdate spec surfaces an unrelated client-namespace disambiguation (`_DeviceUpdate`) which is by-design TCGC behavior (a client named `DeviceUpdate` collides with the namespace tail) and is out of scope for this PR.
