### PR TITLE
Fix MRW JSON write core override for custom bases

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.Xml.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.Xml.cs
@@ -67,7 +67,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             MethodSignatureModifiers modifiers = _isStruct
                 ? MethodSignatureModifiers.Private
                 : MethodSignatureModifiers.Internal | MethodSignatureModifiers.Virtual;
-            if (_shouldOverrideMethods)
+            if (_shouldOverrideXmlMethods)
             {
                 modifiers = MethodSignatureModifiers.Internal | MethodSignatureModifiers.Override;
             }
@@ -81,7 +81,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         private MethodBodyStatement[] BuildXmlModelWriteCoreMethodBody()
         {
-            var categorizedProperties = _shouldOverrideMethods
+            var categorizedProperties = _shouldOverrideXmlMethods
                 ? CategorizedXmlProperties
                 : AllCategorizedXmlProperties;
             var statements = new List<MethodBodyStatement>
@@ -90,7 +90,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 MethodBodyStatement.EmptyLine
             };
 
-            if (_shouldOverrideMethods)
+            if (_shouldOverrideXmlMethods)
             {
                 statements.Add(Base.Invoke(XmlModelWriteCoreMethodName, _xmlWriterParameter, _serializationOptionsParameter).Terminate());
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -53,10 +53,14 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private readonly ScopedApi<ModelReaderWriterOptions> _mrwOptionsParameterSnippet;
         private readonly ScopedApi<JsonElement> _jsonElementParameterSnippet;
         private readonly ScopedApi<bool> _isNotEqualToWireConditionSnippet;
-        private readonly CSharpType _jsonModelTInterface;
-        private readonly CSharpType? _jsonModelObjectInterface;
-        private readonly CSharpType _persistableModelTInterface;
-        private readonly CSharpType? _persistableModelObjectInterface;
+        // These interface types depend on _model.Type. Build them lazily so we do not cache a
+        // CSharpType before delayed base model resolution has updated the model's inheritance.
+        private CSharpType? _jsonModelTInterfaceValue;
+        private CSharpType _jsonModelTInterface => _jsonModelTInterfaceValue ??= new CSharpType(typeof(IJsonModel<>), SerializationInterfaceType.Type);
+        private CSharpType? _jsonModelObjectInterface => _isStruct ? (CSharpType)typeof(IJsonModel<object>) : null;
+        private CSharpType? _persistableModelTInterfaceValue;
+        private CSharpType _persistableModelTInterface => _persistableModelTInterfaceValue ??= new CSharpType(typeof(IPersistableModel<>), SerializationInterfaceType.Type);
+        private CSharpType? _persistableModelObjectInterface => _isStruct ? (CSharpType)typeof(IPersistableModel<object>) : null;
         private readonly ModelProvider _model;
         private readonly InputModelType _inputModel;
         private readonly FieldProvider? _rawDataField;
@@ -67,9 +71,17 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private readonly bool _supportsXml;
         private ConstructorProvider? _serializationConstructor;
         // Flag to determine if the model should override the serialization methods
-        private readonly bool _shouldOverrideMethods;
-        private readonly bool _shouldSkipDerivedSerializationMethodOverrides;
+        private bool ShouldOverrideMethods => _model.BaseModelProvider != null && !_isStruct;
+        private bool ShouldSkipSerializationMethodOverrides => ShouldSkipDerivedSerializationMethodOverrides(_model.BaseModelProvider);
+        private readonly bool _shouldOverrideXmlMethods;
         private readonly Lazy<PropertyProvider[]> _additionalProperties;
+
+        // Unknown discriminator models use their base model as the serialization interface type.
+        // This can also touch model.Type, so defer it until serialization method/interface emission.
+        private TypeProvider SerializationInterfaceType => _serializationInterfaceType ??= _inputModel.IsUnknownDiscriminatorModel
+            ? ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(_inputModel.BaseModel!)!
+            : _model;
+        private TypeProvider? _serializationInterfaceType;
 
         private CSharpType RootType => _rootType ??= GetRootModelType();
         private CSharpType? _rootType;
@@ -84,17 +96,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             _isStruct = _model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Struct);
             _supportsXml = inputModel.Usage.HasFlag(InputModelTypeUsage.Xml);
             _supportsJson = inputModel.Usage.HasFlag(InputModelTypeUsage.Json) || !_supportsXml;
-            // Initialize the serialization interfaces
-            var interfaceType = inputModel.IsUnknownDiscriminatorModel ? ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputModel.BaseModel!)! : _model;
-            _jsonModelTInterface = new CSharpType(typeof(IJsonModel<>), interfaceType.Type);
-            _jsonModelObjectInterface = _isStruct ? (CSharpType)typeof(IJsonModel<object>) : null;
-            _persistableModelTInterface = new CSharpType(typeof(IPersistableModel<>), interfaceType.Type);
-            _persistableModelObjectInterface = _isStruct ? (CSharpType)typeof(IPersistableModel<object>) : null;
+            _shouldOverrideXmlMethods = _model.BaseModelProvider != null && !_isStruct;
             _rawDataField = _model.Fields.FirstOrDefault(f => f.Name == AdditionalPropertiesHelper.AdditionalBinaryDataPropsFieldName);
             _additionalBinaryDataProperty = new(GetAdditionalBinaryDataPropertiesProp);
             _additionalProperties = new(() => [.. _model.Properties.Where(p => p.IsAdditionalProperties)]);
-            _shouldOverrideMethods = _model.BaseModelProvider != null && !_isStruct;
-            _shouldSkipDerivedSerializationMethodOverrides = ShouldSkipDerivedSerializationMethodOverrides(_model.BaseModelProvider);
             _utf8JsonWriterSnippet = _utf8JsonWriterParameter.As<Utf8JsonWriter>();
             _mrwOptionsParameterSnippet = _serializationOptionsParameter.As<ModelReaderWriterOptions>();
             _jsonElementParameterSnippet = _jsonElementDeserializationParam.As<JsonElement>();
@@ -530,7 +535,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             MethodSignatureModifiers modifiers = _isStruct
                 ? MethodSignatureModifiers.Private
                 : MethodSignatureModifiers.Protected | MethodSignatureModifiers.Virtual;
-            if (_shouldOverrideMethods)
+            if (ShouldOverrideMethods)
             {
                 modifiers = MethodSignatureModifiers.Protected | MethodSignatureModifiers.Override;
             }
@@ -552,7 +557,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 ? MethodSignatureModifiers.Private
                 : MethodSignatureModifiers.Protected | MethodSignatureModifiers.Virtual;
 
-            if (_shouldOverrideMethods && !_shouldSkipDerivedSerializationMethodOverrides)
+            if (ShouldOverrideMethods && !ShouldSkipSerializationMethodOverrides)
             {
                 modifiers = MethodSignatureModifiers.Protected | MethodSignatureModifiers.Override;
             }
@@ -576,7 +581,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 ? MethodSignatureModifiers.Private
                 : MethodSignatureModifiers.Protected | MethodSignatureModifiers.Virtual;
 
-            if (_shouldOverrideMethods && !_shouldSkipDerivedSerializationMethodOverrides)
+            if (ShouldOverrideMethods && !ShouldSkipSerializationMethodOverrides)
             {
                 modifiers = MethodSignatureModifiers.Protected | MethodSignatureModifiers.Override;
             }
@@ -624,7 +629,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 ? MethodSignatureModifiers.Private
                 : MethodSignatureModifiers.Protected | MethodSignatureModifiers.Virtual;
 
-            if (_shouldOverrideMethods && !_shouldSkipDerivedSerializationMethodOverrides)
+            if (ShouldOverrideMethods && !ShouldSkipSerializationMethodOverrides)
             {
                 modifiers = MethodSignatureModifiers.Protected | MethodSignatureModifiers.Override;
             }
@@ -1055,7 +1060,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private MethodBodyStatement CallBaseJsonModelWriteCore(bool isDynamicModelWithNonDynamicBase)
         {
             // base.<JsonModelWriteCore>()
-            bool callBaseWriteMethod = _shouldOverrideMethods
+            bool callBaseWriteMethod = ShouldOverrideMethods
                 && (_jsonPatchProperty is null || !isDynamicModelWithNonDynamicBase);
             return callBaseWriteMethod ?
                 Base.Invoke(JsonModelWriteCoreMethodName, [_utf8JsonWriterParameter, _serializationOptionsParameter]).Terminate()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -57,10 +57,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         // CSharpType before delayed base model resolution has updated the model's inheritance.
         private CSharpType? _jsonModelTInterfaceValue;
         private CSharpType _jsonModelTInterface => _jsonModelTInterfaceValue ??= new CSharpType(typeof(IJsonModel<>), SerializationInterfaceType.Type);
-        private CSharpType? _jsonModelObjectInterface => _isStruct ? (CSharpType)typeof(IJsonModel<object>) : null;
+        private CSharpType? _jsonModelObjectInterface;
+        private CSharpType? JsonModelObjectInterface => _isStruct ? _jsonModelObjectInterface ??= (CSharpType)typeof(IJsonModel<object>) : null;
         private CSharpType? _persistableModelTInterfaceValue;
         private CSharpType _persistableModelTInterface => _persistableModelTInterfaceValue ??= new CSharpType(typeof(IPersistableModel<>), SerializationInterfaceType.Type);
-        private CSharpType? _persistableModelObjectInterface => _isStruct ? (CSharpType)typeof(IPersistableModel<object>) : null;
+        private CSharpType? _persistableModelObjectInterface;
+        private CSharpType? PersistableModelObjectInterface => _isStruct ? _persistableModelObjectInterface ??= (CSharpType)typeof(IPersistableModel<object>) : null;
         private readonly ModelProvider _model;
         private readonly InputModelType _inputModel;
         private readonly FieldProvider? _rawDataField;
@@ -71,8 +73,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private readonly bool _supportsXml;
         private ConstructorProvider? _serializationConstructor;
         // Flag to determine if the model should override the serialization methods
-        private bool ShouldOverrideMethods => _model.BaseModelProvider != null && !_isStruct;
-        private bool ShouldSkipSerializationMethodOverrides => ShouldSkipDerivedSerializationMethodOverrides(_model.BaseModelProvider);
+        private bool? _shouldOverrideMethods;
+        private bool ShouldOverrideMethods => _shouldOverrideMethods ??= _model.BaseModelProvider != null && !_isStruct;
+        private bool? _shouldSkipSerializationMethodOverrides;
+        private bool ShouldSkipSerializationMethodOverrides => _shouldSkipSerializationMethodOverrides ??= ShouldSkipDerivedSerializationMethodOverrides(_model.BaseModelProvider);
         private readonly bool _shouldOverrideXmlMethods;
         private readonly Lazy<PropertyProvider[]> _additionalProperties;
 
@@ -434,17 +438,19 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             if (_supportsJson)
             {
                 interfaces.Add(_jsonModelTInterface);
-                if (_jsonModelObjectInterface != null)
+                var jsonModelObjectInterface = JsonModelObjectInterface;
+                if (jsonModelObjectInterface != null)
                 {
-                    interfaces.Add(_jsonModelObjectInterface);
+                    interfaces.Add(jsonModelObjectInterface);
                 }
             }
             else if (_supportsXml)
             {
                 interfaces.Add(_persistableModelTInterface);
-                if (_persistableModelObjectInterface != null)
+                var persistableModelObjectInterface = PersistableModelObjectInterface;
+                if (persistableModelObjectInterface != null)
                 {
-                    interfaces.Add(_persistableModelObjectInterface);
+                    interfaces.Add(persistableModelObjectInterface);
                 }
             }
 
@@ -474,7 +480,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var castToT = This.CastTo(_jsonModelTInterface);
             return new MethodProvider
             (
-              new MethodSignature(nameof(IJsonModel<object>.Write), null, MethodSignatureModifiers.None, null, null, [_utf8JsonWriterParameter, _serializationOptionsParameter], ExplicitInterface: _jsonModelObjectInterface),
+              new MethodSignature(nameof(IJsonModel<object>.Write), null, MethodSignatureModifiers.None, null, null, [_utf8JsonWriterParameter, _serializationOptionsParameter], ExplicitInterface: JsonModelObjectInterface),
               castToT.Invoke(nameof(IJsonModel<object>.Write), [_utf8JsonWriterParameter, _serializationOptionsParameter]),
               this
             );
@@ -489,7 +495,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var castToT = This.CastTo(_jsonModelTInterface);
             return new MethodProvider
             (
-              new MethodSignature(nameof(IJsonModel<object>.Create), null, MethodSignatureModifiers.None, typeof(object), null, [_utf8JsonReaderParameter, _serializationOptionsParameter], ExplicitInterface: _jsonModelObjectInterface),
+              new MethodSignature(nameof(IJsonModel<object>.Create), null, MethodSignatureModifiers.None, typeof(object), null, [_utf8JsonReaderParameter, _serializationOptionsParameter], ExplicitInterface: JsonModelObjectInterface),
               castToT.Invoke(nameof(IJsonModel<object>.Create), [_utf8JsonReaderParameter.AsArgument(), _serializationOptionsParameter]),
               this
             );
@@ -505,7 +511,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var returnType = typeof(BinaryData);
             return new MethodProvider
             (
-              new MethodSignature(nameof(IPersistableModel<object>.Write), null, MethodSignatureModifiers.None, returnType, null, [_serializationOptionsParameter], ExplicitInterface: _persistableModelObjectInterface),
+              new MethodSignature(nameof(IPersistableModel<object>.Write), null, MethodSignatureModifiers.None, returnType, null, [_serializationOptionsParameter], ExplicitInterface: PersistableModelObjectInterface),
               castToT.Invoke(nameof(IPersistableModel<object>.Write), [_serializationOptionsParameter]),
               this
             );
@@ -521,7 +527,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             var returnType = typeof(object);
             return new MethodProvider
             (
-              new MethodSignature(nameof(IPersistableModel<object>.Create), null, MethodSignatureModifiers.None, returnType, null, [_dataParameter, _serializationOptionsParameter], ExplicitInterface: _persistableModelObjectInterface),
+              new MethodSignature(nameof(IPersistableModel<object>.Create), null, MethodSignatureModifiers.None, returnType, null, [_dataParameter, _serializationOptionsParameter], ExplicitInterface: PersistableModelObjectInterface),
               castToT.Invoke(nameof(IPersistableModel<object>.Create), [_dataParameter, _serializationOptionsParameter]),
               this
             );
@@ -801,7 +807,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // string IPersistableModel<object>.GetFormatFromOptions(ModelReaderWriterOptions options) => ((IPersistableModel<T>)this).GetFormatFromOptions(options);
             return new MethodProvider
             (
-                new MethodSignature(nameof(IPersistableModel<object>.GetFormatFromOptions), null, MethodSignatureModifiers.None, typeof(string), null, [_serializationOptionsParameter], ExplicitInterface: _persistableModelObjectInterface),
+                new MethodSignature(nameof(IPersistableModel<object>.GetFormatFromOptions), null, MethodSignatureModifiers.None, typeof(string), null, [_serializationOptionsParameter], ExplicitInterface: PersistableModelObjectInterface),
                 castToT.Invoke(nameof(IPersistableModel<object>.GetFormatFromOptions), [_serializationOptionsParameter]),
                 this
             );

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/SystemObjectModelSerializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/SystemObjectModelSerializationTests.cs
@@ -121,6 +121,31 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 "JsonModelWriteCore should be 'override' with regular base too");
         }
 
+        [Test]
+        public void JsonModelWriteCore_IsOverride_WhenBaseProviderIsResolvedAfterSerialization()
+        {
+            var baseInputModel = InputFactory.Model("Resource");
+            var derivedInputModel = InputFactory.Model("TrackedResource", properties: [InputFactory.Property("Location", InputPrimitiveType.String)]);
+            MockHelpers.LoadMockGenerator(inputModels: () => [baseInputModel, derivedInputModel]);
+
+            var derived = new DelayedBaseModelProvider(derivedInputModel);
+            var serialization = new MrwSerializationTypeDefinition(derivedInputModel, derived);
+
+            // The serialization provider can be constructed before later visitors/customization
+            // resolution make the base model provider available.
+            derived.BaseModel = new SystemObjectModelProvider(new CSharpType(typeof(object)), baseInputModel);
+
+            var method = serialization.BuildJsonModelWriteCoreMethod();
+
+            Assert.AreEqual(derived.BaseModel.Type, derived.Type.BaseType,
+                "The generated model type should inherit the base resolved after serialization construction.");
+            Assert.AreEqual(derived.BaseModel.Type, serialization.Type.BaseType,
+                "The serialization type should inherit the same resolved base.");
+            Assert.IsTrue(method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Override),
+                "JsonModelWriteCore should evaluate BaseModelProvider when the method is built, not when serialization is constructed");
+            Assert.IsFalse(method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Virtual));
+        }
+
         // -------------------------------------------------------------------
         // PersistableModelWriteCore: 'virtual' with system base, 'override' with regular
         // (the framework base already implements this; derived model re-introduces it)
@@ -327,6 +352,15 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
 
             string IPersistableModel<FakeMrwBase>.GetFormatFromOptions(ModelReaderWriterOptions options)
                 => "J";
+        }
+
+        private class DelayedBaseModelProvider(InputModelType inputModel) : ModelProvider(inputModel)
+        {
+            public ModelProvider? BaseModel { get; set; }
+
+            protected override ModelProvider? BuildBaseModelProvider() => BaseModel;
+
+            protected override CSharpType? BuildBaseType() => BaseModel?.Type;
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes MRW JSON serialization generation when a serialization provider is constructed before its model's `BaseModelProvider` is available.

`MrwSerializationTypeDefinition` previously cached the JSON override decision in the constructor. In customization/visitor scenarios, the model can later resolve to a `SystemObjectModelProvider` base. One example is an Azure management model customized to inherit from `TrackedResourceData`: the generated model declaration can correctly inherit from the system base, but the serialization provider still uses the stale constructor-time decision and emits `protected virtual JsonModelWriteCore(...)`, hiding the inherited base method.

This keeps the existing `BaseModelProvider != null` behavior and evaluates it when JSON serialization methods are built, after the delayed base provider can be resolved. It also makes the JSON/Persistable serialization interface `CSharpType`s lazy so the constructor does not force `_model.Type` and cache a type before the delayed base is available.

The XML path intentionally keeps its existing constructor-scoped behavior instead of broadly late-emitting `internal override XmlModelWriteCore(...)` for external/system bases, where that XML core method may not exist or be accessible.

## Validation
- `dotnet test /home/huwe/src/typespec/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj --filter JsonModelWriteCore_IsOverride_WhenBaseProviderIsResolvedAfterSerialization --no-restore`
- `dotnet test /home/huwe/src/typespec/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj --filter "SystemObjectModelSerializationTests|XmlSerializationTests|XmlSerializationCustomizationTests" --no-restore`
- Verified with the Azure SDK MPG regression by temporarily referencing this local MTG project: `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --filter ResourceDataModelWithCustomTrackedResourceBaseOverridesSerialization`
