### PR TITLE
fix(http-client-csharp): serialize enum/string JSON request bodies AOT-safely

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -272,8 +272,21 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         private IEnumerable<MethodBodyStatement> GetStackVariablesForProtocolParamConversion(IReadOnlyList<ParameterProvider> convenienceMethodParameters, out Dictionary<string, ValueExpression> declarations)
         {
             List<MethodBodyStatement> statements = new List<MethodBodyStatement>();
-            declarations = new Dictionary<string, ValueExpression>();
+            var localDeclarations = declarations = new Dictionary<string, ValueExpression>();
             var requestContentType = ScmCodeModelGenerator.Instance.TypeFactory.RequestContentApi.RequestContentType;
+
+            // Serializes the body via Utf8JsonWriter to stay AOT/trim safe (avoids BinaryData.FromObjectAsJson<T>, which trips IL2026/IL3050).
+            void AddUtf8JsonContent(CSharpType serializationType, ValueExpression value)
+            {
+                statements.Add(Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content));
+                statements.Add(ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(
+                    serializationType,
+                    value,
+                    content.JsonWriter(),
+                    ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
+                    SerializationFormat.Default));
+                localDeclarations["content"] = content;
+            }
 
             foreach (var parameter in convenienceMethodParameters)
             {
@@ -309,15 +322,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     {
                         if (ServiceMethod.Operation.RequestMediaTypes?.Contains("application/json") == true)
                         {
-                            // Serialize via Utf8JsonWriter to stay AOT/trim safe (avoids BinaryData.FromObjectAsJson<T>, which trips IL2026/IL3050).
-                            statements.Add(Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content));
-                            statements.Add(ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(
-                                parameter.Type,
-                                parameter,
-                                content.JsonWriter(),
-                                ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
-                                SerializationFormat.Default));
-                            declarations["content"] = content;
+                            AddUtf8JsonContent(parameter.Type, parameter);
                         }
                         else
                         {
@@ -327,15 +332,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     }
                     else if (parameter.Type.IsEnum)
                     {
-                        // Serialize via Utf8JsonWriter to stay AOT/trim safe (avoids BinaryData.FromObjectAsJson<T>, which trips IL2026/IL3050).
-                        statements.Add(Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content));
-                        statements.Add(ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(
-                            parameter.Type,
-                            parameter,
-                            content.JsonWriter(),
-                            ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
-                            SerializationFormat.Default));
-                        declarations["content"] = content;
+                        AddUtf8JsonContent(parameter.Type, parameter);
                     }
                     else if (parameter.Type.IsFrameworkType && !parameter.Type.Equals(typeof(BinaryData)) && IsConvertibleFromBinaryData(parameter.Type))
                     {
@@ -344,14 +341,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     }
                     else if (parameter.Type.IsFrameworkType && !parameter.Type.Equals(typeof(BinaryData)))
                     {
-                        statements.Add(Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content));
-                        statements.Add(ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(
-                            parameter.Type.FrameworkType,
-                            parameter,
-                            content.JsonWriter(),
-                            ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
-                            SerializationFormat.Default));
-                        declarations["content"] = content;
+                        AddUtf8JsonContent(parameter.Type.FrameworkType, parameter);
                     }
                     else
                     {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -307,10 +307,34 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     }
                     else if (parameter.Type.Equals(typeof(string)))
                     {
-                        var bdExpression = ServiceMethod.Operation.RequestMediaTypes?.Contains("application/json") == true
-                            ? BinaryDataSnippets.FromObjectAsJson(parameter)
-                            : BinaryDataSnippets.FromString(parameter);
-                        statements.Add(UsingDeclare("content", RequestContentApiSnippets.Create(bdExpression), out var content));
+                        if (ServiceMethod.Operation.RequestMediaTypes?.Contains("application/json") == true)
+                        {
+                            // Serialize via Utf8JsonWriter to stay AOT/trim safe (avoids BinaryData.FromObjectAsJson<T>, which trips IL2026/IL3050).
+                            statements.Add(Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content));
+                            statements.Add(ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(
+                                parameter.Type,
+                                parameter,
+                                content.JsonWriter(),
+                                ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
+                                SerializationFormat.Default));
+                            declarations["content"] = content;
+                        }
+                        else
+                        {
+                            statements.Add(UsingDeclare("content", RequestContentApiSnippets.Create(BinaryDataSnippets.FromString(parameter)), out var content));
+                            declarations["content"] = content;
+                        }
+                    }
+                    else if (parameter.Type.IsEnum)
+                    {
+                        // Serialize via Utf8JsonWriter to stay AOT/trim safe (avoids BinaryData.FromObjectAsJson<T>, which trips IL2026/IL3050).
+                        statements.Add(Declare("content", New.Instance<Utf8JsonBinaryContentDefinition>(), out var content));
+                        statements.Add(ScmCodeModelGenerator.Instance.TypeFactory.SerializeJsonValue(
+                            parameter.Type,
+                            parameter,
+                            content.JsonWriter(),
+                            ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
+                            SerializationFormat.Default));
                         declarations["content"] = content;
                     }
                     else if (parameter.Type.IsFrameworkType && !parameter.Type.Equals(typeof(BinaryData)) && IsConvertibleFromBinaryData(parameter.Type))
@@ -945,8 +969,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         }
                         else if (convenienceParam.Type.IsEnum)
                         {
-                            AddArgument(protocolParam, RequestContentApiSnippets.Create(
-                                BinaryDataSnippets.FromObjectAsJson(convenienceParam.Type.ToSerial(convenienceParam))));
+                            AddArgument(protocolParam, declarations["content"]);
                         }
                         else if (convenienceParam.Type.Equals(typeof(BinaryData)))
                         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -388,6 +388,72 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             }
         }
 
+        // Enum bodies must be serialized via Utf8JsonWriter (not BinaryData.FromObjectAsJson<T>) to stay AOT/trim safe (IL2026/IL3050).
+        [TestCase(false, false, "content.JsonWriter.WriteStringValue(color.ToSerialString())")]
+        [TestCase(true, false, "content.JsonWriter.WriteStringValue(color.ToString())")]
+        [TestCase(false, true, "content.JsonWriter.WriteNumberValue(((int)color))")]
+        [TestCase(true, true, "content.JsonWriter.WriteNumberValue(color.ToSerialInt32())")]
+        public void EnumBodySerializedWithUtf8JsonWriter(bool isExtensible, bool useInt, string expectedWriteExpression)
+        {
+            InputType enumType = useInt
+                ? InputFactory.Int32Enum("color", [("red", 1), ("green", 2)], isExtensible: isExtensible)
+                : InputFactory.StringEnum("color", [("red", "red"), ("green", "green")], isExtensible: isExtensible);
+
+            var inputOperation = InputFactory.Operation(
+                "PutColor",
+                parameters: [InputFactory.BodyParameter("color", enumType, isRequired: true)],
+                responses: [InputFactory.OperationResponse([200])]);
+            var inputServiceMethod = InputFactory.BasicServiceMethod(
+                "PutColor",
+                inputOperation,
+                parameters: [InputFactory.MethodParameter("color", enumType, location: InputRequestLocation.Body, isRequired: true)]);
+            var inputClient = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+
+            MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+
+            var methodCollection = new ScmMethodProviderCollection(inputServiceMethod, client!);
+            var convenienceMethod = methodCollection.FirstOrDefault(
+                m => !m.Signature.Parameters.Any(p => p.Name == "options") && m.Signature.Name == "PutColor");
+            Assert.IsNotNull(convenienceMethod);
+
+            var statements = convenienceMethod!.BodyStatements!.ToDisplayString();
+            StringAssert.Contains("new global::Sample.Utf8JsonBinaryContent()", statements);
+            StringAssert.Contains(expectedWriteExpression, statements);
+            StringAssert.DoesNotContain("FromObjectAsJson", statements);
+        }
+
+        // String bodies with a JSON media type must be serialized via Utf8JsonWriter (not BinaryData.FromObjectAsJson<T>) to stay AOT/trim safe (IL2026/IL3050).
+        [Test]
+        public void JsonStringBodySerializedWithUtf8JsonWriter()
+        {
+            var inputOperation = InputFactory.Operation(
+                "PutString",
+                parameters: [InputFactory.BodyParameter("value", InputPrimitiveType.String, isRequired: true)],
+                responses: [InputFactory.OperationResponse([200])],
+                requestMediaTypes: ["application/json"]);
+            var inputServiceMethod = InputFactory.BasicServiceMethod(
+                "PutString",
+                inputOperation,
+                parameters: [InputFactory.MethodParameter("value", InputPrimitiveType.String, location: InputRequestLocation.Body, isRequired: true)]);
+            var inputClient = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+
+            MockHelpers.LoadMockGenerator();
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+
+            var methodCollection = new ScmMethodProviderCollection(inputServiceMethod, client!);
+            var convenienceMethod = methodCollection.FirstOrDefault(
+                m => !m.Signature.Parameters.Any(p => p.Name == "options") && m.Signature.Name == "PutString");
+            Assert.IsNotNull(convenienceMethod);
+
+            var statements = convenienceMethod!.BodyStatements!.ToDisplayString();
+            StringAssert.Contains("new global::Sample.Utf8JsonBinaryContent()", statements);
+            StringAssert.Contains("content.JsonWriter.WriteStringValue(value)", statements);
+            StringAssert.DoesNotContain("FromObjectAsJson", statements);
+        }
+
         [TestCase(true, false, true)]
         [TestCase(true, true, true)]
         [TestCase(false, false, false)]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -378,11 +378,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             {
                 if (isExtensible)
                 {
-                    StringAssert.Contains("BinaryData.FromObjectAsJson(color.ToString())", convenienceMethod.BodyStatements!.ToDisplayString());
+                    StringAssert.Contains("content.JsonWriter.WriteStringValue(color.ToString())", convenienceMethod.BodyStatements!.ToDisplayString());
                 }
                 else
                 {
-                    StringAssert.Contains("BinaryData.FromObjectAsJson(color.ToSerialString())",
+                    StringAssert.Contains("content.JsonWriter.WriteStringValue(color.ToSerialString())",
                         convenienceMethod.BodyStatements!.ToDisplayString());
                 }
             }


### PR DESCRIPTION
## Problem

The C# emitter generated `BinaryData.FromObjectAsJson(importType.ToString())` for top-level **enum** request bodies (and `BinaryData.FromObjectAsJson(value)` for JSON **string** bodies). The generic `BinaryData.FromObjectAsJson<T>` is annotated with `RequiresUnreferencedCode`/`RequiresDynamicCode`, so even though the runtime value is just a string/number, the trim/AOT analyzer raises **IL2026 / IL3050**, which AOT-enabled builds treat as errors.

## Fix

Route enum and JSON string request bodies through the same AOT/trim-safe `Utf8JsonBinaryContent` + `Utf8JsonWriter` path the emitter already uses for other framework-type bodies (`ScmMethodProviderCollection.GetStackVariablesForProtocolParamConversion`):

- string-backed enum -> `content.JsonWriter.WriteStringValue(x.ToString())`
- fixed string enum -> `content.JsonWriter.WriteStringValue(x.ToSerialString())`
- number-backed enum -> `content.JsonWriter.WriteNumberValue(...)`
- JSON `string` body -> `content.JsonWriter.WriteStringValue(value)` (non-JSON media types keep `BinaryData.FromString`)

The generated wire output is identical (e.g. a string enum still serializes to the JSON string `"Cloud"`), but no longer uses the trim/AOT-unfriendly generic API.

## Validation

- Updated `ListMethodWithEnumParameter` unit-test expectations.
- ClientModel project builds with 0 warnings (StyleCop enforced).
- `ScmMethodProviderCollectionTests`: 92/92 passing.