### PR TITLE
fix(http-client-java): treat per-service api-version map as undefined

### DIFF
--- a/.chronus/changes/http-client-java_fix-api-version-map-2026-6-30-11-25-0.md
+++ b/.chronus/changes/http-client-java_fix-api-version-map-2026-6-30-11-25-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+Do not throw on a per-service api-version map; treat it as undefined so a client with a single api-version can still be generated.

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -249,6 +249,8 @@ export class CodeModelBuilder {
 
   // current apiVersion name to generate code
   // it would be undefined, if mixed api-versions
+  // when it has value, its usage is at "getFilteredApiVersions" (to filter the api-versions for
+  // the client), and as the constant value of the "api-version" parameter for ARM
   private apiVersion: string | undefined;
 
   public constructor(program1: Program, context: EmitContext<EmitterOptions>) {

--- a/packages/http-client-java/emitter/src/versioning-utils.ts
+++ b/packages/http-client-java/emitter/src/versioning-utils.ts
@@ -192,21 +192,20 @@ export function isVersionEarlierThan(version: string, compareTo: string): boolea
  *
  * TCGC supports a per-service api-version map (`Record<string, string>`), but the Java
  * emitter currently only supports a single api-version, "latest", or "all". A map value
- * is therefore rejected.
+ * is therefore treated as undefined.
  *
  * TODO(xiaofei): support the per-service api-version map in a future PR.
  *
  * @param apiVersion the api-version option from TCGC, a string, a per-service map, or undefined
- * @returns the api-version string, or undefined when not set
- * @throws if the api-version option is a per-service map
+ * @returns the api-version string, or undefined when not set or a per-service map
  */
 export function resolveApiVersionOption(
   apiVersion: string | Record<string, string> | undefined,
 ): string | undefined {
   if (apiVersion !== undefined && typeof apiVersion !== "string") {
-    throw new Error(
-      "A per-service api-version map is not supported. The 'api-version' option must be a single api-version, 'latest', or 'all'.",
-    );
+    // There is a possibility that the overall package contains multiple api-versions, but this
+    // specific client only includes a single api-version. For this case we will need refinement.
+    return undefined;
   }
   return apiVersion;
 }

--- a/packages/http-client-java/emitter/test/utils.test.ts
+++ b/packages/http-client-java/emitter/test/utils.test.ts
@@ -66,9 +66,7 @@ describe("versioning-utils", () => {
     expect(resolveApiVersionOption("latest")).toBe("latest");
     expect(resolveApiVersionOption("all")).toBe("all");
     expect(resolveApiVersionOption("2024-06-01")).toBe("2024-06-01");
-    expect(() => resolveApiVersionOption({ service: "2024-06-01" })).toThrow(
-      /per-service api-version map is not supported/,
-    );
+    expect(resolveApiVersionOption({ ComputeDisk: "2025-01-02" })).toBe(undefined);
   });
 
   it("filterApiVersionsByStability filters preview versions for stable target", () => {


### PR DESCRIPTION
## Summary

Replaces the `throw` in `resolveApiVersionOption` for a per-service api-version map (`Record<string, string>`) with `return undefined`, so a client that only includes a single api-version can still be generated even when the overall package contains multiple api-versions. A code comment marks this as a spot needing future refinement.

## Changes

- `versioning-utils.ts`: return `undefined` instead of throwing for a per-service map; updated JSDoc.
- `code-model-builder.ts`: documented the `apiVersion` field usage (`getFilteredApiVersions`, and the ARM `api-version` parameter constant value).
- `utils.test.ts`: updated test to expect `undefined` for `{ ComputeDisk: "2025-01-02" }`.
- Added changelog entry (fix).
