### PR TITLE
Publish core packages to ADO azure-sdk-for-js feed

### DIFF
--- a/eng/tsp-core/pipelines/jobs/publish-npm.yml
+++ b/eng/tsp-core/pipelines/jobs/publish-npm.yml
@@ -35,6 +35,13 @@ jobs:
             - script: ls $(Pipeline.Workspace)/${{ parameters.artifactName }}
               displayName: List files in artifact
 
+            # Publish to the Azure DevOps feed first (bypasses the 7-day npmjs.org quarantine),
+            # then publish to npmjs.org via ESRP.
+            - template: /eng/tsp-core/pipelines/templates/release/ado-feed-release.yml
+              parameters:
+                tag: ${{ parameters.tag }}
+                path: "$(Pipeline.Workspace)/${{ parameters.artifactName }}"
+
             - template: /eng/tsp-core/pipelines/templates/release/esrp-release.yml
               parameters:
                 tag: ${{ parameters.tag }}

--- a/eng/tsp-core/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/tsp-core/pipelines/templates/release/ado-feed-release.yml
@@ -1,0 +1,49 @@
+# cspell:ignore EPUBLISHCONFLICT
+parameters:
+  - name: tag
+    type: string
+    default: latest
+  - name: path
+    type: string
+  - name: registryUrl
+    type: string
+    default: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
+
+steps:
+  # Publishing the packages directly to the Azure DevOps `azure-sdk-for-js` feed bypasses the
+  # upstream npmjs.org quarantine (which blocks newly released packages for 7 days) so CI can
+  # consume freshly released packages immediately.
+  - template: /eng/emitters/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: ${{ parameters.path }}/.npmrc
+      registryUrl: ${{ parameters.registryUrl }}
+
+  - pwsh: |
+      $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
+      $hadError = $false
+      foreach ($file in $packageFiles.Name) {
+        Write-Host "npm publish $file --verbose --access public --tag ${{ parameters.tag }}"
+        $output = npm publish $file --verbose --access public --tag ${{ parameters.tag }} 2>&1
+        $output | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) {
+          $text = $output -join "`n"
+          # Treat "version already exists" as a no-op, matching the npm/ESRP behavior of not
+          # republishing an existing version. Any other failure is a genuine error and must fail.
+          if ($text -match 'EPUBLISHCONFLICT' -or
+              $text -match 'cannot publish over the previously published versions' -or
+              $text -match 'You cannot publish over the previously published versions' -or
+              $text -match 'previously published version' -or
+              $text -match '\b409\b') {
+            Write-Warning "Version for $file already exists in the feed, skipping."
+          } else {
+            Write-Error "Failed to publish $file to the DevOps feed."
+            $hadError = $true
+          }
+        }
+      }
+      if ($hadError) {
+        exit 1
+      }
+    displayName: Publish to DevOps feed (${{ parameters.tag }})
+    condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
+    workingDirectory: ${{ parameters.path }}


### PR DESCRIPTION
## Problem

CI (and this repo's emitter pipelines) install npm packages from the ADO feed `azure-sdk-for-js` (`https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/`), which **quarantines newly released npmjs packages for 7 days**. Core `@typespec/*` packages currently publish **only to npmjs via ESRP**, so freshly released versions are not installable from the feed for a week.

## Change

Publish the built `.tgz` artifacts **directly to the ADO feed** (which bypasses the upstream quarantine) **before** the existing npm/ESRP publish, applying the dual-publish pattern already used by this repo's emitter pipeline (`eng/emitters/.../emitter-stages.yml`) and every Azure SDK repo (`archetype-typespec-emitter.yml`).

- **New** `eng/tsp-core/pipelines/templates/release/ado-feed-release.yml` — mirrors `esrp-release.yml`; reuses `create-authenticated-npmrc.yml` (registry = the feed) + a `npm publish --access public --tag <tag>` loop.
  - **Already-published versions are skipped** (detects `EPUBLISHCONFLICT`/409), matching today's npm behavior of not republishing.
  - **Genuine failures fail the pipeline** so the quarantine-bypass gap is visible.
  - Gated by `SkipPublishing` for dry runs.
- **Edited** `eng/tsp-core/pipelines/jobs/publish-npm.yml` — runs the ADO-feed step before ESRP, for both stable/`latest` and next/`next` (no change to `publish.yml`).

## Notes / follow-ups
- Requires the pipeline identity to have `@typespec/*` publish rights on the `azure-sdk-for-js` feed (emitters already publish `@azure-tools/*` there). Please confirm with EngSys.
- If the 1ES `releaseJob` restricts `npmAuthenticate`/`npm publish`, fallback is to move the ADO publish to a separate normal job that the ESRP deployment job `dependsOn`.
- eng/CI-only change \u2014 no changelog entry.