### PR TITLE
[http-client-csharp] Fix explode object query parameter serialization

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/RestClientProvider.cs
@@ -547,6 +547,18 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         {
             if (paramType?.IsCollection != true)
             {
+                // A model-typed query parameter marked with `explode` must be expanded into one query
+                // entry per property (RFC 6570 form explode, e.g. `?field=status&value=active`) rather
+                // than serialized via the object's ToString (which previously produced the type name).
+                if (inputQueryParameter.Explode && inputQueryParameter.Type is InputModelType inputModel)
+                {
+                    var explodeStatement = BuildExplodeModelQueryStatement(uri, inputModel, valueExpression);
+                    if (explodeStatement != null)
+                    {
+                        return explodeStatement;
+                    }
+                }
+
                 var toStringExpression = GetQueryParameterStringExpression(paramType, valueExpression, serializationFormat);
                 return uri.AppendQuery(Literal(inputQueryParameter.SerializedName), toStringExpression, true).Terminate();
             }
@@ -601,6 +613,70 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 forEachStatement.Add(uri.AppendQuery(Literal(inputQueryParameter.SerializedName), convertedItem, true).Terminate());
                 return forEachStatement;
             }
+        }
+
+        /// <summary>
+        /// Builds the statements for a model-typed query parameter that uses form-style `explode`.
+        /// Each (simple) property of the model is emitted as its own query entry using the property's
+        /// wire name (RFC 6570 form explode, e.g. <c>?field=status&amp;value=active</c>).
+        /// Returns <c>null</c> when the model contains a property that is not a simple scalar/enum
+        /// (e.g. a nested object or a collection), in which case the caller falls back to the default
+        /// handling. Nested/complex expansion is tracked separately (see issue #11123).
+        /// </summary>
+        private static MethodBodyStatement? BuildExplodeModelQueryStatement(
+            ScopedApi uri,
+            InputModelType inputModel,
+            ValueExpression valueExpression)
+        {
+            var modelProvider = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputModel);
+            if (modelProvider is null)
+            {
+                return null;
+            }
+
+            var properties = modelProvider.CanonicalView.Properties;
+            if (properties.Count == 0)
+            {
+                return null;
+            }
+
+            // Only expand when every property is a simple scalar or enum. Nested objects and
+            // collections are not defined by RFC 6570 form explode and require a separate design
+            // decision, so we fall back to the default handling for those.
+            foreach (var property in properties)
+            {
+                if (property.WireInfo is null ||
+                    property.Type.IsCollection ||
+                    (!property.Type.IsFrameworkType && !property.Type.IsEnum))
+                {
+                    return null;
+                }
+            }
+
+            var statements = new List<MethodBodyStatement>();
+            foreach (var property in properties)
+            {
+                var propertyAccess = valueExpression.Property(property.Name);
+                var propertyType = property.Type;
+
+                ValueExpression convertedValue = propertyType.IsEnum
+                    ? propertyType.ToSerial(propertyAccess).ConvertToString()
+                    : GetQueryParameterStringExpression(propertyType, propertyAccess, property.SerializationFormat);
+
+                MethodBodyStatement appendStatement =
+                    uri.AppendQuery(Literal(property.WireInfo!.SerializedName), convertedValue, true).Terminate();
+
+                if (!property.WireInfo.IsRequired ||
+                    propertyType.IsNullable ||
+                    (propertyType is { IsValueType: false, IsFrameworkType: true } && propertyType.FrameworkType != typeof(string)))
+                {
+                    appendStatement = BuildQueryOrHeaderOrPathParameterNullCheck(propertyType, propertyAccess, appendStatement);
+                }
+
+                statements.Add(appendStatement);
+            }
+
+            return statements;
         }
 
         private static IfStatement BuildQueryOrHeaderOrPathParameterNullCheck(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/RestClientProviders/RestClientProviderTests.cs
@@ -736,6 +736,38 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.RestClientPro
         }
 
         [Test]
+        public void TestBuildCreateRequestMethodWithExplodedModelQueryParameter()
+        {
+            var filterModel = InputFactory.Model(
+                "filterOptions",
+                properties:
+                [
+                    InputFactory.Property("field", InputPrimitiveType.String, isRequired: true),
+                    InputFactory.Property("value", InputPrimitiveType.String, isRequired: true),
+                ]);
+            var operation = InputFactory.Operation(
+                "sampleOp",
+                parameters: [InputFactory.QueryParameter("filter", filterModel, isRequired: true, explode: true)]);
+            var client = InputFactory.Client(
+                "TestClient",
+                methods: [InputFactory.BasicServiceMethod("Test", operation)]);
+            var clientProvider = new ClientProvider(client);
+            var restClientProvider = new MockClientProvider(client, clientProvider);
+
+            var method = restClientProvider.Methods.FirstOrDefault(m => m.Signature.Name == "CreateSampleOpRequest");
+            Assert.IsNotNull(method);
+            var body = method!.BodyStatements!.ToDisplayString();
+
+            // A model-typed query parameter with `explode` is expanded into one query entry per
+            // property (RFC 6570 form explode) using each property's wire name, instead of serializing
+            // the whole object via ConvertToString (which produced the type name).
+            Assert.IsTrue(body.Contains("uri.AppendQuery(\"field\", filter.Field, true);"), body);
+            Assert.IsTrue(body.Contains("uri.AppendQuery(\"value\", filter.Value, true);"), body);
+            Assert.IsFalse(body.Contains("AppendQuery(\"filter\""), body);
+            Assert.IsFalse(body.Contains("ConvertToString(filter)"), body);
+        }
+
+        [Test]
         public void TestBuildCreateRequestMethodWithQueryParameters()
         {
             List<string> stringEnum = ["bar"];


### PR DESCRIPTION
Fixes #11123

## Problem

A model-typed query parameter marked with `@query(#{ explode: true })` was serialized via the object's `ToString`, producing the type name in the URL:

```csharp
uri.AppendQuery("filter", TypeFormatters.ConvertToString(filter), true);
// => GET /api/v1/items?filter=Example.FilterOptions
```

## Fix

`RestClientProvider.BuildAppendQueryStatement` now expands a model-typed `explode` query parameter into one query entry per property, using each property's wire name (RFC 6570 form explode):

```csharp
uri.AppendQuery("field", filter.Field, true);
uri.AppendQuery("value", filter.Value, true);
// => GET /parameters/query/explode/object?field=status&value=active
```

Models whose properties are all simple scalars/enums are expanded. Nested objects and collections fall back to the previous behavior pending a separate design decision (they are not defined by RFC 6570 form explode).

## Tests

- Added `TestBuildCreateRequestMethodWithExplodedModelQueryParameter` unit test.
- All 70 `RestClientProviderTests` pass (no regressions).

The end-to-end Spector scenario and C# Spector test that exercise this against a live mock server are in a follow-up PR (the shared `@typespec/http-specs` scenario + generated client).
