### PR TITLE
Add missing flags to Enum

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelTypeUsage.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelTypeUsage.cs
@@ -22,5 +22,6 @@ namespace Microsoft.TypeSpec.Generator.Input
         LroInitial = 2048,
         LroPolling = 4096,
         LroFinalEnvelope = 8192,
+        External = 16384,
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputConverterTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputConverterTests.cs
@@ -565,6 +565,42 @@ namespace Microsoft.TypeSpec.Generator.Input.Tests
         }
 
         [Test]
+        public void DeserializeModelWithExternalUsagePreservesInputAndOutput()
+        {
+            // TCGC emits the External usage flag (UsageFlags.External) for models that are also
+            // referenced by external types. The C# InputModelTypeUsage enum must recognize it so
+            // that Enum.TryParse does not fail on the unknown token and collapse the whole usage to
+            // None, which would strip Input/Output and make every property get-only.
+            var json = @"{
+                ""$id"": ""1"",
+                ""kind"": ""model"",
+                ""name"": ""TestModel"",
+                ""namespace"": ""Test.Models"",
+                ""crossLanguageDefinitionId"": ""Test.Models.TestModel"",
+                ""usage"": ""Input,Output,External"",
+                ""properties"": []
+            }";
+
+            var referenceHandler = new TypeSpecReferenceHandler();
+            var options = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                Converters =
+                {
+                    new InputTypeConverter(referenceHandler),
+                    new InputModelTypeConverter(referenceHandler),
+                    new InputExternalTypeMetadataConverter()
+                }
+            };
+
+            var model = JsonSerializer.Deserialize<InputModelType>(json, options);
+            Assert.IsNotNull(model);
+            Assert.IsTrue(model!.Usage.HasFlag(InputModelTypeUsage.Input), "Model should retain Input usage flag");
+            Assert.IsTrue(model.Usage.HasFlag(InputModelTypeUsage.Output), "Model should retain Output usage flag");
+            Assert.IsTrue(model.Usage.HasFlag(InputModelTypeUsage.External), "Model should have External usage flag");
+        }
+
+        [Test]
         public void DeserializeArrayWithExternalMetadata()
         {
             var json = @"{


### PR DESCRIPTION
Recognize the  External  usage flag when deserializing models

Problem

Models whose usage includes the  External  flag (e.g.  "usage": "Input,Output,External" ) were generated with get-only properties — no setters — even for optional properties and round-trip ( Input,Output ) models. This affects any model that extends a base type reused from an external package (via an  external  block), which TCGC marks with  UsageFlags.External .

Root cause

TCGC defines  UsageFlags.External = 16384  and the emitter serializes usage flags by name into  tspCodeModel.json  ( code-model-writer.ts ,  transformJSONProperties ). The C#  InputModelTypeUsage  enum, however, was never updated to include  External .

When the model converter parses the usage string:
```C#
// InputModelTypeConverter.cs
var parsedUsage = Enum.TryParse<InputModelTypeUsage>(usageString, ignoreCase: true, out var usage)
    ? usage
    : InputModelTypeUsage.None;
```
 Enum.TryParse  is all-or-nothing: an unknown token ( External ) makes the entire parse fail, so  parsedUsage  collapses to  None  (then gets  |= Json ). The  Input  and  Output  flags are silently dropped.

Downstream,  PropertyProvider.PropertyHasSetter  short-circuits on the now-missing  Input  flag:

```C#
// Output-only properties don't need setters.
if (!inputProperty.EnclosingType!.Usage.HasFlag(InputModelTypeUsage.Input))
{
    return false;
}
```
→ every property becomes get-only. The lost usage flags also affect constructor accessibility and serialization direction.

Fix

Add the missing member to  InputModelTypeUsage  so it stays in sync with TCGC's  UsageFlags :
``` C#
LroFinalEnvelope = 8192,
External = 16384,
```
With the token recognized,  Enum.TryParse  succeeds and  Input / Output  are preserved. The C# generator does not otherwise consume the  External  usage flag (external-type linkage is handled separately via  InputModelType.External ), so this change is inert beyond fixing the parse.

Tests

• Added  DeserializeModelWithExternalUsagePreservesInputAndOutput  in  TypeSpecInputConverterTests , asserting that a model with  usage: "Input,Output,External"  retains the  Input ,  Output , and  External  flags.
• Full  Microsoft.TypeSpec.Generator.Input  suite: 148/148 passing.
• Verified end-to-end by packing the emitter and regenerating  Azure.AI.Extensions.OpenAI :  A2AToolCall  /  A2AToolCallOutput  properties (which extend the external OpenAI  ResponseItem  base) now generate with  get; set; .

Changed files

•  packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelTypeUsage.cs 
•  packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/TypeSpecInputConverterTests.cs 