### PR TITLE
[http-client-csharp] Visit synthesized back-compatibility members

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/LibraryVisitor.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/LibraryVisitor.cs
@@ -168,7 +168,7 @@ namespace Microsoft.TypeSpec.Generator
         /// </summary>
         /// <param name="constructor">The original <see cref="ConstructorProvider"/>.</param>
         /// <returns>Null if it should be removed otherwise the modified version of the <see cref="ConstructorProvider"/>.</returns>
-        protected virtual ConstructorProvider? VisitConstructor(ConstructorProvider constructor)
+        protected internal virtual ConstructorProvider? VisitConstructor(ConstructorProvider constructor)
         {
             return constructor;
         }
@@ -302,7 +302,7 @@ namespace Microsoft.TypeSpec.Generator
         /// </summary>
         /// <param name="field">The original <see cref="FieldProvider"/>.</param>
         /// <returns>Null if it should be removed otherwise the modified version of the <see cref="FieldProvider"/>.</returns>
-        protected virtual FieldProvider? VisitField(FieldProvider field)
+        protected internal virtual FieldProvider? VisitField(FieldProvider field)
         {
             return field;
         }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -741,8 +741,73 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 {
                     _enumValues = updatedEnumValues;
                 }
+
+                // Back-compatibility processing intentionally runs after the library visitor pass so
+                // that the contract comparison uses the final, post-visitor member signatures (otherwise
+                // we could incorrectly decide whether a back-compat member is needed). As a result, any
+                // members synthesized above (e.g. back-compat overloads) have not been visited yet. Run
+                // only those newly-added members through the visitors now so visitor transforms apply to
+                // them as well, without re-visiting members that were already visited during the main pass.
+                if (newMethods != null)
+                {
+                    newMethods = VisitNewMembers(newMethods, Methods, static (member, visitor) => member.Accept(visitor));
+                }
+                if (newConstructors != null)
+                {
+                    newConstructors = VisitNewMembers(newConstructors, Constructors, static (member, visitor) => visitor.VisitConstructor(member));
+                }
+                if (newFields != null)
+                {
+                    newFields = VisitNewMembers(newFields, Fields, static (member, visitor) => visitor.VisitField(member));
+                }
+
                 Update(fields: newFields, methods: newMethods, constructors: newConstructors);
             }
+        }
+
+        // Runs newly-added back-compatibility members through every registered visitor while leaving
+        // members that were already visited during the main visitor pass untouched. Membership in the
+        // already-visited set is determined by reference identity against the pre-Update collection.
+        private static IReadOnlyList<T> VisitNewMembers<T>(
+            IEnumerable<T> allMembers,
+            IReadOnlyList<T> alreadyVisited,
+            Func<T, LibraryVisitor, T?> visit)
+            where T : class
+        {
+            var visitors = CodeModelGenerator.Instance.Visitors;
+            var materialized = allMembers as IReadOnlyList<T> ?? [.. allMembers];
+            if (visitors.Count == 0)
+            {
+                return materialized;
+            }
+
+            var alreadyVisitedSet = new HashSet<T>(alreadyVisited, ReferenceEqualityComparer.Instance);
+            var result = new List<T>(materialized.Count);
+            foreach (var member in materialized)
+            {
+                if (alreadyVisitedSet.Contains(member))
+                {
+                    result.Add(member);
+                    continue;
+                }
+
+                T? visited = member;
+                foreach (var visitor in visitors)
+                {
+                    visited = visit(visited, visitor);
+                    if (visited == null)
+                    {
+                        break;
+                    }
+                }
+
+                if (visited != null)
+                {
+                    result.Add(visited);
+                }
+            }
+
+            return result;
         }
 
         protected internal virtual IReadOnlyList<EnumTypeMember>? BuildEnumValuesForBackCompatibility(IReadOnlyList<EnumTypeMember> originalEnumValues)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/OutputLibraryVisitorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/OutputLibraryVisitorTests.cs
@@ -451,7 +451,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
                 return method;
             }
 
-            protected override ConstructorProvider? VisitConstructor(ConstructorProvider constructor)
+            protected internal override ConstructorProvider? VisitConstructor(ConstructorProvider constructor)
             {
                 if (constructor.Signature.Parameters.Count > 0)
                 {
@@ -469,7 +469,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
                 return property;
             }
 
-            protected override FieldProvider? VisitField(FieldProvider field)
+            protected internal override FieldProvider? VisitField(FieldProvider field)
             {
                 if (field.Name == "TestField")
                 {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -975,6 +975,61 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             Assert.AreEqual(4, publicModel1Methods[0].Signature.Parameters.Count);
         }
 
+        // Back-compat members are synthesized in ProcessTypeForBackCompatibility, which runs after the
+        // main library visitor pass. This test ensures those newly-added members are still run through
+        // the registered visitors (only the new members, not the already-visited existing ones).
+        [Test]
+        public async Task BackCompatibility_BackCompatMethodIsVisited()
+        {
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: ModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(method: "BackCompatibility_NewModelPropertyAdded"))).Object;
+
+            var recordingVisitor = new RecordingMethodVisitor();
+            _instance.AddVisitor(recordingVisitor);
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            var backCompatMethod = modelFactory.Methods
+                .FirstOrDefault(m => m.Signature.Name == "PublicModel1" && m.Signature.Parameters.All(p => p.Name != "dictProp"));
+            Assert.IsNotNull(backCompatMethod, "Expected a back-compat overload to be synthesized.");
+
+            // The synthesized back-compat method must have been visited.
+            Assert.IsTrue(
+                recordingVisitor.VisitedMethods.Contains(backCompatMethod!),
+                "The back-compat method was not visited by the library visitor.");
+
+            // Existing methods that were already part of the contract are not re-visited by the visitor
+            // added after the main pass (they would have been visited during the main pass in a real run).
+            var currentOverloadMethod = modelFactory.Methods
+                .FirstOrDefault(m => m.Signature.Name == "PublicModel1" && m.Signature.Parameters.Any(p => p.Name == "dictProp"));
+            Assert.IsNotNull(currentOverloadMethod);
+            Assert.IsFalse(recordingVisitor.VisitedMethods.Contains(currentOverloadMethod!));
+        }
+
+        // Verifies that a visitor can mutate (rename) a synthesized back-compat method and the change is
+        // reflected in the final generated methods.
+        [Test]
+        public async Task BackCompatibility_BackCompatMethodCanBeMutatedByVisitor()
+        {
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: ModelList,
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(method: "BackCompatibility_NewModelPropertyAdded"))).Object;
+
+            _instance.AddVisitor(new BackCompatMethodRenamingVisitor());
+
+            var modelFactory = _instance!.OutputLibrary.ModelFactory.Value;
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            // The visitor renames any method carrying the EditorBrowsableNever attribute (the back-compat
+            // overload) so the mutation must be observable on the final method collection.
+            var renamed = modelFactory.Methods.FirstOrDefault(m => m.Signature.Name == "PublicModel1Renamed");
+            Assert.IsNotNull(renamed, "The visitor's rename of the back-compat method was not applied.");
+        }
+
         private static InputModelType[] GetTestModels()
         {
             InputType additionalPropertiesUnknown = InputPrimitiveType.Any;
@@ -1001,6 +1056,30 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
                 InputFactory.Model("BaseModel", properties: properties, derivedModels: [derivedModel]),
                 InputFactory.Model("ModelWithUnknownAdditionalProperties", properties: properties, additionalProperties: additionalPropertiesUnknown),
             ];
+        }
+
+        private class RecordingMethodVisitor : LibraryVisitor
+        {
+            public List<MethodProvider> VisitedMethods { get; } = [];
+
+            protected internal override MethodProvider? VisitMethod(MethodProvider method)
+            {
+                VisitedMethods.Add(method);
+                return method;
+            }
+        }
+
+        private class BackCompatMethodRenamingVisitor : LibraryVisitor
+        {
+            protected internal override MethodProvider? VisitMethod(MethodProvider method)
+            {
+                if (method.Signature.Name == "PublicModel1"
+                    && method.Signature.Attributes.Any(a => a.ToDisplayString().Contains("EditorBrowsable")))
+                {
+                    method.Signature.Update(name: "PublicModel1Renamed");
+                }
+                return method;
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem
Back-compatibility members (model factory overloads, client overloads, back-compat enum fields) are synthesized in TypeProvider.ProcessTypeForBackCompatibility(), which intentionally runs **after** the library visitor pass in CSharpGen.cs. That ordering is required: the previous/current contract comparison must use the final, post-visitor member signatures, otherwise we could incorrectly decide whether a back-compat member is needed.

The side effect is that the synthesized members were never run through `VisitMethod` / `VisitConstructor` / `VisitField`, so any visitor transform (renames, statement rewrites, removals) silently skipped them.

## Fix
Keep back-compat processing after the visitor pass, but visit **only the newly-added** members inside `ProcessTypeForBackCompatibility` (before `Update`). A new generic `VisitNewMembers<T>` helper diffs by reference against the pre-`Update` collections so members that were already visited during the main pass are not re-visited/double-transformed. Because this lives in the base `TypeProvider`, it applies to all providers (model factory, client, enums).

- `LibraryVisitor.VisitConstructor`/`VisitField` widened to `protected internal` (matching `VisitMethod`) so `TypeProvider` can invoke them. Cross-assembly overrides (e.g. `StubLibraryVisitor`) correctly remain `protected`.

## Tests
- `BackCompatibility_BackCompatMethodIsVisited` – the synthesized overload is visited; existing members are not re-visited.
- `BackCompatibility_BackCompatMethodCanBeMutatedByVisitor` – a visitor's rename of the back-compat method is reflected in the final output.

Full `Microsoft.TypeSpec.Generator` (1536) and `ClientModel` (1429) suites pass.