### PR TITLE
[http-client-csharp] Add Update method to InputModelType

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/InputTypes/InputModelType.cs
@@ -159,6 +159,124 @@ namespace Microsoft.TypeSpec.Generator.Input
             }
         }
 
+        /// <summary>
+        /// Updates the properties of the input model type.
+        /// </summary>
+        /// <param name="name">The new name for the model.</param>
+        /// <param name="namespace">The new namespace for the model.</param>
+        /// <param name="crossLanguageDefinitionId">The new cross-language definition ID for the model.</param>
+        /// <param name="access">The new access modifier for the model.</param>
+        /// <param name="deprecation">The new deprecation message for the model.</param>
+        /// <param name="summary">The new summary for the model.</param>
+        /// <param name="doc">The new documentation for the model.</param>
+        /// <param name="usage">The new usage for the model.</param>
+        /// <param name="properties">The new properties for the model.</param>
+        /// <param name="baseModel">The new base model for the model.</param>
+        /// <param name="discriminatorValue">The new discriminator value for the model.</param>
+        /// <param name="discriminatorProperty">The new discriminator property for the model.</param>
+        /// <param name="additionalProperties">The new additional properties type for the model.</param>
+        /// <param name="modelAsStruct">The new value indicating whether the model should be generated as a struct.</param>
+        /// <param name="serializationOptions">The new serialization options for the model.</param>
+        /// <param name="isDynamicModel">The new value indicating whether the model is dynamic.</param>
+        public void Update(
+            string? name = null,
+            string? @namespace = null,
+            string? crossLanguageDefinitionId = null,
+            string? access = null,
+            string? deprecation = null,
+            string? summary = null,
+            string? doc = null,
+            InputModelTypeUsage? usage = null,
+            IEnumerable<InputModelProperty>? properties = null,
+            InputModelType? baseModel = null,
+            string? discriminatorValue = null,
+            InputModelProperty? discriminatorProperty = null,
+            InputType? additionalProperties = null,
+            bool? modelAsStruct = null,
+            InputSerializationOptions? serializationOptions = null,
+            bool? isDynamicModel = null)
+        {
+            if (name != null)
+            {
+                Name = name;
+            }
+
+            if (@namespace != null)
+            {
+                Namespace = @namespace;
+            }
+
+            if (crossLanguageDefinitionId != null)
+            {
+                CrossLanguageDefinitionId = crossLanguageDefinitionId;
+            }
+
+            if (access != null)
+            {
+                Access = access;
+            }
+
+            if (deprecation != null)
+            {
+                Deprecation = deprecation;
+            }
+
+            if (summary != null)
+            {
+                Summary = summary;
+            }
+
+            if (doc != null)
+            {
+                Doc = doc;
+            }
+
+            if (usage.HasValue)
+            {
+                Usage = usage.Value;
+            }
+
+            if (properties != null)
+            {
+                Properties = [.. properties];
+            }
+
+            if (baseModel != null)
+            {
+                BaseModel = baseModel;
+            }
+
+            if (discriminatorValue != null)
+            {
+                DiscriminatorValue = discriminatorValue;
+            }
+
+            if (discriminatorProperty != null)
+            {
+                DiscriminatorProperty = discriminatorProperty;
+            }
+
+            if (additionalProperties != null)
+            {
+                AdditionalProperties = additionalProperties;
+            }
+
+            if (modelAsStruct.HasValue)
+            {
+                ModelAsStruct = modelAsStruct.Value;
+            }
+
+            if (serializationOptions != null)
+            {
+                SerializationOptions = serializationOptions;
+            }
+
+            if (isDynamicModel.HasValue)
+            {
+                IsDynamicModel = isDynamicModel.Value;
+            }
+        }
+
         private string GetDebuggerDisplay()
         {
             return $"Model (Name: {Name})";

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/InputModelTypeTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/InputModelTypeTests.cs
@@ -266,5 +266,227 @@ namespace Microsoft.TypeSpec.Generator.Input.Tests
             Assert.IsTrue(unknownModel.Usage.HasFlag(InputModelTypeUsage.Input), "Unknown model should have Input usage flag from base");
             Assert.IsTrue(unknownModel.Usage.HasFlag(InputModelTypeUsage.Output), "Unknown model should have Output usage flag from base");
         }
+
+        [Test]
+        public void CanUpdateModelName()
+        {
+            var model = InputFactory.Model("OriginalName");
+            model.Update(name: "UpdatedName");
+
+            Assert.AreEqual("UpdatedName", model.Name);
+        }
+
+        [Test]
+        public void CanUpdateModelNamespace()
+        {
+            var model = InputFactory.Model("TestModel");
+            model.Update(@namespace: "Updated.Namespace");
+
+            Assert.AreEqual("Updated.Namespace", model.Namespace);
+        }
+
+        [Test]
+        public void CanUpdateModelCrossLanguageDefinitionId()
+        {
+            var model = InputFactory.Model("TestModel");
+            model.Update(crossLanguageDefinitionId: "Updated.Id");
+
+            Assert.AreEqual("Updated.Id", model.CrossLanguageDefinitionId);
+        }
+
+        [Test]
+        public void CanUpdateModelAccess()
+        {
+            var model = InputFactory.Model("TestModel", access: "public");
+            model.Update(access: "internal");
+
+            Assert.AreEqual("internal", model.Access);
+        }
+
+        [Test]
+        public void CanUpdateModelDeprecation()
+        {
+            var model = InputFactory.Model("TestModel");
+            model.Update(deprecation: "This model is deprecated");
+
+            Assert.AreEqual("This model is deprecated", model.Deprecation);
+        }
+
+        [Test]
+        public void CanUpdateModelSummary()
+        {
+            var model = InputFactory.Model("TestModel");
+            model.Update(summary: "Updated summary");
+
+            Assert.AreEqual("Updated summary", model.Summary);
+        }
+
+        [Test]
+        public void CanUpdateModelDoc()
+        {
+            var model = InputFactory.Model("TestModel");
+            model.Update(doc: "Updated documentation");
+
+            Assert.AreEqual("Updated documentation", model.Doc);
+        }
+
+        [Test]
+        public void CanUpdateModelUsage()
+        {
+            var model = InputFactory.Model("TestModel", usage: InputModelTypeUsage.Input);
+            model.Update(usage: InputModelTypeUsage.Output);
+
+            Assert.AreEqual(InputModelTypeUsage.Output, model.Usage);
+        }
+
+        [Test]
+        public void CanUpdateModelProperties()
+        {
+            var model = InputFactory.Model("TestModel");
+            var newProperty = InputFactory.Property("NewProperty", InputPrimitiveType.Int32);
+
+            model.Update(properties: [newProperty]);
+
+            Assert.AreEqual(1, model.Properties.Count);
+            Assert.AreEqual(newProperty, model.Properties[0]);
+        }
+
+        [Test]
+        public void UpdateModelPropertiesSetsEnclosingType()
+        {
+            var model = InputFactory.Model("TestModel");
+            var newProperty = InputFactory.Property("NewProperty", InputPrimitiveType.Int32);
+
+            model.Update(properties: [newProperty]);
+
+            Assert.AreEqual(model, newProperty.EnclosingType);
+        }
+
+        [Test]
+        public void CanUpdateModelBaseModel()
+        {
+            var model = InputFactory.Model("TestModel");
+            var baseModel = InputFactory.Model("BaseModel");
+
+            model.Update(baseModel: baseModel);
+
+            Assert.AreEqual(baseModel, model.BaseModel);
+        }
+
+        [Test]
+        public void CanUpdateModelDiscriminatorValue()
+        {
+            var model = InputFactory.Model("TestModel");
+            model.Update(discriminatorValue: "updatedKind");
+
+            Assert.AreEqual("updatedKind", model.DiscriminatorValue);
+        }
+
+        [Test]
+        public void CanUpdateModelDiscriminatorProperty()
+        {
+            var model = InputFactory.Model("TestModel");
+            var discriminatorProperty = InputFactory.Property("kind", InputPrimitiveType.String, isDiscriminator: true);
+
+            model.Update(discriminatorProperty: discriminatorProperty);
+
+            Assert.AreEqual(discriminatorProperty, model.DiscriminatorProperty);
+        }
+
+        [Test]
+        public void CanUpdateModelAdditionalProperties()
+        {
+            var model = InputFactory.Model("TestModel");
+            model.Update(additionalProperties: InputPrimitiveType.String);
+
+            Assert.AreEqual(InputPrimitiveType.String, model.AdditionalProperties);
+        }
+
+        [Test]
+        public void CanUpdateModelAsStruct()
+        {
+            var model = InputFactory.Model("TestModel", modelAsStruct: false);
+            model.Update(modelAsStruct: true);
+
+            Assert.IsTrue(model.ModelAsStruct);
+        }
+
+        [Test]
+        public void CanUpdateModelSerializationOptions()
+        {
+            var model = InputFactory.Model("TestModel");
+            var serializationOptions = new InputSerializationOptions(json: new InputJsonSerializationOptions("jsonName"));
+
+            model.Update(serializationOptions: serializationOptions);
+
+            Assert.AreEqual(serializationOptions, model.SerializationOptions);
+        }
+
+        [Test]
+        public void CanUpdateModelIsDynamicModel()
+        {
+            var model = InputFactory.Model("TestModel", isDynamicModel: false);
+            model.Update(isDynamicModel: true);
+
+            Assert.IsTrue(model.IsDynamicModel);
+        }
+
+        [Test]
+        public void CanUpdateMultipleModelPropertiesAtOnce()
+        {
+            var model = InputFactory.Model("OriginalName", usage: InputModelTypeUsage.Input, modelAsStruct: false);
+
+            model.Update(
+                name: "UpdatedName",
+                summary: "Updated summary",
+                usage: InputModelTypeUsage.Output,
+                modelAsStruct: true);
+
+            Assert.AreEqual("UpdatedName", model.Name);
+            Assert.AreEqual("Updated summary", model.Summary);
+            Assert.AreEqual(InputModelTypeUsage.Output, model.Usage);
+            Assert.IsTrue(model.ModelAsStruct);
+        }
+
+        [Test]
+        public void UpdateWithNullParametersDoesNotChangeModel()
+        {
+            var model = InputFactory.Model("OriginalName", usage: InputModelTypeUsage.Input, modelAsStruct: true, isDynamicModel: true);
+            var originalName = model.Name;
+            var originalNamespace = model.Namespace;
+            var originalCrossLanguageDefinitionId = model.CrossLanguageDefinitionId;
+            var originalAccess = model.Access;
+            var originalDeprecation = model.Deprecation;
+            var originalSummary = model.Summary;
+            var originalDoc = model.Doc;
+            var originalUsage = model.Usage;
+            var originalProperties = model.Properties;
+            var originalBaseModel = model.BaseModel;
+            var originalDiscriminatorValue = model.DiscriminatorValue;
+            var originalDiscriminatorProperty = model.DiscriminatorProperty;
+            var originalAdditionalProperties = model.AdditionalProperties;
+            var originalModelAsStruct = model.ModelAsStruct;
+            var originalSerializationOptions = model.SerializationOptions;
+            var originalIsDynamicModel = model.IsDynamicModel;
+
+            model.Update(); // All parameters are null
+
+            Assert.AreEqual(originalName, model.Name);
+            Assert.AreEqual(originalNamespace, model.Namespace);
+            Assert.AreEqual(originalCrossLanguageDefinitionId, model.CrossLanguageDefinitionId);
+            Assert.AreEqual(originalAccess, model.Access);
+            Assert.AreEqual(originalDeprecation, model.Deprecation);
+            Assert.AreEqual(originalSummary, model.Summary);
+            Assert.AreEqual(originalDoc, model.Doc);
+            Assert.AreEqual(originalUsage, model.Usage);
+            Assert.AreEqual(originalProperties, model.Properties);
+            Assert.AreEqual(originalBaseModel, model.BaseModel);
+            Assert.AreEqual(originalDiscriminatorValue, model.DiscriminatorValue);
+            Assert.AreEqual(originalDiscriminatorProperty, model.DiscriminatorProperty);
+            Assert.AreEqual(originalAdditionalProperties, model.AdditionalProperties);
+            Assert.AreEqual(originalModelAsStruct, model.ModelAsStruct);
+            Assert.AreEqual(originalSerializationOptions, model.SerializationOptions);
+            Assert.AreEqual(originalIsDynamicModel, model.IsDynamicModel);
+        }
     }
 }


### PR DESCRIPTION
## Description

Adds an `Update` method to `InputModelType` so that library visitors can mutate model properties, consistent with the `Update` methods already available on other input types (e.g. `InputModelProperty`, `InputClient`, `InputServiceMethod`, `InputOperation`, `InputParameter`).

Previously `InputModelType` had no `Update` method, so visitors could not mutate its properties.

## Changes

- Added `InputModelType.Update(...)` covering the mutable fields (name, namespace, cross-language definition id, access, deprecation, summary, doc, usage, properties, base model, discriminator value/property, additional properties, model-as-struct, serialization options, is-dynamic). Updating `properties` also re-establishes the `EnclosingType` back-reference.
- Added unit tests in `InputModelTypeTests` covering each updatable field, multi-field updates, no-op update, and enclosing type wiring.