### PR TITLE
Fix cookie consent banner positioning

### DIFF
--- a/website/public/1ds-init.js
+++ b/website/public/1ds-init.js
@@ -13,6 +13,13 @@ function ensureCookieBannerPlaceholder() {
   if (!el) {
     el = document.createElement("div");
     el.id = "cookie-banner";
+    // Pin the banner to the bottom of the viewport, above all other content,
+    // so it stays visible and doesn't fight with the fixed page header.
+    el.style.position = "fixed";
+    el.style.left = "0";
+    el.style.right = "0";
+    el.style.bottom = "0";
+    el.style.zIndex = "9999";
     document.body.appendChild(el);
   }
   return el;


### PR DESCRIPTION
## Problem

Following #11152, the MSCC cookie consent banner renders, but positioning was awkward: the `#cookie-banner` placeholder was placed in the normal document flow, so it either appeared at the very bottom of the page (had to scroll to see it) or, when inserted at the top, rendered *behind* the fixed page header (`z-index: 500`).

## Change

- `website/public/1ds-init.js`: give the `#cookie-banner` container `position: fixed; bottom: 0; left/right: 0; z-index: 9999` so the banner is pinned to the bottom of the viewport, stays visible without scrolling, and never fights with the fixed page header.

<img width="2282" height="875" alt="image" src="https://github.com/user-attachments/assets/6d9a330e-abcb-41a6-94f0-0463633791fc" />
