### PR TITLE
Fix flaky playground e2e tests

### DIFF
--- a/packages/playground-website/e2e/playwright.config.ts
+++ b/packages/playground-website/e2e/playwright.config.ts
@@ -7,11 +7,21 @@ const root = resolve(__dirname, "..");
 
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
+  // Safety net for the occasional e2e flake in CI.
+  retries: process.env.CI ? 1 : 0,
   timeout: 120 * 1000,
   expect: { timeout: 10_000 },
   webServer: {
-    command: "pnpm watch",
+    // Serve the pre-built app instead of the Vite dev server (`pnpm watch`).
+    // The dev server transforms modules on demand and re-optimizes dependencies
+    // on the first page load; discovering a new dependency mid-load triggers a
+    // full page reload that aborts the in-flight `page.goto` (net::ERR_ABORTED),
+    // which intermittently failed whichever test ran first. `vite preview` serves
+    // the static build (the `test:e2e` task already depends on `build`), so there
+    // is no on-demand transform, dependency re-optimization, or HMR reload.
+    command: "vite preview --port 5173 --strictPort",
     port: 5173,
+    cwd: root,
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Problem

The `@typespec/playground-website` e2e tests are flaky in CI — the first one or two tests (`compiled http sample`, `report compilation errors`) intermittently fail at `page.goto` (`ui.e2e.ts:24`), while the later tests pass.

**This is not a timeout** — `page.goto` completes in ~1–2.5s locally. The root cause is the Playwright `webServer` using the Vite **dev** server (`pnpm watch`). The dev server transforms modules on demand and re-optimizes dependencies on the first page load; when it discovers a new dependency mid-load it issues a **full page reload that aborts the in-flight navigation** (`net::ERR_ABORTED`). That fails fast and only affects whichever test runs first — subsequent tests hit an already-optimized server and pass.

## Change

- Serve the **pre-built** app with `vite preview` instead of the dev server. The `test:e2e` turbo task already `dependsOn: ["build"]`, so `dist/web` is always available. There is no on-demand transform, dependency re-optimization, or HMR reload, so the first navigation is deterministic (full suite: ~6s vs ~2m before).
  - Set `cwd` to the package root so `vite preview` resolves `vite.config.ts` (`build.outDir = dist/web`).
- Keep a single CI retry as a safety net.

## Validation

- `CI=1 pnpm test:e2e` — 4/4 tests pass consistently in ~6s (previously ~2.1m with intermittent first-test failures).
- `pnpm lint` passes.

## Note

The dev-server dependency re-optimization reload is timing-dependent, so it does not reproduce on every cold local run; CI's slower/different timing is what surfaces it. Serving the static build removes the mechanism entirely regardless of timing.