### PR TITLE
Add Install PNPM Template

### DIFF
--- a/eng/common/pipelines/ci.yml
+++ b/eng/common/pipelines/ci.yml
@@ -32,10 +32,7 @@ extends:
 
               - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
 
-              - pwsh: |
-                  $packageJson = Get-Content -Raw "$(Build.SourcesDirectory)/package.json" | ConvertFrom-Json
-                  npm install -g $packageJson.packageManager # Pnpm manage-package-manager-versions will respect packageManager field
-                displayName: Install pnpm
+              - template: /eng/common/pipelines/templates/steps/install-pnpm.yml
 
               - script: pnpm install
                 displayName: Install JavaScript Dependencies

--- a/eng/common/pipelines/templates/steps/install-pnpm.yml
+++ b/eng/common/pipelines/templates/steps/install-pnpm.yml
@@ -1,0 +1,5 @@
+steps:
+  - pwsh: |
+      $packageJson = Get-Content -Raw "$(Build.SourcesDirectory)/package.json" | ConvertFrom-Json
+      npm install -g $packageJson.packageManager
+    displayName: Install pnpm

--- a/eng/emitters/pipelines/templates/stages/emitter-stages.yml
+++ b/eng/emitters/pipelines/templates/stages/emitter-stages.yml
@@ -409,8 +409,7 @@ stages:
                   - script: npm run ${{ parameters.PlaygroundBundleBuildScript }}
                     displayName: Build emitter for playground bundle
                     workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}
-                  - script: npm install -g pnpm
-                    displayName: Install pnpm for playground bundle upload
+                  - template: /eng/common/pipelines/templates/steps/install-pnpm.yml
                   - script: pnpm install --filter "@typespec/bundle-uploader..."
                     displayName: Install bundle-uploader dependencies
                     workingDirectory: $(Build.SourcesDirectory)

--- a/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
+++ b/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
@@ -44,10 +44,7 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
 
-      - script: |
-          $packageJson = Get-Content -Raw "$(Build.SourcesDirectory)/package.json" | ConvertFrom-Json
-          npm install -g $packageJson.packageManager
-        displayName: Install pnpm
+      - template: /eng/common/pipelines/templates/steps/install-pnpm.yml
 
       - script: pnpm install --filter "@typespec/standalone-cli"
         displayName: Install JavaScript Dependencies

--- a/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
+++ b/eng/tsp-core/pipelines/jobs/cli/build-tsp-cli.yml
@@ -44,7 +44,9 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
 
-      - script: npm install -g pnpm
+      - script: |
+          $packageJson = Get-Content -Raw "$(Build.SourcesDirectory)/package.json" | ConvertFrom-Json
+          npm install -g $packageJson.packageManager
         displayName: Install pnpm
 
       - script: pnpm install --filter "@typespec/standalone-cli"

--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -26,10 +26,7 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
 
-  - pwsh: |
-      $packageJson = Get-Content -Raw "$(Build.SourcesDirectory)/package.json" | ConvertFrom-Json
-      npm install -g $packageJson.packageManager # Pnpm manage-package-manager-versions will respect packageManager field
-    displayName: Install pnpm
+  - template: /eng/common/pipelines/templates/steps/install-pnpm.yml
 
   - script: pnpm config set store-dir ${{ parameters.pnpmStorePath }}
     displayName: Setup pnpm cache dir


### PR DESCRIPTION
This pull request refactors the way `pnpm` is installed across multiple pipeline configurations by centralizing the installation logic into a reusable template. This change ensures consistency and reduces duplication in the pipeline setup scripts.

**Pipeline step refactoring:**

* Introduced a new template `install-pnpm.yml` that encapsulates the logic for installing `pnpm` based on the `packageManager` specified in `package.json`.
* Updated various pipeline YAML files (`ci.yml`, `emitter-stages.yml`, `build-tsp-cli.yml`, and `install.yml`) to use the new `install-pnpm.yml` template instead of duplicating the installation script or using inline scripts. [[1]](diffhunk://#diff-50653fd56ca297fe36cce63c692f3bb54b6e0c6ec4845cec48f3f9e31e03a89fL35-R35) [[2]](diffhunk://#diff-dda08ab39d3fa47345cdb9dc131fca57b121bd5630dbce9116b1838054b04232L412-R412) [[3]](diffhunk://#diff-9e0ecf3eecec8baef1816b5d44be550486a40f4738b975bffd2efd55e90c4512L47-R47) [[4]](diffhunk://#diff-4e7c6928f4ef45999e81f7e57bbc59d49275f6496fd2cfa7476dc218555d23afL29-R29)