### PR TITLE
Fix stale create-authenticated-npmrc template path in ado-feed-release

### DIFF
--- a/eng/tsp-core/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/tsp-core/pipelines/templates/release/ado-feed-release.yml
@@ -13,7 +13,7 @@ steps:
   # Publishing the packages directly to the Azure DevOps `azure-sdk-for-js` feed bypasses the
   # upstream npmjs.org quarantine (which blocks newly released packages for 7 days) so CI can
   # consume freshly released packages immediately.
-  - template: /eng/emitters/pipelines/templates/steps/create-authenticated-npmrc.yml
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     parameters:
       npmrcPath: ${{ parameters.path }}/.npmrc
       registryUrl: ${{ parameters.registryUrl }}


### PR DESCRIPTION
## Problem

The newly merged ADO publish job (#11118) fails with:

```
/eng/tsp-core/pipelines/templates/release/ado-feed-release.yml: Could not find /eng/emitters/pipelines/templates/steps/create-authenticated-npmrc.yml in repository self ... GitHub reported the error, "Not Found"
```

which in turn surfaces as the misleading `The 'stages' parameter is not a valid StageList.` YAML-parse error.

## Root cause

`create-authenticated-npmrc.yml` was moved from `eng/emitters/pipelines/templates/steps/` to `eng/common/pipelines/templates/steps/` in #11045 (commit `a4a569ecba`). PR #11118 branched before that move, so the merge left a stale path in `ado-feed-release.yml`.

## Change

Point `ado-feed-release.yml` at the current template location `/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml`. The target template's parameters (`npmrcPath`, `registryUrl`) match what is passed, and no other stale references remain.

eng/CI-only change — no changelog entry.