### PR TITLE
[skip chg] ci: Bump version to 0.15.0 in package.json

### DIFF
--- a/packages/http-client-js/CHANGELOG.md
+++ b/packages/http-client-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - @typespec/http-client-js
 
+## 0.15.0
+
+Manual release due to dependencies upgrade.
+
 ## 0.14.1
 
 ### Bump dependencies

--- a/packages/http-client-js/package.json
+++ b/packages/http-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-js",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "type": "module",
   "homepage": "https://typespec.io",
   "readme": "https://github.com/microsoft/typespec/blob/main/packages/http-client-js/README.md",


### PR DESCRIPTION
in order to trigger a release since the package has not been published in over 4 months and that's creating misalignments