### PR TITLE
Stop publishing typespec-vscode/typespec-vs to npm & run build on Linux

### DIFF
--- a/eng/tsp-core/pipelines/jobs/build-packages.yml
+++ b/eng/tsp-core/pipelines/jobs/build-packages.yml
@@ -2,8 +2,14 @@ jobs:
   - job: build
     displayName: Build Packages
 
+    pool:
+      name: $(LINUXPOOL)
+      image: $(LINUXVMIMAGE)
+      os: linux
+
     variables:
       TYPESPEC_SKIP_WEBSITE_BUILD: true # Disable docusaurus build
+      TYPESPEC_SKIP_VS_BUILD: true # VS extension is built in the dedicated build-vs (Windows) job
 
     steps:
       - template: /eng/tsp-core/pipelines/templates/install.yml
@@ -32,18 +38,11 @@ jobs:
           Contents: "*.vsix"
           TargetFolder: "$(Build.ArtifactStagingDirectory)/vscode-extension"
 
-      - task: CopyFiles@2
-        displayName: "Copy VS extension .vsix to artifact directory"
-        inputs:
-          SourceFolder: "$(Build.SourcesDirectory)/packages/typespec-vs"
-          Contents: "*.vsix"
-          TargetFolder: "$(Build.ArtifactStagingDirectory)/vs-extension"
-
       - task: AzureCLI@2
         displayName: "Publish bundled packages to package storage"
         inputs:
           azureSubscription: "Azure SDK Engineering System"
-          scriptType: batch
+          scriptType: bash
           scriptLocation: inlineScript
           inlineScript: node ./eng/tsp-core/scripts/upload-bundler-packages.js
 
@@ -74,15 +73,15 @@ jobs:
         displayName: "Publish playground"
         inputs:
           azureSubscription: "Azure SDK Engineering System"
-          scriptType: batch
+          scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            az storage blob upload-batch ^
-              --auth-mode login ^
-              --destination $web ^
-              --account-name "cadlplayground" ^
-              --destination-path / ^
-              --source "./packages/playground-website/dist/web/" ^
+            az storage blob upload-batch \
+              --auth-mode login \
+              --destination '$web' \
+              --account-name "cadlplayground" \
+              --destination-path / \
+              --source "./packages/playground-website/dist/web/" \
               --overwrite
 
     templateContext:
@@ -104,8 +103,3 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)/vscode-extension
           artifact: vscode-extension-unsigned
           displayName: Publish VSCode extension(.vsix) as pipeline artifacts
-
-        - output: pipelineArtifact
-          path: $(Build.ArtifactStagingDirectory)/vs-extension
-          artifact: vs-extension-unsigned
-          displayName: Publish VS extension(.vsix) as pipeline artifacts

--- a/eng/tsp-core/pipelines/jobs/build-vs.yml
+++ b/eng/tsp-core/pipelines/jobs/build-vs.yml
@@ -1,0 +1,34 @@
+jobs:
+  - job: build_vs
+    displayName: Build VS extension
+
+    pool:
+      name: $(WINDOWSPOOL)
+      image: $(WINDOWSVMIMAGE)
+      os: windows
+
+    variables:
+      TYPESPEC_SKIP_WEBSITE_BUILD: true # Disable docusaurus build
+      TYPESPEC_VS_CI_BUILD: true # Enable official Visual Studio extension build
+
+    steps:
+      - template: /eng/tsp-core/pipelines/templates/install.yml
+        parameters:
+          useDotNet: true
+
+      - script: pnpm -r --filter "typespec-vs..." build
+        displayName: Build
+
+      - task: CopyFiles@2
+        displayName: "Copy VS extension .vsix to artifact directory"
+        inputs:
+          SourceFolder: "$(Build.SourcesDirectory)/packages/typespec-vs"
+          Contents: "*.vsix"
+          TargetFolder: "$(Build.ArtifactStagingDirectory)/vs-extension"
+
+    templateContext:
+      outputs:
+        - output: pipelineArtifact
+          path: $(Build.ArtifactStagingDirectory)/vs-extension
+          artifact: vs-extension-unsigned
+          displayName: Publish VS extension(.vsix) as pipeline artifacts

--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -27,13 +27,9 @@ extends:
         dependsOn: []
         displayName: Build
 
-        pool:
-          name: $(WINDOWSPOOL)
-          image: $(WINDOWSVMIMAGE)
-          os: windows
-
         jobs:
-          - template: /eng/tsp-core/pipelines/jobs/build-for-publish.yml@self
+          - template: /eng/tsp-core/pipelines/jobs/build-packages.yml@self
+          - template: /eng/tsp-core/pipelines/jobs/build-vs.yml@self
           - template: /eng/tsp-core/pipelines/jobs/cli/build-tsp-cli-all.yml@self
           - template: /eng/tsp-core/pipelines/jobs/e2e.yml@self
             parameters:

--- a/packages/typespec-vs/package.json
+++ b/packages/typespec-vs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "typespec-vs",
+  "private": true,
   "author": "Microsoft Corporation",
   "version": "1.13.0",
   "description": "TypeSpec Language Support for Visual Studio",

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -1,5 +1,6 @@
 {
   "name": "typespec-vscode",
+  "private": true,
   "version": "1.13.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec language support for VS Code",


### PR DESCRIPTION
Fixes part of #11168 (part 2). Re-implements the build optimization from the closed #6907.

Now that the VS Code and Visual Studio extensions are installed from their respective marketplaces (part 1, #11169), publishing `typespec-vscode` and `typespec-vs` to npm is redundant. This PR stops publishing them and optimizes the build pipeline.

## Stop publishing to npm

- Mark `typespec-vscode` and `typespec-vs` as `"private": true`.
- `chronus pack` iterates only non-private packages, so they drop out of the `npm-packages-*` artifacts and are no longer pushed to npm.
- They remain in their chronus lockstep version policies (`typespec-stable` / `typespec-preview`), so the extension versions keep advancing for marketplace releases. This mirrors the existing `@typespec/standalone-cli` pattern (`private: true` + still in a lockstep policy).

## Optimize the build pipeline (re-implements #6907)

The `build` stage previously ran entirely on **Windows** solely to build the Visual Studio extension (.NET/VS SDK). This splits that out so the bulk of the build runs on **Linux**:

- Renamed `build-for-publish.yml` → `build-packages.yml`, moved it to a **Linux** pool, and set `TYPESPEC_SKIP_VS_BUILD: true`. It still builds/tests everything else and produces the npm packs, the VS Code `.vsix`, bundler packages, scenario manifest, and playground.
- Added `build-vs.yml`, a dedicated **Windows** job that builds only the VS extension (`TYPESPEC_VS_CI_BUILD: true`) and outputs the `vs-extension-unsigned` artifact (same name as before).
- Updated `publish.yml` to drop the stage-level Windows pool and reference both jobs.

Artifact names (`npm-packages-stable`, `npm-packages-next`, `vscode-extension-unsigned`, `vs-extension-unsigned`) and the `build` job/pack step names are preserved, so the downstream sign/publish stages are unchanged.

## Validation

- `chronus verify` passes; `pnpm install --frozen-lockfile` is unaffected by the `private` flag.
- ⚠️ The ADO publish pipeline restructure (pool split) can't be executed locally and should be validated with a real pipeline run before merge.
