### PR TITLE
Discover MRW models inside response wrappers

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -176,7 +176,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 {
                     var returnType = method.Signature.ReturnType;
 
-                    // Unwrap Task/Task<T> and collection types to get to the actual model type
+                    // Unwrap framework wrappers and collection types to get to the actual model type
                     var actualType = UnwrapReturnType(returnType);
 
                     if (actualType != null && actualType.IsFrameworkType)
@@ -280,7 +280,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         }
 
         /// <summary>
-        /// Unwraps a return type to get the actual model type by stripping away Task, Task&lt;T&gt;, and collection wrappers.
+        /// Unwraps a return type to get the actual model type by stripping away wrapper and collection types.
         /// </summary>
         private static CSharpType? UnwrapReturnType(CSharpType? returnType)
         {
@@ -304,6 +304,12 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     // Task without type argument doesn't have a model
                     return null;
                 }
+            }
+
+            // Unwrap generic framework wrappers such as Response<T>.
+            while (type.IsFrameworkType && type.Arguments.Count == 1 && !ImplementsModelReaderWriter(type.FrameworkType))
+            {
+                type = type.Arguments[0];
             }
 
             // Unwrap collection types to get the element type

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
@@ -42,6 +42,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
             Assert.IsTrue(contextDefinition.BaseType!.Equals(typeof(ModelReaderWriterContext)));
         }
 
+        public class FrameworkResponse<T>
+        {
+        }
+
         [Test]
         public void ValidateModelReaderWriterBuildableAttributesAreGenerated()
         {
@@ -1530,6 +1534,27 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
         }
 
         [Test]
+        public void ValidateFrameworkReturnTypesAreDiscoveredFromGenericResponseWrappers()
+        {
+            var clientProvider = new TestClientProviderWithWrappedFrameworkReturnType();
+            var outputLibrary = new TestOutputLibrary([clientProvider]);
+            var mockGenerator = MockHelpers.LoadMockGenerator(
+                createOutputLibrary: () => outputLibrary);
+
+            var contextDefinition = new ModelReaderWriterContextDefinition();
+            var attributes = contextDefinition.Attributes;
+
+            Assert.IsNotNull(attributes);
+            Assert.IsTrue(attributes.Count > 0);
+
+            var buildableAttributes = attributes.Where(a => a.Type.IsFrameworkType &&
+                a.Type.FrameworkType == typeof(ModelReaderWriterBuildableAttribute)).ToList();
+
+            Assert.IsTrue(buildableAttributes.Any(a => a.Arguments.First().ToDisplayString().Contains("FrameworkModelWithMRW")),
+                "FrameworkModelWithMRW should be discovered from generic response wrapper return type");
+        }
+
+        [Test]
         public async Task ValidateCustomPropertiesOnModelsAreDiscovered()
         {
             // Test that properties added via custom code are discovered
@@ -1679,6 +1704,32 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
             protected internal override MethodProvider[] BuildMethods()
             {
                 var returnType = new CSharpType(typeof(FrameworkModelWithMRW));
+
+                var signature = new MethodSignature(
+                    Name: "GetFrameworkModel",
+                    Description: null,
+                    Modifiers: MethodSignatureModifiers.Public,
+                    ReturnType: returnType,
+                    ReturnDescription: null,
+                    Parameters: []);
+
+                return
+                [
+                    new MethodProvider(signature, Statements.MethodBodyStatement.Empty, this)
+                ];
+            }
+        }
+
+        // Test client provider that returns a framework MRW type wrapped in a generic response type
+        private class TestClientProviderWithWrappedFrameworkReturnType : TypeProvider
+        {
+            protected override string BuildName() => "TestClient";
+
+            protected override string BuildRelativeFilePath() => "TestClient.cs";
+
+            protected internal override MethodProvider[] BuildMethods()
+            {
+                var returnType = new CSharpType(typeof(FrameworkResponse<>), new CSharpType(typeof(FrameworkModelWithMRW)));
 
                 var signature = new MethodSignature(
                     Name: "GetFrameworkModel",


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-for-net/issues/59433

## Summary

- unwrap generic framework response wrappers when collecting method return types for ModelReaderWriter context metadata
- ensure framework MRW models returned as `Response<T>`-style wrappers get `ModelReaderWriterBuildable` entries
- add regression coverage for a framework MRW model returned through a generic response wrapper

## Validation

- dotnet test packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj --filter "FullyQualifiedName~ModelReaderWriterContextDefinitionTests" --logger "console;verbosity=minimal"
- verified in Azure/azure-sdk-for-net by project-referencing local MTG, running mgmt Generate.ps1, running 243 mgmt generator tests, regenerating ComputeBulkActions with RegenSdkLocal.ps1 after removing the custom workaround, and building the package

## Related

- Enables Azure/azure-sdk-for-net#60665 to use the shared MTG context provider instead of a management-specific workaround.
