### PR TITLE
Fix runtime deserialization failure for polymorphic models with referenced extensible-enum discriminators

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/MrwSerializationTypeDefinitionTests.cs
@@ -663,6 +663,40 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
         }
 
         [Test]
+        public void ReferencedExtensibleEnumUsesInlineConstruction()
+        {
+            // A property typed as a referenced extensible enum (a value-type struct) must deserialize via
+            // inline construction, not the generic ModelReaderWriter.Read<T> fallback (which throws at
+            // runtime because the struct has no MRW builder).
+            var externalEnum = InputFactory.StringEnum(
+                "ExternalKind",
+                [("value1", "value1"), ("value2", "value2")],
+                isExtensible: true,
+                external: new InputExternalTypeMetadata("System.Guid", null, null));
+            var property = InputFactory.Property("kind", externalEnum);
+
+            var inputModel = InputFactory.Model("mockInputModel", properties: [property]);
+            var (_, serialization) = CreateModelAndSerialization(inputModel);
+
+            var deserializationMethod = serialization.Methods.Single(m => m.Signature.Name.StartsWith("Deserialize"));
+            var methodBody = deserializationMethod.BodyStatements!.ToDisplayString();
+
+            Assert.IsFalse(
+                methodBody.Contains("ModelReaderWriter.Read<global::System.Guid>"),
+                "Referenced extensible enum should not use the ModelReaderWriter.Read<T> fallback.");
+            Assert.IsTrue(
+                methodBody.Contains("new global::System.Guid("),
+                "Referenced extensible enum should be constructed inline from its underlying value.");
+
+            // Serialization must use the enum's underlying value (ToString for a string-backed enum),
+            // not a model write.
+            var writeBody = serialization.BuildJsonModelWriteCoreMethod().BodyStatements!.ToDisplayString();
+            Assert.IsTrue(
+                writeBody.Contains("WriteStringValue(") && writeBody.Contains("ToString()"),
+                "Referenced extensible enum should serialize via its underlying string value.");
+        }
+
+        [Test]
         public void TestBuildDeserializationMethodNestedSARD()
         {
             var baseModel = InputFactory.Model("BaseModel");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TypeSpec.Generator.Primitives
     {
         private readonly Type? _type;
         private object? _literal;
-        private readonly Type? _underlyingType;
+        private Type? _underlyingType;
         private IReadOnlyList<CSharpType>? _unionItemTypes;
 
         private bool? _isReadOnlyMemory;
@@ -549,6 +549,37 @@ namespace Microsoft.TypeSpec.Generator.Primitives
                 ? new CSharpType(FrameworkType, Arguments, isNullable)
                 : new CSharpType(Name, Namespace, IsValueType, isNullable, DeclaringType, Arguments, IsPublic, IsStruct, BaseType, _underlyingType);
 
+            // Preserve explicit enum semantics for framework types (e.g. referenced extensible enums,
+            // which are structs and are not recognized as enums via reflection). The framework constructor
+            // recomputes the underlying type from reflection and would otherwise drop it.
+            if (!ReferenceEquals(type, this) && IsFrameworkType && _underlyingType is not null)
+            {
+                type._underlyingType = _underlyingType;
+            }
+
+            type._literal = _literal;
+            type._unionItemTypes = _unionItemTypes;
+
+            return type;
+        }
+
+        /// <summary>
+        /// Returns a framework-backed copy of this <see cref="CSharpType"/> that carries explicit enum
+        /// semantics. This is used for referenced (external) extensible enums, which are implemented as
+        /// value-type structs and therefore are not recognized as enums via reflection
+        /// (<see cref="Type.IsEnum"/> is <c>false</c>). Preserving the underlying enum type lets downstream
+        /// serialization treat the type as an enum (inline construction) instead of falling back to a model read.
+        /// </summary>
+        /// <param name="underlyingEnumType">The underlying value type of the enum (e.g. <see cref="string"/> or <see cref="int"/>).</param>
+        internal CSharpType WithUnderlyingEnumType(Type underlyingEnumType)
+        {
+            if (!IsFrameworkType)
+            {
+                throw new InvalidOperationException("WithUnderlyingEnumType is only valid for framework types.");
+            }
+
+            var type = new CSharpType(FrameworkType, Arguments, IsNullable);
+            type._underlyingType = underlyingEnumType;
             type._literal = _literal;
             type._unionItemTypes = _unionItemTypes;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Primitives/CSharpType.cs
@@ -552,7 +552,7 @@ namespace Microsoft.TypeSpec.Generator.Primitives
             // Preserve explicit enum semantics for framework types (e.g. referenced extensible enums,
             // which are structs and are not recognized as enums via reflection). The framework constructor
             // recomputes the underlying type from reflection and would otherwise drop it.
-            if (!ReferenceEquals(type, this) && IsFrameworkType && _underlyingType is not null)
+            if (IsFrameworkType && _underlyingType is not null)
             {
                 type._underlyingType = _underlyingType;
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -74,7 +74,23 @@ namespace Microsoft.TypeSpec.Generator
             // Check if this type has external type information
             if (inputType.External != null)
             {
-                return CreateExternalType(inputType.External);
+                var externalType = CreateExternalType(inputType.External);
+
+                // A referenced extensible enum is implemented as a value-type struct, so the resolved
+                // framework type is not recognized as an enum via reflection and loses its enum semantics.
+                // Rebuild it preserving the underlying enum type so downstream serialization emits inline
+                // construction (e.g. new Kind(value)) instead of a broken ModelReaderWriter.Read<T> fallback.
+                if (externalType is { IsFrameworkType: true }
+                    && inputType is InputEnumType { IsExtensible: true } externalEnum)
+                {
+                    var underlyingType = CreateCSharpType(externalEnum.ValueType);
+                    if (underlyingType is { IsFrameworkType: true })
+                    {
+                        externalType = externalType.WithUnderlyingEnumType(underlyingType.FrameworkType);
+                    }
+                }
+
+                return externalType;
             }
 
             CSharpType? type;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -74,23 +74,7 @@ namespace Microsoft.TypeSpec.Generator
             // Check if this type has external type information
             if (inputType.External != null)
             {
-                var externalType = CreateExternalType(inputType.External);
-
-                // A referenced extensible enum is implemented as a value-type struct, so the resolved
-                // framework type is not recognized as an enum via reflection and loses its enum semantics.
-                // Rebuild it preserving the underlying enum type so downstream serialization emits inline
-                // construction (e.g. new Kind(value)) instead of a broken ModelReaderWriter.Read<T> fallback.
-                if (externalType is { IsFrameworkType: true }
-                    && inputType is InputEnumType { IsExtensible: true } externalEnum)
-                {
-                    var underlyingType = CreateCSharpType(externalEnum.ValueType);
-                    if (underlyingType is { IsFrameworkType: true })
-                    {
-                        externalType = externalType.WithUnderlyingEnumType(underlyingType.FrameworkType);
-                    }
-                }
-
-                return externalType;
+                return CreateExternalType(inputType.External, inputType);
             }
 
             CSharpType? type;
@@ -338,30 +322,42 @@ namespace Microsoft.TypeSpec.Generator
         /// Factory method for creating a <see cref="CSharpType"/> based on external type properties.
         /// </summary>
         /// <param name="externalProperties">The <see cref="InputExternalTypeMetadata"/> to convert.</param>
+        /// <param name="inputType">The originating <see cref="InputType"/>, when available, used to preserve
+        /// semantics (such as extensible-enum backing) that reflection alone cannot recover from the resolved type.</param>
         /// <returns>A <see cref="CSharpType"/> representing the external type, or null if the type cannot be resolved.</returns>
-        private CSharpType? CreateExternalType(InputExternalTypeMetadata externalProperties)
+        private CSharpType? CreateExternalType(InputExternalTypeMetadata externalProperties, InputType? inputType = null)
         {
-            // 1. Try to create a framework type from the fully qualified name. This stays as the
-            // first attempt because it's free (no I/O) and is the source of truth for BCL types.
-            var frameworkType = CreateFrameworkType(externalProperties.Identity);
-            if (frameworkType != null)
+            // Resolve the type: first as a framework type from the fully qualified name (free, no I/O, and the
+            // source of truth for BCL types), then, on a miss, dynamically from the NuGet package named in the
+            // metadata. ExternalTypeReferenceResolver consults a process-wide cache populated by the eager
+            // pre-walk in CSharpGen.ExecuteAsync, resolving on-demand when the cache misses.
+            var resolvedType = CreateFrameworkType(externalProperties.Identity);
+            if (resolvedType == null && !string.IsNullOrEmpty(externalProperties.Package))
             {
-                return new CSharpType(frameworkType);
+                resolvedType = ExternalTypeReferenceResolver.TryResolve(externalProperties);
             }
 
-            // 2. Fallback: dynamically resolve the type from the NuGet package named in the metadata.
-            // ExternalTypeReferenceResolver consults a process-wide cache populated by the eager
-            // pre-walk in CSharpGen.ExecuteAsync; on a miss it resolves on-demand.
-            if (!string.IsNullOrEmpty(externalProperties.Package))
+            if (resolvedType != null)
             {
-                var resolvedType = ExternalTypeReferenceResolver.TryResolve(externalProperties);
-                if (resolvedType != null)
+                var externalType = new CSharpType(resolvedType);
+
+                // A referenced extensible enum is implemented as a value-type struct, so the resolved
+                // framework type is not recognized as an enum via reflection and loses its enum semantics.
+                // Rebuild it preserving the underlying enum type so downstream serialization emits inline
+                // construction (e.g. new Kind(value)) instead of a broken ModelReaderWriter.Read<T> fallback.
+                if (inputType is InputEnumType { IsExtensible: true } externalEnum)
                 {
-                    return new CSharpType(resolvedType);
+                    var underlyingType = CreateCSharpType(externalEnum.ValueType);
+                    if (underlyingType is { IsFrameworkType: true })
+                    {
+                        externalType = externalType.WithUnderlyingEnumType(underlyingType.FrameworkType);
+                    }
                 }
+
+                return externalType;
             }
 
-            // 3. Neither path worked — emit a diagnostic that explains what was attempted.
+            // Neither path resolved the type — emit a diagnostic that explains what was attempted.
             // Each branch is a self-contained sentence so the final message reads naturally and
             // doesn't repeat "could not be resolved".
             var details = string.IsNullOrEmpty(externalProperties.Package)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
@@ -438,6 +438,7 @@ namespace Microsoft.TypeSpec.Generator.Tests
             Assert.IsTrue(type!.IsFrameworkType);
             Assert.AreEqual(typeof(Uri), type.FrameworkType);
             Assert.IsFalse(type.IsEnum);
+            Assert.Throws<InvalidOperationException>(() => _ = type.UnderlyingEnumType);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/TypeFactoryTests.cs
@@ -380,6 +380,67 @@ namespace Microsoft.TypeSpec.Generator.Tests
         }
 
         [Test]
+        public void CreateCSharpType_ExternalExtensibleStringEnum_PreservesEnumSemantics()
+        {
+            // A referenced extensible enum is implemented as a value-type struct, so reflection does not
+            // report it as an enum. The resolved external type must still carry enum semantics (underlying
+            // type + struct) so serialization emits inline construction instead of a broken model read.
+            var input = InputFactory.StringEnum(
+                "ExternalKind",
+                [("value1", "value1"), ("value2", "value2")],
+                usage: InputModelTypeUsage.Input,
+                isExtensible: true,
+                external: new InputExternalTypeMetadata("System.Guid", null, null));
+
+            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(input);
+
+            Assert.IsNotNull(type);
+            Assert.IsTrue(type!.IsFrameworkType);
+            Assert.AreEqual(typeof(Guid), type.FrameworkType);
+            Assert.IsTrue(type.IsEnum);
+            Assert.IsTrue(type.IsStruct);
+            Assert.AreEqual(typeof(string), type.UnderlyingEnumType);
+        }
+
+        [Test]
+        public void CreateCSharpType_ExternalExtensibleInt32Enum_PreservesEnumSemantics()
+        {
+            var input = InputFactory.Int32Enum(
+                "ExternalKind",
+                [("value1", 1), ("value2", 2)],
+                usage: InputModelTypeUsage.Input,
+                isExtensible: true,
+                external: new InputExternalTypeMetadata("System.Guid", null, null));
+
+            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(input);
+
+            Assert.IsNotNull(type);
+            Assert.IsTrue(type!.IsEnum);
+            Assert.IsTrue(type.IsStruct);
+            Assert.AreEqual(typeof(int), type.UnderlyingEnumType);
+        }
+
+        [Test]
+        public void CreateCSharpType_ExternalFixedEnum_DoesNotForceEnumSemantics()
+        {
+            // Fixed (non-extensible) external enums are left untouched; they resolve to their external
+            // framework type as-is (which, for a real .NET enum, already reports enum semantics).
+            var input = InputFactory.StringEnum(
+                "ExternalKind",
+                [("value1", "value1"), ("value2", "value2")],
+                usage: InputModelTypeUsage.Input,
+                isExtensible: false,
+                external: new InputExternalTypeMetadata("System.Uri", null, null));
+
+            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(input);
+
+            Assert.IsNotNull(type);
+            Assert.IsTrue(type!.IsFrameworkType);
+            Assert.AreEqual(typeof(Uri), type.FrameworkType);
+            Assert.IsFalse(type.IsEnum);
+        }
+
+        [Test]
         public void CreateCSharpType_SelfReferencingModel_DoesNotThrow()
         {
             var selfRefModel = InputFactory.Model("QueryFilter");


### PR DESCRIPTION
Polymorphic models whose discriminator is a referenced (external) extensible enum generated runtime-broken deserialization. The emitter produced:

@type = ModelReaderWriter.Read<ResponseItemKind>(prop.Value.GetUtf8Bytes(), ModelSerializationExtensions.WireOptions, Context.Default);

which throws  No ModelReaderWriterTypeBuilder found  at runtime, because the referenced type isn't registered with  ModelReaderWriter . It now correctly emits inline construction:

@type = new ResponseItemKind(prop.Value.GetString());

Root cause

External types resolve by reflection to a  System.Type . An emitter-generated extensible enum is a  struct , not a real .NET  enum , so reflection's  Type.IsEnum  is  false  →  CSharpType.IsEnum  is  false  → the serialization provider falls through to the  ModelReaderWriter.Read<T>  path instead of the enum path. Real .NET enums survive because reflection detects them; extensible enums lose their enum semantics on the resolved  CSharpType .

Fix

Preserve enum semantics at the type-resolution layer rather than patching the serialization provider (fixes the cause, not the symptom):

•  CSharpType.cs  — made  _underlyingType  settable; added  WithUnderlyingEnumType(Type)  to produce a framework-backed copy that reports  IsEnum . Fixed  WithNullable  to preserve the underlying enum type for framework types (nullable/optional properties were stripping it).
•  TypeFactory.cs  — in  CreateCSharpTypeCore , when an external type resolves to a framework type and the input is  InputEnumType { IsExtensible: true } , reattach the underlying enum type via  WithUnderlyingEnumType .

Because emitter-generated extensible enums always expose a public constructor over their backing value and a public implicit operator (structural invariants of  ExtensibleEnumProvider ),  new T(value)  requires no cooperation from the referenced type, and non-string backing types (int/long/etc.) work automatically via deserialization recursion.

Tests

•  TypeFactoryTests : 3 tests covering external extensible string enum, external extensible int32 enum (both preserve enum semantics), and external fixed enum (does not force enum semantics).
•  MrwSerializationTypeDefinitionTests :  ReferencedExtensibleEnumUsesInlineConstruction  asserts deserialize emits  new ...(  and NOT  ModelReaderWriter.Read<...> , and serialize emits  WriteStringValue(...ToString()) .

Validation

• Core Generator: 1566/1566 passing
• ClientModel: 1450/1450 passing
•  npm run cop : passed
•  pwsh ./eng/scripts/Generate.ps1 : zero diffs to committed generated baselines