### PR TITLE
Preserve generated MRW metadata for wrapped returns

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -222,10 +222,14 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 if (ImplementsModelReaderWriter(typeProvider))
                 {
                     buildableProviders.Add(typeProvider);
+                    CollectBuildableTypeProvidersRecursive(typeProvider, visitedTypes, visitedTypeProviders, visitedBaseProviders, buildableProviders, buildableTypes);
+                    return;
                 }
 
-                CollectBuildableTypeProvidersRecursive(typeProvider, visitedTypes, visitedTypeProviders, visitedBaseProviders, buildableProviders, buildableTypes);
-                return;
+                if (!nonNullableType.IsFrameworkType)
+                {
+                    return;
+                }
             }
 
             if (nonNullableType.IsFrameworkType)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -179,9 +179,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     // Unwrap framework wrappers and collection types to get to the actual model type
                     var actualType = UnwrapReturnType(returnType);
 
-                    if (actualType != null && actualType.IsFrameworkType)
+                    if (actualType != null)
                     {
-                        CollectBuildableTypesRecursive(actualType.WithNullable(false), visitedTypes, buildableTypes);
+                        CollectBuildableTypeFromCSharpType(actualType, visitedTypes, visitedTypeProviders, visitedBaseProviders, buildableProviders, buildableTypes);
                     }
                 }
             }
@@ -206,6 +206,43 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     }
                 }
             }
+        }
+
+        private void CollectBuildableTypeFromCSharpType(
+            CSharpType type,
+            HashSet<CSharpType> visitedTypes,
+            HashSet<TypeProvider> visitedTypeProviders,
+            HashSet<TypeProvider> visitedBaseProviders,
+            HashSet<TypeProvider> buildableProviders,
+            HashSet<CSharpType> buildableTypes)
+        {
+            var nonNullableType = type.WithNullable(false);
+            if (TryResolveTypeProvider(nonNullableType, out var typeProvider))
+            {
+                if (ImplementsModelReaderWriter(typeProvider))
+                {
+                    buildableProviders.Add(typeProvider);
+                }
+
+                CollectBuildableTypeProvidersRecursive(typeProvider, visitedTypes, visitedTypeProviders, visitedBaseProviders, buildableProviders, buildableTypes);
+                return;
+            }
+
+            if (nonNullableType.IsFrameworkType)
+            {
+                CollectBuildableTypesRecursive(nonNullableType, visitedTypes, buildableTypes);
+            }
+        }
+
+        private static bool TryResolveTypeProvider(CSharpType type, [NotNullWhen(true)] out TypeProvider? typeProvider)
+        {
+            if (ScmCodeModelGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(type, out typeProvider) && typeProvider != null)
+            {
+                return true;
+            }
+
+            typeProvider = null;
+            return false;
         }
 
         private void CollectBuildableTypesFromFrameworkType(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
@@ -1540,6 +1540,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
             var outputLibrary = new TestOutputLibrary([clientProvider]);
             var mockGenerator = MockHelpers.LoadMockGenerator(
                 createOutputLibrary: () => outputLibrary);
+            var frameworkModelType = new CSharpType(typeof(FrameworkModelWithMRW));
+            var externalInputModel = InputFactory.Model("FrameworkModelWithMRW");
+            ScmCodeModelGenerator.Instance.TypeFactory.CSharpTypeMap[frameworkModelType] = new SystemObjectModelProvider(frameworkModelType, externalInputModel);
 
             var contextDefinition = new ModelReaderWriterContextDefinition();
             var attributes = contextDefinition.Attributes;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
@@ -1555,6 +1555,38 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
         }
 
         [Test]
+        public void ValidateGeneratedReturnTypesAreDiscoveredFromGenericResponseWrappers()
+        {
+            var returnTypeModel = InputFactory.Model("WrappedReturnTypeModel", properties:
+            [
+                InputFactory.Property("Name", InputPrimitiveType.String)
+            ]);
+
+            var clientProvider = new TestClientProviderWithWrappedGeneratedReturnType(returnTypeModel);
+            var outputLibrary = new TestOutputLibrary([clientProvider]);
+            var mockGenerator = MockHelpers.LoadMockGenerator(
+                inputModels: () => [returnTypeModel],
+                createModelCore: model => new ExperimentalModelProvider(model),
+                createOutputLibrary: () => outputLibrary);
+
+            var contextDefinition = new ModelReaderWriterContextDefinition();
+            var attributes = contextDefinition.Attributes;
+
+            Assert.IsNotNull(attributes);
+            Assert.IsTrue(attributes.Count > 0);
+
+            var buildableAttributes = attributes.Where(a => a.Type.IsFrameworkType &&
+                a.Type.FrameworkType == typeof(ModelReaderWriterBuildableAttribute)).ToList();
+
+            Assert.IsTrue(buildableAttributes.Any(a => a.Arguments.First().ToDisplayString().Contains("WrappedReturnTypeModel")),
+                "WrappedReturnTypeModel should be discovered from generic response wrapper return type");
+            Assert.IsTrue(contextDefinition.GetAttributes().Any(a => a is SuppressionStatement suppression &&
+                suppression.AsStatement<AttributeStatement>()?.Arguments.First().ToDisplayString().Contains("WrappedReturnTypeModel") == true &&
+                suppression.Code.ToDisplayString().Contains("TEST001")),
+                "WrappedReturnTypeModel should use the generated provider path so experimental suppressions are preserved.");
+        }
+
+        [Test]
         public async Task ValidateCustomPropertiesOnModelsAreDiscovered()
         {
             // Test that properties added via custom code are discovered
@@ -1733,6 +1765,39 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
 
                 var signature = new MethodSignature(
                     Name: "GetFrameworkModel",
+                    Description: null,
+                    Modifiers: MethodSignatureModifiers.Public,
+                    ReturnType: returnType,
+                    ReturnDescription: null,
+                    Parameters: []);
+
+                return
+                [
+                    new MethodProvider(signature, Statements.MethodBodyStatement.Empty, this)
+                ];
+            }
+        }
+
+        private class TestClientProviderWithWrappedGeneratedReturnType : TypeProvider
+        {
+            private readonly InputModelType _returnTypeModel;
+
+            public TestClientProviderWithWrappedGeneratedReturnType(InputModelType returnTypeModel)
+            {
+                _returnTypeModel = returnTypeModel;
+            }
+
+            protected override string BuildName() => "TestClient";
+
+            protected override string BuildRelativeFilePath() => "TestClient.cs";
+
+            protected internal override MethodProvider[] BuildMethods()
+            {
+                var modelProvider = ScmCodeModelGenerator.Instance.TypeFactory.CreateCSharpType(_returnTypeModel);
+                var returnType = new CSharpType(typeof(FrameworkResponse<>), modelProvider!);
+
+                var signature = new MethodSignature(
+                    Name: "GetGeneratedModel",
                     Description: null,
                     Modifiers: MethodSignatureModifiers.Public,
                     ReturnType: returnType,


### PR DESCRIPTION
## Summary

Fix ModelReaderWriter context discovery for generated models returned inside generic framework wrappers.

The wrapper-unwrapping change from #11172 correctly discovers external framework MRW types inside wrappers such as `Response<T>`, but generated models also flow through this path. When the unwrapped type is generated, using the framework/reflection path skips the generated `TypeProvider` metadata, which can drop suppressions for attributes like `[Experimental]` in generated SDK output.

This change resolves unwrapped return types back through `TypeFactory.CSharpTypeMap` first. If a generated provider exists, the existing provider-based discovery path is used; otherwise, discovery falls back to the framework MRW reflection path.

## Validation

```bash
dotnet test Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj --filter ModelReaderWriterContextDefinitionTests --no-restore
```

38 passed.
