### PR TITLE
Remove unnecessary allOf around $ref in OpenAPI 3.1

### DIFF
--- a/.chronus/changes/openapi3-flatten-ref-siblings-3-1.md
+++ b/.chronus/changes/openapi3-flatten-ref-siblings-3-1.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+Stop wrapping `$ref` in an unnecessary `allOf` when emitting OpenAPI 3.1 (and 3.2). When a referenced schema carries sibling keywords (for example `description`, `default`, `readOnly`, or `externalDocs`), those keywords are now placed directly next to the `$ref`, as allowed by JSON Schema 2020-12. OpenAPI 3.0 output is unchanged, since it does not permit sibling keywords next to a `$ref`.

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -28,7 +28,6 @@ import {
   Union,
 } from "@typespec/compiler";
 import { MetadataInfo } from "@typespec/http";
-import { shouldInline } from "@typespec/openapi";
 import { getOneOf } from "./decorators.js";
 import { serializeExample } from "./examples.js";
 import { JsonSchemaModule } from "./json-schema.js";
@@ -36,7 +35,7 @@ import { OpenAPI3EmitterOptions, reportDiagnostic } from "./lib.js";
 import { applyEncoding, getRawBinarySchema } from "./openapi-helpers-3-1.js";
 import { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
 import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
-import { Builders, OpenAPI3SchemaEmitterBase } from "./schema-emitter.js";
+import { OpenAPI3SchemaEmitterBase } from "./schema-emitter.js";
 import { JsonType, OpenAPISchema3_1 } from "./types.js";
 import { isBytesKeptRaw, isLiteralType, literalType } from "./util.js";
 import { VisibilityUsageTracker } from "./visibility-usage.js";
@@ -226,6 +225,26 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
     return this.applyConstraints(en, { oneOf });
   }
 
+  protected override combineRefWithConstraints(
+    refSchema: any,
+    constraints: Partial<OpenAPISchema3_1>,
+  ): any {
+    // Some constraints already compose the reference themselves (e.g. the XML module wraps
+    // it in an `allOf`). In that case defer to the base behavior, otherwise we would emit
+    // both a top-level `$ref` and an `allOf` pointing at the same schema.
+    if ("allOf" in constraints) {
+      return super.combineRefWithConstraints(refSchema, constraints);
+    }
+    // OpenAPI 3.1 allows keywords alongside `$ref` (JSON Schema 2020-12 semantics),
+    // so the constraints are merged directly onto the reference instead of wrapping it
+    // in an unnecessary `allOf`.
+    const merged = new ObjectBuilder<OpenAPISchema3_1>(refSchema);
+    for (const [key, value] of Object.entries(constraints)) {
+      setProperty(merged, key, value);
+    }
+    return merged;
+  }
+
   unionSchema(union: Union): ObjectBuilder<OpenAPISchema3_1> {
     const program = this.emitter.getProgram();
     const [discriminated] = getDiscriminatedUnion(program, union);
@@ -279,7 +298,6 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
       { mergeUnionWideConstraints }: { mergeUnionWideConstraints: boolean },
     ): ObjectBuilder<OpenAPISchema3_1> => {
       const schema = schemaMember.schema;
-      const type = schemaMember.type;
       const additionalProps: Partial<OpenAPISchema3_1> = mergeUnionWideConstraints
         ? this.applyConstraints(union, {})
         : {};
@@ -287,26 +305,9 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
       if (Object.keys(additionalProps).length === 0) {
         return new ObjectBuilder(schema);
       } else {
-        if (
-          (schema instanceof Placeholder || "$ref" in schema) &&
-          !(type && shouldInline(program, type))
-        ) {
-          if (type && (type.kind === "Model" || type.kind === "Scalar")) {
-            return new ObjectBuilder({
-              type: "object",
-              allOf: Builders.array([schema]),
-              ...additionalProps,
-            });
-          } else {
-            return new ObjectBuilder({ allOf: Builders.array([schema]), ...additionalProps });
-          }
-        } else {
-          const merged = new ObjectBuilder<OpenAPISchema3_1>(schema);
-          for (const [key, value] of Object.entries(additionalProps)) {
-            setProperty(merged, key, value);
-          }
-          return merged;
-        }
+        // OpenAPI 3.1 allows sibling keywords next to `$ref`, so union-wide
+        // constraints are merged directly onto the member schema.
+        return this.combineRefWithConstraints(schema, additionalProps);
       }
     };
 

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -462,10 +462,7 @@ export class OpenAPI3SchemaEmitterBase<
         if (additionalProps.xml?.attribute) {
           return additionalProps;
         } else {
-          return {
-            allOf: [schema],
-            ...additionalProps,
-          };
+          return this.combineRefWithConstraints(schema, additionalProps);
         }
       }
     } else {
@@ -481,6 +478,22 @@ export class OpenAPI3SchemaEmitterBase<
 
       return merged;
     }
+  }
+
+  /**
+   * Combine a referenced schema (`$ref`) with additional sibling constraints such as
+   * `description`, `default`, or `readOnly`.
+   *
+   * OpenAPI 3.0 does not allow keywords alongside a `$ref`, so the reference is nested
+   * in an `allOf` and the constraints are emitted as siblings of that `allOf`. Emitters
+   * for spec versions that allow `$ref` siblings (OpenAPI 3.1, following JSON Schema
+   * 2020-12) override this to place the constraints directly next to the `$ref`.
+   */
+  protected combineRefWithConstraints(refSchema: any, constraints: Partial<Schema>): any {
+    return {
+      allOf: [refSchema],
+      ...constraints,
+    };
   }
 
   booleanLiteral(boolean: BooleanLiteral): EmitterOutput<object> {

--- a/packages/openapi3/test/documentation.test.ts
+++ b/packages/openapi3/test/documentation.test.ts
@@ -2,7 +2,7 @@ import { deepStrictEqual, strictEqual } from "assert";
 import { expect, it } from "vitest";
 import { supportedVersions, worksFor } from "./works-for.js";
 
-worksFor(supportedVersions, ({ openApiFor }) => {
+worksFor(supportedVersions, ({ openApiFor, version }) => {
   it("supports summary and description", async () => {
     const openApi = await openApiFor(`
       @summary("This is a summary")
@@ -60,12 +60,22 @@ worksFor(supportedVersions, ({ openApiFor }) => {
       }
       model Bar {}
       `);
-    expect(openApi.components.schemas.Foo.properties.name).toEqual({
-      allOf: [{ $ref: "#/components/schemas/Bar" }],
-      externalDocs: {
-        url: "https://example.com",
-        description: "more info",
-      },
-    });
+    const externalDocs = {
+      url: "https://example.com",
+      description: "more info",
+    };
+    if (version === "3.0.0") {
+      // OpenAPI 3.0 does not allow keywords next to a `$ref`, so the reference is
+      // wrapped in an `allOf`.
+      expect(openApi.components.schemas.Foo.properties.name).toEqual({
+        allOf: [{ $ref: "#/components/schemas/Bar" }],
+        externalDocs,
+      });
+    } else {
+      expect(openApi.components.schemas.Foo.properties.name).toEqual({
+        $ref: "#/components/schemas/Bar",
+        externalDocs,
+      });
+    }
   });
 });

--- a/packages/openapi3/test/models.test.ts
+++ b/packages/openapi3/test/models.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it } from "vitest";
 import { emitOpenApiWithDiagnostics } from "./test-host.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
-worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel, openApiFor }) => {
+worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel, openApiFor, version }) => {
+  // OpenAPI 3.0 does not allow sibling keywords next to a `$ref`, so it is wrapped in an
+  // `allOf`; 3.1+ (JSON Schema 2020-12) places the keywords directly alongside the `$ref`.
+  const refWithSiblings = (ref: string, siblings: Record<string, unknown>) =>
+    version === "3.0.0" ? { allOf: [{ $ref: ref }], ...siblings } : { $ref: ref, ...siblings };
   it("defines models", async () => {
     const res = await oapiForModel(
       "Foo",
@@ -228,10 +232,7 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel, openApiFor }) =
     deepStrictEqual(res.schemas.Foo, {
       type: "object",
       properties: {
-        optionalEnum: {
-          allOf: [{ $ref: "#/components/schemas/MyEnum" }],
-          default: "a-value",
-        },
+        optionalEnum: refWithSiblings("#/components/schemas/MyEnum", { default: "a-value" }),
       },
     });
   });
@@ -254,10 +255,7 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel, openApiFor }) =
     deepStrictEqual(res.schemas.Foo, {
       type: "object",
       properties: {
-        optionalUnion: {
-          allOf: [{ $ref: "#/components/schemas/MyUnion" }],
-          default: "a-value",
-        },
+        optionalUnion: refWithSiblings("#/components/schemas/MyUnion", { default: "a-value" }),
       },
     });
   });
@@ -1020,7 +1018,7 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel, openApiFor }) =
     });
   });
 
-  describe("wraps property $ref in allOf when extra attributes", () => {
+  describe("referenced property with extra attributes", () => {
     it("with doc", async () => {
       const res = await openApiFor(
         `
@@ -1031,10 +1029,10 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel, openApiFor }) =
         `,
       );
 
-      deepStrictEqual(res.components.schemas.Foo.properties.prop, {
-        allOf: [{ $ref: "#/components/schemas/Bar" }],
-        description: "Some doc",
-      });
+      deepStrictEqual(
+        res.components.schemas.Foo.properties.prop,
+        refWithSiblings("#/components/schemas/Bar", { description: "Some doc" }),
+      );
     });
 
     it("circular reference", async () => {
@@ -1046,10 +1044,10 @@ worksFor(supportedVersions, ({ diagnoseOpenApiFor, oapiForModel, openApiFor }) =
         `,
       );
 
-      deepStrictEqual(res.components.schemas.Foo.properties.prop, {
-        allOf: [{ $ref: "#/components/schemas/Foo" }],
-        description: "Some doc",
-      });
+      deepStrictEqual(
+        res.components.schemas.Foo.properties.prop,
+        refWithSiblings("#/components/schemas/Foo", { description: "Some doc" }),
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #6514

## Problem

OpenAPI 3.0 only permits `summary`/`description` next to a `$ref`, so when a referenced schema needs sibling keywords the emitter wraps the reference in an `allOf`:

```json
{ "allOf": [{ "$ref": "#/components/schemas/Bar" }], "description": "..." }
```

OpenAPI 3.1 follows JSON Schema 2020-12, where any keyword may sit alongside `$ref`, so that `allOf` is unnecessary. The emitter was still producing it for 3.1 (and 3.2) output.

## Change

The `$ref`-with-siblings decision is now a protected `combineRefWithConstraints` hook on the base schema emitter:

- The base emitter (used for 3.0) keeps the `allOf` wrapper.
- `OpenAPI31SchemaEmitter` overrides it to merge the sibling keywords directly onto the reference.

So 3.1 / 3.2 output becomes:

```json
{ "$ref": "#/components/schemas/Bar", "description": "..." }
```

This is applied to both places that produced the wrapper: referenced model properties carrying constraints (`modelPropertyLiteral`) and single-member unions with union-wide constraints. It mirrors the version-gated handling already used for `default` on a referenced parameter in `openapi.ts`.

**OpenAPI 3.0 output is unchanged.**

### Note on the XML module

`@typespec/openapi3`'s XML support composes some references into an `allOf` itself (`xml-module.ts`). Rather than half-change that separate subsystem, the 3.1 override defers to the base behavior whenever the constraints already carry an `allOf`, so XML output is unchanged. Flattening the XML reference cases (including array `items`) would mean threading spec-version awareness through `xml-module.ts` and is left as a follow-up.

## Testing

- Updated `documentation.test.ts` and `models.test.ts` to assert the version-specific shape (`allOf` for 3.0, siblings for 3.1/3.2) via the `worksFor` version parameter.
- `@typespec/openapi3` build, full test suite (2547 tests), `oxlint`, and Prettier all pass.
