### PR TITLE
fix: only discover plugins under src

### DIFF
--- a/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
+++ b/packages/http-client-csharp/eng/scripts/Submit-AzureSdkForNetPr.ps1
@@ -584,12 +584,22 @@ try {
                 Write-Host "No SDK libraries found matching emitter patterns. Skipping SDK regeneration."
             } else {
                 $serviceProj = Join-Path $tempDir "eng/service.proj"
+
+                # Service directories whose libraries share a single code generator plugin that each
+                # library's generation builds into a common output folder. These services are regenerated
+                # serially since they share a common plugin project that shouldn't be built in parallel.
+                $serialCodeGenServiceDirectories = @("ai")
+
                 foreach ($serviceDirectory in $serviceDirectories) {
                     Write-Host "Regenerating code for service directory: $serviceDirectory"
                     $previousErrorAction = $ErrorActionPreference
                     $ErrorActionPreference = "Continue"
                     try {
-                        Invoke "dotnet msbuild $serviceProj /restore /t:GenerateCode /p:ServiceDirectory=$serviceDirectory" $tempDir
+                        $generateCommand = "dotnet msbuild $serviceProj /restore /t:GenerateCode /p:Trace=true /p:ServiceDirectory=$serviceDirectory"
+                        if ($serialCodeGenServiceDirectories -contains $serviceDirectory) {
+                            $generateCommand += " /m:1 /p:BuildInParallel=false"
+                        }
+                        Invoke $generateCommand $tempDir
                         if ($LASTEXITCODE -ne 0) {
                             Write-Warning "Code generation failed for $serviceDirectory with exit code $LASTEXITCODE. Continuing with next service directory."
                             Write-Host "##vso[task.complete result=SucceededWithIssues;]"

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
@@ -19,6 +19,7 @@ namespace Microsoft.TypeSpec.Generator
     internal class GeneratorHandler
     {
         private const string NodeModulesDir = "node_modules";
+        private const string SrcDir = "src";
 
         public void LoadGenerator(CommandLineOptions options)
         {
@@ -191,14 +192,50 @@ namespace Microsoft.TypeSpec.Generator
         /// </summary>
         internal static string? BuildPluginIfNeeded(string directory, Emitter emitter)
         {
-            var csprojFiles = Directory.GetFiles(directory, "*.csproj", SearchOption.AllDirectories);
-            if (csprojFiles.Length == 0)
+            var csprojPath = FindPluginProject(directory);
+            if (csprojPath == null)
             {
                 return null;
             }
 
-            return BuildPlugin(csprojFiles[0], directory, emitter);
+            return BuildPlugin(csprojPath, directory, emitter);
         }
+
+        /// <summary>
+        /// Selects the plugin project to build from <paramref name="directory"/>.
+        /// A plugin directory may contain multiple projects. This method prefers a project under
+        /// a 'src' directory to avoid building a test or sample project, and returns a
+        /// deterministic result that is stable across platforms and filesystems.
+        /// </summary>
+        internal static string? FindPluginProject(string directory)
+        {
+            // Fast path: search a top-level 'src' directory first.
+            var srcDirectory = Path.Combine(directory, SrcDir);
+            if (Directory.Exists(srcDirectory))
+            {
+                var srcProject = SelectDeterministic(
+                    Directory.EnumerateFiles(srcDirectory, "*.csproj", SearchOption.AllDirectories));
+                if (srcProject != null)
+                {
+                    return srcProject;
+                }
+            }
+
+            // Fall back to a full recursive search.
+            var allProjects = Directory
+                .EnumerateFiles(directory, "*.csproj", SearchOption.AllDirectories)
+                .ToArray();
+            if (allProjects.Length == 0)
+            {
+                return null;
+            }
+
+            return SelectDeterministic(allProjects.Where(path => ContainsDirectorySegment(path, SrcDir)))
+                ?? SelectDeterministic(allProjects);
+        }
+
+        private static string? SelectDeterministic(IEnumerable<string> paths) =>
+            paths.OrderBy(path => path, StringComparer.Ordinal).FirstOrDefault();
 
         /// <summary>
         /// Builds a plugin .csproj and returns the path to the output DLL by scanning
@@ -232,7 +269,7 @@ namespace Microsoft.TypeSpec.Generator
             var buildSucceeded = process.ExitCode == 0;
             if (!buildSucceeded)
             {
-                // Log an error instead of throwing so that a failed plugin build does not abort
+                // Log a warning instead of an error so that a failed plugin build does not abort
                 // the entire generation. The build may fail when the same plugin is being built
                 // in parallel for multiple referenced projects within a single solution folder,
                 // in which case a previously built assembly may already exist and can still be
@@ -240,7 +277,7 @@ namespace Microsoft.TypeSpec.Generator
                 emitter.ReportDiagnostic(
                     DiagnosticCodes.PluginBuildFailed,
                     $"Failed to build plugin '{csprojPath}'. Exit code: {process.ExitCode}\n{stdout}\n{stderr}",
-                    severity: EmitterDiagnosticSeverity.Error);
+                    severity: EmitterDiagnosticSeverity.Warning);
             }
 
             var dllPath = FindPluginAssembly(csprojPath, scanDirectory);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
@@ -368,6 +368,102 @@ namespace TypedPlugin { public class MyType { public int Value => 42; } }");
         }
 
         [Test]
+        public void FindPluginProject_ReturnsNullWhenNoCsproj()
+        {
+            using var testDir = new TempDirectory();
+            File.WriteAllText(Path.Combine(testDir.Path, "readme.txt"), "no csproj here");
+
+            Assert.IsNull(GeneratorHandler.FindPluginProject(testDir.Path));
+        }
+
+        [Test]
+        public void FindPluginProject_ReturnsRootProjectWhenNoSrcFolder()
+        {
+            using var testDir = new TempDirectory();
+            var csproj = Path.Combine(testDir.Path, "RootPlugin.csproj");
+            File.WriteAllText(csproj, EmptyProject);
+
+            Assert.AreEqual(csproj, GeneratorHandler.FindPluginProject(testDir.Path));
+        }
+
+        [Test]
+        public void FindPluginProject_ReturnsDeterministicProjectForNestedLayoutWithoutSrc()
+        {
+            // No 'src' folder anywhere, and the projects live in nested subdirectories. The fast
+            // path is skipped and the recursive fallback runs; with no 'src' project to prefer,
+            // selection falls back to the ordinal-first project deterministically.
+            using var testDir = new TempDirectory();
+
+            var betaDir = Directory.CreateDirectory(Path.Combine(testDir.Path, "beta", "lib")).FullName;
+            var betaProject = Path.Combine(betaDir, "Beta.csproj");
+            File.WriteAllText(betaProject, EmptyProject);
+
+            var alphaDir = Directory.CreateDirectory(Path.Combine(testDir.Path, "alpha", "lib")).FullName;
+            var alphaProject = Path.Combine(alphaDir, "Alpha.csproj");
+            File.WriteAllText(alphaProject, EmptyProject);
+
+            var result = GeneratorHandler.FindPluginProject(testDir.Path);
+
+            Assert.AreEqual(alphaProject, result);
+            // Selection is stable across repeated calls regardless of enumeration order.
+            Assert.AreEqual(alphaProject, GeneratorHandler.FindPluginProject(testDir.Path));
+        }
+
+        [Test]
+        public void FindPluginProject_PrefersProjectUnderSrcOverTest()
+        {
+            using var testDir = new TempDirectory();
+
+            var srcDir = Directory.CreateDirectory(Path.Combine(testDir.Path, "src")).FullName;
+            var srcProject = Path.Combine(srcDir, "Contoso.Plugin.csproj");
+            File.WriteAllText(srcProject, EmptyProject);
+
+            var testProjDir = Directory.CreateDirectory(Path.Combine(testDir.Path, "test")).FullName;
+            File.WriteAllText(Path.Combine(testProjDir, "Contoso.Plugin.Tests.csproj"), EmptyProject);
+
+            Assert.AreEqual(srcProject, GeneratorHandler.FindPluginProject(testDir.Path));
+        }
+
+        [Test]
+        public void FindPluginProject_PrefersSrcProjectWhenNestedDeeper()
+        {
+            using var testDir = new TempDirectory();
+
+            var nestedSrc = Directory.CreateDirectory(
+                Path.Combine(testDir.Path, "packages", "core", "src")).FullName;
+            var srcProject = Path.Combine(nestedSrc, "Core.csproj");
+            File.WriteAllText(srcProject, EmptyProject);
+
+            var testProjDir = Directory.CreateDirectory(
+                Path.Combine(testDir.Path, "packages", "core", "test")).FullName;
+            File.WriteAllText(Path.Combine(testProjDir, "Core.Tests.csproj"), EmptyProject);
+
+            Assert.AreEqual(srcProject, GeneratorHandler.FindPluginProject(testDir.Path));
+        }
+
+        [Test]
+        public void FindPluginProject_IsDeterministicWithMultipleSrcProjects()
+        {
+            // When several projects live under 'src', selection must be deterministic (ordinal-first)
+            // and identical across platforms rather than depending on filesystem enumeration order.
+            using var testDir = new TempDirectory();
+            var srcDir = Directory.CreateDirectory(Path.Combine(testDir.Path, "src")).FullName;
+
+            var aProject = Path.Combine(srcDir, "AAA.csproj");
+            var bProject = Path.Combine(srcDir, "BBB.csproj");
+            var cProject = Path.Combine(srcDir, "CCC.csproj");
+            File.WriteAllText(cProject, EmptyProject);
+            File.WriteAllText(aProject, EmptyProject);
+            File.WriteAllText(bProject, EmptyProject);
+
+            var result = GeneratorHandler.FindPluginProject(testDir.Path);
+
+            Assert.AreEqual(aProject, result);
+            // Selection is stable across repeated calls.
+            Assert.AreEqual(aProject, GeneratorHandler.FindPluginProject(testDir.Path));
+        }
+
+        [Test]
         public void AddConfiguredPluginDlls_NoPluginPaths_DoesNothing()
         {
             var config = new Configuration(
@@ -698,5 +794,32 @@ namespace MultiTarget { public class Dummy { } }");
                 try { Directory.Delete(testDir, true); } catch { }
             }
         }
+
+        /// <summary>Minimal, buildable-shaped project file used by project-selection tests.</summary>
+        private const string EmptyProject = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+        /// <summary>Creates a unique temp directory and removes it on dispose.</summary>
+        private sealed class TempDirectory : IDisposable
+        {
+            public string Path { get; }
+
+            public TempDirectory()
+            {
+                Path = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(),
+                    "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                try { Directory.Delete(Path, true); } catch { }
+            }
+        }
     }
 }
+


### PR DESCRIPTION
This PR attempts to address an issue when discovering configurable plugins. With this change, only the first plugin under a `src` directory path will be considered. The regen script used in CI was also fixed to regenerate the ai libraries sequentially, as building their plugins in parallel is causing flakiness in generation.