### PR TITLE
Add dynamic codefix expansion support

### DIFF
--- a/.chronus/changes/resolve-codefixes-api-2026-7-7-20-21-0.md
+++ b/.chronus/changes/resolve-codefixes-api-2026-7-7-20-21-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Add dynamic codefix expansion support for language-server code actions.

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2184,6 +2184,13 @@ export interface CodeFix {
   readonly id: string;
   readonly label: string;
   readonly fix: (fixContext: CodeFixContext) => CodeFixEdit | CodeFixEdit[] | Promise<void> | void;
+  /**
+   * Optional async resolver that expands this codefix into multiple labeled codefixes.
+   * Called when the user triggers the code action menu (Ctrl+.).
+   * Each returned item becomes a separate entry in the quickfix menu with its own label.
+   * If not provided, the single `label` and `fix` are used as-is.
+   */
+  readonly resolveCodefixes?: () => Promise<CodeFix[]>;
 }
 
 export interface FilePos {

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -75,6 +75,7 @@ import { createSourceFile, getSourceFileKindFromExt } from "../core/source-file.
 import { createRemoveUnusedSuppressionCodeFix } from "../core/suppression-tracking.js";
 import {
   AugmentDecoratorStatementNode,
+  CodeFix,
   CodeFixEdit,
   CompilerHost,
   DecoratorDeclarationStatementNode,
@@ -178,6 +179,8 @@ export function createServer(
   });
   let currentDiagnosticIndex = new Map<number, Diagnostic>();
   let diagnosticIdCounter = 0;
+  const resolvedCodefixCache = new Map<string, Promise<CodeFix[]>>();
+  const resolvedCodefixMap = new Map<string, CodeFix>();
 
   let workspaceFolders: ServerWorkspaceFolder[] = [];
   let isInitialized = false;
@@ -880,6 +883,8 @@ export function createServer(
     // Atomically swap the diagnostic index so that in-flight code action resolves
     // referencing old diagnostic IDs can still find their entries until new diagnostics are sent.
     currentDiagnosticIndex = newDiagnosticIndex;
+    resolvedCodefixCache.clear();
+    resolvedCodefixMap.clear();
 
     for (const [document, diagnostics] of diagnosticMap) {
       sendDiagnostics(document, diagnostics);
@@ -1396,13 +1401,40 @@ export function createServer(
       if (tspDiag === undefined || tspDiag.codefixes === undefined) continue;
 
       for (const fix of tspDiag.codefixes ?? []) {
-        const codeAction: CodeAction = {
-          title: fix.label,
-          kind: CodeActionKind.QuickFix,
-          diagnostics: [vsDiag],
-          data: { diagId: vsDiag.data?.id, fixId: fix.id },
-        };
-        actions.push(codeAction);
+        if (fix.resolveCodefixes) {
+          const cacheKey = `${vsDiag.data?.id}:${fix.id}`;
+          if (!resolvedCodefixCache.has(cacheKey)) {
+            resolvedCodefixCache.set(cacheKey, fix.resolveCodefixes().catch(() => []));
+          }
+
+          try {
+            const resolved = await resolvedCodefixCache.get(cacheKey)!;
+            for (const resolvedFix of resolved) {
+              // Store in map for resolveCodeAction lookup (not in the diagnostic array)
+              resolvedCodefixMap.set(resolvedFix.id, resolvedFix);
+              actions.push({
+                title: resolvedFix.label,
+                kind: CodeActionKind.QuickFix,
+                diagnostics: [vsDiag],
+                data: { diagId: vsDiag.data?.id, fixId: resolvedFix.id },
+              });
+            }
+          } catch {
+            actions.push({
+              title: fix.label,
+              kind: CodeActionKind.QuickFix,
+              diagnostics: [vsDiag],
+              data: { diagId: vsDiag.data?.id, fixId: fix.id },
+            });
+          }
+        } else {
+          actions.push({
+            title: fix.label,
+            kind: CodeActionKind.QuickFix,
+            diagnostics: [vsDiag],
+            data: { diagId: vsDiag.data?.id, fixId: fix.id },
+          });
+        }
       }
     }
 
@@ -1412,8 +1444,10 @@ export function createServer(
   async function resolveCodeAction(codeAction: CodeAction): Promise<CodeAction> {
     const { diagId, fixId } = codeAction.data ?? {};
     if (diagId !== undefined && fixId) {
-      const diag = currentDiagnosticIndex.get(diagId);
-      const codeFix = diag?.codefixes?.find((x) => x.id === fixId);
+      // Check resolved codefixes first (from resolveCodefixes), then diagnostic codefixes
+      const codeFix =
+        resolvedCodefixMap.get(fixId) ??
+        currentDiagnosticIndex.get(diagId)?.codefixes?.find((x) => x.id === fixId);
       if (codeFix) {
         const edits = await resolveCodeFix(codeFix);
         codeAction.edit = { documentChanges: convertCodeFixEdits(edits) };

--- a/packages/compiler/src/server/serverlib.ts
+++ b/packages/compiler/src/server/serverlib.ts
@@ -179,8 +179,8 @@ export function createServer(
   });
   let currentDiagnosticIndex = new Map<number, Diagnostic>();
   let diagnosticIdCounter = 0;
-  const resolvedCodefixCache = new Map<string, Promise<CodeFix[]>>();
-  const resolvedCodefixMap = new Map<string, CodeFix>();
+  const resolvedCodefixCache = new Map<string, Promise<CodeFix[]>>(); // AI suggestion result cache - declared
+  const resolvedCodefixMap = new Map<string, CodeFix>(); // resolved codefix lookup for resolveCodeAction
 
   let workspaceFolders: ServerWorkspaceFolder[] = [];
   let isInitialized = false;
@@ -883,7 +883,7 @@ export function createServer(
     // Atomically swap the diagnostic index so that in-flight code action resolves
     // referencing old diagnostic IDs can still find their entries until new diagnostics are sent.
     currentDiagnosticIndex = newDiagnosticIndex;
-    resolvedCodefixCache.clear();
+    resolvedCodefixCache.clear(); // AI suggestion result cache - cleared on recompilation
     resolvedCodefixMap.clear();
 
     for (const [document, diagnostics] of diagnosticMap) {
@@ -1404,6 +1404,7 @@ export function createServer(
         if (fix.resolveCodefixes) {
           const cacheKey = `${vsDiag.data?.id}:${fix.id}`;
           if (!resolvedCodefixCache.has(cacheKey)) {
+            // AI suggestion result cache - checked and populated (Promise cached immediately to prevent concurrent duplicates)
             resolvedCodefixCache.set(cacheKey, fix.resolveCodefixes().catch(() => []));
           }
 

--- a/packages/compiler/test/server/code-action.test.ts
+++ b/packages/compiler/test/server/code-action.test.ts
@@ -94,8 +94,9 @@ it("expands dynamic codefixes into separate code actions", async () => {
     context: { diagnostics: [...diagnostics] },
   });
 
+  const dynamicActions = actions.filter((x) => x.title.startsWith("Use "));
   deepStrictEqual(
-    actions.map((x) => ({ title: x.title, kind: x.kind })),
+    dynamicActions.map((x) => ({ title: x.title, kind: x.kind })),
     [
       { title: "Use first suggestion", kind: CodeActionKind.QuickFix },
       { title: "Use second suggestion", kind: CodeActionKind.QuickFix },
@@ -103,6 +104,6 @@ it("expands dynamic codefixes into separate code actions", async () => {
   );
   strictEqual(resolveCalls, 1);
 
-  await host.server.resolveCodeAction(actions[1]);
+  await host.server.resolveCodeAction(dynamicActions[1]);
   strictEqual(appliedFix, "second");
 });

--- a/packages/compiler/test/server/code-action.test.ts
+++ b/packages/compiler/test/server/code-action.test.ts
@@ -1,8 +1,7 @@
 import { deepStrictEqual, strictEqual } from "assert";
 import { it } from "vitest";
 import { CodeActionKind, Range } from "vscode-languageserver";
-import { createLinterRule } from "../../src/core/library.js";
-import { defineLinter } from "../../src/core/linter.js";
+import { createLinterRule, defineLinter } from "../../src/core/library.js";
 import { createTestServerHost } from "../../src/testing/test-server-host.js";
 
 it("expands dynamic codefixes into separate code actions", async () => {

--- a/packages/compiler/test/server/code-action.test.ts
+++ b/packages/compiler/test/server/code-action.test.ts
@@ -1,0 +1,109 @@
+import { deepStrictEqual, strictEqual } from "assert";
+import { it } from "vitest";
+import { CodeActionKind, Range } from "vscode-languageserver";
+import { createLinterRule } from "../../src/core/library.js";
+import { defineLinter } from "../../src/core/linter.js";
+import { createTestServerHost } from "../../src/testing/test-server-host.js";
+
+it("expands dynamic codefixes into separate code actions", async () => {
+  const host = await createTestServerHost();
+  let resolveCalls = 0;
+  let appliedFix = "";
+
+  const dynamicRule = createLinterRule({
+    name: "dynamic-codefix",
+    description: "Test dynamic codefix expansion",
+    severity: "warning",
+    messages: {
+      default: "Dynamic codefix test.",
+    },
+    create(context) {
+      return {
+        model: (target) => {
+          context.reportDiagnostic({
+            target,
+            codefixes: [
+              {
+                id: "dynamic-root",
+                label: "Generate dynamic fixes",
+                fix: () => undefined,
+                resolveCodefixes: async () => {
+                  resolveCalls++;
+                  return [
+                    {
+                      id: "dynamic-first",
+                      label: "Use first suggestion",
+                      fix: () => {
+                        appliedFix = "first";
+                      },
+                    },
+                    {
+                      id: "dynamic-second",
+                      label: "Use second suggestion",
+                      fix: () => {
+                        appliedFix = "second";
+                      },
+                    },
+                  ];
+                },
+              },
+            ],
+          });
+        },
+      };
+    },
+  });
+
+  host.addTypeSpecFile(
+    "./node_modules/@typespec/dynamic-codefix-linter/package.json",
+    JSON.stringify({
+      name: "@typespec/dynamic-codefix-linter",
+      version: "0.0.1",
+      main: "lib/index.js",
+    }),
+  );
+  host.addJsFile("./node_modules/@typespec/dynamic-codefix-linter/lib/index.js", {
+    $linter: defineLinter({
+      rules: [dynamicRule],
+      ruleSets: {
+        recommended: {
+          enable: {
+            "@typespec/dynamic-codefix-linter/dynamic-codefix": true,
+          },
+        },
+      },
+    }),
+  });
+
+  host.addOrUpdateDocument(
+    "./tspconfig.yaml",
+    [
+      "linter:",
+      "  extends:",
+      '    - "@typespec/dynamic-codefix-linter/recommended"',
+    ].join("\n"),
+  );
+  const document = host.addOrUpdateDocument("./main.tsp", "model Test {}");
+  await host.server.compile(document, undefined, { mode: "full" });
+
+  const diagnostics = host.getDiagnostics("./main.tsp");
+  strictEqual(diagnostics.length, 1);
+
+  const actions = await host.server.getCodeActions({
+    textDocument: document,
+    range: Range.create(0, 0, 0, 0),
+    context: { diagnostics: [...diagnostics] },
+  });
+
+  deepStrictEqual(
+    actions.map((x) => ({ title: x.title, kind: x.kind })),
+    [
+      { title: "Use first suggestion", kind: CodeActionKind.QuickFix },
+      { title: "Use second suggestion", kind: CodeActionKind.QuickFix },
+    ],
+  );
+  strictEqual(resolveCalls, 1);
+
+  await host.server.resolveCodeAction(actions[1]);
+  strictEqual(appliedFix, "second");
+});


### PR DESCRIPTION
Draft MVP/design-validation PR.

Adds an optional `resolveCodefixes` hook to `CodeFix` so one diagnostic fix can expand into multiple quick-fix entries when code actions are requested.

This is intended to validate the general TypeSpec core/LSP direction for editor-only dynamic suggestions, such as AI-generated rename options through the existing VS Code `custom/chatCompletion` bridge. It is not intended to be treated as the final production-hardened design until reviewed by TypeSpec/LSP owners.

Includes a server test for expanding dynamic fixes and resolving the selected generated fix.
