### PR TITLE
Switch nuget.config to public DevOps CFS

### DIFF
--- a/.github/actions/nuget-auth/action.yml
+++ b/.github/actions/nuget-auth/action.yml
@@ -1,0 +1,20 @@
+name: Authenticate to NuGet
+description: Equivalent of Azure Pipelines' NuGetAuthenticate@1 — authenticates to Azure DevOps feeds referenced in nuget.config via OIDC.
+
+runs:
+  using: composite
+  steps:
+    - uses: azure/login@v2
+      with:
+        client-id: 5786d1fb-187e-4ca9-9a81-ab89ea278986
+        tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+        allow-no-subscriptions: true
+
+    - name: Export VSS_NUGET_ACCESSTOKEN
+      shell: bash
+      run: |
+        TOKEN=$(az account get-access-token \
+          --resource 499b84ac-1321-427f-aa17-267ca6975798 \
+          --query accessToken -o tsv)
+        echo "::add-mask::$TOKEN"
+        echo "VSS_NUGET_ACCESSTOKEN=$TOKEN" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       core: ${{ steps.filter.outputs.core }}
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - uses: ./.github/actions/nuget-auth
+
       # cspell:ignore dorny
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter

--- a/eng/tsp-core/pipelines/templates/install.yml
+++ b/eng/tsp-core/pipelines/templates/install.yml
@@ -13,6 +13,9 @@ parameters:
     default: $(Pipeline.Workspace)/.pnpm-store
 
 steps:
+  # Need to authenticate so our pipeline can update packages in the feed.
+  - task: NuGetAuthenticate@1
+  
   - task: UseNode@1
     displayName: Install Node.js
     retryCountOnTaskFailure: 3

--- a/packages/typespec-vs/nuget.config
+++ b/packages/typespec-vs/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <!-- Do not add any additional feeds if new packages are needed they need to come from our azure-sdk-for-net DevOps feed which has an upstream set to nuget.org -->
+    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This pull request updates the NuGet package source configuration to ensure that all packages are retrieved from the organization's Azure DevOps feed rather than directly from nuget.org. This centralizes package management and enforces the use of the approved feed.

NuGet package source update:

* Updated `nuget.config` to remove the direct nuget.org feed and instead use the `azure-sdk-for-net` Azure DevOps feed, which itself has nuget.org as an upstream source. This ensures all packages are routed through the organization's feed.