### PR TITLE
Remove redundant top-level describe wrappers from tests (24 packages)

### DIFF
--- a/.chronus/changes/cleanup-http-test-describe-wrappers-2026-7-8-10-47-50.md
+++ b/.chronus/changes/cleanup-http-test-describe-wrappers-2026-7-8-10-47-50.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/http"
----
-
-Remove redundant top-level `describe` wrappers from `@typespec/http` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-http-test-describe-wrappers-2026-7-8-10-47-50.md
+++ b/.chronus/changes/cleanup-http-test-describe-wrappers-2026-7-8-10-47-50.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+
+Remove redundant top-level `describe` wrappers from `@typespec/http` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-json-schema-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-json-schema-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/json-schema"
+---
+
+Remove redundant top-level `describe` wrappers from `@typespec/json-schema` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-json-schema-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-json-schema-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/json-schema"
----
-
-Remove redundant top-level `describe` wrappers from `@typespec/json-schema` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-openapi-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-openapi-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/openapi"
----
-
-Remove redundant top-level `describe` wrappers from `@typespec/openapi` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-openapi-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-openapi-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/openapi"
+---
+
+Remove redundant top-level `describe` wrappers from `@typespec/openapi` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-rest-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-rest-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/rest"
+---
+
+Remove redundant top-level `describe` wrappers from `@typespec/rest` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-rest-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-rest-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/rest"
----
-
-Remove redundant top-level `describe` wrappers from `@typespec/rest` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-sse-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-sse-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/sse"
+---
+
+Remove redundant top-level `describe` wrappers from `@typespec/sse` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-sse-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-sse-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/sse"
----
-
-Remove redundant top-level `describe` wrappers from `@typespec/sse` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-test-describe-wrappers-2026-7-8-10-47-50.md
+++ b/.chronus/changes/cleanup-test-describe-wrappers-2026-7-8-10-47-50.md
@@ -7,6 +7,16 @@ packages:
   - "@typespec/versioning"
   - "@typespec/openapi"
   - "@typespec/sse"
+  - "@typespec/emitter-framework"
+  - "@typespec/http-server-csharp"
+  - "@typespec/spec-api"
+  - "@typespec/http-server-js"
+  - "@typespec/asset-emitter"
+  - "@typespec/internal-build-utils"
+  - "@typespec/html-program-viewer"
+  - "@typespec/streams"
+  - "@typespec/library-linter"
+  - "@typespec/bundler"
 ---
 
 Remove redundant top-level `describe` wrappers from tests per the documented test conventions.

--- a/.chronus/changes/cleanup-test-describe-wrappers-2026-7-8-10-47-50.md
+++ b/.chronus/changes/cleanup-test-describe-wrappers-2026-7-8-10-47-50.md
@@ -17,6 +17,14 @@ packages:
   - "@typespec/streams"
   - "@typespec/library-linter"
   - "@typespec/bundler"
+  - "@typespec/playground"
+  - "@typespec/spector"
+  - "@typespec/prettier-plugin-typespec"
+  - "@typespec/samples"
+  - "@typespec/spec-dashboard"
+  - "@typespec/tspd"
+  - "typespec-vscode"
+  - "@typespec/protobuf"
 ---
 
 Remove redundant top-level `describe` wrappers from tests per the documented test conventions.

--- a/.chronus/changes/cleanup-test-describe-wrappers-2026-7-8-10-47-50.md
+++ b/.chronus/changes/cleanup-test-describe-wrappers-2026-7-8-10-47-50.md
@@ -1,0 +1,12 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+  - "@typespec/json-schema"
+  - "@typespec/rest"
+  - "@typespec/versioning"
+  - "@typespec/openapi"
+  - "@typespec/sse"
+---
+
+Remove redundant top-level `describe` wrappers from tests per the documented test conventions.

--- a/.chronus/changes/cleanup-versioning-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-versioning-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/versioning"
+---
+
+Remove redundant top-level `describe` wrappers from `@typespec/versioning` tests per the documented test conventions.

--- a/.chronus/changes/cleanup-versioning-test-describe-wrappers-2026-7-8-11-11-55.md
+++ b/.chronus/changes/cleanup-versioning-test-describe-wrappers-2026-7-8-11-11-55.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@typespec/versioning"
----
-
-Remove redundant top-level `describe` wrappers from `@typespec/versioning` tests per the documented test conventions.

--- a/packages/asset-emitter/test/circular-ref.test.ts
+++ b/packages/asset-emitter/test/circular-ref.test.ts
@@ -20,142 +20,140 @@ import {
 } from "../src/index.js";
 import { getHostForTypeSpecFile } from "./host.js";
 
-describe("compiler: emitter-framework: circular references", () => {
-  interface FindOptions {
-    modelsInline: boolean;
-    circleReference: boolean;
-  }
+interface FindOptions {
+  modelsInline: boolean;
+  circleReference: boolean;
+}
 
-  interface CircularRefEntry {
-    target: EmitEntity<any>;
-    cycle: ReferenceCycle;
-  }
-  async function findCircularReferences(code: string, options: FindOptions) {
-    const invalidReferences: CircularRefEntry[] = [];
+interface CircularRefEntry {
+  target: EmitEntity<any>;
+  cycle: ReferenceCycle;
+}
+async function findCircularReferences(code: string, options: FindOptions) {
+  const invalidReferences: CircularRefEntry[] = [];
 
-    const cls = class extends TypeEmitter<any, any> {
-      modelDeclaration(model: Model, _: string): EmitterOutput<object> {
+  const cls = class extends TypeEmitter<any, any> {
+    modelDeclaration(model: Model, _: string): EmitterOutput<object> {
+      const obj = new ObjectBuilder();
+      obj.set("props", this.emitter.emitModelProperties(model));
+      if (options.modelsInline) {
+        return obj; // Never make a declaration
+      } else {
+        return this.emitter.result.declaration(model.name, obj);
+      }
+    }
+
+    modelProperties(model: Model) {
+      const arr = new ArrayBuilder();
+      for (const prop of model.properties.values()) {
+        arr.push(this.emitter.emitModelProperty(prop));
+      }
+      return arr;
+    }
+
+    modelPropertyLiteral(property: ModelProperty) {
+      if (options.circleReference) {
+        return this.emitter.emitTypeReference(property.type);
+      } else {
         const obj = new ObjectBuilder();
-        obj.set("props", this.emitter.emitModelProperties(model));
-        if (options.modelsInline) {
-          return obj; // Never make a declaration
-        } else {
-          return this.emitter.result.declaration(model.name, obj);
-        }
+        obj.set("name", property.name);
+        return obj;
       }
+    }
 
-      modelProperties(model: Model) {
-        const arr = new ArrayBuilder();
-        for (const prop of model.properties.values()) {
-          arr.push(this.emitter.emitModelProperty(prop));
-        }
-        return arr;
+    arrayLiteral(array: Model, elementType: Type) {
+      return { type: "array", items: this.emitter.emitTypeReference(elementType) };
+    }
+
+    programContext(program: Program): Context {
+      const sourceFile = this.emitter.createSourceFile("main");
+      return { scope: sourceFile.globalScope };
+    }
+
+    circularReference(target: EmitEntity<any>, scope: Scope<any>, cycle: ReferenceCycle) {
+      if (!cycle.containsDeclaration) {
+        invalidReferences.push({ target, cycle });
+        return target;
       }
+      return super.circularReference(target, scope, cycle);
+    }
+  };
 
-      modelPropertyLiteral(property: ModelProperty) {
-        if (options.circleReference) {
-          return this.emitter.emitTypeReference(property.type);
-        } else {
-          const obj = new ObjectBuilder();
-          obj.set("name", property.name);
-          return obj;
-        }
-      }
+  const host = await getHostForTypeSpecFile(code);
+  const assetEmitter = createAssetEmitter(host.program, cls, {
+    emitterOutputDir: host.program.compilerOptions.outputDir!,
+    options: {},
+  } as any);
+  assetEmitter.emitProgram();
 
-      arrayLiteral(array: Model, elementType: Type) {
-        return { type: "array", items: this.emitter.emitTypeReference(elementType) };
-      }
+  return invalidReferences;
+}
 
-      programContext(program: Program): Context {
-        const sourceFile = this.emitter.createSourceFile("main");
-        return { scope: sourceFile.globalScope };
-      }
+const selfRef = `model Foo { foo: Foo }`;
+it("self referencing with declaration works fine", async () => {
+  const invalidReferences = await findCircularReferences(selfRef, {
+    modelsInline: false,
+    circleReference: true,
+  });
+  strictEqual(invalidReferences.length, 0);
+});
 
-      circularReference(target: EmitEntity<any>, scope: Scope<any>, cycle: ReferenceCycle) {
-        if (!cycle.containsDeclaration) {
-          invalidReferences.push({ target, cycle });
-          return target;
-        }
-        return super.circularReference(target, scope, cycle);
-      }
-    };
+it("self referencing without declaration report circular reference", async () => {
+  const invalidReferences = await findCircularReferences(selfRef, {
+    modelsInline: true,
+    circleReference: true,
+  });
+  strictEqual(invalidReferences.length, 1);
+});
 
-    const host = await getHostForTypeSpecFile(code);
-    const assetEmitter = createAssetEmitter(host.program, cls, {
-      emitterOutputDir: host.program.compilerOptions.outputDir!,
-      options: {},
-    } as any);
-    assetEmitter.emitProgram();
+it("without circular reference inline types cause no issue", async () => {
+  const invalidReferences = await findCircularReferences(selfRef, {
+    modelsInline: true,
+    circleReference: false,
+  });
+  strictEqual(invalidReferences.length, 0);
+});
 
-    return invalidReferences;
-  }
+it("resolve the circular reference stack", async () => {
+  const code = `
+    model First { foo: Foo }
+    model Foo { foo: Bar }
+    model Bar { bar: Foo }
+  `;
+  const result = await findCircularReferences(code, {
+    modelsInline: true,
+    circleReference: true,
+  });
+  strictEqual(result.length, 1);
 
-  const selfRef = `model Foo { foo: Foo }`;
-  it("self referencing with declaration works fine", async () => {
-    const invalidReferences = await findCircularReferences(selfRef, {
+  deepStrictEqual(result[0].cycle.containsDeclaration, false);
+  deepStrictEqual(
+    [...result[0].cycle].map((x) => getTypeName(x.type)),
+    ["Foo", "Foo.foo", "Bar", "Bar.bar"],
+  );
+});
+
+describe("cycle with declaration inside", () => {
+  it("doesn't report issue if referencing a declaration in the cycle", async () => {
+    const code = `
+      model First { foo: Foo }
+      model Foo { foo: Foo[] }
+    `;
+    const result = await findCircularReferences(code, {
       modelsInline: false,
       circleReference: true,
     });
-    strictEqual(invalidReferences.length, 0);
+    strictEqual(result.length, 0);
   });
-
-  it("self referencing without declaration report circular reference", async () => {
-    const invalidReferences = await findCircularReferences(selfRef, {
-      modelsInline: true,
-      circleReference: true,
-    });
-    strictEqual(invalidReferences.length, 1);
-  });
-
-  it("without circular reference inline types cause no issue", async () => {
-    const invalidReferences = await findCircularReferences(selfRef, {
-      modelsInline: true,
-      circleReference: false,
-    });
-    strictEqual(invalidReferences.length, 0);
-  });
-
-  it("resolve the circular reference stack", async () => {
+  it("doesn't report issue if referencing an inline type in the cycle", async () => {
     const code = `
-      model First { foo: Foo }
-      model Foo { foo: Bar }
-      model Bar { bar: Foo }
+      model First { foo: Foo[] }
+      model Foo { foo: Foo[] }
     `;
     const result = await findCircularReferences(code, {
-      modelsInline: true,
+      modelsInline: false,
       circleReference: true,
     });
-    strictEqual(result.length, 1);
-
-    deepStrictEqual(result[0].cycle.containsDeclaration, false);
-    deepStrictEqual(
-      [...result[0].cycle].map((x) => getTypeName(x.type)),
-      ["Foo", "Foo.foo", "Bar", "Bar.bar"],
-    );
-  });
-
-  describe("cycle with declaration inside", () => {
-    it("doesn't report issue if referencing a declaration in the cycle", async () => {
-      const code = `
-        model First { foo: Foo }
-        model Foo { foo: Foo[] }
-      `;
-      const result = await findCircularReferences(code, {
-        modelsInline: false,
-        circleReference: true,
-      });
-      strictEqual(result.length, 0);
-    });
-    it("doesn't report issue if referencing an inline type in the cycle", async () => {
-      const code = `
-        model First { foo: Foo[] }
-        model Foo { foo: Foo[] }
-      `;
-      const result = await findCircularReferences(code, {
-        modelsInline: false,
-        circleReference: true,
-      });
-      strictEqual(result.length, 0);
-    });
+    strictEqual(result.length, 0);
   });
 });

--- a/packages/asset-emitter/test/context.test.ts
+++ b/packages/asset-emitter/test/context.test.ts
@@ -12,542 +12,540 @@ import {
 } from "../src/index.js";
 import { emitTypeSpec, getHostForTypeSpecFile } from "./host.js";
 
-describe("emitter-framework: emitter context", () => {
-  describe("program context", () => {
-    it("should be initialized to empty state", async () => {
-      class Emitter extends CodeTypeEmitter {
-        modelDeclaration(model: Model, name: string): EmitterOutput<string> {
-          const context = this.emitter.getContext();
-          assert.deepStrictEqual(context, {});
-          return super.modelDeclaration(model, name);
-        }
+describe("program context", () => {
+  it("should be initialized to empty state", async () => {
+    class Emitter extends CodeTypeEmitter {
+      modelDeclaration(model: Model, name: string): EmitterOutput<string> {
+        const context = this.emitter.getContext();
+        assert.deepStrictEqual(context, {});
+        return super.modelDeclaration(model, name);
       }
+    }
 
-      await emitTypeSpec(Emitter, `model Foo { }`);
-    });
-
-    it("should set program state for the whole program", async () => {
-      class Emitter extends CodeTypeEmitter {
-        programContext(program: Program) {
-          return {
-            inProgram: true,
-          };
-        }
-        modelDeclaration(model: Model, name: string): EmitterOutput<string> {
-          const context = this.emitter.getContext();
-          assert.deepStrictEqual(context, { inProgram: true });
-          return super.modelDeclaration(model, name);
-        }
-      }
-
-      await emitTypeSpec(Emitter, `model Foo { }`);
-    });
+    await emitTypeSpec(Emitter, `model Foo { }`);
   });
 
-  describe("namespace context", () => {
-    it("should set context for everything inside the namespace", async () => {
-      class Emitter extends CodeTypeEmitter {
-        namespaceContext(namespace: Namespace): Context {
-          return { inNamespace: true };
-        }
-
-        namespace(namespace: Namespace): EmitterOutput<string> {
-          assert.deepStrictEqual(this.emitter.getContext(), {
-            inNamespace: true,
-          });
-
-          return super.namespace(namespace);
-        }
-      }
-
-      await emitTypeSpec(Emitter, `namespace Foo {  }`);
-    });
-
-    it("should set context for everything inside the namespace, multiple namespaces", async () => {
-      class Emitter extends CodeTypeEmitter {
-        namespaceContext(namespace: Namespace): Context {
-          return { inNamespace: namespace.name };
-        }
-
-        namespace(namespace: Namespace): EmitterOutput<string> {
-          assert.deepStrictEqual(this.emitter.getContext(), {
-            inNamespace: namespace.name,
-          });
-
-          return super.namespace(namespace);
-        }
-      }
-
-      await emitTypeSpec(Emitter, `namespace Foo {  } namespace Bar { }`, {
-        namespaceContext: 2,
-        namespace: 2,
-      });
-    });
-
-    it("should set context for everything inside the namespace, nested namespaces", async () => {
-      class Emitter extends CodeTypeEmitter {
-        namespaceContext(namespace: Namespace): Context {
-          const newState: Record<string, boolean> = {};
-          if (namespace.name === "Foo") {
-            newState.foo = true;
-          } else {
-            newState.bar = true;
-          }
-
-          return newState;
-        }
-
-        namespace(namespace: Namespace): EmitterOutput<string> {
-          const expectedContext: Record<string, boolean> = { foo: true };
-
-          if (namespace.name === "Bar") {
-            expectedContext.bar = true;
-          }
-
-          assert.deepStrictEqual(
-            this.emitter.getContext(),
-            expectedContext,
-            "context for namespace " + namespace.name,
-          );
-
-          return super.namespace(namespace);
-        }
-      }
-
-      await emitTypeSpec(Emitter, `namespace Foo { namespace Bar { } }`, {
-        namespaceContext: 2,
-        namespace: 2,
-      });
-    });
-  });
-
-  describe("model context", () => {
-    it("sets model context for models and properties", async () => {
-      class Emitter extends CodeTypeEmitter {
-        modelDeclarationContext(model: Model, name: string): Context {
-          return {
-            inModel: true,
-          };
-        }
-        modelDeclaration(model: Model, name: string): EmitterOutput<string> {
-          assert.deepStrictEqual(this.emitter.getContext(), {
-            inModel: true,
-          });
-          return super.modelDeclaration(model, name);
-        }
-
-        modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
-          assert.deepStrictEqual(this.emitter.getContext(), {
-            inModel: true,
-          });
-          return super.modelPropertyLiteral(property);
-        }
-      }
-
-      await emitTypeSpec(
-        Emitter,
-        `model Foo {
-        prop: string;
-      }`,
-      );
-    });
-
-    it("sets model context for nested model literals", async () => {
-      class Emitter extends CodeTypeEmitter {
-        modelDeclarationContext(model: Model, name: string): Context {
-          return {
-            inModel: true,
-          };
-        }
-
-        modelLiteral(model: Model): EmitterOutput<string> {
-          assert.deepStrictEqual(this.emitter.getContext(), {
-            inModel: true,
-          });
-
-          return super.modelLiteral(model);
-        }
-      }
-
-      await emitTypeSpec(
-        Emitter,
-        `model Foo {
-        prop: {
-          nested: true
+  it("should set program state for the whole program", async () => {
+    class Emitter extends CodeTypeEmitter {
+      programContext(program: Program) {
+        return {
+          inProgram: true,
         };
-      }`,
-      );
-    });
-  });
-
-  describe("references", () => {
-    it("namespace context is preserved for models in that namespace even with references", async () => {
-      class TestEmitter extends CodeTypeEmitter {
-        namespaceContext(namespace: Namespace): Context {
-          return {
-            inANamespace: namespace.name === "A",
-          };
-        }
-
-        modelDeclaration(model: Model, name: string): EmitterOutput<string> {
-          const context = this.emitter.getContext();
-          if (name === "Foo") {
-            assert(context.inANamespace);
-          } else {
-            assert(!context.inANamespace);
-          }
-
-          return super.modelDeclaration(model, name);
-        }
       }
-
-      await emitTypeSpec(
-        TestEmitter,
-        `
-        model Bar { prop: A.Foo };
-        namespace A {
-          model Foo { prop: string };
-        }
-      `,
-        {
-          namespaceContext: 2,
-          modelDeclaration: 2,
-        },
-      );
-    });
-  });
-
-  describe("reference context", () => {
-    it("propagates reference context", async () => {
-      const seenContexts: Set<boolean> = new Set();
-      const propSeenContexts: Set<boolean> = new Set();
-
-      class TestEmitter extends CodeTypeEmitter {
-        namespaceReferenceContext(namespace: Namespace): Context {
-          if (namespace.name === "Foo") {
-            return { refFromNs: true };
-          }
-          return {};
-        }
-
-        modelDeclaration(model: Model, name: string): EmitterOutput<string> {
-          const context = this.emitter.getContext();
-          if (model.name === "N") {
-            seenContexts.add(context.refFromNs ?? false);
-          }
-          return super.modelDeclaration(model, name);
-        }
-
-        modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
-          const context = this.emitter.getContext();
-          if (property.name === "test") {
-            propSeenContexts.add(context.refFromNs ?? false);
-          }
-          return super.modelPropertyLiteral(property);
-        }
+      modelDeclaration(model: Model, name: string): EmitterOutput<string> {
+        const context = this.emitter.getContext();
+        assert.deepStrictEqual(context, { inProgram: true });
+        return super.modelDeclaration(model, name);
       }
-
-      await emitTypeSpec(
-        TestEmitter,
-        `
-        namespace Foo {
-          model M { x: Bar.N }
-        }
-        namespace Bar {
-          model N {
-            test: string;
-          }
-        }
-      `,
-        {
-          namespaceReferenceContext: 3,
-          modelDeclaration: 3,
-          modelPropertyLiteral: 3,
-        },
-      );
-
-      assert(seenContexts.has(true), "N has ref context");
-      assert(seenContexts.has(false), "N doesn't ref context also");
-    });
-
-    it("propagates reference context across multiple references", async () => {
-      let seenContext: Context;
-      class TestEmitter extends CodeTypeEmitter {
-        namespaceReferenceContext(namespace: Namespace): Context {
-          if (namespace.name === "Foo") {
-            return { refFromFoo: true };
-          } else if (namespace.name === "Bar") {
-            return { refFromBar: true };
-          }
-
-          return {};
-        }
-
-        modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
-          const context = this.emitter.getContext();
-          if (property.name === "prop") {
-            seenContext = context;
-          }
-          return super.modelPropertyLiteral(property);
-        }
-      }
-      const code = `
-        namespace Foo {
-          model M { x: Bar.N }
-        }
-        namespace Bar {
-          model N {
-            test: Baz.O;
-          }
-        }
-        namespace Baz {
-          model O {
-            prop: string;
-          }
-        }
-      `;
-
-      const host = await getHostForTypeSpecFile(code);
-      const emitter = createAssetEmitter(host.program, TestEmitter, {
-        emitterOutputDir: "tsp-output",
-        options: {},
-      } as any);
-
-      await emitter.emitType(host.program.resolveTypeReference("Foo")[0]!);
-
-      assert.deepStrictEqual(seenContext!, { refFromFoo: true, refFromBar: true });
-    });
-
-    it("doesn't emit model multiple times when reference context is the same", async () => {
-      class TestEmitter extends CodeTypeEmitter {
-        modelDeclarationReferenceContext(model: Model): Context {
-          if (model.name === "Qux") {
-            return {};
-          }
-          return { ref: true };
-        }
-
-        modelDeclaration(model: Model, name: string): EmitterOutput<string> {
-          return super.modelDeclaration(model, name);
-        }
-      }
-
-      await emitTypeSpec(
-        TestEmitter,
-        `
-        model Foo { x: Qux }
-        model Bar { x: Qux }
-        model Qux { }
-      `,
-        {
-          modelDeclarationReferenceContext: 4,
-          modelDeclaration: 4,
-        },
-      );
-    });
-  });
-
-  describe("setting context via emitTypeReference", () => {
-    async function emitType(
-      Emitter: typeof TypeEmitter<any>,
-      code: string,
-      ref: string,
-      referenceContext?: Record<string, any>,
-    ): Promise<EmitEntity<any>> {
-      const host = await getHostForTypeSpecFile(code);
-      const emitter = createAssetEmitter(host.program, Emitter, {
-        emitterOutputDir: "tsp-output",
-        options: {},
-      } as any);
-      const type = host.program.resolveTypeReference(ref)[0]!;
-      ok(type, `Expected to have found reference ${ref}`);
-      return emitter.emitType(type, { referenceContext });
     }
 
-    function objTypeReference(
-      emitter: AssetEmitter<any>,
-      target: Type,
-      contextValue: string | undefined,
-    ) {
-      return (
-        emitter.emitTypeReference(target, {
-          referenceContext: contextValue ? { contextValue } : {},
-        }) as any
-      ).value;
+    await emitTypeSpec(Emitter, `model Foo { }`);
+  });
+});
+
+describe("namespace context", () => {
+  it("should set context for everything inside the namespace", async () => {
+    class Emitter extends CodeTypeEmitter {
+      namespaceContext(namespace: Namespace): Context {
+        return { inNamespace: true };
+      }
+
+      namespace(namespace: Namespace): EmitterOutput<string> {
+        assert.deepStrictEqual(this.emitter.getContext(), {
+          inNamespace: true,
+        });
+
+        return super.namespace(namespace);
+      }
     }
 
-    it("set reference context value when calling emitTypeReference", async () => {
-      class TestEmitter extends TypeEmitter<any, any> {
-        modelDeclaration(model: Model, name: string): EmitterOutput<any> {
-          if (model.name === "Foo") {
-            const prop = model.properties.get("prop")!.type;
+    await emitTypeSpec(Emitter, `namespace Foo {  }`);
+  });
 
-            return {
-              context1: objTypeReference(this.emitter, prop, "context1"),
-              context2: objTypeReference(this.emitter, prop, "context2"),
-              noSet: objTypeReference(this.emitter, prop, undefined),
-            };
-          }
-          return this.emitter.getContext().contextValue;
-        }
+  it("should set context for everything inside the namespace, multiple namespaces", async () => {
+    class Emitter extends CodeTypeEmitter {
+      namespaceContext(namespace: Namespace): Context {
+        return { inNamespace: namespace.name };
       }
 
-      const result = await emitType(
-        TestEmitter,
-        `
-        model Foo { prop: Bar }
-        model Bar {}
-      `,
-        "Foo",
-      );
-      strictEqual(result.kind, "code");
-      deepStrictEqual(result.value, {
-        context1: "context1",
-        context2: "context2",
-        noSet: undefined,
-      });
-    });
+      namespace(namespace: Namespace): EmitterOutput<string> {
+        assert.deepStrictEqual(this.emitter.getContext(), {
+          inNamespace: namespace.name,
+        });
 
-    it("set reference context on model properties ", async () => {
-      class TestEmitter extends TypeEmitter<any, any> {
-        modelDeclaration(model: Model, name: string): EmitterOutput<any> {
-          if (model.name === "Foo") {
-            const prop = model.properties.get("prop")!;
-
-            return {
-              context1: objTypeReference(this.emitter, prop, "context1"),
-              context2: objTypeReference(this.emitter, prop, "context2"),
-              noSet: objTypeReference(this.emitter, prop, undefined),
-            };
-          }
-          return this.emitter.getContext().contextValue;
-        }
+        return super.namespace(namespace);
       }
+    }
 
-      const result = await emitType(
-        TestEmitter,
-        `
-        model Foo { prop: Bar }
-        model Bar {}
-      `,
-        "Foo",
-      );
-      strictEqual(result.kind, "code");
-      deepStrictEqual(result.value, {
-        context1: "context1",
-        context2: "context2",
-        noSet: undefined,
-      });
-    });
-
-    it("merge with incoming reference context", async () => {
-      class TestEmitter extends TypeEmitter<any, any> {
-        modelDeclaration(model: Model, name: string): EmitterOutput<any> {
-          if (model.name === "Foo") {
-            const prop = model.properties.get("prop")!.type;
-            return {
-              context1: objTypeReference(this.emitter, prop, "context1"),
-            };
-          }
-          return {
-            contextValue: this.emitter.getContext().contextValue,
-            incoming: this.emitter.getContext().incoming,
-          };
-        }
-      }
-
-      const result = await emitType(
-        TestEmitter,
-        `
-        model Foo { prop: Bar }
-        model Bar {}
-      `,
-        "Foo",
-        { incoming: "incoming-value" },
-      );
-      strictEqual(result.kind, "code");
-      deepStrictEqual(result.value, {
-        context1: {
-          contextValue: "context1",
-          incoming: "incoming-value",
-        },
-      });
-    });
-
-    it("ReferenceContext hook always wins", async () => {
-      class TestEmitter extends TypeEmitter<any, any> {
-        modelDeclarationReferenceContext(model: Model, name: string): Context {
-          return { contextValue: "context-override" };
-        }
-        modelDeclaration(model: Model, name: string): EmitterOutput<any> {
-          if (model.name === "Foo") {
-            const prop = model.properties.get("prop")!.type;
-            return {
-              context1: objTypeReference(this.emitter, prop, "context1"),
-            };
-          }
-          return this.emitter.getContext().contextValue;
-        }
-      }
-
-      const result = await emitType(
-        TestEmitter,
-        `
-        model Foo { prop: Bar }
-        model Bar {}
-      `,
-        "Foo",
-      );
-      strictEqual(result.kind, "code");
-      deepStrictEqual(result.value, {
-        context1: "context-override",
-      });
+    await emitTypeSpec(Emitter, `namespace Foo {  } namespace Bar { }`, {
+      namespaceContext: 2,
+      namespace: 2,
     });
   });
 
-  describe("instantiation context", () => {
-    it("restores  context when after referencing a type with a circular reference", async () => {
-      class Emitter extends CodeTypeEmitter {
-        programContext(program: Program): Context {
-          return {
-            scope: this.emitter.createSourceFile("foo.txt").globalScope,
-          };
+  it("should set context for everything inside the namespace, nested namespaces", async () => {
+    class Emitter extends CodeTypeEmitter {
+      namespaceContext(namespace: Namespace): Context {
+        const newState: Record<string, boolean> = {};
+        if (namespace.name === "Foo") {
+          newState.foo = true;
+        } else {
+          newState.bar = true;
         }
-        modelDeclarationContext(model: Model, name: string): Context {
-          return {
-            inModel: name,
-          };
-        }
-        modelDeclaration(model: Model, name: string): EmitterOutput<string> {
-          super.modelDeclaration(model, name);
-          return this.emitter.result.declaration(name, "Declaration for model " + name);
-        }
-        modelPropertyLiteralContext(property: ModelProperty): Context {
-          return { inProp: property.name };
-        }
-        modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
-          const beforeContext = this.emitter.getContext();
-          const res = super.modelPropertyLiteral(property);
-          assert.deepStrictEqual(beforeContext, this.emitter.getContext());
-          return res;
-        }
+
+        return newState;
       }
 
-      await emitTypeSpec(
-        Emitter,
-        `
-        model A {
-          a: B;
+      namespace(namespace: Namespace): EmitterOutput<string> {
+        const expectedContext: Record<string, boolean> = { foo: true };
+
+        if (namespace.name === "Bar") {
+          expectedContext.bar = true;
         }
-  
-        model B {
-          b: B;
-        }
-        
-        `,
-        {},
-        false,
-      );
+
+        assert.deepStrictEqual(
+          this.emitter.getContext(),
+          expectedContext,
+          "context for namespace " + namespace.name,
+        );
+
+        return super.namespace(namespace);
+      }
+    }
+
+    await emitTypeSpec(Emitter, `namespace Foo { namespace Bar { } }`, {
+      namespaceContext: 2,
+      namespace: 2,
     });
+  });
+});
+
+describe("model context", () => {
+  it("sets model context for models and properties", async () => {
+    class Emitter extends CodeTypeEmitter {
+      modelDeclarationContext(model: Model, name: string): Context {
+        return {
+          inModel: true,
+        };
+      }
+      modelDeclaration(model: Model, name: string): EmitterOutput<string> {
+        assert.deepStrictEqual(this.emitter.getContext(), {
+          inModel: true,
+        });
+        return super.modelDeclaration(model, name);
+      }
+
+      modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
+        assert.deepStrictEqual(this.emitter.getContext(), {
+          inModel: true,
+        });
+        return super.modelPropertyLiteral(property);
+      }
+    }
+
+    await emitTypeSpec(
+      Emitter,
+      `model Foo {
+      prop: string;
+    }`,
+    );
+  });
+
+  it("sets model context for nested model literals", async () => {
+    class Emitter extends CodeTypeEmitter {
+      modelDeclarationContext(model: Model, name: string): Context {
+        return {
+          inModel: true,
+        };
+      }
+
+      modelLiteral(model: Model): EmitterOutput<string> {
+        assert.deepStrictEqual(this.emitter.getContext(), {
+          inModel: true,
+        });
+
+        return super.modelLiteral(model);
+      }
+    }
+
+    await emitTypeSpec(
+      Emitter,
+      `model Foo {
+      prop: {
+        nested: true
+      };
+    }`,
+    );
+  });
+});
+
+describe("references", () => {
+  it("namespace context is preserved for models in that namespace even with references", async () => {
+    class TestEmitter extends CodeTypeEmitter {
+      namespaceContext(namespace: Namespace): Context {
+        return {
+          inANamespace: namespace.name === "A",
+        };
+      }
+
+      modelDeclaration(model: Model, name: string): EmitterOutput<string> {
+        const context = this.emitter.getContext();
+        if (name === "Foo") {
+          assert(context.inANamespace);
+        } else {
+          assert(!context.inANamespace);
+        }
+
+        return super.modelDeclaration(model, name);
+      }
+    }
+
+    await emitTypeSpec(
+      TestEmitter,
+      `
+      model Bar { prop: A.Foo };
+      namespace A {
+        model Foo { prop: string };
+      }
+    `,
+      {
+        namespaceContext: 2,
+        modelDeclaration: 2,
+      },
+    );
+  });
+});
+
+describe("reference context", () => {
+  it("propagates reference context", async () => {
+    const seenContexts: Set<boolean> = new Set();
+    const propSeenContexts: Set<boolean> = new Set();
+
+    class TestEmitter extends CodeTypeEmitter {
+      namespaceReferenceContext(namespace: Namespace): Context {
+        if (namespace.name === "Foo") {
+          return { refFromNs: true };
+        }
+        return {};
+      }
+
+      modelDeclaration(model: Model, name: string): EmitterOutput<string> {
+        const context = this.emitter.getContext();
+        if (model.name === "N") {
+          seenContexts.add(context.refFromNs ?? false);
+        }
+        return super.modelDeclaration(model, name);
+      }
+
+      modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
+        const context = this.emitter.getContext();
+        if (property.name === "test") {
+          propSeenContexts.add(context.refFromNs ?? false);
+        }
+        return super.modelPropertyLiteral(property);
+      }
+    }
+
+    await emitTypeSpec(
+      TestEmitter,
+      `
+      namespace Foo {
+        model M { x: Bar.N }
+      }
+      namespace Bar {
+        model N {
+          test: string;
+        }
+      }
+    `,
+      {
+        namespaceReferenceContext: 3,
+        modelDeclaration: 3,
+        modelPropertyLiteral: 3,
+      },
+    );
+
+    assert(seenContexts.has(true), "N has ref context");
+    assert(seenContexts.has(false), "N doesn't ref context also");
+  });
+
+  it("propagates reference context across multiple references", async () => {
+    let seenContext: Context;
+    class TestEmitter extends CodeTypeEmitter {
+      namespaceReferenceContext(namespace: Namespace): Context {
+        if (namespace.name === "Foo") {
+          return { refFromFoo: true };
+        } else if (namespace.name === "Bar") {
+          return { refFromBar: true };
+        }
+
+        return {};
+      }
+
+      modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
+        const context = this.emitter.getContext();
+        if (property.name === "prop") {
+          seenContext = context;
+        }
+        return super.modelPropertyLiteral(property);
+      }
+    }
+    const code = `
+      namespace Foo {
+        model M { x: Bar.N }
+      }
+      namespace Bar {
+        model N {
+          test: Baz.O;
+        }
+      }
+      namespace Baz {
+        model O {
+          prop: string;
+        }
+      }
+    `;
+
+    const host = await getHostForTypeSpecFile(code);
+    const emitter = createAssetEmitter(host.program, TestEmitter, {
+      emitterOutputDir: "tsp-output",
+      options: {},
+    } as any);
+
+    await emitter.emitType(host.program.resolveTypeReference("Foo")[0]!);
+
+    assert.deepStrictEqual(seenContext!, { refFromFoo: true, refFromBar: true });
+  });
+
+  it("doesn't emit model multiple times when reference context is the same", async () => {
+    class TestEmitter extends CodeTypeEmitter {
+      modelDeclarationReferenceContext(model: Model): Context {
+        if (model.name === "Qux") {
+          return {};
+        }
+        return { ref: true };
+      }
+
+      modelDeclaration(model: Model, name: string): EmitterOutput<string> {
+        return super.modelDeclaration(model, name);
+      }
+    }
+
+    await emitTypeSpec(
+      TestEmitter,
+      `
+      model Foo { x: Qux }
+      model Bar { x: Qux }
+      model Qux { }
+    `,
+      {
+        modelDeclarationReferenceContext: 4,
+        modelDeclaration: 4,
+      },
+    );
+  });
+});
+
+describe("setting context via emitTypeReference", () => {
+  async function emitType(
+    Emitter: typeof TypeEmitter<any>,
+    code: string,
+    ref: string,
+    referenceContext?: Record<string, any>,
+  ): Promise<EmitEntity<any>> {
+    const host = await getHostForTypeSpecFile(code);
+    const emitter = createAssetEmitter(host.program, Emitter, {
+      emitterOutputDir: "tsp-output",
+      options: {},
+    } as any);
+    const type = host.program.resolveTypeReference(ref)[0]!;
+    ok(type, `Expected to have found reference ${ref}`);
+    return emitter.emitType(type, { referenceContext });
+  }
+
+  function objTypeReference(
+    emitter: AssetEmitter<any>,
+    target: Type,
+    contextValue: string | undefined,
+  ) {
+    return (
+      emitter.emitTypeReference(target, {
+        referenceContext: contextValue ? { contextValue } : {},
+      }) as any
+    ).value;
+  }
+
+  it("set reference context value when calling emitTypeReference", async () => {
+    class TestEmitter extends TypeEmitter<any, any> {
+      modelDeclaration(model: Model, name: string): EmitterOutput<any> {
+        if (model.name === "Foo") {
+          const prop = model.properties.get("prop")!.type;
+
+          return {
+            context1: objTypeReference(this.emitter, prop, "context1"),
+            context2: objTypeReference(this.emitter, prop, "context2"),
+            noSet: objTypeReference(this.emitter, prop, undefined),
+          };
+        }
+        return this.emitter.getContext().contextValue;
+      }
+    }
+
+    const result = await emitType(
+      TestEmitter,
+      `
+      model Foo { prop: Bar }
+      model Bar {}
+    `,
+      "Foo",
+    );
+    strictEqual(result.kind, "code");
+    deepStrictEqual(result.value, {
+      context1: "context1",
+      context2: "context2",
+      noSet: undefined,
+    });
+  });
+
+  it("set reference context on model properties ", async () => {
+    class TestEmitter extends TypeEmitter<any, any> {
+      modelDeclaration(model: Model, name: string): EmitterOutput<any> {
+        if (model.name === "Foo") {
+          const prop = model.properties.get("prop")!;
+
+          return {
+            context1: objTypeReference(this.emitter, prop, "context1"),
+            context2: objTypeReference(this.emitter, prop, "context2"),
+            noSet: objTypeReference(this.emitter, prop, undefined),
+          };
+        }
+        return this.emitter.getContext().contextValue;
+      }
+    }
+
+    const result = await emitType(
+      TestEmitter,
+      `
+      model Foo { prop: Bar }
+      model Bar {}
+    `,
+      "Foo",
+    );
+    strictEqual(result.kind, "code");
+    deepStrictEqual(result.value, {
+      context1: "context1",
+      context2: "context2",
+      noSet: undefined,
+    });
+  });
+
+  it("merge with incoming reference context", async () => {
+    class TestEmitter extends TypeEmitter<any, any> {
+      modelDeclaration(model: Model, name: string): EmitterOutput<any> {
+        if (model.name === "Foo") {
+          const prop = model.properties.get("prop")!.type;
+          return {
+            context1: objTypeReference(this.emitter, prop, "context1"),
+          };
+        }
+        return {
+          contextValue: this.emitter.getContext().contextValue,
+          incoming: this.emitter.getContext().incoming,
+        };
+      }
+    }
+
+    const result = await emitType(
+      TestEmitter,
+      `
+      model Foo { prop: Bar }
+      model Bar {}
+    `,
+      "Foo",
+      { incoming: "incoming-value" },
+    );
+    strictEqual(result.kind, "code");
+    deepStrictEqual(result.value, {
+      context1: {
+        contextValue: "context1",
+        incoming: "incoming-value",
+      },
+    });
+  });
+
+  it("ReferenceContext hook always wins", async () => {
+    class TestEmitter extends TypeEmitter<any, any> {
+      modelDeclarationReferenceContext(model: Model, name: string): Context {
+        return { contextValue: "context-override" };
+      }
+      modelDeclaration(model: Model, name: string): EmitterOutput<any> {
+        if (model.name === "Foo") {
+          const prop = model.properties.get("prop")!.type;
+          return {
+            context1: objTypeReference(this.emitter, prop, "context1"),
+          };
+        }
+        return this.emitter.getContext().contextValue;
+      }
+    }
+
+    const result = await emitType(
+      TestEmitter,
+      `
+      model Foo { prop: Bar }
+      model Bar {}
+    `,
+      "Foo",
+    );
+    strictEqual(result.kind, "code");
+    deepStrictEqual(result.value, {
+      context1: "context-override",
+    });
+  });
+});
+
+describe("instantiation context", () => {
+  it("restores  context when after referencing a type with a circular reference", async () => {
+    class Emitter extends CodeTypeEmitter {
+      programContext(program: Program): Context {
+        return {
+          scope: this.emitter.createSourceFile("foo.txt").globalScope,
+        };
+      }
+      modelDeclarationContext(model: Model, name: string): Context {
+        return {
+          inModel: name,
+        };
+      }
+      modelDeclaration(model: Model, name: string): EmitterOutput<string> {
+        super.modelDeclaration(model, name);
+        return this.emitter.result.declaration(name, "Declaration for model " + name);
+      }
+      modelPropertyLiteralContext(property: ModelProperty): Context {
+        return { inProp: property.name };
+      }
+      modelPropertyLiteral(property: ModelProperty): EmitterOutput<string> {
+        const beforeContext = this.emitter.getContext();
+        const res = super.modelPropertyLiteral(property);
+        assert.deepStrictEqual(beforeContext, this.emitter.getContext());
+        return res;
+      }
+    }
+
+    await emitTypeSpec(
+      Emitter,
+      `
+      model A {
+        a: B;
+      }
+
+      model B {
+        b: B;
+      }
+      
+      `,
+      {},
+      false,
+    );
   });
 });

--- a/packages/asset-emitter/test/object-builder.test.ts
+++ b/packages/asset-emitter/test/object-builder.test.ts
@@ -2,47 +2,45 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { ObjectBuilder } from "../src/index.js";
 import { Placeholder } from "../src/placeholder.js";
 
-describe("ObjectBuilder", () => {
-  it("create simple builder", () => {
-    const builder = new ObjectBuilder({
-      foo: "bar",
-    });
+it("create simple builder", () => {
+  const builder = new ObjectBuilder({
+    foo: "bar",
+  });
+  expect(builder.foo).toBe("bar");
+});
+
+it("create adds elements to builder", () => {
+  const builder = new ObjectBuilder({
+    foo: "bar",
+  });
+  builder.set("bar", "baz");
+  expect(builder.foo).toBe("bar");
+  expect(builder.bar).toBe("baz");
+});
+
+describe("when working with placeholders", () => {
+  let placeholder: Placeholder<any>;
+
+  beforeEach(() => {
+    placeholder = new Placeholder();
+  });
+
+  it("has no values to start with", () => {
+    const builder = new ObjectBuilder(placeholder);
+    expect(builder.foo).toBeUndefined();
+  });
+
+  it("resolve values from placeholder", () => {
+    const builder = new ObjectBuilder(placeholder);
+    expect(builder.foo).toBeUndefined();
+    placeholder.setValue({ foo: "bar" });
     expect(builder.foo).toBe("bar");
   });
 
-  it("create adds elements to builder", () => {
-    const builder = new ObjectBuilder({
-      foo: "bar",
-    });
-    builder.set("bar", "baz");
-    expect(builder.foo).toBe("bar");
-    expect(builder.bar).toBe("baz");
-  });
-
-  describe("when working with placeholders", () => {
-    let placeholder: Placeholder<any>;
-
-    beforeEach(() => {
-      placeholder = new Placeholder();
-    });
-
-    it("has no values to start with", () => {
-      const builder = new ObjectBuilder(placeholder);
-      expect(builder.foo).toBeUndefined();
-    });
-
-    it("resolve values from placeholder", () => {
-      const builder = new ObjectBuilder(placeholder);
-      expect(builder.foo).toBeUndefined();
-      placeholder.setValue({ foo: "bar" });
-      expect(builder.foo).toBe("bar");
-    });
-
-    it("create object builder from another object builder with a placeholder", () => {
-      const builder1 = new ObjectBuilder(placeholder);
-      const builder2 = new ObjectBuilder(builder1);
-      placeholder.setValue({ foo: "bar" });
-      expect(builder2.foo).toBe("bar");
-    });
+  it("create object builder from another object builder with a placeholder", () => {
+    const builder1 = new ObjectBuilder(placeholder);
+    const builder2 = new ObjectBuilder(builder1);
+    placeholder.setValue({ foo: "bar" });
+    expect(builder2.foo).toBe("bar");
   });
 });

--- a/packages/bundler/test/test.test.ts
+++ b/packages/bundler/test/test.test.ts
@@ -1,110 +1,106 @@
 import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { createTypeSpecBundle } from "../src/bundler.js";
 
-describe("bundler", () => {
-  /**
-   * Regression test: TypeSpec decorator functions are identified by their `.name` property
-   * at runtime (e.g., `d.decorator.name === "$armResourceOperations"`).
-   * When esbuild minifies library bundles, it can rename functions, changing their `.name`.
-   * The bundler must use `keepNames: true` to preserve function names in minified output.
-   */
-  it("preserves function names when minifying", async () => {
-    const tmpDir = await mkdtemp(join(tmpdir(), "typespec-bundler-test-"));
-    try {
-      // Create a minimal TypeSpec library with named decorator function exports
-      await writeFile(
-        join(tmpDir, "package.json"),
-        JSON.stringify({
-          name: "test-lib",
-          version: "1.0.0",
-          main: "index.js",
-          tspMain: "main.tsp",
-          peerDependencies: {},
-        }),
-      );
-      await writeFile(
-        join(tmpDir, "main.tsp"),
-        ['import "./index.js";', "namespace TestLib;"].join("\n"),
-      );
-      await writeFile(
-        join(tmpDir, "index.js"),
-        [
-          "export function $testDecorator(context, target) { }",
-          "export function $anotherDecorator(context, target) { }",
-        ].join("\n"),
-      );
+/**
+ * Regression test: TypeSpec decorator functions are identified by their `.name` property
+ * at runtime (e.g., `d.decorator.name === "$armResourceOperations"`).
+ * When esbuild minifies library bundles, it can rename functions, changing their `.name`.
+ * The bundler must use `keepNames: true` to preserve function names in minified output.
+ */
+it("preserves function names when minifying", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "typespec-bundler-test-"));
+  try {
+    // Create a minimal TypeSpec library with named decorator function exports
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({
+        name: "test-lib",
+        version: "1.0.0",
+        main: "index.js",
+        tspMain: "main.tsp",
+        peerDependencies: {},
+      }),
+    );
+    await writeFile(
+      join(tmpDir, "main.tsp"),
+      ['import "./index.js";', "namespace TestLib;"].join("\n"),
+    );
+    await writeFile(
+      join(tmpDir, "index.js"),
+      [
+        "export function $testDecorator(context, target) { }",
+        "export function $anotherDecorator(context, target) { }",
+      ].join("\n"),
+    );
 
-      const bundle = await createTypeSpecBundle(tmpDir, { minify: true });
-      const indexFile = bundle.files.find((f) => f.filename === "index.js");
-      expect(indexFile, "index.js should be in bundle output").toBeDefined();
+    const bundle = await createTypeSpecBundle(tmpDir, { minify: true });
+    const indexFile = bundle.files.find((f) => f.filename === "index.js");
+    expect(indexFile, "index.js should be in bundle output").toBeDefined();
 
-      // The bundle's jsSourceFiles should contain modules where the function
-      // .name property is preserved. With keepNames, esbuild emits a helper
-      // that restores the original name via Object.defineProperty.
-      // We verify the original function names appear as string literals in the output.
-      expect(indexFile!.content).toContain('"$testDecorator"');
-      expect(indexFile!.content).toContain('"$anotherDecorator"');
-    } finally {
-      await rm(tmpDir, { recursive: true });
-    }
-  });
+    // The bundle's jsSourceFiles should contain modules where the function
+    // .name property is preserved. With keepNames, esbuild emits a helper
+    // that restores the original name via Object.defineProperty.
+    // We verify the original function names appear as string literals in the output.
+    expect(indexFile!.content).toContain('"$testDecorator"');
+    expect(indexFile!.content).toContain('"$anotherDecorator"');
+  } finally {
+    await rm(tmpDir, { recursive: true });
+  }
+});
 
-  it("includes typespec source files from sub-exports", async () => {
-    const tmpDir = await mkdtemp(join(tmpdir(), "typespec-bundler-test-"));
-    try {
-      await mkdir(join(tmpDir, "lib", "sub"), { recursive: true });
+it("includes typespec source files from sub-exports", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "typespec-bundler-test-"));
+  try {
+    await mkdir(join(tmpDir, "lib", "sub"), { recursive: true });
 
-      await writeFile(
-        join(tmpDir, "package.json"),
-        JSON.stringify({
-          name: "test-lib",
-          version: "1.0.0",
-          main: "index.js",
-          tspMain: "lib/main.tsp",
-          peerDependencies: {},
-          exports: {
-            ".": {
-              typespec: "./lib/main.tsp",
-              default: "./index.js",
-            },
-            "./sub": {
-              typespec: "./lib/sub/main.tsp",
-              default: "./sub.js",
-            },
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({
+        name: "test-lib",
+        version: "1.0.0",
+        main: "index.js",
+        tspMain: "lib/main.tsp",
+        peerDependencies: {},
+        exports: {
+          ".": {
+            typespec: "./lib/main.tsp",
+            default: "./index.js",
           },
-        }),
-      );
-      await writeFile(
-        join(tmpDir, "lib", "main.tsp"),
-        ['import "../index.js";', "namespace TestLib;"].join("\n"),
-      );
-      await writeFile(
-        join(tmpDir, "lib", "sub", "main.tsp"),
-        [
-          'import "../../index.js";',
-          "namespace TestLib.Sub;",
-          "model SubModel { x: string; }",
-        ].join("\n"),
-      );
-      await writeFile(join(tmpDir, "index.js"), "export function $myDec(context, target) { }");
-      await writeFile(join(tmpDir, "sub.js"), "export const subExport = true;");
+          "./sub": {
+            typespec: "./lib/sub/main.tsp",
+            default: "./sub.js",
+          },
+        },
+      }),
+    );
+    await writeFile(
+      join(tmpDir, "lib", "main.tsp"),
+      ['import "../index.js";', "namespace TestLib;"].join("\n"),
+    );
+    await writeFile(
+      join(tmpDir, "lib", "sub", "main.tsp"),
+      ['import "../../index.js";', "namespace TestLib.Sub;", "model SubModel { x: string; }"].join(
+        "\n",
+      ),
+    );
+    await writeFile(join(tmpDir, "index.js"), "export function $myDec(context, target) { }");
+    await writeFile(join(tmpDir, "sub.js"), "export const subExport = true;");
 
-      const bundle = await createTypeSpecBundle(tmpDir, { minify: false });
-      const indexFile = bundle.files.find((f) => f.filename === "index.js");
-      expect(indexFile).toBeDefined();
+    const bundle = await createTypeSpecBundle(tmpDir, { minify: false });
+    const indexFile = bundle.files.find((f) => f.filename === "index.js");
+    expect(indexFile).toBeDefined();
 
-      // The main bundle should include the sub-export's typespec source files
-      expect(indexFile!.content).toContain("lib/sub/main.tsp");
-      expect(indexFile!.content).toContain("SubModel");
+    // The main bundle should include the sub-export's typespec source files
+    expect(indexFile!.content).toContain("lib/sub/main.tsp");
+    expect(indexFile!.content).toContain("SubModel");
 
-      // The sub-export JS entry should also be bundled
-      const subFile = bundle.files.find((f) => f.filename === "sub.js");
-      expect(subFile, "sub.js should be in bundle output").toBeDefined();
-    } finally {
-      await rm(tmpDir, { recursive: true });
-    }
-  });
+    // The sub-export JS entry should also be bundled
+    const subFile = bundle.files.find((f) => f.filename === "sub.js");
+    expect(subFile, "sub.js should be in bundle output").toBeDefined();
+  } finally {
+    await rm(tmpDir, { recursive: true });
+  }
 });

--- a/packages/emitter-framework/src/core/scc-set.test.ts
+++ b/packages/emitter-framework/src/core/scc-set.test.ts
@@ -2,266 +2,264 @@ import { Tester } from "#test/test-host.js";
 import { computed } from "@alloy-js/core";
 import type { Type } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
-import { describe, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 import { SCCSet, type NestedArray, type SCCComponent } from "./scc-set.js";
 import { typeDependencyConnector } from "./type-connector.js";
 
-describe("SCCSet", () => {
-  it("topologically orders items", () => {
-    const edges = new Map<string, string[]>([
-      ["model", ["serializer"]],
-      ["serializer", ["helpers"]],
-      ["helpers", []],
-    ]);
+it("topologically orders items", () => {
+  const edges = new Map<string, string[]>([
+    ["model", ["serializer"]],
+    ["serializer", ["helpers"]],
+    ["helpers", []],
+  ]);
 
-    const set = new SCCSet<string>((item) => edges.get(item) ?? []);
-    set.add("model");
-    set.add("serializer");
-    set.add("helpers");
+  const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+  set.add("model");
+  set.add("serializer");
+  set.add("helpers");
 
-    expect([...set.items]).toEqual(["helpers", "serializer", "model"]);
-    expect(componentValues(set)).toEqual(["helpers", "serializer", "model"]);
+  expect([...set.items]).toEqual(["helpers", "serializer", "model"]);
+  expect(componentValues(set)).toEqual(["helpers", "serializer", "model"]);
+});
+
+it("groups strongly connected components", () => {
+  const edges = new Map<string, string[]>([
+    ["a", ["b"]],
+    ["b", ["a", "c"]],
+    ["c", []],
+  ]);
+
+  const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+  set.add("a");
+  set.add("b");
+  set.add("c");
+
+  expect(componentValues(set)).toEqual(["c", ["a", "b"]]);
+  expect(set.items).toEqual(["c", "a", "b"]);
+});
+
+it("defers placeholders until added", () => {
+  const edges = new Map<string, string[]>([
+    ["root", ["child"]],
+    ["child", []],
+  ]);
+
+  const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+
+  set.add("root");
+  expect(set.items).toEqual(["root"]);
+  expect(componentValues(set)).toEqual(["root"]);
+
+  set.add("child");
+  expect(set.items).toEqual(["child", "root"]);
+  expect(componentValues(set)).toEqual(["child", "root"]);
+});
+
+it("surfaces reachable nodes when requested", () => {
+  const edges = new Map<string, string[]>([
+    ["root", ["child"]],
+    ["child", ["leaf"]],
+    ["leaf", []],
+  ]);
+
+  const set = new SCCSet<string>((item) => edges.get(item) ?? [], { includeReachable: true });
+  set.add("root");
+
+  expect(set.items).toEqual(["leaf", "child", "root"]);
+  expect(componentValues(set)).toEqual(["leaf", "child", "root"]);
+});
+
+it("mutates arrays in place when adding", () => {
+  const edges = new Map<string, string[]>([["only", []]]);
+  const connector = vi.fn((item: string) => edges.get(item) ?? []);
+
+  const set = new SCCSet(connector);
+  set.add("only");
+
+  const firstItems = set.items;
+  const firstComponents = set.components;
+
+  expect(set.items).toBe(firstItems);
+  expect(set.components).toBe(firstComponents);
+  expect(connector).toHaveBeenCalledTimes(1);
+
+  set.add("late");
+  expect(connector).toHaveBeenCalledTimes(2);
+  expect(set.items).toBe(firstItems);
+  expect(set.components).toBe(firstComponents);
+  expect(firstItems).toEqual(["only", "late"]);
+  expect(componentValuesFrom(firstComponents)).toEqual(["only", "late"]);
+});
+
+it("notifies computed observers", () => {
+  const edges = new Map<string, string[]>([
+    ["model", ["serializer"]],
+    ["serializer", ["helpers"]],
+    ["helpers", []],
+    ["cycle-a", ["cycle-b"]],
+    ["cycle-b", ["cycle-a"]],
+  ]);
+
+  const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+  const observedItems = computed(() => [...set.items]);
+  const observedComponents = computed(() => componentValues(set));
+  const observedCycle = computed(() => {
+    const cycle = set.components.find((component) => Array.isArray(component.value));
+    if (!cycle || !Array.isArray(cycle.value)) {
+      return [];
+    }
+    return [...cycle.value];
   });
 
-  it("groups strongly connected components", () => {
-    const edges = new Map<string, string[]>([
-      ["a", ["b"]],
-      ["b", ["a", "c"]],
-      ["c", []],
-    ]);
+  expect(observedItems.value).toEqual([]);
+  expect(observedComponents.value).toEqual([]);
+  expect(observedCycle.value).toEqual([]);
 
-    const set = new SCCSet<string>((item) => edges.get(item) ?? []);
-    set.add("a");
-    set.add("b");
-    set.add("c");
+  set.add("model");
+  expect(observedItems.value).toEqual(["model"]);
+  expect(observedComponents.value).toEqual(["model"]);
 
-    expect(componentValues(set)).toEqual(["c", ["a", "b"]]);
-    expect(set.items).toEqual(["c", "a", "b"]);
-  });
+  set.add("serializer");
+  expect(observedItems.value).toEqual(["serializer", "model"]);
+  expect(observedComponents.value).toEqual(["serializer", "model"]);
 
-  it("defers placeholders until added", () => {
-    const edges = new Map<string, string[]>([
-      ["root", ["child"]],
-      ["child", []],
-    ]);
+  set.add("helpers");
+  expect(observedItems.value).toEqual(["helpers", "serializer", "model"]);
+  expect(observedComponents.value).toEqual(["helpers", "serializer", "model"]);
 
-    const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+  set.add("cycle-a");
+  expect(observedCycle.value).toEqual([]);
 
-    set.add("root");
-    expect(set.items).toEqual(["root"]);
-    expect(componentValues(set)).toEqual(["root"]);
+  set.add("cycle-b");
+  expect(observedCycle.value).toEqual(["cycle-a", "cycle-b"]);
+});
 
-    set.add("child");
-    expect(set.items).toEqual(["child", "root"]);
-    expect(componentValues(set)).toEqual(["child", "root"]);
-  });
+it("orders dependent nodes even when added out of order", () => {
+  const edges = new Map<string, string[]>([
+    ["Leaf", []],
+    ["Indexed", ["Record"]],
+    ["Record", ["Leaf"]],
+    ["Base", ["Leaf"]],
+    ["Derived", ["Base", "Indexed"]],
+    ["CycleA", ["CycleB"]],
+    ["CycleB", ["CycleA"]],
+  ]);
 
-  it("surfaces reachable nodes when requested", () => {
-    const edges = new Map<string, string[]>([
-      ["root", ["child"]],
-      ["child", ["leaf"]],
-      ["leaf", []],
-    ]);
+  const insertionOrder = ["Derived", "Indexed", "Leaf", "Base", "CycleA", "CycleB"];
+  const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+  for (const item of insertionOrder) {
+    set.add(item);
+  }
 
-    const set = new SCCSet<string>((item) => edges.get(item) ?? [], { includeReachable: true });
-    set.add("root");
+  expect([...set.items]).toEqual(["Leaf", "Indexed", "Base", "Derived", "CycleA", "CycleB"]);
+  expect(componentValues(set)).toEqual([
+    "Leaf",
+    "Indexed",
+    "Base",
+    "Derived",
+    ["CycleA", "CycleB"],
+  ]);
+});
 
-    expect(set.items).toEqual(["leaf", "child", "root"]);
-    expect(componentValues(set)).toEqual(["leaf", "child", "root"]);
-  });
+it("batch adds nodes and recomputes once", () => {
+  const edges = new Map<string, string[]>([
+    ["Leaf", []],
+    ["Indexed", ["Record"]],
+    ["Record", ["Leaf"]],
+    ["Base", ["Leaf"]],
+    ["Derived", ["Base", "Indexed"]],
+    ["CycleA", ["CycleB"]],
+    ["CycleB", ["CycleA"]],
+  ]);
 
-  it("mutates arrays in place when adding", () => {
-    const edges = new Map<string, string[]>([["only", []]]);
-    const connector = vi.fn((item: string) => edges.get(item) ?? []);
+  const insertionOrder = ["Derived", "Indexed", "Leaf", "Base", "CycleA", "CycleB"];
+  const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+  set.addAll(insertionOrder);
 
-    const set = new SCCSet(connector);
-    set.add("only");
+  expect([...set.items]).toEqual(["Leaf", "Indexed", "Base", "Derived", "CycleA", "CycleB"]);
+  expect(componentValues(set)).toEqual([
+    "Leaf",
+    "Indexed",
+    "Base",
+    "Derived",
+    ["CycleA", "CycleB"],
+  ]);
+});
 
-    const firstItems = set.items;
-    const firstComponents = set.components;
+it("exposes component connections", () => {
+  const edges = new Map<string, string[]>([
+    ["Leaf", []],
+    ["Base", ["Leaf"]],
+    ["Indexed", ["Leaf"]],
+    ["Derived", ["Base", "Indexed"]],
+    ["CycleA", ["CycleB"]],
+    ["CycleB", ["CycleA"]],
+  ]);
 
-    expect(set.items).toBe(firstItems);
-    expect(set.components).toBe(firstComponents);
-    expect(connector).toHaveBeenCalledTimes(1);
+  const set = new SCCSet<string>((item) => edges.get(item) ?? []);
+  set.addAll(["Derived", "Base", "Indexed", "Leaf", "CycleA", "CycleB"]);
 
-    set.add("late");
-    expect(connector).toHaveBeenCalledTimes(2);
-    expect(set.items).toBe(firstItems);
-    expect(set.components).toBe(firstComponents);
-    expect(firstItems).toEqual(["only", "late"]);
-    expect(componentValuesFrom(firstComponents)).toEqual(["only", "late"]);
-  });
+  const getSingleton = (name: string) =>
+    set.components.find((component) => component.value === name)!;
+  const format = (components: Iterable<SCCComponent<string>>) =>
+    Array.from(components, (component) =>
+      Array.isArray(component.value) ? component.value.join(",") : component.value,
+    ).sort();
 
-  it("notifies computed observers", () => {
-    const edges = new Map<string, string[]>([
-      ["model", ["serializer"]],
-      ["serializer", ["helpers"]],
-      ["helpers", []],
-      ["cycle-a", ["cycle-b"]],
-      ["cycle-b", ["cycle-a"]],
-    ]);
+  const derived = getSingleton("Derived");
+  const base = getSingleton("Base");
+  const indexed = getSingleton("Indexed");
+  const leaf = getSingleton("Leaf");
+  const cycle = set.components.find((component) => Array.isArray(component.value))!;
 
-    const set = new SCCSet<string>((item) => edges.get(item) ?? []);
-    const observedItems = computed(() => [...set.items]);
-    const observedComponents = computed(() => componentValues(set));
-    const observedCycle = computed(() => {
-      const cycle = set.components.find((component) => Array.isArray(component.value));
-      if (!cycle || !Array.isArray(cycle.value)) {
-        return [];
+  expect(format(derived.references)).toEqual(["Base", "Indexed"]);
+  expect(format(base.references)).toEqual(["Leaf"]);
+  expect(format(base.referencedBy)).toEqual(["Derived"]);
+  expect(format(indexed.referencedBy)).toEqual(["Derived"]);
+  expect(format(leaf.referencedBy)).toEqual(["Base", "Indexed"]);
+  expect(format(cycle.references)).toEqual([]);
+  expect(format(cycle.referencedBy)).toEqual([]);
+});
+
+it("orders TypeSpec models via connector", async () => {
+  const tester = await Tester.createInstance();
+  const { Leaf, Indexed, Base, Derived, CycleA, CycleB } = await tester.compile(
+    t.code`
+      @test model ${t.model("Leaf")} {
+        value: string;
       }
-      return [...cycle.value];
-    });
 
-    expect(observedItems.value).toEqual([]);
-    expect(observedComponents.value).toEqual([]);
-    expect(observedCycle.value).toEqual([]);
+      @test model ${t.model("Indexed")} extends Record<Leaf> {}
 
-    set.add("model");
-    expect(observedItems.value).toEqual(["model"]);
-    expect(observedComponents.value).toEqual(["model"]);
+      @test model ${t.model("Base")} {
+        leaf: Leaf;
+      }
 
-    set.add("serializer");
-    expect(observedItems.value).toEqual(["serializer", "model"]);
-    expect(observedComponents.value).toEqual(["serializer", "model"]);
+      @test model ${t.model("Derived")} extends Base {
+        payload: Indexed;
+      }
 
-    set.add("helpers");
-    expect(observedItems.value).toEqual(["helpers", "serializer", "model"]);
-    expect(observedComponents.value).toEqual(["helpers", "serializer", "model"]);
+      @test model ${t.model("CycleA")} {
+        next: CycleB;
+      }
 
-    set.add("cycle-a");
-    expect(observedCycle.value).toEqual([]);
+      @test model ${t.model("CycleB")} {
+        prev: CycleA;
+      }
+    `,
+  );
 
-    set.add("cycle-b");
-    expect(observedCycle.value).toEqual(["cycle-a", "cycle-b"]);
-  });
+  const models = [Derived, Indexed, Leaf, Base, CycleA, CycleB] as Type[];
+  const set = new SCCSet<Type>(typeDependencyConnector);
+  for (const type of models) {
+    set.add(type);
+  }
 
-  it("orders dependent nodes even when added out of order", () => {
-    const edges = new Map<string, string[]>([
-      ["Leaf", []],
-      ["Indexed", ["Record"]],
-      ["Record", ["Leaf"]],
-      ["Base", ["Leaf"]],
-      ["Derived", ["Base", "Indexed"]],
-      ["CycleA", ["CycleB"]],
-      ["CycleB", ["CycleA"]],
-    ]);
+  const itemNames = set.items.map(getTypeLabel);
+  expect(itemNames).toEqual(["Leaf", "Indexed", "Base", "Derived", "CycleA", "CycleB"]);
 
-    const insertionOrder = ["Derived", "Indexed", "Leaf", "Base", "CycleA", "CycleB"];
-    const set = new SCCSet<string>((item) => edges.get(item) ?? []);
-    for (const item of insertionOrder) {
-      set.add(item);
-    }
-
-    expect([...set.items]).toEqual(["Leaf", "Indexed", "Base", "Derived", "CycleA", "CycleB"]);
-    expect(componentValues(set)).toEqual([
-      "Leaf",
-      "Indexed",
-      "Base",
-      "Derived",
-      ["CycleA", "CycleB"],
-    ]);
-  });
-
-  it("batch adds nodes and recomputes once", () => {
-    const edges = new Map<string, string[]>([
-      ["Leaf", []],
-      ["Indexed", ["Record"]],
-      ["Record", ["Leaf"]],
-      ["Base", ["Leaf"]],
-      ["Derived", ["Base", "Indexed"]],
-      ["CycleA", ["CycleB"]],
-      ["CycleB", ["CycleA"]],
-    ]);
-
-    const insertionOrder = ["Derived", "Indexed", "Leaf", "Base", "CycleA", "CycleB"];
-    const set = new SCCSet<string>((item) => edges.get(item) ?? []);
-    set.addAll(insertionOrder);
-
-    expect([...set.items]).toEqual(["Leaf", "Indexed", "Base", "Derived", "CycleA", "CycleB"]);
-    expect(componentValues(set)).toEqual([
-      "Leaf",
-      "Indexed",
-      "Base",
-      "Derived",
-      ["CycleA", "CycleB"],
-    ]);
-  });
-
-  it("exposes component connections", () => {
-    const edges = new Map<string, string[]>([
-      ["Leaf", []],
-      ["Base", ["Leaf"]],
-      ["Indexed", ["Leaf"]],
-      ["Derived", ["Base", "Indexed"]],
-      ["CycleA", ["CycleB"]],
-      ["CycleB", ["CycleA"]],
-    ]);
-
-    const set = new SCCSet<string>((item) => edges.get(item) ?? []);
-    set.addAll(["Derived", "Base", "Indexed", "Leaf", "CycleA", "CycleB"]);
-
-    const getSingleton = (name: string) =>
-      set.components.find((component) => component.value === name)!;
-    const format = (components: Iterable<SCCComponent<string>>) =>
-      Array.from(components, (component) =>
-        Array.isArray(component.value) ? component.value.join(",") : component.value,
-      ).sort();
-
-    const derived = getSingleton("Derived");
-    const base = getSingleton("Base");
-    const indexed = getSingleton("Indexed");
-    const leaf = getSingleton("Leaf");
-    const cycle = set.components.find((component) => Array.isArray(component.value))!;
-
-    expect(format(derived.references)).toEqual(["Base", "Indexed"]);
-    expect(format(base.references)).toEqual(["Leaf"]);
-    expect(format(base.referencedBy)).toEqual(["Derived"]);
-    expect(format(indexed.referencedBy)).toEqual(["Derived"]);
-    expect(format(leaf.referencedBy)).toEqual(["Base", "Indexed"]);
-    expect(format(cycle.references)).toEqual([]);
-    expect(format(cycle.referencedBy)).toEqual([]);
-  });
-
-  it("orders TypeSpec models via connector", async () => {
-    const tester = await Tester.createInstance();
-    const { Leaf, Indexed, Base, Derived, CycleA, CycleB } = await tester.compile(
-      t.code`
-        @test model ${t.model("Leaf")} {
-          value: string;
-        }
-
-        @test model ${t.model("Indexed")} extends Record<Leaf> {}
-
-        @test model ${t.model("Base")} {
-          leaf: Leaf;
-        }
-
-        @test model ${t.model("Derived")} extends Base {
-          payload: Indexed;
-        }
-
-        @test model ${t.model("CycleA")} {
-          next: CycleB;
-        }
-
-        @test model ${t.model("CycleB")} {
-          prev: CycleA;
-        }
-      `,
-    );
-
-    const models = [Derived, Indexed, Leaf, Base, CycleA, CycleB] as Type[];
-    const set = new SCCSet<Type>(typeDependencyConnector);
-    for (const type of models) {
-      set.add(type);
-    }
-
-    const itemNames = set.items.map(getTypeLabel);
-    expect(itemNames).toEqual(["Leaf", "Indexed", "Base", "Derived", "CycleA", "CycleB"]);
-
-    const componentNames = set.components.map(formatComponent);
-    expect(componentNames).toEqual(["Leaf", "Indexed", "Base", "Derived", ["CycleA", "CycleB"]]);
-  });
+  const componentNames = set.components.map(formatComponent);
+  expect(componentNames).toEqual(["Leaf", "Indexed", "Base", "Derived", ["CycleA", "CycleB"]]);
 });
 
 function componentValues<T>(set: SCCSet<T>): NestedArray<T>[] {

--- a/packages/emitter-framework/src/python/components/class-declaration/class-member.test.tsx
+++ b/packages/emitter-framework/src/python/components/class-declaration/class-member.test.tsx
@@ -4,203 +4,201 @@ import { describe, expect, it } from "vitest";
 import { ClassDeclaration } from "../../../../src/python/components/class-declaration/class-declaration.js";
 import { getOutput } from "../../test-utils.js";
 
-describe("Python Class Members", () => {
-  describe("default values", () => {
-    it("renders string default values", async () => {
-      const { program, MyModel } = await Tester.compile(t.code`
-      model ${t.model("MyModel")} {
-        name: string = "default";
-        description?: string = "optional with default";
-        emptyString: string = "";
-      }
-      `);
+describe("default values", () => {
+  it("renders string default values", async () => {
+    const { program, MyModel } = await Tester.compile(t.code`
+    model ${t.model("MyModel")} {
+      name: string = "default";
+      description?: string = "optional with default";
+      emptyString: string = "";
+    }
+    `);
 
-      expect(getOutput(program, [<ClassDeclaration type={MyModel} />])).toRenderTo(
-        `
-          from dataclasses import dataclass
-          from typing import TYPE_CHECKING
+    expect(getOutput(program, [<ClassDeclaration type={MyModel} />])).toRenderTo(
+      `
+        from dataclasses import dataclass
+        from typing import TYPE_CHECKING
 
-          if TYPE_CHECKING:
-              from typing import Optional
-
-
-          @dataclass(kw_only=True)
-          class MyModel:
-              name: str = "default"
-              description: Optional[str] = "optional with default"
-              empty_string: str = ""
-          
-          `,
-      );
-    });
-
-    it("renders boolean default values", async () => {
-      const { program, BooleanModel } = await Tester.compile(t.code`
-      model ${t.model("BooleanModel")} {
-        isActive: boolean = true;
-        isDeleted: boolean = false;
-        optional?: boolean = true;
-      }
-      `);
-
-      expect(getOutput(program, [<ClassDeclaration type={BooleanModel} />])).toRenderTo(
-        `
-          from dataclasses import dataclass
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from typing import Optional
+        if TYPE_CHECKING:
+            from typing import Optional
 
 
-          @dataclass(kw_only=True)
-          class BooleanModel:
-              is_active: bool = True
-              is_deleted: bool = False
-              optional: Optional[bool] = True
-          
-          `,
-      );
-    });
-
-    it("renders array default values", async () => {
-      const { program, ArrayModel } = await Tester.compile(t.code`
-      model ${t.model("ArrayModel")} {
-        tags: string[] = #["tag1", "tag2"];
-        emptyArray: int32[] = #[];
-        numbers: int32[] = #[1, 2, 3];
-      }
-      `);
-
-      expect(getOutput(program, [<ClassDeclaration type={ArrayModel} />])).toRenderTo(
-        `
-          from dataclasses import dataclass
-
-
-          @dataclass(kw_only=True)
-          class ArrayModel:
-              tags: list[str] = ["tag1", "tag2"]
-              empty_array: list[int] = []
-              numbers: list[int] = [1, 2, 3]
-          
-          `,
-      );
-    });
-
-    it("renders integer default values without .0 suffix", async () => {
-      const { program, IntegerModel } = await Tester.compile(t.code`
-      model ${t.model("IntegerModel")} {
-        count: int32 = 42;
-        bigNumber: int64 = 1000000;
-        smallNumber: int8 = 127;
-        unsignedValue: uint32 = 100;
-        safeIntValue: safeint = 999;
-      }
-      `);
-
-      expect(getOutput(program, [<ClassDeclaration type={IntegerModel} />])).toRenderTo(
-        `
-          from dataclasses import dataclass
-
-
-          @dataclass(kw_only=True)
-          class IntegerModel:
-              count: int = 42
-              big_number: int = 1000000
-              small_number: int = 127
-              unsigned_value: int = 100
-              safe_int_value: int = 999
-          
-          `,
-      );
-    });
-
-    it("renders float and decimal default values correctly", async () => {
-      const { program, NumericDefaults } = await Tester.compile(t.code`
-
-      scalar customFloat extends float;
-      scalar customDecimal extends decimal;
-
-      model ${t.model("NumericDefaults")} {
-        // Float variants with decimal values
-        floatBase: float = 1.5;
-        float32Value: float32 = 2.5;
-        float64Value: float64 = 3.5;
-        customFloatValue: customFloat = 4.5;
+        @dataclass(kw_only=True)
+        class MyModel:
+            name: str = "default"
+            description: Optional[str] = "optional with default"
+            empty_string: str = ""
         
-        // Float variants with integer values (should render with .0)
-        floatInt: float = 10;
-        float32Int: float32 = 20;
-        float64Int: float64 = 30;
+        `,
+    );
+  });
+
+  it("renders boolean default values", async () => {
+    const { program, BooleanModel } = await Tester.compile(t.code`
+    model ${t.model("BooleanModel")} {
+      isActive: boolean = true;
+      isDeleted: boolean = false;
+      optional?: boolean = true;
+    }
+    `);
+
+    expect(getOutput(program, [<ClassDeclaration type={BooleanModel} />])).toRenderTo(
+      `
+        from dataclasses import dataclass
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from typing import Optional
+
+
+        @dataclass(kw_only=True)
+        class BooleanModel:
+            is_active: bool = True
+            is_deleted: bool = False
+            optional: Optional[bool] = True
         
-        // Decimal variants
-        decimalBase: decimal = 100.25;
-        decimal128Value: decimal128 = 200.75;
-        customDecimalValue: customDecimal = 300.125;
+        `,
+    );
+  });
+
+  it("renders array default values", async () => {
+    const { program, ArrayModel } = await Tester.compile(t.code`
+    model ${t.model("ArrayModel")} {
+      tags: string[] = #["tag1", "tag2"];
+      emptyArray: int32[] = #[];
+      numbers: int32[] = #[1, 2, 3];
+    }
+    `);
+
+    expect(getOutput(program, [<ClassDeclaration type={ArrayModel} />])).toRenderTo(
+      `
+        from dataclasses import dataclass
+
+
+        @dataclass(kw_only=True)
+        class ArrayModel:
+            tags: list[str] = ["tag1", "tag2"]
+            empty_array: list[int] = []
+            numbers: list[int] = [1, 2, 3]
         
-        // Decimal with integer values (should render with .0)
-        decimalInt: decimal = 400;
-        decimal128Int: decimal128 = 500;
-      }
-      `);
+        `,
+    );
+  });
 
-      expect(getOutput(program, [<ClassDeclaration type={NumericDefaults} />])).toRenderTo(
-        `
-          from dataclasses import dataclass
-          from typing import TYPE_CHECKING
+  it("renders integer default values without .0 suffix", async () => {
+    const { program, IntegerModel } = await Tester.compile(t.code`
+    model ${t.model("IntegerModel")} {
+      count: int32 = 42;
+      bigNumber: int64 = 1000000;
+      smallNumber: int8 = 127;
+      unsignedValue: uint32 = 100;
+      safeIntValue: safeint = 999;
+    }
+    `);
 
-          if TYPE_CHECKING:
-              from decimal import Decimal
-
-
-          @dataclass(kw_only=True)
-          class NumericDefaults:
-              float_base: float = 1.5
-              float32_value: float = 2.5
-              float64_value: float = 3.5
-              custom_float_value: float = 4.5
-              float_int: float = 10.0
-              float32_int: float = 20.0
-              float64_int: float = 30.0
-              decimal_base: Decimal = 100.25
-              decimal128_value: Decimal = 200.75
-              custom_decimal_value: Decimal = 300.125
-              decimal_int: Decimal = 400.0
-              decimal128_int: Decimal = 500.0
-          
-          `,
-      );
-    });
-
-    it("distinguishes between integer and float types with same numeric value", async () => {
-      const { program, MixedNumeric } = await Tester.compile(t.code`
-      model ${t.model("MixedNumeric")} {
-        intValue: int32 = 100;
-        int64Value: int64 = 100;
-        floatValue: float = 100;
-        float64Value: float64 = 100;
-        decimalValue: decimal = 100;
-      }
-      `);
-
-      expect(getOutput(program, [<ClassDeclaration type={MixedNumeric} />])).toRenderTo(
-        `
-          from dataclasses import dataclass
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from decimal import Decimal
+    expect(getOutput(program, [<ClassDeclaration type={IntegerModel} />])).toRenderTo(
+      `
+        from dataclasses import dataclass
 
 
-          @dataclass(kw_only=True)
-          class MixedNumeric:
-              int_value: int = 100
-              int64_value: int = 100
-              float_value: float = 100.0
-              float64_value: float = 100.0
-              decimal_value: Decimal = 100.0
-          
-          `,
-      );
-    });
+        @dataclass(kw_only=True)
+        class IntegerModel:
+            count: int = 42
+            big_number: int = 1000000
+            small_number: int = 127
+            unsigned_value: int = 100
+            safe_int_value: int = 999
+        
+        `,
+    );
+  });
+
+  it("renders float and decimal default values correctly", async () => {
+    const { program, NumericDefaults } = await Tester.compile(t.code`
+
+    scalar customFloat extends float;
+    scalar customDecimal extends decimal;
+
+    model ${t.model("NumericDefaults")} {
+      // Float variants with decimal values
+      floatBase: float = 1.5;
+      float32Value: float32 = 2.5;
+      float64Value: float64 = 3.5;
+      customFloatValue: customFloat = 4.5;
+      
+      // Float variants with integer values (should render with .0)
+      floatInt: float = 10;
+      float32Int: float32 = 20;
+      float64Int: float64 = 30;
+      
+      // Decimal variants
+      decimalBase: decimal = 100.25;
+      decimal128Value: decimal128 = 200.75;
+      customDecimalValue: customDecimal = 300.125;
+      
+      // Decimal with integer values (should render with .0)
+      decimalInt: decimal = 400;
+      decimal128Int: decimal128 = 500;
+    }
+    `);
+
+    expect(getOutput(program, [<ClassDeclaration type={NumericDefaults} />])).toRenderTo(
+      `
+        from dataclasses import dataclass
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from decimal import Decimal
+
+
+        @dataclass(kw_only=True)
+        class NumericDefaults:
+            float_base: float = 1.5
+            float32_value: float = 2.5
+            float64_value: float = 3.5
+            custom_float_value: float = 4.5
+            float_int: float = 10.0
+            float32_int: float = 20.0
+            float64_int: float = 30.0
+            decimal_base: Decimal = 100.25
+            decimal128_value: Decimal = 200.75
+            custom_decimal_value: Decimal = 300.125
+            decimal_int: Decimal = 400.0
+            decimal128_int: Decimal = 500.0
+        
+        `,
+    );
+  });
+
+  it("distinguishes between integer and float types with same numeric value", async () => {
+    const { program, MixedNumeric } = await Tester.compile(t.code`
+    model ${t.model("MixedNumeric")} {
+      intValue: int32 = 100;
+      int64Value: int64 = 100;
+      floatValue: float = 100;
+      float64Value: float64 = 100;
+      decimalValue: decimal = 100;
+    }
+    `);
+
+    expect(getOutput(program, [<ClassDeclaration type={MixedNumeric} />])).toRenderTo(
+      `
+        from dataclasses import dataclass
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from decimal import Decimal
+
+
+        @dataclass(kw_only=True)
+        class MixedNumeric:
+            int_value: int = 100
+            int64_value: int = 100
+            float_value: float = 100.0
+            float64_value: float = 100.0
+            decimal_value: Decimal = 100.0
+        
+        `,
+    );
   });
 });

--- a/packages/emitter-framework/src/python/components/enum-declaration/enum-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/enum-declaration/enum-declaration.test.tsx
@@ -7,313 +7,311 @@ import { describe, expect, it } from "vitest";
 import { getOutput } from "../../test-utils.js";
 import { EnumDeclaration } from "./enum-declaration.js";
 
-describe("Python Enum Declaration", () => {
-  it("takes an enum type parameter", async () => {
-    const { program, Foo } = await Tester.compile(t.code`
-      enum ${t.enum("Foo")} {
-        one: 1,
-        two: 2,
-        three: 3
+it("takes an enum type parameter", async () => {
+  const { program, Foo } = await Tester.compile(t.code`
+    enum ${t.enum("Foo")} {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `);
+
+  expect(getOutput(program, [<EnumDeclaration type={Foo} />])).toRenderTo(d`
+    from enum import IntEnum
+
+
+    class Foo(IntEnum):
+        ONE = 1
+        TWO = 2
+        THREE = 3
+
+
+  `);
+});
+
+it("adds Python doc from TypeSpec", async () => {
+  const { program, Foo } = await Tester.compile(t.code`
+    /**
+     * This is a test enum
+     */
+    enum ${t.enum("Foo")} {
+      @doc("This is one")
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `);
+  const output = getOutput(program, [<EnumDeclaration type={Foo} />]);
+
+  expect(output).toRenderTo(d`
+    from enum import IntEnum
+
+
+    class Foo(IntEnum):
+        """
+        This is a test enum
+        """
+
+        ONE = 1
+        """
+        This is one
+        """
+        TWO = 2
+        THREE = 3
+
+
+  `);
+});
+
+it("explicit doc take precedence", async () => {
+  const { program, Foo } = await Tester.compile(t.code`
+    /**
+     * This is a test enum
+     */
+    enum ${t.enum("Foo")} {
+      @doc("This is one")
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `);
+  const output = getOutput(program, [
+    <EnumDeclaration type={Foo} doc={["This is an explicit doc"]} />,
+  ]);
+
+  expect(output).toRenderTo(d`
+    from enum import IntEnum
+
+
+    class Foo(IntEnum):
+        """
+        This is an explicit doc
+        """
+
+        ONE = 1
+        """
+        This is one
+        """
+        TWO = 2
+        THREE = 3
+
+
+  `);
+});
+
+it("takes a union type parameter", async () => {
+  const { program, Foo } = await Tester.compile(t.code`
+    union ${t.union("Foo")} {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `);
+  const output = getOutput(program, [<EnumDeclaration type={Foo} />]);
+
+  expect(output).toRenderTo(d`
+    from enum import IntEnum
+
+
+    class Foo(IntEnum):
+        ONE = 1
+        TWO = 2
+        THREE = 3
+
+
+  `);
+});
+
+it("can be referenced", async () => {
+  const { program, Foo } = await Tester.compile(t.code`
+    enum ${t.enum("Foo")} {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `);
+
+  const output = getOutput(program, [
+    <EnumDeclaration type={Foo} />,
+    <py.StatementList>
+      {efRefkey(Foo)}
+      {efRefkey(Foo.members.get("one"))}
+    </py.StatementList>,
+  ]);
+
+  expect(output).toRenderTo(d`
+    from enum import IntEnum
+
+
+    class Foo(IntEnum):
+        ONE = 1
+        TWO = 2
+        THREE = 3
+
+
+    Foo
+    Foo.ONE
+  `);
+});
+
+it("can be referenced using union", async () => {
+  const { program, Foo } = await Tester.compile(t.code`
+    union ${t.union("Foo")}  {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `);
+
+  const output = getOutput(program, [
+    <EnumDeclaration type={Foo} />,
+    <py.StatementList>
+      {efRefkey(Foo)}
+      {efRefkey(Foo.variants.get("one"))}
+    </py.StatementList>,
+  ]);
+
+  expect(output).toRenderTo(d`
+    from enum import IntEnum
+
+
+    class Foo(IntEnum):
+        ONE = 1
+        TWO = 2
+        THREE = 3
+
+
+    Foo
+    Foo.ONE
+  `);
+});
+
+describe("Enum Type Detection", () => {
+  it("generates IntEnum if all values are integer values", async () => {
+    const { program, StatusCode } = await Tester.compile(t.code`
+      enum ${t.enum("StatusCode")} {
+        success: 200,
+        notFound: 404,
+        serverError: 500
       }
     `);
-
-    expect(getOutput(program, [<EnumDeclaration type={Foo} />])).toRenderTo(d`
-      from enum import IntEnum
-
-
-      class Foo(IntEnum):
-          ONE = 1
-          TWO = 2
-          THREE = 3
-
-
-    `);
-  });
-
-  it("adds Python doc from TypeSpec", async () => {
-    const { program, Foo } = await Tester.compile(t.code`
-      /**
-       * This is a test enum
-       */
-      enum ${t.enum("Foo")} {
-        @doc("This is one")
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `);
-    const output = getOutput(program, [<EnumDeclaration type={Foo} />]);
+    const output = getOutput(program, [<EnumDeclaration type={StatusCode} />]);
 
     expect(output).toRenderTo(d`
       from enum import IntEnum
 
 
-      class Foo(IntEnum):
-          """
-          This is a test enum
-          """
-
-          ONE = 1
-          """
-          This is one
-          """
-          TWO = 2
-          THREE = 3
+      class StatusCode(IntEnum):
+          SUCCESS = 200
+          NOT_FOUND = 404
+          SERVER_ERROR = 500
 
 
     `);
   });
 
-  it("explicit doc take precedence", async () => {
-    const { program, Foo } = await Tester.compile(t.code`
-      /**
-       * This is a test enum
-       */
-      enum ${t.enum("Foo")} {
-        @doc("This is one")
-        one: 1,
-        two: 2,
-        three: 3
+  it("generates StrEnum if all values are string values", async () => {
+    const { program, Color } = await Tester.compile(t.code`
+      enum ${t.enum("Color")} {
+        red: "red",
+        green: "green",
+        blue: "blue"
+      }
+    `);
+    const output = getOutput(program, [<EnumDeclaration type={Color} />]);
+
+    expect(output).toRenderTo(d`
+      from enum import StrEnum
+
+
+      class Color(StrEnum):
+          RED = "red"
+          GREEN = "green"
+          BLUE = "blue"
+
+
+    `);
+  });
+
+  it("generates StrEnum if all values are string values with custom values", async () => {
+    const { program, Color } = await Tester.compile(t.code`
+      enum ${t.enum("Color")} {
+        red: "This is red",
+        green: "This is green",
+        blue: "This is blue"
       }
     `);
     const output = getOutput(program, [
-      <EnumDeclaration type={Foo} doc={["This is an explicit doc"]} />,
-    ]);
-
-    expect(output).toRenderTo(d`
-      from enum import IntEnum
-
-
-      class Foo(IntEnum):
-          """
-          This is an explicit doc
-          """
-
-          ONE = 1
-          """
-          This is one
-          """
-          TWO = 2
-          THREE = 3
-
-
-    `);
-  });
-
-  it("takes a union type parameter", async () => {
-    const { program, Foo } = await Tester.compile(t.code`
-      union ${t.union("Foo")} {
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `);
-    const output = getOutput(program, [<EnumDeclaration type={Foo} />]);
-
-    expect(output).toRenderTo(d`
-      from enum import IntEnum
-
-
-      class Foo(IntEnum):
-          ONE = 1
-          TWO = 2
-          THREE = 3
-
-
-    `);
-  });
-
-  it("can be referenced", async () => {
-    const { program, Foo } = await Tester.compile(t.code`
-      enum ${t.enum("Foo")} {
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `);
-
-    const output = getOutput(program, [
-      <EnumDeclaration type={Foo} />,
+      <EnumDeclaration type={Color} />,
       <py.StatementList>
-        {efRefkey(Foo)}
-        {efRefkey(Foo.members.get("one"))}
+        {efRefkey(Color.members.get("red"))}
+        {efRefkey(Color.members.get("green"))}
+        {efRefkey(Color.members.get("blue"))}
       </py.StatementList>,
     ]);
 
     expect(output).toRenderTo(d`
-      from enum import IntEnum
+      from enum import StrEnum
 
 
-      class Foo(IntEnum):
-          ONE = 1
-          TWO = 2
-          THREE = 3
+      class Color(StrEnum):
+          RED = "This is red"
+          GREEN = "This is green"
+          BLUE = "This is blue"
 
 
-      Foo
-      Foo.ONE
+      Color.RED
+      Color.GREEN
+      Color.BLUE
+
     `);
   });
 
-  it("can be referenced using union", async () => {
-    const { program, Foo } = await Tester.compile(t.code`
-      union ${t.union("Foo")}  {
-        one: 1,
-        two: 2,
-        three: 3
+  it("generates Enum for mixed value types", async () => {
+    const { program, Mixed } = await Tester.compile(t.code`
+      enum ${t.enum("Mixed")} {
+        stringValue: "hello",
+        numericValue: 42,
+        autoValue
       }
     `);
-
-    const output = getOutput(program, [
-      <EnumDeclaration type={Foo} />,
-      <py.StatementList>
-        {efRefkey(Foo)}
-        {efRefkey(Foo.variants.get("one"))}
-      </py.StatementList>,
-    ]);
+    const output = getOutput(program, [<EnumDeclaration type={Mixed} />]);
 
     expect(output).toRenderTo(d`
-      from enum import IntEnum
+      from enum import auto
+      from enum import Enum
 
 
-      class Foo(IntEnum):
-          ONE = 1
-          TWO = 2
-          THREE = 3
-
-
-      Foo
-      Foo.ONE
+      class Mixed(Enum):
+          STRING_VALUE = "hello"
+          NUMERIC_VALUE = 42
+          AUTO_VALUE = auto()
+      
+      
     `);
   });
 
-  describe("Enum Type Detection", () => {
-    it("generates IntEnum if all values are integer values", async () => {
-      const { program, StatusCode } = await Tester.compile(t.code`
-        enum ${t.enum("StatusCode")} {
-          success: 200,
-          notFound: 404,
-          serverError: 500
-        }
-      `);
-      const output = getOutput(program, [<EnumDeclaration type={StatusCode} />]);
+  it("handles correctly enums without values", async () => {
+    const { program, EnumWithoutValues } = await Tester.compile(t.code`
+      enum ${t.enum("EnumWithoutValues")} {
+        someValue,
+        anotherValue,
+        yetAnotherValue
+      }
+    `);
+    const output = getOutput(program, [<EnumDeclaration type={EnumWithoutValues} />]);
 
-      expect(output).toRenderTo(d`
-        from enum import IntEnum
-
-
-        class StatusCode(IntEnum):
-            SUCCESS = 200
-            NOT_FOUND = 404
-            SERVER_ERROR = 500
+    expect(output).toRenderTo(d`
+      from enum import auto
+      from enum import Enum
 
 
-      `);
-    });
-
-    it("generates StrEnum if all values are string values", async () => {
-      const { program, Color } = await Tester.compile(t.code`
-        enum ${t.enum("Color")} {
-          red: "red",
-          green: "green",
-          blue: "blue"
-        }
-      `);
-      const output = getOutput(program, [<EnumDeclaration type={Color} />]);
-
-      expect(output).toRenderTo(d`
-        from enum import StrEnum
-
-
-        class Color(StrEnum):
-            RED = "red"
-            GREEN = "green"
-            BLUE = "blue"
-
-
-      `);
-    });
-
-    it("generates StrEnum if all values are string values with custom values", async () => {
-      const { program, Color } = await Tester.compile(t.code`
-        enum ${t.enum("Color")} {
-          red: "This is red",
-          green: "This is green",
-          blue: "This is blue"
-        }
-      `);
-      const output = getOutput(program, [
-        <EnumDeclaration type={Color} />,
-        <py.StatementList>
-          {efRefkey(Color.members.get("red"))}
-          {efRefkey(Color.members.get("green"))}
-          {efRefkey(Color.members.get("blue"))}
-        </py.StatementList>,
-      ]);
-
-      expect(output).toRenderTo(d`
-        from enum import StrEnum
-
-
-        class Color(StrEnum):
-            RED = "This is red"
-            GREEN = "This is green"
-            BLUE = "This is blue"
-
-
-        Color.RED
-        Color.GREEN
-        Color.BLUE
-
-      `);
-    });
-
-    it("generates Enum for mixed value types", async () => {
-      const { program, Mixed } = await Tester.compile(t.code`
-        enum ${t.enum("Mixed")} {
-          stringValue: "hello",
-          numericValue: 42,
-          autoValue
-        }
-      `);
-      const output = getOutput(program, [<EnumDeclaration type={Mixed} />]);
-
-      expect(output).toRenderTo(d`
-        from enum import auto
-        from enum import Enum
-
-
-        class Mixed(Enum):
-            STRING_VALUE = "hello"
-            NUMERIC_VALUE = 42
-            AUTO_VALUE = auto()
-        
-        
-      `);
-    });
-
-    it("handles correctly enums without values", async () => {
-      const { program, EnumWithoutValues } = await Tester.compile(t.code`
-        enum ${t.enum("EnumWithoutValues")} {
-          someValue,
-          anotherValue,
-          yetAnotherValue
-        }
-      `);
-      const output = getOutput(program, [<EnumDeclaration type={EnumWithoutValues} />]);
-
-      expect(output).toRenderTo(d`
-        from enum import auto
-        from enum import Enum
-
-
-        class EnumWithoutValues(Enum):
-            SOME_VALUE = auto()
-            ANOTHER_VALUE = auto()
-            YET_ANOTHER_VALUE = auto()
-        
-        
-      `);
-    });
+      class EnumWithoutValues(Enum):
+          SOME_VALUE = auto()
+          ANOTHER_VALUE = auto()
+          YET_ANOTHER_VALUE = auto()
+      
+      
+    `);
   });
 });

--- a/packages/emitter-framework/src/python/components/function-declaration/function-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/function-declaration/function-declaration.test.tsx
@@ -2,584 +2,579 @@ import { getOutput } from "#python/test-utils.js";
 import { Tester } from "#test/test-host.js";
 import * as py from "@alloy-js/python";
 import { t } from "@typespec/compiler/testing";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { FunctionDeclaration } from "./function-declaration.js";
 
-describe("Python Function Declaration", () => {
-  it("creates a function with single positional param", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+it("creates a function with single positional param", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
+
+  expect(getOutput(program, [<FunctionDeclaration type={getName} />])).toRenderTo(`
+    def get_name(id: str) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={getName} />])).toRenderTo(`
-      def get_name(id: str) -> str:
-          pass
-      
-      `);
-  });
+it("creates an async function", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("creates an async function", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+  expect(getOutput(program, [<FunctionDeclaration async type={getName} />])).toRenderTo(`
+    async def get_name(id: str) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration async type={getName} />])).toRenderTo(`
-      async def get_name(id: str) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with a custom name", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("creates a function with a custom name", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+  expect(getOutput(program, [<FunctionDeclaration name="new_name" type={getName} />])).toRenderTo(`
+    def new_name(id: str) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration name="new_name" type={getName} />]))
-      .toRenderTo(`
-      def new_name(id: str) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with additional keyword-only parameters", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
+  `);
 
-  it("creates a function with additional keyword-only parameters", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={createPerson}
+        parameters={[
+          { name: "name", type: "str" },
+          { name: "age", type: "float" },
+        ]}
+      />,
+    ]),
+  ).toRenderTo(`
+    def create_person(id: str, *, name: str, age: float) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={createPerson}
-          parameters={[
-            { name: "name", type: "str" },
-            { name: "age", type: "float" },
-          ]}
-        />,
-      ]),
-    ).toRenderTo(`
-      def create_person(id: str, *, name: str, age: float) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with additional keyword-only parameters (string shorthand)", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
+  `);
 
-  it("creates a function with additional keyword-only parameters (string shorthand)", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+  expect(
+    getOutput(program, [<FunctionDeclaration type={createPerson} parameters={["name", "age"]} />]),
+  ).toRenderTo(`
+    def create_person(id: str, *, name, age) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration type={createPerson} parameters={["name", "age"]} />,
-      ]),
-    ).toRenderTo(`
-      def create_person(id: str, *, name, age) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function replacing parameters with raw params provided", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
+  `);
 
-  it("creates a function replacing parameters with raw params provided", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={createPerson}
+        parameters={["name", "age"]}
+        replaceParameters={true}
+      />,
+    ]),
+  ).toRenderTo(`
+    def create_person(*, name, age) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={createPerson}
-          parameters={["name", "age"]}
-          replaceParameters={true}
-        />,
-      ]),
-    ).toRenderTo(`
-      def create_person(*, name, age) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function replacing parameters with params having defaults (requires * marker)", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
+  `);
 
-  it("creates a function replacing parameters with params having defaults (requires * marker)", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={createPerson}
+        parameters={[
+          { name: "name", type: "str", default: <py.Atom jsValue={"alice"} /> },
+          { name: "age", type: "int", default: <py.Atom jsValue={30} /> },
+        ]}
+        replaceParameters={true}
+      />,
+    ]),
+  ).toRenderTo(`
+    def create_person(*, name: str = "alice", age: int = 30) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={createPerson}
-          parameters={[
-            { name: "name", type: "str", default: <py.Atom jsValue={"alice"} /> },
-            { name: "age", type: "int", default: <py.Atom jsValue={30} /> },
-          ]}
-          replaceParameters={true}
-        />,
-      ]),
-    ).toRenderTo(`
-      def create_person(*, name: str = "alice", age: int = 30) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with defaults in raw parameter descriptors", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string, locale: string = "en-US"): string;
+  `);
 
-  it("creates a function with defaults in raw parameter descriptors", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string, locale: string = "en-US"): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={createPerson}
+        parameters={[
+          { name: "limit", type: "int", default: <py.Atom jsValue={10} /> },
+          { name: "verbose", type: "bool", default: <py.Atom jsValue={true} /> },
+        ]}
+      />,
+    ]),
+  ).toRenderTo(`
+    def create_person(id: str, *, locale: str = "en-US", limit: int = 10, verbose: bool = True) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={createPerson}
-          parameters={[
-            { name: "limit", type: "int", default: <py.Atom jsValue={10} /> },
-            { name: "verbose", type: "bool", default: <py.Atom jsValue={true} /> },
-          ]}
-        />,
-      ]),
-    ).toRenderTo(`
-      def create_person(id: str, *, locale: str = "en-US", limit: int = 10, verbose: bool = True) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function building parameters from a model via parametersModel (will replace parameters)", async () => {
+  const { program, createPerson, Foo } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
 
-  it("creates a function building parameters from a model via parametersModel (will replace parameters)", async () => {
-    const { program, createPerson, Foo } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+    model ${t.model("Foo")} {
+      name: string;
+      age: int32;
+    }
+  `);
 
-      model ${t.model("Foo")} {
-        name: string;
-        age: int32;
-      }
+  expect(getOutput(program, [<FunctionDeclaration type={createPerson} parametersModel={Foo} />]))
+    .toRenderTo(`
+    def create_person(name: str, age: int) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={createPerson} parametersModel={Foo} />]))
-      .toRenderTo(`
-      def create_person(name: str, age: int) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with parametersModel applying defaults and optionals", async () => {
+  const { program, createPerson, Foo } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
 
-  it("creates a function with parametersModel applying defaults and optionals", async () => {
-    const { program, createPerson, Foo } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+    model ${t.model("Foo")} {
+      requiredName?: string = "alice";
+      optionalAge?: int32;
+    }
+  `);
 
-      model ${t.model("Foo")} {
-        requiredName?: string = "alice";
-        optionalAge?: int32;
-      }
+  expect(getOutput(program, [<FunctionDeclaration type={createPerson} parametersModel={Foo} />]))
+    .toRenderTo(`
+    def create_person(*, required_name: str = "alice", optional_age: int = None) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={createPerson} parametersModel={Foo} />]))
-      .toRenderTo(`
-      def create_person(*, required_name: str = "alice", optional_age: int = None) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function that replaces parameters with parametersModel even when extras are provided", async () => {
+  const { program, createPerson, Foo } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
 
-  it("creates a function that replaces parameters with parametersModel even when extras are provided", async () => {
-    const { program, createPerson, Foo } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+    model ${t.model("Foo")} {
+      name: string;
+      age: int32;
+    }
+  `);
 
-      model ${t.model("Foo")} {
-        name: string;
-        age: int32;
-      }
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration type={createPerson} parametersModel={Foo} parameters={["extra"]} />,
+    ]),
+  ).toRenderTo(`
+    def create_person(name: str, age: int) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration type={createPerson} parametersModel={Foo} parameters={["extra"]} />,
-      ]),
-    ).toRenderTo(`
-      def create_person(name: str, age: int) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function overriding the return type", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("creates a function overriding the return type", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+  expect(getOutput(program, [<FunctionDeclaration type={getName} returnType="ASpecialString" />]))
+    .toRenderTo(`
+    def get_name(id: str) -> ASpecialString:
+        pass
+    
     `);
+});
+it("creates a function with body", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string): string;
+  `);
 
-    expect(getOutput(program, [<FunctionDeclaration type={getName} returnType="ASpecialString" />]))
-      .toRenderTo(`
-      def get_name(id: str) -> ASpecialString:
-          pass
-      
-      `);
-  });
-  it("creates a function with body", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration type={createPerson}>
+        <>print("Hello World!")</>
+      </FunctionDeclaration>,
+    ]),
+  ).toRenderTo(`
+    def create_person(id: str) -> str:
+        print("Hello World!")
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration type={createPerson}>
-          <>print("Hello World!")</>
-        </FunctionDeclaration>,
-      ]),
-    ).toRenderTo(`
-      def create_person(id: str) -> str:
-          print("Hello World!")
-      
-      `);
-  });
+it("creates a function with a doc", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("creates a function with a doc", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+  expect(getOutput(program, [<FunctionDeclaration type={getName} doc={"This is a test doc"} />]))
+    .toRenderTo(`
+    def get_name(id: str) -> str:
+        """
+        This is a test doc
+        """
+
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={getName} doc={"This is a test doc"} />]))
-      .toRenderTo(`
-      def get_name(id: str) -> str:
-          """
-          This is a test doc
-          """
+it("creates a function with a multi-paragraph FunctionDoc", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-          pass
-      
-      `);
-  });
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={getName}
+        doc={<py.FunctionDoc description={[<>First paragraph</>, <>Second paragraph</>]} />}
+      />,
+    ]),
+  ).toRenderTo(`
+    def get_name(id: str) -> str:
+        """
+        First paragraph
 
-  it("creates a function with a multi-paragraph FunctionDoc", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+        Second paragraph
+        """
+
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={getName}
-          doc={<py.FunctionDoc description={[<>First paragraph</>, <>Second paragraph</>]} />}
-        />,
-      ]),
-    ).toRenderTo(`
-      def get_name(id: str) -> str:
-          """
-          First paragraph
+it("creates a function with doc as string[]", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-          Second paragraph
-          """
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration type={getName} doc={["First paragraph", "Second paragraph"]} />,
+    ]),
+  ).toRenderTo(`
+    def get_name(id: str) -> str:
+        """
+        First paragraph
 
-          pass
-      
-      `);
-  });
+        Second paragraph
+        """
 
-  it("creates a function with doc as string[]", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration type={getName} doc={["First paragraph", "Second paragraph"]} />,
-      ]),
-    ).toRenderTo(`
-      def get_name(id: str) -> str:
-          """
-          First paragraph
+it("creates a function with doc as Children[]", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-          Second paragraph
-          """
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration type={getName} doc={[<>First paragraph</>, <>Second paragraph</>]} />,
+    ]),
+  ).toRenderTo(`
+    def get_name(id: str) -> str:
+        """
+        First paragraph
 
-          pass
-      
-      `);
-  });
+        Second paragraph
+        """
 
-  it("creates a function with doc as Children[]", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration type={getName} doc={[<>First paragraph</>, <>Second paragraph</>]} />,
-      ]),
-    ).toRenderTo(`
-      def get_name(id: str) -> str:
-          """
-          First paragraph
+it("creates a function with doc lines (string with newlines)", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
-          Second paragraph
-          """
+  expect(getOutput(program, [<FunctionDeclaration type={getName} doc={"Line 1\nLine 2"} />]))
+    .toRenderTo(`
+    def get_name(id: str) -> str:
+        """
+        Line 1
+        Line 2
+        """
 
-          pass
-      
-      `);
-  });
-
-  it("creates a function with doc lines (string with newlines)", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={getName} doc={"Line 1\nLine 2"} />]))
-      .toRenderTo(`
-      def get_name(id: str) -> str:
-          """
-          Line 1
-          Line 2
-          """
+it("creates a function with no parameters", async () => {
+  const { program, ping } = await Tester.compile(t.code`
+    op ${t.op("ping")}(): string;
+  `);
 
-          pass
-      
-      `);
-  });
-
-  it("creates a function with no parameters", async () => {
-    const { program, ping } = await Tester.compile(t.code`
-      op ${t.op("ping")}(): string;
+  expect(getOutput(program, [<FunctionDeclaration type={ping} />])).toRenderTo(`
+    def ping() -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={ping} />])).toRenderTo(`
-      def ping() -> str:
-          pass
-      
-      `);
-  });
+it("creates a function that returns None for void", async () => {
+  const { program, ping } = await Tester.compile(t.code`
+    op ${t.op("ping")}(): void;
+  `);
 
-  it("creates a function that returns None for void", async () => {
-    const { program, ping } = await Tester.compile(t.code`
-      op ${t.op("ping")}(): void;
+  expect(getOutput(program, [<FunctionDeclaration type={ping} />])).toRenderTo(`
+    def ping() -> None:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={ping} />])).toRenderTo(`
-      def ping() -> None:
-          pass
-      
-      `);
-  });
+it("creates a function that returns Never for never", async () => {
+  const { program, abort } = await Tester.compile(t.code`
+    op ${t.op("abort")}(): never;
+  `);
 
-  it("creates a function that returns Never for never", async () => {
-    const { program, abort } = await Tester.compile(t.code`
-      op ${t.op("abort")}(): never;
+  expect(getOutput(program, [<FunctionDeclaration type={abort} />])).toRenderTo(`
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import Never
+
+
+    def abort() -> Never:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={abort} />])).toRenderTo(`
-      from typing import TYPE_CHECKING
+it("creates a function that correctly handles simple unions", async () => {
+  const { program, get } = await Tester.compile(t.code`
+    op ${t.op("get")}(): int32 | string;
+  `);
 
-      if TYPE_CHECKING:
-          from typing import Never
-
-
-      def abort() -> Never:
-          pass
-      
-      `);
-  });
-
-  it("creates a function that correctly handles simple unions", async () => {
-    const { program, get } = await Tester.compile(t.code`
-      op ${t.op("get")}(): int32 | string;
+  expect(getOutput(program, [<FunctionDeclaration type={get} />])).toRenderTo(`
+    def get() -> int | str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={get} />])).toRenderTo(`
-      def get() -> int | str:
-          pass
-      
-      `);
-  });
+it("creates a function with only keyword-only parameters (requires * marker for params with defaults)", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(name: string = "alice", age: int32 = 30): string;
+  `);
 
-  it("creates a function with only keyword-only parameters (requires * marker for params with defaults)", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(name: string = "alice", age: int32 = 30): string;
+  expect(getOutput(program, [<FunctionDeclaration type={createPerson} />])).toRenderTo(`
+    def create_person(*, name: str = "alice", age: int = 30) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={createPerson} />])).toRenderTo(`
-      def create_person(*, name: str = "alice", age: int = 30) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with operation params positional and additional params keyword-only", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string, locale: string = "en-US"): string;
+  `);
 
-  it("creates a function with operation params positional and additional params keyword-only", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string, locale: string = "en-US"): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={createPerson}
+        parameters={[
+          { name: "version", type: "int" },
+          { name: "debug", type: "bool", default: <py.Atom jsValue={false} /> },
+        ]}
+      />,
+    ]),
+  ).toRenderTo(`
+    def create_person(id: str, *, version: int, locale: str = "en-US", debug: bool = False) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={createPerson}
-          parameters={[
-            { name: "version", type: "int" },
-            { name: "debug", type: "bool", default: <py.Atom jsValue={false} /> },
-          ]}
-        />,
-      ]),
-    ).toRenderTo(`
-      def create_person(id: str, *, version: int, locale: str = "en-US", debug: bool = False) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with TSP params in wrong order (default before required) - reorders correctly", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(locale: string = "en-US", id: string): string;
+  `);
 
-  it("creates a function with TSP params in wrong order (default before required) - reorders correctly", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(locale: string = "en-US", id: string): string;
+  expect(getOutput(program, [<FunctionDeclaration type={createPerson} />])).toRenderTo(`
+    def create_person(id: str, *, locale: str = "en-US") -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={createPerson} />])).toRenderTo(`
-      def create_person(id: str, *, locale: str = "en-US") -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with only positional params when adding params to empty operation", async () => {
+  const { program, ping } = await Tester.compile(t.code`
+    op ${t.op("ping")}(): string;
+  `);
 
-  it("creates a function with only positional params when adding params to empty operation", async () => {
-    const { program, ping } = await Tester.compile(t.code`
-      op ${t.op("ping")}(): string;
+  expect(getOutput(program, [<FunctionDeclaration type={ping} parameters={["name", "age"]} />]))
+    .toRenderTo(`
+    def ping(name, age) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={ping} parameters={["name", "age"]} />]))
-      .toRenderTo(`
-      def ping(name, age) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with multiple positional params", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string, name: string, age: int32): string;
+  `);
 
-  it("creates a function with multiple positional params", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string, name: string, age: int32): string;
+  expect(getOutput(program, [<FunctionDeclaration type={createPerson} />])).toRenderTo(`
+    def create_person(id: str, name: str, age: int) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={createPerson} />])).toRenderTo(`
-      def create_person(id: str, name: str, age: int) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function adding keyword-only params to operation with only positional params", async () => {
+  const { program, createPerson } = await Tester.compile(t.code`
+    op ${t.op("createPerson")}(id: string, name: string): string;
+  `);
 
-  it("creates a function adding keyword-only params to operation with only positional params", async () => {
-    const { program, createPerson } = await Tester.compile(t.code`
-      op ${t.op("createPerson")}(id: string, name: string): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={createPerson}
+        parameters={[
+          "email",
+          { name: "notify", type: "bool", default: <py.Atom jsValue={false} /> },
+        ]}
+      />,
+    ]),
+  ).toRenderTo(`
+    def create_person(id: str, name: str, *, email, notify: bool = False) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={createPerson}
-          parameters={[
-            "email",
-            { name: "notify", type: "bool", default: <py.Atom jsValue={false} /> },
-          ]}
-        />,
-      ]),
-    ).toRenderTo(`
-      def create_person(id: str, name: str, *, email, notify: bool = False) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with multiple params with defaults (all keyword-only)", async () => {
+  const { program, search } = await Tester.compile(t.code`
+    op ${t.op("search")}(
+      limit: int32 = 10,
+      offset: int32 = 0,
+      sortBy: string = "name"
+    ): string;
+  `);
 
-  it("creates a function with multiple params with defaults (all keyword-only)", async () => {
-    const { program, search } = await Tester.compile(t.code`
-      op ${t.op("search")}(
-        limit: int32 = 10,
-        offset: int32 = 0,
-        sortBy: string = "name"
-      ): string;
+  expect(getOutput(program, [<FunctionDeclaration type={search} />])).toRenderTo(`
+    def search(*, limit: int = 10, offset: int = 0, sort_by: str = "name") -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={search} />])).toRenderTo(`
-      def search(*, limit: int = 10, offset: int = 0, sort_by: str = "name") -> str:
-          pass
-      
-      `);
-  });
+it("creates a function adding params without defaults to operation with only defaults", async () => {
+  const { program, search } = await Tester.compile(t.code`
+    op ${t.op("search")}(limit: int32 = 10, offset: int32 = 0): string;
+  `);
 
-  it("creates a function adding params without defaults to operation with only defaults", async () => {
-    const { program, search } = await Tester.compile(t.code`
-      op ${t.op("search")}(limit: int32 = 10, offset: int32 = 0): string;
+  expect(getOutput(program, [<FunctionDeclaration type={search} parameters={["query"]} />]))
+    .toRenderTo(`
+    def search(*, query, limit: int = 10, offset: int = 0) -> str:
+        pass
+    
     `);
+});
 
-    expect(getOutput(program, [<FunctionDeclaration type={search} parameters={["query"]} />]))
-      .toRenderTo(`
-      def search(*, query, limit: int = 10, offset: int = 0) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with complex parameter mix", async () => {
+  const { program, complexOp } = await Tester.compile(t.code`
+    op ${t.op("complexOp")}(
+      required1: string,
+      required2: int32,
+      optional1: string = "default",
+      optional2: int32 = 42
+    ): string;
+  `);
 
-  it("creates a function with complex parameter mix", async () => {
-    const { program, complexOp } = await Tester.compile(t.code`
-      op ${t.op("complexOp")}(
-        required1: string,
-        required2: int32,
-        optional1: string = "default",
-        optional2: int32 = 42
-      ): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={complexOp}
+        parameters={[
+          "additionalRequired",
+          { name: "additionalOptional", type: "bool", default: <py.Atom jsValue={true} /> },
+        ]}
+      />,
+    ]),
+  ).toRenderTo(`
+    def complex_op(required1: str, required2: int, *, additional_required, optional1: str = "default", optional2: int = 42, additional_optional: bool = True) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={complexOp}
-          parameters={[
-            "additionalRequired",
-            { name: "additionalOptional", type: "bool", default: <py.Atom jsValue={true} /> },
-          ]}
-        />,
-      ]),
-    ).toRenderTo(`
-      def complex_op(required1: str, required2: int, *, additional_required, optional1: str = "default", optional2: int = 42, additional_optional: bool = True) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function with single positional param and additional keyword-only", async () => {
+  const { program, getUser } = await Tester.compile(t.code`
+    op ${t.op("getUser")}(id: string): string;
+  `);
 
-  it("creates a function with single positional param and additional keyword-only", async () => {
-    const { program, getUser } = await Tester.compile(t.code`
-      op ${t.op("getUser")}(id: string): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={getUser}
+        parameters={[
+          { name: "includeDeleted", type: "bool", default: <py.Atom jsValue={false} /> },
+        ]}
+      />,
+    ]),
+  ).toRenderTo(`
+    def get_user(id: str, *, include_deleted: bool = False) -> str:
+        pass
+    
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={getUser}
-          parameters={[
-            { name: "includeDeleted", type: "bool", default: <py.Atom jsValue={false} /> },
-          ]}
-        />,
-      ]),
-    ).toRenderTo(`
-      def get_user(id: str, *, include_deleted: bool = False) -> str:
-          pass
-      
-      `);
-  });
+it("creates a function adding only params with defaults to empty operation", async () => {
+  const { program, ping } = await Tester.compile(t.code`
+    op ${t.op("ping")}(): string;
+  `);
 
-  it("creates a function adding only params with defaults to empty operation", async () => {
-    const { program, ping } = await Tester.compile(t.code`
-      op ${t.op("ping")}(): string;
+  expect(
+    getOutput(program, [
+      <FunctionDeclaration
+        type={ping}
+        parameters={[
+          { name: "timeout", type: "int", default: <py.Atom jsValue={30} /> },
+          { name: "retries", type: "int", default: <py.Atom jsValue={3} /> },
+        ]}
+      />,
+    ]),
+  ).toRenderTo(`
+    def ping(*, timeout: int = 30, retries: int = 3) -> str:
+        pass
+    
     `);
-
-    expect(
-      getOutput(program, [
-        <FunctionDeclaration
-          type={ping}
-          parameters={[
-            { name: "timeout", type: "int", default: <py.Atom jsValue={30} /> },
-            { name: "retries", type: "int", default: <py.Atom jsValue={3} /> },
-          ]}
-        />,
-      ]),
-    ).toRenderTo(`
-      def ping(*, timeout: int = 30, retries: int = 3) -> str:
-          pass
-      
-      `);
-  });
 });

--- a/packages/emitter-framework/src/python/components/protocol-declaration/protocol-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/protocol-declaration/protocol-declaration.test.tsx
@@ -1,106 +1,101 @@
 import { TypeExpression } from "#python/components/type-expression/type-expression.js";
 import { Tester } from "#test/test-host.js";
 import { t } from "@typespec/compiler/testing";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { getOutput } from "../../test-utils.js";
 import { ProtocolDeclaration } from "./protocol-declaration.js";
 
-describe("Python ProtocolDeclaration", () => {
-  it("emits a callback Protocol for an operation", async () => {
-    const { program, getName, getOtherName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
-      op ${t.op("getOtherName")}(id: string): string;
+it("emits a callback Protocol for an operation", async () => {
+  const { program, getName, getOtherName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+    op ${t.op("getOtherName")}(id: string): string;
+  `);
+
+  expect(
+    getOutput(program, [
+      <ProtocolDeclaration type={getName} />,
+      <ProtocolDeclaration type={getOtherName} />,
+    ]),
+  ).toRenderTo(`
+    from typing import Protocol
+
+
+    class GetName(Protocol):
+        def __call__(self, id: str) -> str:
+            ...
+
+
+
+    class GetOtherName(Protocol):
+        def __call__(self, id: str) -> str:
+            ...
+
+
     `);
+});
 
-    expect(
-      getOutput(program, [
-        <ProtocolDeclaration type={getName} />,
-        <ProtocolDeclaration type={getOtherName} />,
-      ]),
-    ).toRenderTo(`
-      from typing import Protocol
+it("emits no return annotation when return type omitted", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
 
+  // Create a shallow clone without returnType to simulate missing return info
+  const getNameNoReturn: any = { ...(getName as any) };
+  delete getNameNoReturn.returnType;
 
-      class GetName(Protocol):
-          def __call__(self, id: str) -> str:
-              ...
-
-
-
-      class GetOtherName(Protocol):
-          def __call__(self, id: str) -> str:
-              ...
+  expect(getOutput(program, [<ProtocolDeclaration type={getNameNoReturn} />])).toRenderTo(`
+    from typing import Protocol
 
 
-      `);
-  });
+    class GetName(Protocol):
+        def __call__(self, id: str):
+            ...
 
-  it("emits no return annotation when return type omitted", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+    
     `);
+});
 
-    // Create a shallow clone without returnType to simulate missing return info
-    const getNameNoReturn: any = { ...(getName as any) };
-    delete getNameNoReturn.returnType;
+it("emits a Protocol for a TypeSpec interface (methods only)", async () => {
+  const { program, Greeter } = await Tester.compile(t.code`
+    interface ${t.interface("Greeter")} {
+      op getName(id: string): string;
+      op getOtherName(id: string): string;
+    }
+  `);
 
-    expect(getOutput(program, [<ProtocolDeclaration type={getNameNoReturn} />])).toRenderTo(`
-      from typing import Protocol
+  expect(getOutput(program, [<ProtocolDeclaration type={Greeter} />])).toRenderTo(`
+    from typing import Protocol
 
 
-      class GetName(Protocol):
-          def __call__(self, id: str):
-              ...
+    class Greeter(Protocol):
+        def get_name(self, id: str) -> str:
+            ...
 
-      
-      `);
-  });
-
-  it("emits a Protocol for a TypeSpec interface (methods only)", async () => {
-    const { program, Greeter } = await Tester.compile(t.code`
-      interface ${t.interface("Greeter")} {
-        op getName(id: string): string;
-        op getOtherName(id: string): string;
-      }
+        def get_other_name(self, id: str) -> str:
+            ...
+    
+    
     `);
+});
 
-    expect(getOutput(program, [<ProtocolDeclaration type={Greeter} />])).toRenderTo(`
-      from typing import Protocol
+it("emits both a Protocol and a Callable for the same operation", async () => {
+  const { program, getName } = await Tester.compile(t.code`
+    op ${t.op("getName")}(id: string): string;
+  `);
+
+  expect(
+    getOutput(program, [<ProtocolDeclaration type={getName} />, <TypeExpression type={getName} />]),
+  ).toRenderTo(`
+    from typing import Callable
+    from typing import Protocol
 
 
-      class Greeter(Protocol):
-          def get_name(self, id: str) -> str:
-              ...
+    class GetName(Protocol):
+        def __call__(self, id: str) -> str:
+            ...
 
-          def get_other_name(self, id: str) -> str:
-              ...
-      
-      
-      `);
-  });
-
-  it("emits both a Protocol and a Callable for the same operation", async () => {
-    const { program, getName } = await Tester.compile(t.code`
-      op ${t.op("getName")}(id: string): string;
+    
+    
+    Callable[[str], str]
     `);
-
-    expect(
-      getOutput(program, [
-        <ProtocolDeclaration type={getName} />,
-        <TypeExpression type={getName} />,
-      ]),
-    ).toRenderTo(`
-      from typing import Callable
-      from typing import Protocol
-
-
-      class GetName(Protocol):
-          def __call__(self, id: str) -> str:
-              ...
-
-      
-      
-      Callable[[str], str]
-      `);
-  });
 });

--- a/packages/emitter-framework/src/python/components/type-alias-declaration/type-alias-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/type-alias-declaration/type-alias-declaration.test.tsx
@@ -4,135 +4,133 @@ import { describe, expect, it } from "vitest";
 import { getOutput } from "../../test-utils.js";
 import { TypeAliasDeclaration } from "./type-alias-declaration.js";
 
-describe("Python Declaration equivalency to Type Alias", () => {
-  describe("Type Alias Declaration bound to Typespec Scalar", () => {
-    describe("Scalar extends utcDateTime", () => {
-      it("creates a type alias declaration for a utcDateTime without encoding", async () => {
-        const { program, MyDate } = await Tester.compile(t.code`
-          scalar ${t.scalar("MyDate")} extends utcDateTime;
-        `);
-
-        expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
-          from datetime import datetime
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from typing import TypeAlias
-
-
-          my_date: TypeAlias = datetime`);
-      });
-
-      it("creates a type alias declaration with doc", async () => {
-        const { program, MyDate } = await Tester.compile(t.code`
-          /**
-           * Type to represent a date
-           */
-          scalar ${t.scalar("MyDate")} extends utcDateTime;
-        `);
-
-        expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
-          from datetime import datetime
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from typing import TypeAlias
-
-
-          # Type to represent a date
-          my_date: TypeAlias = datetime`);
-      });
-
-      it("can override JSDoc", async () => {
-        const { program, MyDate } = await Tester.compile(t.code`
-          /**
-           * Type to represent a date
-           */
-          scalar ${t.scalar("MyDate")} extends utcDateTime;
-        `);
-
-        expect(getOutput(program, [<TypeAliasDeclaration doc={"Overridden Doc"} type={MyDate} />]))
-          .toRenderTo(`
-          from datetime import datetime
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from typing import TypeAlias
-
-
-          # Overridden Doc
-          my_date: TypeAlias = datetime`);
-      });
-
-      it("creates a type alias declaration for a utcDateTime with unixTimeStamp encoding", async () => {
-        const { program, MyDate } = await Tester.compile(t.code`
-          @encode("unixTimestamp", int32)
-          scalar ${t.scalar("MyDate")} extends utcDateTime;
-        `);
-
-        expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
-          from datetime import datetime
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from typing import TypeAlias
-
-
-          my_date: TypeAlias = datetime`);
-      });
-
-      it("creates a type alias declaration for a utcDateTime with rfc7231 encoding", async () => {
-        const { program, MyDate } = await Tester.compile(t.code`
-          @encode("rfc7231")
-          scalar ${t.scalar("MyDate")} extends utcDateTime;
-        `);
-
-        expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
-          from datetime import datetime
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from typing import TypeAlias
-
-
-          my_date: TypeAlias = datetime`);
-      });
-
-      it("creates a type alias declaration for a utcDateTime with rfc3339 encoding", async () => {
-        const { program, MyDate } = await Tester.compile(t.code`
-          @encode("rfc3339")
-          scalar ${t.scalar("MyDate")} extends utcDateTime;
-        `);
-
-        expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
-          from datetime import datetime
-          from typing import TYPE_CHECKING
-
-          if TYPE_CHECKING:
-              from typing import TypeAlias
-
-
-          my_date: TypeAlias = datetime`);
-      });
-    });
-  });
-
-  describe("Type Alias Declaration for Operation (Callable)", () => {
-    it("creates a type alias for an operation type reference", async () => {
-      const { program, Handler } = await Tester.compile(t.code`
-        op handleRequest(id: string): string;
-        alias ${t.type("Handler")} = handleRequest;
+describe("Type Alias Declaration bound to Typespec Scalar", () => {
+  describe("Scalar extends utcDateTime", () => {
+    it("creates a type alias declaration for a utcDateTime without encoding", async () => {
+      const { program, MyDate } = await Tester.compile(t.code`
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
       `);
 
-      expect(getOutput(program, [<TypeAliasDeclaration type={Handler} />])).toRenderTo(`
-        from typing import Callable
+      expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
+        from datetime import datetime
         from typing import TYPE_CHECKING
 
         if TYPE_CHECKING:
             from typing import TypeAlias
 
 
-        handle_request: TypeAlias = Callable[[str], str]`);
+        my_date: TypeAlias = datetime`);
     });
+
+    it("creates a type alias declaration with doc", async () => {
+      const { program, MyDate } = await Tester.compile(t.code`
+        /**
+         * Type to represent a date
+         */
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
+      `);
+
+      expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
+        from datetime import datetime
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from typing import TypeAlias
+
+
+        # Type to represent a date
+        my_date: TypeAlias = datetime`);
+    });
+
+    it("can override JSDoc", async () => {
+      const { program, MyDate } = await Tester.compile(t.code`
+        /**
+         * Type to represent a date
+         */
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
+      `);
+
+      expect(getOutput(program, [<TypeAliasDeclaration doc={"Overridden Doc"} type={MyDate} />]))
+        .toRenderTo(`
+        from datetime import datetime
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from typing import TypeAlias
+
+
+        # Overridden Doc
+        my_date: TypeAlias = datetime`);
+    });
+
+    it("creates a type alias declaration for a utcDateTime with unixTimeStamp encoding", async () => {
+      const { program, MyDate } = await Tester.compile(t.code`
+        @encode("unixTimestamp", int32)
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
+      `);
+
+      expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
+        from datetime import datetime
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from typing import TypeAlias
+
+
+        my_date: TypeAlias = datetime`);
+    });
+
+    it("creates a type alias declaration for a utcDateTime with rfc7231 encoding", async () => {
+      const { program, MyDate } = await Tester.compile(t.code`
+        @encode("rfc7231")
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
+      `);
+
+      expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
+        from datetime import datetime
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from typing import TypeAlias
+
+
+        my_date: TypeAlias = datetime`);
+    });
+
+    it("creates a type alias declaration for a utcDateTime with rfc3339 encoding", async () => {
+      const { program, MyDate } = await Tester.compile(t.code`
+        @encode("rfc3339")
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
+      `);
+
+      expect(getOutput(program, [<TypeAliasDeclaration type={MyDate} />])).toRenderTo(`
+        from datetime import datetime
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from typing import TypeAlias
+
+
+        my_date: TypeAlias = datetime`);
+    });
+  });
+});
+
+describe("Type Alias Declaration for Operation (Callable)", () => {
+  it("creates a type alias for an operation type reference", async () => {
+    const { program, Handler } = await Tester.compile(t.code`
+      op handleRequest(id: string): string;
+      alias ${t.type("Handler")} = handleRequest;
+    `);
+
+    expect(getOutput(program, [<TypeAliasDeclaration type={Handler} />])).toRenderTo(`
+      from typing import Callable
+      from typing import TYPE_CHECKING
+
+      if TYPE_CHECKING:
+          from typing import TypeAlias
+
+
+      handle_request: TypeAlias = Callable[[str], str]`);
   });
 });

--- a/packages/emitter-framework/src/python/components/type-declaration/type-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/type-declaration/type-declaration.test.tsx
@@ -1,64 +1,62 @@
 import { Tester } from "#test/test-host.js";
 import { d } from "@alloy-js/core/testing";
 import { t } from "@typespec/compiler/testing";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { getOutput } from "../../test-utils.js";
 import { TypeDeclaration } from "./type-declaration.js";
 
-describe("Python TypeDeclaration dispatcher", () => {
-  it("dispatches to EnumDeclaration for enums", async () => {
-    const { program, Foo } = await Tester.compile(t.code`
-      enum ${t.enum("Foo")} {
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `);
+it("dispatches to EnumDeclaration for enums", async () => {
+  const { program, Foo } = await Tester.compile(t.code`
+    enum ${t.enum("Foo")} {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `);
 
-    const output = getOutput(program, [<TypeDeclaration type={Foo} />]);
-    expect(output).toRenderTo(d`
-      from enum import IntEnum
-
-
-      class Foo(IntEnum):
-          ONE = 1
-          TWO = 2
-          THREE = 3
+  const output = getOutput(program, [<TypeDeclaration type={Foo} />]);
+  expect(output).toRenderTo(d`
+    from enum import IntEnum
 
 
-    `);
-  });
-
-  it("dispatches scalars to TypeAliasDeclaration", async () => {
-    const { program, MyDate } = await Tester.compile(t.code`
-      scalar ${t.scalar("MyDate")} extends utcDateTime;
-    `);
-
-    const output = getOutput(program, [<TypeDeclaration type={MyDate} />]);
-    expect(output).toRenderTo(d`
-      from datetime import datetime
-      from typing import TYPE_CHECKING
-
-      if TYPE_CHECKING:
-          from typing import TypeAlias
+    class Foo(IntEnum):
+        ONE = 1
+        TWO = 2
+        THREE = 3
 
 
-      my_date: TypeAlias = datetime`);
-  });
+  `);
+});
 
-  it("dispatches arrays (model is Array<T>) to type alias with list[T]", async () => {
-    const { program, Items } = await Tester.compile(t.code`
-      model ${t.model("Items")} is Array<int32>;
-    `);
+it("dispatches scalars to TypeAliasDeclaration", async () => {
+  const { program, MyDate } = await Tester.compile(t.code`
+    scalar ${t.scalar("MyDate")} extends utcDateTime;
+  `);
 
-    const output = getOutput(program, [<TypeDeclaration type={Items} />]);
-    expect(output).toRenderTo(d`
-      from typing import TYPE_CHECKING
+  const output = getOutput(program, [<TypeDeclaration type={MyDate} />]);
+  expect(output).toRenderTo(d`
+    from datetime import datetime
+    from typing import TYPE_CHECKING
 
-      if TYPE_CHECKING:
-          from typing import TypeAlias
+    if TYPE_CHECKING:
+        from typing import TypeAlias
 
 
-      items: TypeAlias = list[int]`);
-  });
+    my_date: TypeAlias = datetime`);
+});
+
+it("dispatches arrays (model is Array<T>) to type alias with list[T]", async () => {
+  const { program, Items } = await Tester.compile(t.code`
+    model ${t.model("Items")} is Array<int32>;
+  `);
+
+  const output = getOutput(program, [<TypeDeclaration type={Items} />]);
+  expect(output).toRenderTo(d`
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import TypeAlias
+
+
+    items: TypeAlias = list[int]`);
 });

--- a/packages/emitter-framework/test/testing/snippet-extractor-python.test.ts
+++ b/packages/emitter-framework/test/testing/snippet-extractor-python.test.ts
@@ -1,43 +1,41 @@
 import { d } from "@alloy-js/core/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import {
   createPythonExtractorConfig,
   createSnippetExtractor,
   type SnippetExtractor,
 } from "../../src/testing/index.js";
 
-describe("Python Snippet Extractor", () => {
-  let extractor: SnippetExtractor;
+let extractor: SnippetExtractor;
 
-  beforeEach(async () => {
-    extractor = createSnippetExtractor(await createPythonExtractorConfig());
-  });
+beforeEach(async () => {
+  extractor = createSnippetExtractor(await createPythonExtractorConfig());
+});
 
-  it("should extract a class", () => {
-    const content = d`
+it("should extract a class", () => {
+  const content = d`
+  class Foo:
+      def __init__(self):
+          print("Hello")
+  `;
+
+  const snippet = extractor.getClass(content, "Foo");
+  expect(snippet).toBe(d`
     class Foo:
         def __init__(self):
             print("Hello")
-    `;
+  `);
+});
 
-    const snippet = extractor.getClass(content, "Foo");
-    expect(snippet).toBe(d`
-      class Foo:
-          def __init__(self):
-              print("Hello")
-    `);
-  });
+it("should extract a function", () => {
+  const content = d`
+  def greet(name: str) -> str:
+      return f"Hello {name}"
+  `;
 
-  it("should extract a function", () => {
-    const content = d`
+  const snippet = extractor.getFunction(content, "greet");
+  expect(snippet).toBe(d`
     def greet(name: str) -> str:
         return f"Hello {name}"
-    `;
-
-    const snippet = extractor.getFunction(content, "greet");
-    expect(snippet).toBe(d`
-      def greet(name: str) -> str:
-          return f"Hello {name}"
-    `);
-  });
+  `);
 });

--- a/packages/emitter-framework/test/typescript/components/arrow-function.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/arrow-function.test.tsx
@@ -1,67 +1,62 @@
 import { Tester } from "#test/test-host.js";
 import { SourceFile } from "@alloy-js/typescript";
 import { type TesterInstance, t } from "@typespec/compiler/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { Output } from "../../../src/core/components/output.jsx";
 import { ArrowFunction } from "../../../src/typescript/components/arrow-function.jsx";
 
-describe("arrow functions with a `type` prop", () => {
-  let runner: TesterInstance;
+let runner: TesterInstance;
 
-  beforeEach(async () => {
-    runner = await Tester.createInstance();
-  });
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
 
-  it("creates a function", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+it("creates a function", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
+
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <ArrowFunction type={getName}>console.log("Hello!");</ArrowFunction>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      (id: string): string => {
+        console.log("Hello!");
+      }
     `);
+});
 
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <ArrowFunction type={getName}>console.log("Hello!");</ArrowFunction>
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        (id: string): string => {
-          console.log("Hello!");
-        }
-      `);
-  });
+it("creates an async function", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("creates an async function", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <ArrowFunction async type={getName} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      async (id: string): Promise<string> => {}
     `);
+});
 
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <ArrowFunction async type={getName} />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        async (id: string): Promise<string> => {}
-      `);
-  });
+it("can append extra parameters with raw params provided", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("can append extra parameters with raw params provided", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <ArrowFunction type={getName} parameters={[{ name: "additionalParam", type: "number" }]} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      (additionalParam: number, id: string): string => {}
     `);
-
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <ArrowFunction
-            type={getName}
-            parameters={[{ name: "additionalParam", type: "number" }]}
-          />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        (additionalParam: number, id: string): string => {}
-      `);
-  });
 });

--- a/packages/emitter-framework/test/typescript/components/enum-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/enum-declaration.test.tsx
@@ -1,204 +1,202 @@
 import { List, StatementList } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
 import type { Enum, Union } from "@typespec/compiler";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { TspContext } from "../../../src/core/index.js";
 import { EnumDeclaration } from "../../../src/typescript/components/enum-declaration.js";
 import { efRefkey } from "../../../src/typescript/utils/refkey.js";
 import { getEmitOutput } from "../../utils.js";
 
-describe("Typescript Enum Declaration", () => {
-  it("takes an enum type parameter", async () => {
-    const code = `
-      enum Foo {
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `;
-    const output = await getEmitOutput(code, (program) => {
-      const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
-      return (
-        <TspContext.Provider value={{ program }}>
+it("takes an enum type parameter", async () => {
+  const code = `
+    enum Foo {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `;
+  const output = await getEmitOutput(code, (program) => {
+    const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
+    return (
+      <TspContext.Provider value={{ program }}>
+        <EnumDeclaration type={Foo} />
+      </TspContext.Provider>
+    );
+  });
+
+  expect(output).toBe(d`
+    enum Foo {
+      one = 1,
+      two = 2,
+      three = 3
+    }
+  `);
+});
+
+it("adds JSDoc from TypeSpec", async () => {
+  const code = `
+    /**
+     * This is a test enum
+     */
+    enum Foo {
+      @doc("This is one")
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `;
+  const output = await getEmitOutput(code, (program) => {
+    const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
+    return (
+      <TspContext.Provider value={{ program }}>
+        <EnumDeclaration type={Foo} />
+      </TspContext.Provider>
+    );
+  });
+
+  expect(output).toBe(d`
+    /**
+     * This is a test enum
+     */
+    enum Foo {
+      /**
+       * This is one
+       */
+      one = 1,
+      two = 2,
+      three = 3
+    }
+  `);
+});
+
+it("explicit doc take precedence", async () => {
+  const code = `
+    /**
+     * This is a test enum
+     */
+    enum Foo {
+      @doc("This is one")
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `;
+  const output = await getEmitOutput(code, (program) => {
+    const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
+    return (
+      <TspContext.Provider value={{ program }}>
+        <EnumDeclaration type={Foo} doc={["This is an explicit doc"]} />
+      </TspContext.Provider>
+    );
+  });
+
+  expect(output).toBe(d`
+    /**
+     * This is an explicit doc
+     */
+    enum Foo {
+      /**
+       * This is one
+       */
+      one = 1,
+      two = 2,
+      three = 3
+    }
+  `);
+});
+
+it("takes a union type parameter", async () => {
+  const code = `
+    union Foo {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `;
+  const output = await getEmitOutput(code, (program) => {
+    const Foo = program.resolveTypeReference("Foo")[0]! as Union;
+    return (
+      <TspContext.Provider value={{ program }}>
+        <EnumDeclaration type={Foo} />
+      </TspContext.Provider>
+    );
+  });
+
+  expect(output).toBe(d`
+    enum Foo {
+      one = 1,
+      two = 2,
+      three = 3
+    }
+  `);
+});
+
+it("can be referenced", async () => {
+  const code = `
+    enum Foo {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `;
+
+  const output = await getEmitOutput(code, (program) => {
+    const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
+    return (
+      <TspContext.Provider value={{ program }}>
+        <List hardline>
           <EnumDeclaration type={Foo} />
-        </TspContext.Provider>
-      );
-    });
-
-    expect(output).toBe(d`
-      enum Foo {
-        one = 1,
-        two = 2,
-        three = 3
-      }
-    `);
+          <StatementList>
+            {efRefkey(Foo)}
+            {efRefkey(Foo.members.get("one"))}
+          </StatementList>
+        </List>
+      </TspContext.Provider>
+    );
   });
 
-  it("adds JSDoc from TypeSpec", async () => {
-    const code = `
-      /**
-       * This is a test enum
-       */
-      enum Foo {
-        @doc("This is one")
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `;
-    const output = await getEmitOutput(code, (program) => {
-      const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
-      return (
-        <TspContext.Provider value={{ program }}>
+  expect(output).toBe(d`
+    enum Foo {
+      one = 1,
+      two = 2,
+      three = 3
+    }
+    Foo;
+    Foo.one;
+  `);
+});
+
+it("can be referenced using union", async () => {
+  const code = `
+    union Foo {
+      one: 1,
+      two: 2,
+      three: 3
+    }
+  `;
+
+  const output = await getEmitOutput(code, (program) => {
+    const Foo = program.resolveTypeReference("Foo")[0]! as Union;
+    return (
+      <TspContext.Provider value={{ program }}>
+        <List hardline>
           <EnumDeclaration type={Foo} />
-        </TspContext.Provider>
-      );
-    });
-
-    expect(output).toBe(d`
-      /**
-       * This is a test enum
-       */
-      enum Foo {
-        /**
-         * This is one
-         */
-        one = 1,
-        two = 2,
-        three = 3
-      }
-    `);
+          <StatementList>
+            {efRefkey(Foo)}
+            {efRefkey(Foo.variants.get("one"))}
+          </StatementList>
+        </List>
+      </TspContext.Provider>
+    );
   });
 
-  it("explicit doc take precedence", async () => {
-    const code = `
-      /**
-       * This is a test enum
-       */
-      enum Foo {
-        @doc("This is one")
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `;
-    const output = await getEmitOutput(code, (program) => {
-      const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
-      return (
-        <TspContext.Provider value={{ program }}>
-          <EnumDeclaration type={Foo} doc={["This is an explicit doc"]} />
-        </TspContext.Provider>
-      );
-    });
-
-    expect(output).toBe(d`
-      /**
-       * This is an explicit doc
-       */
-      enum Foo {
-        /**
-         * This is one
-         */
-        one = 1,
-        two = 2,
-        three = 3
-      }
-    `);
-  });
-
-  it("takes a union type parameter", async () => {
-    const code = `
-      union Foo {
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `;
-    const output = await getEmitOutput(code, (program) => {
-      const Foo = program.resolveTypeReference("Foo")[0]! as Union;
-      return (
-        <TspContext.Provider value={{ program }}>
-          <EnumDeclaration type={Foo} />
-        </TspContext.Provider>
-      );
-    });
-
-    expect(output).toBe(d`
-      enum Foo {
-        one = 1,
-        two = 2,
-        three = 3
-      }
-    `);
-  });
-
-  it("can be referenced", async () => {
-    const code = `
-      enum Foo {
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `;
-
-    const output = await getEmitOutput(code, (program) => {
-      const Foo = program.resolveTypeReference("Foo")[0]! as Enum;
-      return (
-        <TspContext.Provider value={{ program }}>
-          <List hardline>
-            <EnumDeclaration type={Foo} />
-            <StatementList>
-              {efRefkey(Foo)}
-              {efRefkey(Foo.members.get("one"))}
-            </StatementList>
-          </List>
-        </TspContext.Provider>
-      );
-    });
-
-    expect(output).toBe(d`
-      enum Foo {
-        one = 1,
-        two = 2,
-        three = 3
-      }
-      Foo;
-      Foo.one;
-    `);
-  });
-
-  it("can be referenced using union", async () => {
-    const code = `
-      union Foo {
-        one: 1,
-        two: 2,
-        three: 3
-      }
-    `;
-
-    const output = await getEmitOutput(code, (program) => {
-      const Foo = program.resolveTypeReference("Foo")[0]! as Union;
-      return (
-        <TspContext.Provider value={{ program }}>
-          <List hardline>
-            <EnumDeclaration type={Foo} />
-            <StatementList>
-              {efRefkey(Foo)}
-              {efRefkey(Foo.variants.get("one"))}
-            </StatementList>
-          </List>
-        </TspContext.Provider>
-      );
-    });
-
-    expect(output).toBe(d`
-      enum Foo {
-        one = 1,
-        two = 2,
-        three = 3
-      }
-      Foo;
-      Foo.one;
-    `);
-  });
+  expect(output).toBe(d`
+    enum Foo {
+      one = 1,
+      two = 2,
+      three = 3
+    }
+    Foo;
+    Foo.one;
+  `);
 });

--- a/packages/emitter-framework/test/typescript/components/function-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/function-declaration.test.tsx
@@ -7,213 +7,211 @@ import { describe, expect, it } from "vitest";
 import { Output } from "../../../src/core/components/output.jsx";
 import { FunctionDeclaration } from "../../../src/typescript/components/function-declaration.js";
 
-describe("Typescript Function Declaration", () => {
-  describe("Function bound to Typespec Types", () => {
-    describe("Bound to Operation", () => {
-      it("creates a function", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        op getName(id: string): string;
-        `);
+describe("Function bound to Typespec Types", () => {
+  describe("Bound to Operation", () => {
+    it("creates a function", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      op getName(id: string): string;
+      `);
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration type={operation} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`function getName(id: string): string {}`);
-      });
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration type={operation} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`function getName(id: string): string {}`);
+    });
 
-      it("creates a function with JSDoc", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
+    it("creates a function with JSDoc", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      /**
+       * This is a test function
+       */
+      op getName(
+      @doc("This is the id")
+      id: string, name: string): string;
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration type={operation} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
         /**
          * This is a test function
+         *
+         * @param {string} id - This is the id
+         * @param {string} name
          */
-        op getName(
-        @doc("This is the id")
-        id: string, name: string): string;
-        `);
+        function getName(id: string, name: string): string {}`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
+    it("creates a function with overridden JSDoc", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      /**
+       * This is a test function
+       */
+      op getName(id: string): string;`);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration type={operation} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          /**
-           * This is a test function
-           *
-           * @param {string} id - This is the id
-           * @param {string} name
-           */
-          function getName(id: string, name: string): string {}`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-      it("creates a function with overridden JSDoc", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration doc={["This is a custom description"]} type={operation} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
         /**
-         * This is a test function
+         * This is a custom description
+         *
+         * @param {string} id
          */
-        op getName(id: string): string;`);
+        function getName(id: string): string {}`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
+    it("creates an async function", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      op getName(id: string): string;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration doc={["This is a custom description"]} type={operation} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          /**
-           * This is a custom description
-           *
-           * @param {string} id
-           */
-          function getName(id: string): string {}`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-      it("creates an async function", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        op getName(id: string): string;
-        `);
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration async type={operation} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(d`async function getName(id: string): Promise<string> {}`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
+    it("exports a function", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      op getName(id: string): string;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration async type={operation} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(d`async function getName(id: string): Promise<string> {}`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-      it("exports a function", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        op getName(id: string): string;
-        `);
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration export type={operation} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`export function getName(id: string): string {}`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
+    it("can override name", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      op getName(id: string): string;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration export type={operation} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`export function getName(id: string): string {}`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-      it("can override name", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        op getName(id: string): string;
-        `);
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration name="newName" type={operation} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`function newName(id: string): string {}`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
+    it("can append extra parameters with raw params provided", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      op createPerson(id: string): string;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration name="newName" type={operation} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`function newName(id: string): string {}`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-      it("can append extra parameters with raw params provided", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        op createPerson(id: string): string;
-        `);
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration
+              type={operation}
+              parameters={[
+                { name: "name", type: "string" },
+                { name: "age", type: "number" },
+              ]}
+            />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`function createPerson(name: string, age: number, id: string): string {}`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
+    it.skip("can override parameters with an array of ModelProperties", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      op createPerson(id: string): string;
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration
-                type={operation}
-                parameters={[
-                  { name: "name", type: "string" },
-                  { name: "age", type: "number" },
-                ]}
-              />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`function createPerson(name: string, age: number, id: string): string {}`);
-      });
+      model Foo {
+        name: string;
+        age: int32;
+      }
+      `);
 
-      it.skip("can override parameters with an array of ModelProperties", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        op createPerson(id: string): string;
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
+      const model = Array.from((namespace as Namespace).models.values())[0];
 
-        model Foo {
-          name: string;
-          age: int32;
-        }
-        `);
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration type={operation}>
+              <FunctionDeclaration.Parameters type={model} />
+            </FunctionDeclaration>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`function createPerson(name: string, age: number): string {}`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
-        const model = Array.from((namespace as Namespace).models.values())[0];
+    it("can render function body", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      op createPerson(id: string): string;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration type={operation}>
-                <FunctionDeclaration.Parameters type={model} />
-              </FunctionDeclaration>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`function createPerson(name: string, age: number): string {}`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-      it("can render function body", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        op createPerson(id: string): string;
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const operation = Array.from((namespace as Namespace).operations.values())[0];
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration export type={operation}>
-                {code`
-                  const message = "Hello World!";
-                  console.log(message);
-                `}
-              </FunctionDeclaration>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export function createPerson(id: string): string {
-            const message = "Hello World!";
-            console.log(message);
-          }`);
-      });
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <FunctionDeclaration export type={operation}>
+              {code`
+                const message = "Hello World!";
+                console.log(message);
+              `}
+            </FunctionDeclaration>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export function createPerson(id: string): string {
+          const message = "Hello World!";
+          console.log(message);
+        }`);
     });
   });
 });

--- a/packages/emitter-framework/test/typescript/components/function-expression.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/function-expression.test.tsx
@@ -1,67 +1,65 @@
 import { Tester } from "#test/test-host.js";
 import { SourceFile } from "@alloy-js/typescript";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { Output } from "../../../src/core/components/output.jsx";
 import { FunctionExpression } from "../../../src/typescript/components/function-expression.jsx";
 
-describe("function expressions with a `type` prop", () => {
-  let runner: TesterInstance;
+let runner: TesterInstance;
 
-  beforeEach(async () => {
-    runner = await Tester.createInstance();
-  });
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
 
-  it("creates a function", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+it("creates a function", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
+
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <FunctionExpression type={getName}>console.log("Hello!");</FunctionExpression>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      function (id: string): string {
+        console.log("Hello!");
+      }
     `);
+});
 
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <FunctionExpression type={getName}>console.log("Hello!");</FunctionExpression>
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        function (id: string): string {
-          console.log("Hello!");
-        }
-      `);
-  });
+it("creates an async function", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("creates an async function", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <FunctionExpression async type={getName} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      async function (id: string): Promise<string> {}
     `);
+});
 
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <FunctionExpression async type={getName} />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        async function (id: string): Promise<string> {}
-      `);
-  });
+it("can append extra parameters with raw params provided", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("can append extra parameters with raw params provided", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <FunctionExpression
+          type={getName}
+          parameters={[{ name: "additionalParam", type: "number" }]}
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      function (additionalParam: number, id: string): string {}
     `);
-
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <FunctionExpression
-            type={getName}
-            parameters={[{ name: "additionalParam", type: "number" }]}
-          />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        function (additionalParam: number, id: string): string {}
-      `);
-  });
 });

--- a/packages/emitter-framework/test/typescript/components/function-type.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/function-type.test.tsx
@@ -2,62 +2,60 @@ import { Tester } from "#test/test-host.js";
 import { SourceFile } from "@alloy-js/typescript";
 import type { Operation } from "@typespec/compiler";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { Output } from "../../../src/core/components/output.jsx";
 import { FunctionType } from "../../../src/typescript/index.js";
 
-describe("function types with a `type` prop", () => {
-  let runner: TesterInstance;
+let runner: TesterInstance;
 
-  beforeEach(async () => {
-    runner = await Tester.createInstance();
-  });
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
 
-  it("creates a function type", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+it("creates a function type", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
+
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <FunctionType type={getName} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      (id: string) => string
     `);
+});
 
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <FunctionType type={getName} />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        (id: string) => string
-      `);
-  });
+it("creates an async function type", async () => {
+  const { getName } = await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `);
 
-  it("creates an async function type", async () => {
-    const { getName } = await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <FunctionType async type={getName} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      (id: string) => Promise<string>
     `);
+});
 
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <FunctionType async type={getName} />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        (id: string) => Promise<string>
-      `);
-  });
+it("can append extra parameters with raw params provided", async () => {
+  const { getName } = (await runner.compile(t.code`
+    @test op ${t.op("getName")}(id: string): string;
+  `)) as { getName: Operation };
 
-  it("can append extra parameters with raw params provided", async () => {
-    const { getName } = (await runner.compile(t.code`
-      @test op ${t.op("getName")}(id: string): string;
-    `)) as { getName: Operation };
-
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <FunctionType type={getName} parameters={[{ name: "additionalParam", type: "number" }]} />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo(`
-        (additionalParam: number, id: string) => string
-      `);
-  });
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <FunctionType type={getName} parameters={[{ name: "additionalParam", type: "number" }]} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+      (additionalParam: number, id: string) => string
+    `);
 });

--- a/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/interface-declaration.test.tsx
@@ -6,712 +6,710 @@ import { describe, expect, it } from "vitest";
 import { Output } from "../../../src/core/components/output.jsx";
 import { InterfaceDeclaration } from "../../../src/typescript/components/interface-declaration.js";
 
-describe("Typescript Interface", () => {
-  describe("Interface bound to Typespec Types", () => {
-    it("declares an interface with multi line docs, explicit docs passed", async () => {
-      const program = await getProgram(`
-          namespace DemoService;
+describe("Interface bound to Typespec Types", () => {
+  it("declares an interface with multi line docs, explicit docs passed", async () => {
+    const program = await getProgram(`
+        namespace DemoService;
 
-          /**
-           * This is a test
-           * with multiple lines
-           */
-          model Foo {
-            knownProp: string;
-          }
-          `);
-
-      const [namespace] = program.resolveTypeReference("DemoService");
-      const models = Array.from((namespace as Namespace).models.values());
-
-      expect(
-        <Output program={program}>
-          <SourceFile path="test.ts">
-            <List hardline>
-              {models.map((model) => (
-                <InterfaceDeclaration
-                  export
-                  type={model}
-                  doc={["This is an overridden doc comment\nwith multiple lines"]}
-                />
-              ))}
-            </List>
-          </SourceFile>
-        </Output>,
-      ).toRenderTo(
-        `
-            /**
-             * This is an overridden doc comment
-             * with multiple lines
-             */
-            export interface Foo {
-              knownProp: string;
-            }
-            `,
-      );
-    });
-    it("declares an interface with multi line docs", async () => {
-      const program = await getProgram(`
-          namespace DemoService;
-
-          /**
-           * This is a test
-           * with multiple lines
-           */
-          model Foo {
-            knownProp: string;
-          }
-          `);
-
-      const [namespace] = program.resolveTypeReference("DemoService");
-      const models = Array.from((namespace as Namespace).models.values());
-
-      expect(
-        <Output program={program}>
-          <SourceFile path="test.ts">
-            <List hardline>
-              {models.map((model) => (
-                <InterfaceDeclaration export type={model} />
-              ))}
-            </List>
-          </SourceFile>
-        </Output>,
-      ).toRenderTo(
-        `
-            /**
-             * This is a test
-             * with multiple lines
-             */
-            export interface Foo {
-              knownProp: string;
-            }
-            `,
-      );
-    });
-    it("declares an interface with @doc", async () => {
-      const program = await getProgram(`
-          namespace DemoService;
-
-          @doc("This is a test")
-          model Foo {
-            knownProp: string;
-          }
-          `);
-
-      const [namespace] = program.resolveTypeReference("DemoService");
-      const models = Array.from((namespace as Namespace).models.values());
-
-      expect(
-        <Output program={program}>
-          <SourceFile path="test.ts">
-            <List hardline>
-              {models.map((model) => (
-                <InterfaceDeclaration export type={model} />
-              ))}
-            </List>
-          </SourceFile>
-        </Output>,
-      ).toRenderTo(
-        `
-            /**
-             * This is a test
-             */
-            export interface Foo {
-              knownProp: string;
-            }
-            `,
-      );
-    });
-    it("declares an interface with doc", async () => {
-      const program = await getProgram(`
-          namespace DemoService;
-
-          /**
-           * This is a test
-           */
-          model Foo {
-            @doc("This is a known property")
-            knownProp: string;
-          }
-          `);
-
-      const [namespace] = program.resolveTypeReference("DemoService");
-      const models = Array.from((namespace as Namespace).models.values());
-
-      expect(
-        <Output program={program}>
-          <SourceFile path="test.ts">
-            <List hardline>
-              {models.map((model) => (
-                <InterfaceDeclaration export type={model} />
-              ))}
-            </List>
-          </SourceFile>
-        </Output>,
-      ).toRenderTo(
-        `
-            /**
-             * This is a test
-             */
-            export interface Foo {
-              /**
-               * This is a known property
-               */
-              knownProp: string;
-            }
-            `,
-      );
-    });
-    describe("Bound to Model", () => {
-      it("creates an interface that extends a model for Record spread", async () => {
-        const program = await getProgram(`
-          namespace DemoService;
-
-          model DifferentSpreadModelRecord {
-            knownProp: string;
-            ...Record<unknown>;
-          }
-          `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <List hardline>
-                {models.map((model) => (
-                  <InterfaceDeclaration export type={model} />
-                ))}
-              </List>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-            export interface DifferentSpreadModelRecord {
-              knownProp: string;
-              additionalProperties?: Record<string, unknown>;
-            }
-            `);
-      });
-
-      it("creates an interface for a model that 'is' an array ", async () => {
-        const program = await getProgram(`
-          namespace DemoService;
-
-          model Foo is Array<string>;
-          `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = (namespace as Namespace).models;
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <For each={Array.from(models.values())} hardline>
-                {(model) => <InterfaceDeclaration export type={model} />}
-              </For>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface Foo extends Array<string> {}`);
-      });
-
-      it("creates an interface for a model that 'is' a record ", async () => {
-        const program = await getProgram(`
-          namespace DemoService;
-
-          model Foo is Record<string>;
+        /**
+         * This is a test
+         * with multiple lines
+         */
+        model Foo {
+          knownProp: string;
+        }
         `);
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = (namespace as Namespace).models;
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const models = Array.from((namespace as Namespace).models.values());
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <For each={Array.from(models.values())} hardline>
-                {(model) => <InterfaceDeclaration export type={model} />}
-              </For>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
+    expect(
+      <Output program={program}>
+        <SourceFile path="test.ts">
+          <List hardline>
+            {models.map((model) => (
+              <InterfaceDeclaration
+                export
+                type={model}
+                doc={["This is an overridden doc comment\nwith multiple lines"]}
+              />
+            ))}
+          </List>
+        </SourceFile>
+      </Output>,
+    ).toRenderTo(
+      `
+          /**
+           * This is an overridden doc comment
+           * with multiple lines
+           */
           export interface Foo {
-            additionalProperties?: Record<string, string>;
-          }`);
-      });
-
-      it("creates an interface of a model that spreads a Record", async () => {
-        const program = await getProgram(`
-          namespace DemoService;
-
-          model Foo {
-            ...Record<string>
-          }
-          `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = (namespace as Namespace).models;
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <For each={Array.from(models.values())} hardline>
-                {(model) => <InterfaceDeclaration export type={model} />}
-              </For>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-            export interface Foo {
-              additionalProperties?: Record<string, string>;
-            }
-            `);
-      });
-
-      it("creates an interface that extends an spread model", async () => {
-        const program = await getProgram(`
-          namespace DemoService;
-
-          model ModelForRecord {
-            state: string;
-          }
-
-          model DifferentSpreadModelRecord {
             knownProp: string;
-            ...Record<ModelForRecord>;
           }
+          `,
+    );
+  });
+  it("declares an interface with multi line docs", async () => {
+    const program = await getProgram(`
+        namespace DemoService;
 
-          model DifferentSpreadModelDerived extends DifferentSpreadModelRecord {
-            derivedProp: ModelForRecord;
+        /**
+         * This is a test
+         * with multiple lines
+         */
+        model Foo {
+          knownProp: string;
+        }
+        `);
+
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const models = Array.from((namespace as Namespace).models.values());
+
+    expect(
+      <Output program={program}>
+        <SourceFile path="test.ts">
+          <List hardline>
+            {models.map((model) => (
+              <InterfaceDeclaration export type={model} />
+            ))}
+          </List>
+        </SourceFile>
+      </Output>,
+    ).toRenderTo(
+      `
+          /**
+           * This is a test
+           * with multiple lines
+           */
+          export interface Foo {
+            knownProp: string;
           }
-          `);
+          `,
+    );
+  });
+  it("declares an interface with @doc", async () => {
+    const program = await getProgram(`
+        namespace DemoService;
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = (namespace as Namespace).models;
+        @doc("This is a test")
+        model Foo {
+          knownProp: string;
+        }
+        `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <For each={Array.from(models.values())} hardline>
-                {(model) => <InterfaceDeclaration export type={model} />}
-              </For>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface ModelForRecord {
-            state: string;
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const models = Array.from((namespace as Namespace).models.values());
+
+    expect(
+      <Output program={program}>
+        <SourceFile path="test.ts">
+          <List hardline>
+            {models.map((model) => (
+              <InterfaceDeclaration export type={model} />
+            ))}
+          </List>
+        </SourceFile>
+      </Output>,
+    ).toRenderTo(
+      `
+          /**
+           * This is a test
+           */
+          export interface Foo {
+            knownProp: string;
           }
+          `,
+    );
+  });
+  it("declares an interface with doc", async () => {
+    const program = await getProgram(`
+        namespace DemoService;
+
+        /**
+         * This is a test
+         */
+        model Foo {
+          @doc("This is a known property")
+          knownProp: string;
+        }
+        `);
+
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const models = Array.from((namespace as Namespace).models.values());
+
+    expect(
+      <Output program={program}>
+        <SourceFile path="test.ts">
+          <List hardline>
+            {models.map((model) => (
+              <InterfaceDeclaration export type={model} />
+            ))}
+          </List>
+        </SourceFile>
+      </Output>,
+    ).toRenderTo(
+      `
+          /**
+           * This is a test
+           */
+          export interface Foo {
+            /**
+             * This is a known property
+             */
+            knownProp: string;
+          }
+          `,
+    );
+  });
+  describe("Bound to Model", () => {
+    it("creates an interface that extends a model for Record spread", async () => {
+      const program = await getProgram(`
+        namespace DemoService;
+
+        model DifferentSpreadModelRecord {
+          knownProp: string;
+          ...Record<unknown>;
+        }
+        `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <List hardline>
+              {models.map((model) => (
+                <InterfaceDeclaration export type={model} />
+              ))}
+            </List>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
           export interface DifferentSpreadModelRecord {
             knownProp: string;
-            additionalProperties?: Record<string, ModelForRecord>;
-          }
-          export interface DifferentSpreadModelDerived extends DifferentSpreadModelRecord {
-            derivedProp: ModelForRecord;
-            additionalProperties?: Record<string, ModelForRecord>;
-          }`);
-      });
-
-      it("creates an interface that has additional properties", async () => {
-        const program = await getProgram(`
-          namespace DemoService;
-          model Widget extends Record<unknown> {
-            id: string;
-            weight: int32;
-            color: "blue" | "red";
-          }
-          `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              {models.map((model) => (
-                <InterfaceDeclaration export type={model} />
-              ))}
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface Widget {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
             additionalProperties?: Record<string, unknown>;
-          }`);
-      });
-
-      it("handles a type reference to a union variant", async () => {
-        const program = await getProgram(`
-          namespace DemoService;
-
-          union Color {
-            red: "RED",
-            blue: "BLUE"
-          }
-      
-          model Widget{
-            id: string;
-            weight: int32;
-            color: Color.blue
           }
           `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration type={models[0]} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          interface Widget {
-            id: string;
-            weight: number;
-            color: "BLUE";
-          }`);
-      });
-      it("creates an interface", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-    
-        model Widget{
-          id: string;
-          weight: int32;
-          color: "blue" | "red";
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration type={models[0]} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          interface Widget {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
-          }`);
-      });
-
-      it("renders an empty interface with a never-typed member", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-    
-        model Widget{
-          property: never;
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export type={models[0]} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface Widget {}`);
-      });
-
-      it("can override interface name", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-    
-        model Widget{
-          id: string;
-          weight: int32;
-          color: "blue" | "red";
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export name="MyOperations" type={models[0]} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface MyOperations {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
-          }`);
-      });
-
-      it("can add a members to the interface", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-    
-        model Widget{
-          id: string;
-          weight: int32;
-          color: "blue" | "red";
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export name="MyOperations" type={models[0]}>
-                <hbr />
-                <List>
-                  <>customProperty: string;</>
-                  <>customMethod(): void;</>
-                </List>
-              </InterfaceDeclaration>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface MyOperations {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
-            customProperty: string;
-            customMethod(): void;
-          }`);
-      });
-
-      it("interface name can be customized", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-    
-        model Widget{
-          id: string;
-          weight: int32;
-          color: "blue" | "red";
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export name="MyModel" type={models[0]} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface MyModel {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
-          }`);
-      });
-
-      it("interface with extends", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-    
-        model Widget{
-          id: string;
-          weight: int32;
-          color: "blue" | "red";
-        }
-        
-        model ErrorWidget extends Widget {
-          code: int32;
-          message: string;
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <For each={models}>{(model) => <InterfaceDeclaration export type={model} />}</For>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface Widget {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
-          }
-          export interface ErrorWidget extends Widget {
-            code: number;
-            message: string;
-          }`);
-      });
     });
 
-    describe("Bound to Interface", () => {
-      it("creates an interface", async () => {
-        const program = await getProgram(`
+    it("creates an interface for a model that 'is' an array ", async () => {
+      const program = await getProgram(`
         namespace DemoService;
-    
-        interface WidgetOperations {
-          op getName(id: string): string;
-        }
+
+        model Foo is Array<string>;
         `);
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const interfaces = Array.from((namespace as Namespace).interfaces.values());
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = (namespace as Namespace).models;
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export type={interfaces[0]} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface WidgetOperations {
-            getName(id: string): string;
-          }`);
-      });
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <For each={Array.from(models.values())} hardline>
+              {(model) => <InterfaceDeclaration export type={model} />}
+            </For>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface Foo extends Array<string> {}`);
+    });
 
-      it("should handle spread and non spread model parameters", async () => {
-        const program = await getProgram(`
+    it("creates an interface for a model that 'is' a record ", async () => {
+      const program = await getProgram(`
+        namespace DemoService;
+
+        model Foo is Record<string>;
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = (namespace as Namespace).models;
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <For each={Array.from(models.values())} hardline>
+              {(model) => <InterfaceDeclaration export type={model} />}
+            </For>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface Foo {
+          additionalProperties?: Record<string, string>;
+        }`);
+    });
+
+    it("creates an interface of a model that spreads a Record", async () => {
+      const program = await getProgram(`
         namespace DemoService;
 
         model Foo {
-          name: string
-        }
-    
-        interface WidgetOperations {
-          op getName(foo: Foo): string;
-          op getOtherName(...Foo): string
+          ...Record<string>
         }
         `);
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const interfaces = Array.from((namespace as Namespace).interfaces.values());
-        const models = Array.from((namespace as Namespace).models.values());
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = (namespace as Namespace).models;
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export type={interfaces[0]} />
-              <hbr />
-              <InterfaceDeclaration export type={models[0]} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface WidgetOperations {
-            getName(foo: Foo): string;
-            getOtherName(name: string): string;
-          }
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <For each={Array.from(models.values())} hardline>
+              {(model) => <InterfaceDeclaration export type={model} />}
+            </For>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
           export interface Foo {
-            name: string;
-          }`);
-      });
+            additionalProperties?: Record<string, string>;
+          }
+          `);
+    });
 
-      it("creates an interface with Model references", async () => {
-        const program = await getProgram(`
+    it("creates an interface that extends an spread model", async () => {
+      const program = await getProgram(`
         namespace DemoService;
+
+        model ModelForRecord {
+          state: string;
+        }
+
+        model DifferentSpreadModelRecord {
+          knownProp: string;
+          ...Record<ModelForRecord>;
+        }
+
+        model DifferentSpreadModelDerived extends DifferentSpreadModelRecord {
+          derivedProp: ModelForRecord;
+        }
+        `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = (namespace as Namespace).models;
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <For each={Array.from(models.values())} hardline>
+              {(model) => <InterfaceDeclaration export type={model} />}
+            </For>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface ModelForRecord {
+          state: string;
+        }
+        export interface DifferentSpreadModelRecord {
+          knownProp: string;
+          additionalProperties?: Record<string, ModelForRecord>;
+        }
+        export interface DifferentSpreadModelDerived extends DifferentSpreadModelRecord {
+          derivedProp: ModelForRecord;
+          additionalProperties?: Record<string, ModelForRecord>;
+        }`);
+    });
+
+    it("creates an interface that has additional properties", async () => {
+      const program = await getProgram(`
+        namespace DemoService;
+        model Widget extends Record<unknown> {
+          id: string;
+          weight: int32;
+          color: "blue" | "red";
+        }
+        `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            {models.map((model) => (
+              <InterfaceDeclaration export type={model} />
+            ))}
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface Widget {
+          id: string;
+          weight: number;
+          color: "blue" | "red";
+          additionalProperties?: Record<string, unknown>;
+        }`);
+    });
+
+    it("handles a type reference to a union variant", async () => {
+      const program = await getProgram(`
+        namespace DemoService;
+
+        union Color {
+          red: "RED",
+          blue: "BLUE"
+        }
     
+        model Widget{
+          id: string;
+          weight: int32;
+          color: Color.blue
+        }
+        `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration type={models[0]} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        interface Widget {
+          id: string;
+          weight: number;
+          color: "BLUE";
+        }`);
+    });
+    it("creates an interface", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      model Widget{
+        id: string;
+        weight: int32;
+        color: "blue" | "red";
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration type={models[0]} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        interface Widget {
+          id: string;
+          weight: number;
+          color: "blue" | "red";
+        }`);
+    });
+
+    it("renders an empty interface with a never-typed member", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      model Widget{
+        property: never;
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export type={models[0]} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface Widget {}`);
+    });
+
+    it("can override interface name", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      model Widget{
+        id: string;
+        weight: int32;
+        color: "blue" | "red";
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export name="MyOperations" type={models[0]} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface MyOperations {
+          id: string;
+          weight: number;
+          color: "blue" | "red";
+        }`);
+    });
+
+    it("can add a members to the interface", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      model Widget{
+        id: string;
+        weight: int32;
+        color: "blue" | "red";
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export name="MyOperations" type={models[0]}>
+              <hbr />
+              <List>
+                <>customProperty: string;</>
+                <>customMethod(): void;</>
+              </List>
+            </InterfaceDeclaration>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface MyOperations {
+          id: string;
+          weight: number;
+          color: "blue" | "red";
+          customProperty: string;
+          customMethod(): void;
+        }`);
+    });
+
+    it("interface name can be customized", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      model Widget{
+        id: string;
+        weight: int32;
+        color: "blue" | "red";
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export name="MyModel" type={models[0]} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface MyModel {
+          id: string;
+          weight: number;
+          color: "blue" | "red";
+        }`);
+    });
+
+    it("interface with extends", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      model Widget{
+        id: string;
+        weight: int32;
+        color: "blue" | "red";
+      }
+      
+      model ErrorWidget extends Widget {
+        code: int32;
+        message: string;
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <For each={models}>{(model) => <InterfaceDeclaration export type={model} />}</For>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface Widget {
+          id: string;
+          weight: number;
+          color: "blue" | "red";
+        }
+        export interface ErrorWidget extends Widget {
+          code: number;
+          message: string;
+        }`);
+    });
+  });
+
+  describe("Bound to Interface", () => {
+    it("creates an interface", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      interface WidgetOperations {
+        op getName(id: string): string;
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const interfaces = Array.from((namespace as Namespace).interfaces.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export type={interfaces[0]} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface WidgetOperations {
+          getName(id: string): string;
+        }`);
+    });
+
+    it("should handle spread and non spread model parameters", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+
+      model Foo {
+        name: string
+      }
+  
+      interface WidgetOperations {
+        op getName(foo: Foo): string;
+        op getOtherName(...Foo): string
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const interfaces = Array.from((namespace as Namespace).interfaces.values());
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export type={interfaces[0]} />
+            <hbr />
+            <InterfaceDeclaration export type={models[0]} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface WidgetOperations {
+          getName(foo: Foo): string;
+          getOtherName(name: string): string;
+        }
+        export interface Foo {
+          name: string;
+        }`);
+    });
+
+    it("creates an interface with Model references", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      /**
+       * Operations for Widget
+       */
+      interface WidgetOperations {
+        /**
+         * Get the name of the widget
+         */
+        op getName(
+          /**
+           * The id of the widget
+           */
+           id: string
+        ): Widget;
+      }
+
+      model Widget {
+        id: string;
+        weight: int32;
+        color: "blue" | "red";
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const interfaces = Array.from((namespace as Namespace).interfaces.values());
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export type={interfaces[0]} />
+            <hbr />
+            <For each={models}>{(model) => <InterfaceDeclaration export type={model} />}</For>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
         /**
          * Operations for Widget
          */
-        interface WidgetOperations {
+        export interface WidgetOperations {
           /**
            * Get the name of the widget
+           *
+           * @param {string} id - The id of the widget
            */
-          op getName(
-            /**
-             * The id of the widget
-             */
-             id: string
-          ): Widget;
+          getName(id: string): Widget;
         }
-
-        model Widget {
+        export interface Widget {
           id: string;
-          weight: int32;
+          weight: number;
           color: "blue" | "red";
+        }`);
+    });
+
+    it("creates an interface that extends another", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+  
+      interface WidgetOperations {
+        op getName(id: string): Widget;
+      }
+
+      interface WidgetOperationsExtended extends WidgetOperations{
+        op delete(id: string): void;
+      }
+
+      model Widget {
+        id: string;
+        weight: int32;
+        color: "blue" | "red";
+      }
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const interfaces = Array.from((namespace as Namespace).interfaces.values());
+      const models = Array.from((namespace as Namespace).models.values());
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <InterfaceDeclaration export type={interfaces[1]} />
+            <hbr />
+            <For each={models}>{(model) => <InterfaceDeclaration export type={model} />}</For>
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
+        export interface WidgetOperationsExtended {
+          getName(id: string): Widget;
+          delete(id: string): void;
         }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const interfaces = Array.from((namespace as Namespace).interfaces.values());
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export type={interfaces[0]} />
-              <hbr />
-              <For each={models}>{(model) => <InterfaceDeclaration export type={model} />}</For>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          /**
-           * Operations for Widget
-           */
-          export interface WidgetOperations {
-            /**
-             * Get the name of the widget
-             *
-             * @param {string} id - The id of the widget
-             */
-            getName(id: string): Widget;
-          }
-          export interface Widget {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
-          }`);
-      });
-
-      it("creates an interface that extends another", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-    
-        interface WidgetOperations {
-          op getName(id: string): Widget;
-        }
-
-        interface WidgetOperationsExtended extends WidgetOperations{
-          op delete(id: string): void;
-        }
-
-        model Widget {
+        export interface Widget {
           id: string;
-          weight: int32;
+          weight: number;
           color: "blue" | "red";
-        }
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const interfaces = Array.from((namespace as Namespace).interfaces.values());
-        const models = Array.from((namespace as Namespace).models.values());
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <InterfaceDeclaration export type={interfaces[1]} />
-              <hbr />
-              <For each={models}>{(model) => <InterfaceDeclaration export type={model} />}</For>
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          export interface WidgetOperationsExtended {
-            getName(id: string): Widget;
-            delete(id: string): void;
-          }
-          export interface Widget {
-            id: string;
-            weight: number;
-            color: "blue" | "red";
-          }`);
-      });
+        }`);
     });
   });
 });

--- a/packages/emitter-framework/test/typescript/components/type-alias-declaration.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/type-alias-declaration.test.tsx
@@ -7,148 +7,146 @@ import { describe, expect, it } from "vitest";
 import { Output } from "../../../src/core/components/output.jsx";
 import { TypeAliasDeclaration } from "../../../src/typescript/components/type-alias-declaration.jsx";
 
-describe("Typescript Type Alias Declaration", () => {
-  describe("Type Alias bound to Typespec Scalar", () => {
-    describe("Scalar extends utcDateTime", () => {
-      it("creates a type alias declaration for a utcDateTime without encoding", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        scalar MyDate extends utcDateTime;
-        `);
+describe("Type Alias bound to Typespec Scalar", () => {
+  describe("Scalar extends utcDateTime", () => {
+    it("creates a type alias declaration for a utcDateTime without encoding", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      scalar MyDate extends utcDateTime;
+      `);
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const scalar = Array.from((namespace as Namespace).scalars.values())[0];
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`type MyDate = Date;`);
-      });
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <TypeAliasDeclaration type={scalar} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`type MyDate = Date;`);
+    });
 
-      it("creates a type alias declaration with JSDoc", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
+    it("creates a type alias declaration with JSDoc", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      /**
+       * Type to represent a date
+       */
+      scalar MyDate extends utcDateTime;
+      `);
+
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const scalar = Array.from((namespace as Namespace).scalars.values())[0];
+
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <TypeAliasDeclaration type={scalar} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
         /**
          * Type to represent a date
          */
-        scalar MyDate extends utcDateTime;
-        `);
+        type MyDate = Date;`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const scalar = Array.from((namespace as Namespace).scalars.values())[0];
+    it("can override JSDoc", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      /**
+       * Type to represent a date
+       */
+      scalar MyDate extends utcDateTime;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          /**
-           * Type to represent a date
-           */
-          type MyDate = Date;`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-      it("can override JSDoc", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <TypeAliasDeclaration doc={"Overridden Doc"} type={scalar} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`
         /**
-         * Type to represent a date
+         * Overridden Doc
          */
-        scalar MyDate extends utcDateTime;
-        `);
+        type MyDate = Date;`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const scalar = Array.from((namespace as Namespace).scalars.values())[0];
+    it("creates a type alias declaration for a utcDateTime with unixTimeStamp encoding", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      @encode("unixTimestamp", int32)
+      scalar MyDate extends utcDateTime;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <TypeAliasDeclaration doc={"Overridden Doc"} type={scalar} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`
-          /**
-           * Overridden Doc
-           */
-          type MyDate = Date;`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-      it("creates a type alias declaration for a utcDateTime with unixTimeStamp encoding", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        @encode("unixTimestamp", int32)
-        scalar MyDate extends utcDateTime;
-        `);
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <TypeAliasDeclaration type={scalar} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`type MyDate = Date;`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const scalar = Array.from((namespace as Namespace).scalars.values())[0];
+    it("creates a type alias declaration for a utcDateTime with rfc7231 encoding", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      @encode("rfc7231")
+      scalar MyDate extends utcDateTime;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`type MyDate = Date;`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-      it("creates a type alias declaration for a utcDateTime with rfc7231 encoding", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        @encode("rfc7231")
-        scalar MyDate extends utcDateTime;
-        `);
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <TypeAliasDeclaration type={scalar} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`type MyDate = Date;`);
+    });
 
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const scalar = Array.from((namespace as Namespace).scalars.values())[0];
+    it("creates a type alias declaration for a utcDateTime with rfc3339 encoding", async () => {
+      const program = await getProgram(`
+      namespace DemoService;
+      @encode("rfc3339")
+      scalar MyDate extends utcDateTime;
+      `);
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`type MyDate = Date;`);
-      });
+      const [namespace] = program.resolveTypeReference("DemoService");
+      const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-      it("creates a type alias declaration for a utcDateTime with rfc3339 encoding", async () => {
-        const program = await getProgram(`
-        namespace DemoService;
-        @encode("rfc3339")
-        scalar MyDate extends utcDateTime;
-        `);
-
-        const [namespace] = program.resolveTypeReference("DemoService");
-        const scalar = Array.from((namespace as Namespace).scalars.values())[0];
-
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <TypeAliasDeclaration export type={scalar} />
-            </SourceFile>
-          </Output>,
-        ).toRenderTo(`export type MyDate = Date;`);
-      });
+      expect(
+        <Output program={program}>
+          <SourceFile path="test.ts">
+            <TypeAliasDeclaration export type={scalar} />
+          </SourceFile>
+        </Output>,
+      ).toRenderTo(`export type MyDate = Date;`);
     });
   });
+});
 
-  it("creates a type alias of a function", async () => {
-    const runner = await Tester.createInstance();
-    const { getName } = await runner.compile(t.code`
-      @test op  ${t.op("getName")}(id: string): string;
-    `);
+it("creates a type alias of a function", async () => {
+  const runner = await Tester.createInstance();
+  const { getName } = await runner.compile(t.code`
+    @test op  ${t.op("getName")}(id: string): string;
+  `);
 
-    expect(
-      <Output program={runner.program}>
-        <SourceFile path="test.ts">
-          <TypeAliasDeclaration type={getName} />
-        </SourceFile>
-      </Output>,
-    ).toRenderTo("type getName = (id: string) => string;");
-  });
+  expect(
+    <Output program={runner.program}>
+      <SourceFile path="test.ts">
+        <TypeAliasDeclaration type={getName} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo("type getName = (id: string) => string;");
 });

--- a/packages/html-program-viewer/src/react/js-inspector/js-value/js-value.test.tsx
+++ b/packages/html-program-viewer/src/react/js-inspector/js-value/js-value.test.tsx
@@ -1,28 +1,26 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { JsValue } from "./js-value.js";
 
-describe("render values", () => {
-  it.each([
-    [undefined, "undefined"],
-    [null, "null"],
-    [123, "123"],
-    [123.456, "123.456"],
-    [123n, "123n"],
-    ["abc", `"abc"`],
-    [true, "true"],
+it.each([
+  [undefined, "undefined"],
+  [null, "null"],
+  [123, "123"],
+  [123.456, "123.456"],
+  [123n, "123n"],
+  ["abc", `"abc"`],
+  [true, "true"],
 
-    [/[a-z]+/, "/[a-z]+/"],
-    [
-      new Date("2022-04-01T01:02:32Z"),
-      "Fri Apr 01 2022 01:02:32 GMT+0000 (Coordinated Universal Time)",
-    ],
-    [{}, "Object"],
-    [{ name: "abc" }, "Object"],
-    [[1, 2], "Array(2)"],
-    [Symbol("abc"), "Symbol(abc)"],
-  ])("render %s as '%s'", (value, expected) => {
-    const { container } = render(<JsValue value={value} />);
-    expect(container).toHaveTextContent(expected);
-  });
+  [/[a-z]+/, "/[a-z]+/"],
+  [
+    new Date("2022-04-01T01:02:32Z"),
+    "Fri Apr 01 2022 01:02:32 GMT+0000 (Coordinated Universal Time)",
+  ],
+  [{}, "Object"],
+  [{ name: "abc" }, "Object"],
+  [[1, 2], "Array(2)"],
+  [Symbol("abc"), "Symbol(abc)"],
+])("render %s as '%s'", (value, expected) => {
+  const { container } = render(<JsValue value={value} />);
+  expect(container).toHaveTextContent(expected);
 });

--- a/packages/html-program-viewer/src/react/tree-navigation.test.tsx
+++ b/packages/html-program-viewer/src/react/tree-navigation.test.tsx
@@ -1,22 +1,20 @@
 import { render, screen } from "@testing-library/react";
 import type { Type } from "@typespec/compiler";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { NodeIcon } from "./tree-navigation.js";
 
-describe("NodeIcon", () => {
-  it("falls back when type kind is missing", () => {
-    render(
-      <NodeIcon
-        node={{
-          kind: "type",
-          id: "$.broken",
-          name: "broken",
-          type: { kind: undefined } as unknown as Type,
-          children: [],
-        }}
-      />,
-    );
+it("falls back when type kind is missing", () => {
+  render(
+    <NodeIcon
+      node={{
+        kind: "type",
+        id: "$.broken",
+        name: "broken",
+        type: { kind: undefined } as unknown as Type,
+        children: [],
+      }}
+    />,
+  );
 
-    expect(screen.getByText("?")).toBeDefined();
-  });
+  expect(screen.getByText("?")).toBeDefined();
 });

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
@@ -12,7 +12,7 @@ import {
   HttpCanonicalizer,
   type OperationHttpCanonicalization,
 } from "@typespec/http-canonicalization";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { ControllerAction } from "./controller-action.jsx";
 
 let runner: TesterInstance;
@@ -37,64 +37,62 @@ function canonicalizeOp(opType: any): OperationHttpCanonicalization {
   return canonicalizer.canonicalize(opType) as OperationHttpCanonicalization;
 }
 
-describe("ControllerAction", () => {
-  it("renders a GET action", async () => {
-    const { listPets } = await runner.compile(t.code`
-      interface PetStore {
-        @route("/pets") @get ${t.op("listPets")}(): string[];
-      }
-    `);
+it("renders a GET action", async () => {
+  const { listPets } = await runner.compile(t.code`
+    interface PetStore {
+      @route("/pets") @get ${t.op("listPets")}(): string[];
+    }
+  `);
 
-    const canonOp = canonicalizeOp(listPets);
+  const canonOp = canonicalizeOp(listPets);
 
-    expect(
-      <Wrapper>
-        <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
-      </Wrapper>,
-    ).toRenderTo(`
-      using Microsoft.AspNetCore.Mvc;
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
 
-      class TestController
-      {
-          [HttpGet]
-          [Route("/pets")]
-          [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string[]))]
-          public virtual async Task<IActionResult> ListPets()
-          {
-              var result = await PetStoreImpl.ListPetsAsync();
-              return Ok(result);
-          }
-      }
-    `);
-  });
+    class TestController
+    {
+        [HttpGet]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string[]))]
+        public virtual async Task<IActionResult> ListPets()
+        {
+            var result = await PetStoreImpl.ListPetsAsync();
+            return Ok(result);
+        }
+    }
+  `);
+});
 
-  it("renders a DELETE action with path param", async () => {
-    const { deletePet } = await runner.compile(t.code`
-      interface PetStore {
-        @route("/pets/{petId}") @delete ${t.op("deletePet")}(@path petId: string): void;
-      }
-    `);
+it("renders a DELETE action with path param", async () => {
+  const { deletePet } = await runner.compile(t.code`
+    interface PetStore {
+      @route("/pets/{petId}") @delete ${t.op("deletePet")}(@path petId: string): void;
+    }
+  `);
 
-    const canonOp = canonicalizeOp(deletePet);
+  const canonOp = canonicalizeOp(deletePet);
 
-    expect(
-      <Wrapper>
-        <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
-      </Wrapper>,
-    ).toRenderTo(`
-      using Microsoft.AspNetCore.Mvc;
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
 
-      class TestController
-      {
-          [HttpDelete]
-          [Route("/pets/{petId}")]
-          [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
-          public virtual async Task<IActionResult> DeletePet(string petId)
-          {
-              await PetStoreImpl.DeletePetAsync(petId);
-              return NoContent();
-          }
-      }
-    `);
-  });
+    class TestController
+    {
+        [HttpDelete]
+        [Route("/pets/{petId}")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
+        public virtual async Task<IActionResult> DeletePet(string petId)
+        {
+            await PetStoreImpl.DeletePetAsync(petId);
+            return NoContent();
+        }
+    }
+  `);
 });

--- a/packages/http-server-csharp/src/components/controllers/controllers.test.tsx
+++ b/packages/http-server-csharp/src/components/controllers/controllers.test.tsx
@@ -8,7 +8,7 @@ import {
   HttpCanonicalizer,
   type OperationHttpCanonicalization,
 } from "@typespec/http-canonicalization";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { BusinessLogicInterface } from "../interfaces/interfaces.jsx";
 import { Controller } from "./controllers.jsx";
 
@@ -32,47 +32,45 @@ function canonicalizeOp(opType: any): OperationHttpCanonicalization {
   return canonicalizer.canonicalize(opType) as OperationHttpCanonicalization;
 }
 
-describe("Controller", () => {
-  it("renders a controller class with an action method", async () => {
-    const { PetStore, listPets } = await runner.compile(t.code`
-      interface ${t.interface("PetStore")} {
-        @route("/pets") @get ${t.op("listPets")}(): string[];
-      }
-    `);
+it("renders a controller class with an action method", async () => {
+  const { PetStore, listPets } = await runner.compile(t.code`
+    interface ${t.interface("PetStore")} {
+      @route("/pets") @get ${t.op("listPets")}(): string[];
+    }
+  `);
 
-    const canonOp = canonicalizeOp(listPets);
+  const canonOp = canonicalizeOp(listPets);
 
-    expect(
-      <Wrapper>
-        <BusinessLogicInterface type={PetStore} />
-        {"\n"}
-        <Controller type={PetStore} operations={[canonOp]} />
-      </Wrapper>,
-    ).toRenderTo(`
-      using Microsoft.AspNetCore.Mvc;
+  expect(
+    <Wrapper>
+      <BusinessLogicInterface type={PetStore} />
+      {"\n"}
+      <Controller type={PetStore} operations={[canonOp]} />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
 
-      public interface IPetStore
-      {
-          Task<string[]> ListPetsAsync();
-      }
-      [ApiController]
-      public partial class PetStoreController : ControllerBase
-      {
-          internal virtual IPetStore PetStoreImpl { get; }
-          public PetStoreController(IPetStore operations)
-          {
-              PetStoreImpl = operations;
-          }
+    public interface IPetStore
+    {
+        Task<string[]> ListPetsAsync();
+    }
+    [ApiController]
+    public partial class PetStoreController : ControllerBase
+    {
+        internal virtual IPetStore PetStoreImpl { get; }
+        public PetStoreController(IPetStore operations)
+        {
+            PetStoreImpl = operations;
+        }
 
-          [HttpGet]
-          [Route("/pets")]
-          [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string[]))]
-          public virtual async Task<IActionResult> ListPets()
-          {
-              var result = await PetStoreImpl.ListPetsAsync();
-              return Ok(result);
-          }
-      }
-    `);
-  });
+        [HttpGet]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string[]))]
+        public virtual async Task<IActionResult> ListPets()
+        {
+            var result = await PetStoreImpl.ListPetsAsync();
+            return Ok(result);
+        }
+    }
+  `);
 });

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
@@ -3,7 +3,7 @@ import { type Children } from "@alloy-js/core";
 import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { Output } from "@typespec/emitter-framework";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { BusinessLogicInterface } from "./interfaces.jsx";
 
 let runner: TesterInstance;
@@ -21,45 +21,43 @@ function Wrapper(props: { children: Children }) {
   );
 }
 
-describe("BusinessLogicInterface", () => {
-  it("renders an interface with async methods", async () => {
-    const { PetStore } = await runner.compile(t.code`
-      interface ${t.interface("PetStore")} {
-        listPets(): string[];
-        getPet(petId: string): string;
-      }
-    `);
+it("renders an interface with async methods", async () => {
+  const { PetStore } = await runner.compile(t.code`
+    interface ${t.interface("PetStore")} {
+      listPets(): string[];
+      getPet(petId: string): string;
+    }
+  `);
 
-    expect(
-      <Wrapper>
-        <BusinessLogicInterface type={PetStore} />
-      </Wrapper>,
-    ).toRenderTo(`
-      public interface IPetStore
-      {
-          Task<string[]> ListPetsAsync();
+  expect(
+    <Wrapper>
+      <BusinessLogicInterface type={PetStore} />
+    </Wrapper>,
+  ).toRenderTo(`
+    public interface IPetStore
+    {
+        Task<string[]> ListPetsAsync();
 
-          Task<string> GetPetAsync(string petId);
-      }
-    `);
-  });
+        Task<string> GetPetAsync(string petId);
+    }
+  `);
+});
 
-  it("renders an interface with void return type", async () => {
-    const { PetStore } = await runner.compile(t.code`
-      interface ${t.interface("PetStore")} {
-        deletePet(petId: string): void;
-      }
-    `);
+it("renders an interface with void return type", async () => {
+  const { PetStore } = await runner.compile(t.code`
+    interface ${t.interface("PetStore")} {
+      deletePet(petId: string): void;
+    }
+  `);
 
-    expect(
-      <Wrapper>
-        <BusinessLogicInterface type={PetStore} />
-      </Wrapper>,
-    ).toRenderTo(`
-      public interface IPetStore
-      {
-          Task DeletePetAsync(string petId);
-      }
-    `);
-  });
+  expect(
+    <Wrapper>
+      <BusinessLogicInterface type={PetStore} />
+    </Wrapper>,
+  ).toRenderTo(`
+    public interface IPetStore
+    {
+        Task DeletePetAsync(string petId);
+    }
+  `);
 });

--- a/packages/http-server-csharp/src/components/models/models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/models.test.tsx
@@ -4,7 +4,7 @@ import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { Output } from "@typespec/emitter-framework";
 import { ClassDeclaration } from "@typespec/emitter-framework/csharp";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 
 let runner: TesterInstance;
 
@@ -21,110 +21,108 @@ function Wrapper(props: { children: Children }) {
   );
 }
 
-describe("ClassDeclaration for models", () => {
-  it("renders a simple model with properties", async () => {
-    const { Pet } = await runner.compile(t.code`
-      model ${t.model("Pet")} {
-        name: string;
-        age: int32;
-      }
-    `);
+it("renders a simple model with properties", async () => {
+  const { Pet } = await runner.compile(t.code`
+    model ${t.model("Pet")} {
+      name: string;
+      age: int32;
+    }
+  `);
 
-    expect(
-      <Wrapper>
-        <ClassDeclaration type={Pet} jsonAttributes />
-      </Wrapper>,
-    ).toRenderTo(`
-      using System.Text.Json.Serialization;
+  expect(
+    <Wrapper>
+      <ClassDeclaration type={Pet} jsonAttributes />
+    </Wrapper>,
+  ).toRenderTo(`
+    using System.Text.Json.Serialization;
 
-      class Pet
-      {
-          [JsonPropertyName("name")]
-          public required string Name { get; set; }
+    class Pet
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
 
-          [JsonPropertyName("age")]
-          public required int Age { get; set; }
-      }
-    `);
-  });
+        [JsonPropertyName("age")]
+        public required int Age { get; set; }
+    }
+  `);
+});
 
-  it("renders a model with optional property", async () => {
-    const { Pet } = await runner.compile(t.code`
-      model ${t.model("Pet")} {
-        name: string;
-        tag?: string;
-      }
-    `);
+it("renders a model with optional property", async () => {
+  const { Pet } = await runner.compile(t.code`
+    model ${t.model("Pet")} {
+      name: string;
+      tag?: string;
+    }
+  `);
 
-    expect(
-      <Wrapper>
-        <ClassDeclaration type={Pet} jsonAttributes />
-      </Wrapper>,
-    ).toRenderTo(`
-      using System.Text.Json.Serialization;
+  expect(
+    <Wrapper>
+      <ClassDeclaration type={Pet} jsonAttributes />
+    </Wrapper>,
+  ).toRenderTo(`
+    using System.Text.Json.Serialization;
 
-      class Pet
-      {
-          [JsonPropertyName("name")]
-          public required string Name { get; set; }
+    class Pet
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
 
-          [JsonPropertyName("tag")]
-          public string? Tag { get; set; }
-      }
-    `);
-  });
+        [JsonPropertyName("tag")]
+        public string? Tag { get; set; }
+    }
+  `);
+});
 
-  it("renders a model with inheritance", async () => {
-    const { Pet, Dog } = await runner.compile(t.code`
-      model ${t.model("Pet")} {
-        name: string;
-      }
-      model ${t.model("Dog")} extends Pet {
-        breed: string;
-      }
-    `);
+it("renders a model with inheritance", async () => {
+  const { Pet, Dog } = await runner.compile(t.code`
+    model ${t.model("Pet")} {
+      name: string;
+    }
+    model ${t.model("Dog")} extends Pet {
+      breed: string;
+    }
+  `);
 
-    expect(
-      <Wrapper>
-        <ClassDeclaration type={Pet} jsonAttributes />
-        <hbr />
-        <ClassDeclaration type={Dog} jsonAttributes />
-      </Wrapper>,
-    ).toRenderTo(`
-      using System.Text.Json.Serialization;
+  expect(
+    <Wrapper>
+      <ClassDeclaration type={Pet} jsonAttributes />
+      <hbr />
+      <ClassDeclaration type={Dog} jsonAttributes />
+    </Wrapper>,
+  ).toRenderTo(`
+    using System.Text.Json.Serialization;
 
-      class Pet
-      {
-          [JsonPropertyName("name")]
-          public required string Name { get; set; }
-      }
-      class Dog : Pet
-      {
-          [JsonPropertyName("breed")]
-          public required string Breed { get; set; }
-      }
-    `);
-  });
+    class Pet
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
+    }
+    class Dog : Pet
+    {
+        [JsonPropertyName("breed")]
+        public required string Breed { get; set; }
+    }
+  `);
+});
 
-  it("renders a model with nullable union property", async () => {
-    const { Pet } = await runner.compile(t.code`
-      model ${t.model("Pet")} {
-        name: string | null;
-      }
-    `);
+it("renders a model with nullable union property", async () => {
+  const { Pet } = await runner.compile(t.code`
+    model ${t.model("Pet")} {
+      name: string | null;
+    }
+  `);
 
-    expect(
-      <Wrapper>
-        <ClassDeclaration type={Pet} jsonAttributes />
-      </Wrapper>,
-    ).toRenderTo(`
-      using System.Text.Json.Serialization;
+  expect(
+    <Wrapper>
+      <ClassDeclaration type={Pet} jsonAttributes />
+    </Wrapper>,
+  ).toRenderTo(`
+    using System.Text.Json.Serialization;
 
-      class Pet
-      {
-          [JsonPropertyName("name")]
-          public required string? Name { get; set; }
-      }
-    `);
-  });
+    class Pet
+    {
+        [JsonPropertyName("name")]
+        public required string? Name { get; set; }
+    }
+  `);
 });

--- a/packages/http-server-csharp/src/components/project/csproj.test.tsx
+++ b/packages/http-server-csharp/src/components/project/csproj.test.tsx
@@ -1,5 +1,5 @@
 import { Output, render } from "@alloy-js/core";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { Csproj } from "./csproj.jsx";
 
 function getFileContent(output: any, path: string): string | undefined {
@@ -11,28 +11,26 @@ function getFileContent(output: any, path: string): string | undefined {
   return undefined;
 }
 
-describe("Csproj", () => {
-  it("renders a basic .csproj file", () => {
-    const output = render(
-      <Output>
-        <Csproj projectName="TestProject" />
-      </Output>,
-    );
-    const content = getFileContent(output, "TestProject.csproj");
-    expect(content).toBeDefined();
-    expect(content).toContain("Microsoft.NET.Sdk.Web");
-    expect(content).toContain("<TargetFramework>net9.0</TargetFramework>");
-    expect(content).toContain("<Nullable>enable</Nullable>");
-  });
+it("renders a basic .csproj file", () => {
+  const output = render(
+    <Output>
+      <Csproj projectName="TestProject" />
+    </Output>,
+  );
+  const content = getFileContent(output, "TestProject.csproj");
+  expect(content).toBeDefined();
+  expect(content).toContain("Microsoft.NET.Sdk.Web");
+  expect(content).toContain("<TargetFramework>net9.0</TargetFramework>");
+  expect(content).toContain("<Nullable>enable</Nullable>");
+});
 
-  it("includes SwaggerUI package when enabled", () => {
-    const output = render(
-      <Output>
-        <Csproj projectName="TestProject" useSwaggerUI />
-      </Output>,
-    );
-    const content = getFileContent(output, "TestProject.csproj");
-    expect(content).toBeDefined();
-    expect(content).toContain("SwashBuckle.AspNetCore");
-  });
+it("includes SwaggerUI package when enabled", () => {
+  const output = render(
+    <Output>
+      <Csproj projectName="TestProject" useSwaggerUI />
+    </Output>,
+  );
+  const content = getFileContent(output, "TestProject.csproj");
+  expect(content).toBeDefined();
+  expect(content).toContain("SwashBuckle.AspNetCore");
 });

--- a/packages/http-server-csharp/src/components/project/program.test.tsx
+++ b/packages/http-server-csharp/src/components/project/program.test.tsx
@@ -1,5 +1,5 @@
 import { Output, render } from "@alloy-js/core";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { ProgramCs } from "./program.jsx";
 
 function getFileContent(output: any, path: string): string | undefined {
@@ -11,37 +11,35 @@ function getFileContent(output: any, path: string): string | undefined {
   return undefined;
 }
 
-describe("ProgramCs", () => {
-  it("renders Program.cs without swagger", () => {
-    const output = render(
-      <Output>
-        <ProgramCs />
-      </Output>,
-    );
-    const content = getFileContent(output, "Program.cs");
-    expect(content).toBeDefined();
-    expect(content).toContain("var builder = WebApplication.CreateBuilder(args);");
-  });
+it("renders Program.cs without swagger", () => {
+  const output = render(
+    <Output>
+      <ProgramCs />
+    </Output>,
+  );
+  const content = getFileContent(output, "Program.cs");
+  expect(content).toBeDefined();
+  expect(content).toContain("var builder = WebApplication.CreateBuilder(args);");
+});
 
-  it("renders Program.cs with swagger", () => {
-    const output = render(
-      <Output>
-        <ProgramCs useSwaggerUI openApiPath="openapi/spec.yaml" />
-      </Output>,
-    );
-    const content = getFileContent(output, "Program.cs");
-    expect(content).toBeDefined();
-    expect(content).toContain("builder.Services.AddSwaggerGen()");
-  });
+it("renders Program.cs with swagger", () => {
+  const output = render(
+    <Output>
+      <ProgramCs useSwaggerUI openApiPath="openapi/spec.yaml" />
+    </Output>,
+  );
+  const content = getFileContent(output, "Program.cs");
+  expect(content).toBeDefined();
+  expect(content).toContain("builder.Services.AddSwaggerGen()");
+});
 
-  it("renders Program.cs with mocks", () => {
-    const output = render(
-      <Output>
-        <ProgramCs hasMocks />
-      </Output>,
-    );
-    const content = getFileContent(output, "Program.cs");
-    expect(content).toBeDefined();
-    expect(content).toContain("MockRegistration.Register(builder)");
-  });
+it("renders Program.cs with mocks", () => {
+  const output = render(
+    <Output>
+      <ProgramCs hasMocks />
+    </Output>,
+  );
+  const content = getFileContent(output, "Program.cs");
+  expect(content).toBeDefined();
+  expect(content).toContain("MockRegistration.Register(builder)");
 });

--- a/packages/http-server-csharp/src/components/scaffolding/mock-scaffolding.test.tsx
+++ b/packages/http-server-csharp/src/components/scaffolding/mock-scaffolding.test.tsx
@@ -1,5 +1,5 @@
 import { Output, render } from "@alloy-js/core";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { MockHelpers } from "./mock-scaffolding.jsx";
 
 function findFileContent(output: any, pathSuffix: string): string | undefined {
@@ -22,38 +22,36 @@ function findFileContent(output: any, pathSuffix: string): string | undefined {
   return search(output);
 }
 
-describe("MockHelpers", () => {
-  it("renders initializer interface", () => {
-    const output = render(
-      <Output>
-        <MockHelpers interfaceRegistrations={[]} />
-      </Output>,
-    );
-    const content = findFileContent(output, "IInitializer.cs");
-    expect(content).toBeDefined();
-    expect(content).toContain("IInitializer");
-  });
+it("renders initializer interface", () => {
+  const output = render(
+    <Output>
+      <MockHelpers interfaceRegistrations={[]} />
+    </Output>,
+  );
+  const content = findFileContent(output, "IInitializer.cs");
+  expect(content).toBeDefined();
+  expect(content).toContain("IInitializer");
+});
 
-  it("renders initializer implementation", () => {
-    const output = render(
-      <Output>
-        <MockHelpers interfaceRegistrations={[]} />
-      </Output>,
-    );
-    const content = findFileContent(output, "Initializer.cs");
-    expect(content).toBeDefined();
-    expect(content).toContain("class Initializer : IInitializer");
-  });
+it("renders initializer implementation", () => {
+  const output = render(
+    <Output>
+      <MockHelpers interfaceRegistrations={[]} />
+    </Output>,
+  );
+  const content = findFileContent(output, "Initializer.cs");
+  expect(content).toBeDefined();
+  expect(content).toContain("class Initializer : IInitializer");
+});
 
-  it("renders mock registration with interface registrations", () => {
-    const output = render(
-      <Output>
-        <MockHelpers interfaceRegistrations={["IPetStore, MockPetStore"]} />
-      </Output>,
-    );
-    const content = findFileContent(output, "MockRegistration.cs");
-    expect(content).toBeDefined();
-    expect(content).toContain("MockRegistration");
-    expect(content).toContain("IPetStore, MockPetStore");
-  });
+it("renders mock registration with interface registrations", () => {
+  const output = render(
+    <Output>
+      <MockHelpers interfaceRegistrations={["IPetStore, MockPetStore"]} />
+    </Output>,
+  );
+  const content = findFileContent(output, "MockRegistration.cs");
+  expect(content).toBeDefined();
+  expect(content).toContain("MockRegistration");
+  expect(content).toContain("IPetStore, MockPetStore");
 });

--- a/packages/http-server-js/test/datetime.test.ts
+++ b/packages/http-server-js/test/datetime.test.ts
@@ -2,225 +2,223 @@ import { deepStrictEqual, strictEqual, throws } from "assert";
 import { describe, it } from "vitest";
 import { Duration } from "../src/helpers/datetime.js";
 
-describe("datetime", () => {
-  describe("duration", () => {
-    it("parses an ISO8601 duration string", () => {
-      deepStrictEqual(Duration.parseISO8601("P1Y2M3D"), {
-        sign: "+",
-        years: 1,
-        months: 2,
-        weeks: 0,
-        days: 3,
-        hours: 0,
-        minutes: 0,
-        seconds: 0,
+describe("duration", () => {
+  it("parses an ISO8601 duration string", () => {
+    deepStrictEqual(Duration.parseISO8601("P1Y2M3D"), {
+      sign: "+",
+      years: 1,
+      months: 2,
+      weeks: 0,
+      days: 3,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    });
+  });
+
+  it("parses a negative ISO8601 duration string", () => {
+    deepStrictEqual(Duration.parseISO8601("-P1Y2M3D"), {
+      sign: "-",
+      years: 1,
+      months: 2,
+      weeks: 0,
+      days: 3,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    });
+  });
+
+  it("parses a duration string with hours and minutes", () => {
+    deepStrictEqual(Duration.parseISO8601("PT1H2M"), {
+      sign: "+",
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 1,
+      minutes: 2,
+      seconds: 0,
+    });
+  });
+
+  it("parses a duration string with fractional years", () => {
+    deepStrictEqual(Duration.parseISO8601("P1.5Y"), {
+      sign: "+",
+      years: 1.5,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    });
+  });
+
+  it("does not parse an invalid duration string", () => {
+    throws(() => Duration.parseISO8601("1Y2M3D4H"), {
+      message: "Invalid ISO8601 duration: 1Y2M3D4H",
+    });
+  });
+
+  it("does not parse a duration string with too many digits in a component", () => {
+    throws(
+      () =>
+        Duration.parseISO8601(
+          "P123429384502934875023948572039485720394857230948572309485723094857203948572309456789.19821374652345232304958273049582730495827340958720349857452345234529223450928347592834387456928374659238476Y",
+        ),
+      {
+        message:
+          "ISO8601 duration string is too long: P123429384502934875023948572039485720394857230948572309485723094857203948572309456789.19821374652345232304958273049582730495827340958720349857452345234529223450928347592834387456928374659238476Y",
+      },
+    );
+  });
+
+  it("does not parse a duration string with an invalid group", () => {
+    throws(() => Duration.parseISO8601("P1Y2M3D4H5X"), {
+      message: "Invalid ISO8601 duration: P1Y2M3D4H5X",
+    });
+  });
+
+  it("does not parse a duration string with missing group", () => {
+    throws(() => Duration.parseISO8601("P1Y2M3D4H5.5"), {
+      message: "Invalid ISO8601 duration: P1Y2M3D4H5.5",
+    });
+  });
+
+  it("does not parse a duration string with multiple points", () => {
+    throws(() => Duration.parseISO8601("P1.2.3Y"), {
+      message: "Invalid ISO8601 duration: P1.2.3Y",
+    });
+  });
+
+  it("allows comma as decimal separator", () => {
+    deepStrictEqual(Duration.parseISO8601("P1,5Y4.2DT1,005S"), {
+      sign: "+",
+      years: 1.5,
+      months: 0,
+      weeks: 0,
+      days: 4.2,
+      hours: 0,
+      minutes: 0,
+      seconds: 1.005,
+    });
+  });
+
+  it("writes an ISO8601 duration string", () => {
+    const duration: Duration = {
+      sign: "+",
+      years: 1,
+      months: 2,
+      weeks: 3,
+      days: 4,
+      hours: 5,
+      minutes: 6,
+      seconds: 7,
+    };
+
+    strictEqual(Duration.toISO8601(duration), "P1Y2M3W4DT5H6M7S");
+  });
+
+  it("writes a negative ISO8601 duration string", () => {
+    const duration: Duration = {
+      sign: "-",
+      years: 1,
+      months: 2,
+      weeks: 3,
+      days: 4,
+      hours: 5,
+      minutes: 6,
+      seconds: 7,
+    };
+
+    strictEqual(Duration.toISO8601(duration), "-P1Y2M3W4DT5H6M7S");
+  });
+
+  it("writes a duration string with only years", () => {
+    const duration: Duration = {
+      sign: "+",
+      years: 1,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    };
+
+    strictEqual(Duration.toISO8601(duration), "P1Y");
+  });
+
+  it("writes a duration string with only hours", () => {
+    const duration: Duration = {
+      sign: "+",
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 36,
+      minutes: 0,
+      seconds: 0,
+    };
+
+    strictEqual(Duration.toISO8601(duration), "PT36H");
+  });
+
+  it("writes a duration string with fractional amounts", () => {
+    const duration: Duration = {
+      sign: "+",
+      years: 1.5,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 1.005,
+    };
+
+    strictEqual(Duration.toISO8601(duration), "P1.5YT1.005S");
+  });
+
+  it("computes total seconds in durations", () => {
+    const duration = Duration.parseISO8601("PT22H96M60S");
+
+    strictEqual(Duration.totalSeconds(duration), 22 * 60 * 60 + 96 * 60 + 60);
+    strictEqual(Duration.totalSecondsBigInt(duration), 22n * 60n * 60n + 96n * 60n + 60n);
+  });
+
+  it("computes total seconds in durations with fractional amounts", () => {
+    const duration = Duration.parseISO8601("PT1.5H22.005S");
+
+    strictEqual(Duration.totalSeconds(duration), 1.5 * 60 * 60 + 22 + 0.005);
+  });
+
+  it("does not allow total seconds for durations with years, months, weeks, or days", () => {
+    const durations = ["P1Y", "P1M", "P1W", "P1D"].map((iso) => Duration.parseISO8601(iso));
+
+    for (const duration of durations) {
+      throws(() => Duration.totalSeconds(duration), {
+        message:
+          "Cannot calculate total seconds for a duration with years, months, weeks, or days.",
       });
-    });
 
-    it("parses a negative ISO8601 duration string", () => {
-      deepStrictEqual(Duration.parseISO8601("-P1Y2M3D"), {
-        sign: "-",
-        years: 1,
-        months: 2,
-        weeks: 0,
-        days: 3,
-        hours: 0,
-        minutes: 0,
-        seconds: 0,
+      throws(() => Duration.totalSecondsBigInt(duration), {
+        message:
+          "Cannot calculate total seconds for a duration with years, months, weeks, or days.",
       });
-    });
+    }
+  });
 
-    it("parses a duration string with hours and minutes", () => {
-      deepStrictEqual(Duration.parseISO8601("PT1H2M"), {
-        sign: "+",
-        years: 0,
-        months: 0,
-        weeks: 0,
-        days: 0,
-        hours: 1,
-        minutes: 2,
-        seconds: 0,
+  it("does not allow total seconds as bigint for durations with fractional amounts", () => {
+    const durations = ["PT1.5H", "PT1.5M", "PT1.5S", "PT1H1.5M", "PT1H1.5S", "PT1M1.5S"].map(
+      (iso) => Duration.parseISO8601(iso),
+    );
+
+    for (const duration of durations) {
+      throws(() => Duration.totalSecondsBigInt(duration), {
+        message:
+          "Cannot calculate total seconds as a BigInt for a duration with non-integer components.",
       });
-    });
-
-    it("parses a duration string with fractional years", () => {
-      deepStrictEqual(Duration.parseISO8601("P1.5Y"), {
-        sign: "+",
-        years: 1.5,
-        months: 0,
-        weeks: 0,
-        days: 0,
-        hours: 0,
-        minutes: 0,
-        seconds: 0,
-      });
-    });
-
-    it("does not parse an invalid duration string", () => {
-      throws(() => Duration.parseISO8601("1Y2M3D4H"), {
-        message: "Invalid ISO8601 duration: 1Y2M3D4H",
-      });
-    });
-
-    it("does not parse a duration string with too many digits in a component", () => {
-      throws(
-        () =>
-          Duration.parseISO8601(
-            "P123429384502934875023948572039485720394857230948572309485723094857203948572309456789.19821374652345232304958273049582730495827340958720349857452345234529223450928347592834387456928374659238476Y",
-          ),
-        {
-          message:
-            "ISO8601 duration string is too long: P123429384502934875023948572039485720394857230948572309485723094857203948572309456789.19821374652345232304958273049582730495827340958720349857452345234529223450928347592834387456928374659238476Y",
-        },
-      );
-    });
-
-    it("does not parse a duration string with an invalid group", () => {
-      throws(() => Duration.parseISO8601("P1Y2M3D4H5X"), {
-        message: "Invalid ISO8601 duration: P1Y2M3D4H5X",
-      });
-    });
-
-    it("does not parse a duration string with missing group", () => {
-      throws(() => Duration.parseISO8601("P1Y2M3D4H5.5"), {
-        message: "Invalid ISO8601 duration: P1Y2M3D4H5.5",
-      });
-    });
-
-    it("does not parse a duration string with multiple points", () => {
-      throws(() => Duration.parseISO8601("P1.2.3Y"), {
-        message: "Invalid ISO8601 duration: P1.2.3Y",
-      });
-    });
-
-    it("allows comma as decimal separator", () => {
-      deepStrictEqual(Duration.parseISO8601("P1,5Y4.2DT1,005S"), {
-        sign: "+",
-        years: 1.5,
-        months: 0,
-        weeks: 0,
-        days: 4.2,
-        hours: 0,
-        minutes: 0,
-        seconds: 1.005,
-      });
-    });
-
-    it("writes an ISO8601 duration string", () => {
-      const duration: Duration = {
-        sign: "+",
-        years: 1,
-        months: 2,
-        weeks: 3,
-        days: 4,
-        hours: 5,
-        minutes: 6,
-        seconds: 7,
-      };
-
-      strictEqual(Duration.toISO8601(duration), "P1Y2M3W4DT5H6M7S");
-    });
-
-    it("writes a negative ISO8601 duration string", () => {
-      const duration: Duration = {
-        sign: "-",
-        years: 1,
-        months: 2,
-        weeks: 3,
-        days: 4,
-        hours: 5,
-        minutes: 6,
-        seconds: 7,
-      };
-
-      strictEqual(Duration.toISO8601(duration), "-P1Y2M3W4DT5H6M7S");
-    });
-
-    it("writes a duration string with only years", () => {
-      const duration: Duration = {
-        sign: "+",
-        years: 1,
-        months: 0,
-        weeks: 0,
-        days: 0,
-        hours: 0,
-        minutes: 0,
-        seconds: 0,
-      };
-
-      strictEqual(Duration.toISO8601(duration), "P1Y");
-    });
-
-    it("writes a duration string with only hours", () => {
-      const duration: Duration = {
-        sign: "+",
-        years: 0,
-        months: 0,
-        weeks: 0,
-        days: 0,
-        hours: 36,
-        minutes: 0,
-        seconds: 0,
-      };
-
-      strictEqual(Duration.toISO8601(duration), "PT36H");
-    });
-
-    it("writes a duration string with fractional amounts", () => {
-      const duration: Duration = {
-        sign: "+",
-        years: 1.5,
-        months: 0,
-        weeks: 0,
-        days: 0,
-        hours: 0,
-        minutes: 0,
-        seconds: 1.005,
-      };
-
-      strictEqual(Duration.toISO8601(duration), "P1.5YT1.005S");
-    });
-
-    it("computes total seconds in durations", () => {
-      const duration = Duration.parseISO8601("PT22H96M60S");
-
-      strictEqual(Duration.totalSeconds(duration), 22 * 60 * 60 + 96 * 60 + 60);
-      strictEqual(Duration.totalSecondsBigInt(duration), 22n * 60n * 60n + 96n * 60n + 60n);
-    });
-
-    it("computes total seconds in durations with fractional amounts", () => {
-      const duration = Duration.parseISO8601("PT1.5H22.005S");
-
-      strictEqual(Duration.totalSeconds(duration), 1.5 * 60 * 60 + 22 + 0.005);
-    });
-
-    it("does not allow total seconds for durations with years, months, weeks, or days", () => {
-      const durations = ["P1Y", "P1M", "P1W", "P1D"].map((iso) => Duration.parseISO8601(iso));
-
-      for (const duration of durations) {
-        throws(() => Duration.totalSeconds(duration), {
-          message:
-            "Cannot calculate total seconds for a duration with years, months, weeks, or days.",
-        });
-
-        throws(() => Duration.totalSecondsBigInt(duration), {
-          message:
-            "Cannot calculate total seconds for a duration with years, months, weeks, or days.",
-        });
-      }
-    });
-
-    it("does not allow total seconds as bigint for durations with fractional amounts", () => {
-      const durations = ["PT1.5H", "PT1.5M", "PT1.5S", "PT1H1.5M", "PT1H1.5S", "PT1M1.5S"].map(
-        (iso) => Duration.parseISO8601(iso),
-      );
-
-      for (const duration of durations) {
-        throws(() => Duration.totalSecondsBigInt(duration), {
-          message:
-            "Cannot calculate total seconds as a BigInt for a duration with non-integer components.",
-        });
-      }
-    });
+    }
   });
 });

--- a/packages/http-server-js/test/header.test.ts
+++ b/packages/http-server-js/test/header.test.ts
@@ -1,47 +1,45 @@
 import * as http from "node:http";
-import { assert, describe, it } from "vitest";
+import { assert, it } from "vitest";
 import {
   formatContentDispositionAttachment,
   parseHeaderValueParameters,
 } from "../src/helpers/header.js";
 
-describe("headers", () => {
-  it("parses header values with parameters", () => {
-    const { value, params } = parseHeaderValueParameters("text/html; charset=utf-8");
+it("parses header values with parameters", () => {
+  const { value, params } = parseHeaderValueParameters("text/html; charset=utf-8");
 
-    assert.equal(value, "text/html");
-    assert.equal(params.charset, "utf-8");
+  assert.equal(value, "text/html");
+  assert.equal(params.charset, "utf-8");
+});
+
+it("parses a header value with a quoted parameter", () => {
+  const { value, params } = parseHeaderValueParameters('text/html; charset="utf-8"');
+
+  assert.equal(value, "text/html");
+  assert.equal(params.charset, "utf-8");
+});
+
+it("parses a header value with multiple parameters", () => {
+  const { value, params } = parseHeaderValueParameters('text/html; charset="utf-8"; foo=bar');
+
+  assert.equal(value, "text/html");
+  assert.equal(params.charset, "utf-8");
+  assert.equal(params.foo, "bar");
+});
+
+it("formats attachment filenames without invalid header characters", () => {
+  const headerValue = formatContentDispositionAttachment("bad\r\nX-Test: yup\0.zip");
+  const response = new http.ServerResponse({ method: "GET" } as any);
+
+  assert.doesNotThrow(() => {
+    response.setHeader("content-disposition", headerValue);
   });
+  assert.notMatch(headerValue, /[\r\n\0]/);
+});
 
-  it("parses a header value with a quoted parameter", () => {
-    const { value, params } = parseHeaderValueParameters('text/html; charset="utf-8"');
-
-    assert.equal(value, "text/html");
-    assert.equal(params.charset, "utf-8");
-  });
-
-  it("parses a header value with multiple parameters", () => {
-    const { value, params } = parseHeaderValueParameters('text/html; charset="utf-8"; foo=bar');
-
-    assert.equal(value, "text/html");
-    assert.equal(params.charset, "utf-8");
-    assert.equal(params.foo, "bar");
-  });
-
-  it("formats attachment filenames without invalid header characters", () => {
-    const headerValue = formatContentDispositionAttachment("bad\r\nX-Test: yup\0.zip");
-    const response = new http.ServerResponse({ method: "GET" } as any);
-
-    assert.doesNotThrow(() => {
-      response.setHeader("content-disposition", headerValue);
-    });
-    assert.notMatch(headerValue, /[\r\n\0]/);
-  });
-
-  it("escapes quotes and backslashes in attachment filenames", () => {
-    assert.equal(
-      formatContentDispositionAttachment('quote"slash\\semi;name.zip'),
-      'attachment; filename="quote\\"slash\\\\semi;name.zip"',
-    );
-  });
+it("escapes quotes and backslashes in attachment filenames", () => {
+  assert.equal(
+    formatContentDispositionAttachment('quote"slash\\semi;name.zip'),
+    'attachment; filename="quote\\"slash\\\\semi;name.zip"',
+  );
 });

--- a/packages/http-server-js/test/multipart.test.ts
+++ b/packages/http-server-js/test/multipart.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "stream";
-import { assert, describe, it } from "vitest";
+import { assert, it } from "vitest";
 import { createMultipartReadable } from "../src/helpers/multipart.js";
 
 import type * as http from "node:http";
@@ -63,107 +63,105 @@ function createMultipartRequestLike(
   ) as any;
 }
 
-describe("multipart", () => {
-  it("correctly chunks multipart data", async () => {
-    const request = createMultipartRequestLike(exampleMultipart);
+it("correctly chunks multipart data", async () => {
+  const request = createMultipartRequestLike(exampleMultipart);
 
-    const stream = createMultipartReadable(request);
+  const stream = createMultipartReadable(request);
 
-    const parts: Array<{ headers: { [k: string]: string | undefined }; body: string }> = [];
+  const parts: Array<{ headers: { [k: string]: string | undefined }; body: string }> = [];
 
+  for await (const part of stream) {
+    parts.push({
+      headers: part.headers,
+      body: await (async () => {
+        const chunks = [];
+        for await (const chunk of part.body) {
+          chunks.push(chunk);
+        }
+        return Buffer.concat(chunks).toString();
+      })(),
+    });
+  }
+
+  assert.deepStrictEqual(parts, [
+    {
+      headers: {
+        "content-disposition": 'form-data; name="field1"',
+        "content-type": "application/json",
+      },
+      body: '"value1"',
+    },
+    {
+      headers: { "content-disposition": 'form-data; name="field2"' },
+      body: "value2",
+    },
+  ]);
+});
+
+it("detects missing boundary", () => {
+  assert.throws(() => {
+    createMultipartReadable({ headers: {} } as any);
+  }, "missing boundary");
+
+  assert.throws(() => {
+    createMultipartReadable({
+      headers: { "content-type": "multipart/form-data" },
+    } as any);
+  }, "missing boundary");
+});
+
+it("detects unexpected termination", async () => {
+  const request = createMultipartRequestLike(
+    [
+      "--boundary",
+      'Content-Disposition: form-data; name="field1"',
+      "Content-Type: application/json",
+      "",
+      '"value1"',
+      "--boundary asdf asdf",
+    ].join("\r\n"),
+  );
+
+  const stream = createMultipartReadable(request);
+
+  try {
     for await (const part of stream) {
-      parts.push({
-        headers: part.headers,
-        body: await (async () => {
-          const chunks = [];
-          for await (const chunk of part.body) {
-            chunks.push(chunk);
-          }
-          return Buffer.concat(chunks).toString();
-        })(),
-      });
-    }
-
-    assert.deepStrictEqual(parts, [
-      {
-        headers: {
-          "content-disposition": 'form-data; name="field1"',
-          "content-type": "application/json",
-        },
-        body: '"value1"',
-      },
-      {
-        headers: { "content-disposition": 'form-data; name="field2"' },
-        body: "value2",
-      },
-    ]);
-  });
-
-  it("detects missing boundary", () => {
-    assert.throws(() => {
-      createMultipartReadable({ headers: {} } as any);
-    }, "missing boundary");
-
-    assert.throws(() => {
-      createMultipartReadable({
-        headers: { "content-type": "multipart/form-data" },
-      } as any);
-    }, "missing boundary");
-  });
-
-  it("detects unexpected termination", async () => {
-    const request = createMultipartRequestLike(
-      [
-        "--boundary",
-        'Content-Disposition: form-data; name="field1"',
-        "Content-Type: application/json",
-        "",
-        '"value1"',
-        "--boundary asdf asdf",
-      ].join("\r\n"),
-    );
-
-    const stream = createMultipartReadable(request);
-
-    try {
-      for await (const part of stream) {
-        for await (const _ of part.body) {
-          // Do nothing
-        }
+      for await (const _ of part.body) {
+        // Do nothing
       }
-      assert.fail();
-    } catch (e) {
-      assert.equal((e as Error).message, "Unexpected characters after final boundary.");
     }
-  });
+    assert.fail();
+  } catch (e) {
+    assert.equal((e as Error).message, "Unexpected characters after final boundary.");
+  }
+});
 
-  it("detects invalid preamble text", async () => {
-    const request = createMultipartRequestLike(
-      [
-        "This is the preamble text. It should be ignored.--boundary",
-        'Content-Disposition: form-data; name="field1"',
-        "Content-Type: application/json",
-        "",
-        '"value1"',
-        "--boundary",
-        'Content-Disposition: form-data; name="field2"',
-        "",
-        "value2",
-        "--boundary--",
-      ].join("\r\n"),
-    );
+it("detects invalid preamble text", async () => {
+  const request = createMultipartRequestLike(
+    [
+      "This is the preamble text. It should be ignored.--boundary",
+      'Content-Disposition: form-data; name="field1"',
+      "Content-Type: application/json",
+      "",
+      '"value1"',
+      "--boundary",
+      'Content-Disposition: form-data; name="field2"',
+      "",
+      "value2",
+      "--boundary--",
+    ].join("\r\n"),
+  );
 
-    const stream = createMultipartReadable(request);
+  const stream = createMultipartReadable(request);
 
-    try {
-      for await (const part of stream) {
-        for await (const _ of part.body) {
-          // Do nothing
-        }
+  try {
+    for await (const part of stream) {
+      for await (const _ of part.body) {
+        // Do nothing
       }
-      assert.fail();
-    } catch (e) {
-      assert.equal((e as Error).message, "Invalid preamble in multipart body.");
     }
-  });
+    assert.fail();
+  } catch (e) {
+    assert.equal((e as Error).message, "Invalid preamble in multipart body.");
+  }
 });

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -25,1193 +25,1186 @@ import {
 import { includeInapplicableMetadataInPayload } from "../src/private.decorators.js";
 import { Tester } from "./test-host.js";
 
-describe("http: decorators", () => {
-  describe("emit diagnostic if passing arguments to verb decorators", () => {
-    ["get", "post", "put", "delete", "head"].forEach((verb) => {
-      it(`@${verb}`, async () => {
-        const diagnostics = await Tester.diagnose(`
-          @${verb}("/test") op test(): string;
-        `);
-
-        expectDiagnostics(diagnostics, {
-          code: "invalid-argument-count",
-          message: "Expected 0 arguments, but got 1.",
-        });
-      });
-    });
-
-    it(`@patch`, async () => {
+describe("emit diagnostic if passing arguments to verb decorators", () => {
+  ["get", "post", "put", "delete", "head"].forEach((verb) => {
+    it(`@${verb}`, async () => {
       const diagnostics = await Tester.diagnose(`
-        @patch("/test") op test(): string;
-        `);
+        @${verb}("/test") op test(): string;
+      `);
 
       expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-        message: `Argument of type '"/test"' is not assignable to parameter of type 'valueof TypeSpec.Http.PatchOptions'`,
+        code: "invalid-argument-count",
+        message: "Expected 0 arguments, but got 1.",
       });
     });
+  });
 
-    it(`@patch emits deprecation warning when implicitOptionality: true`, async () => {
-      const diagnostics = await Tester.diagnose(`
-        @patch(#{ implicitOptionality: true }) op test(): string;
-        `);
+  it(`@patch`, async () => {
+    const diagnostics = await Tester.diagnose(`
+      @patch("/test") op test(): string;
+      `);
 
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/http/deprecated-implicit-optionality",
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
+      message: `Argument of type '"/test"' is not assignable to parameter of type 'valueof TypeSpec.Http.PatchOptions'`,
+    });
+  });
+
+  it(`@patch emits deprecation warning when implicitOptionality: true`, async () => {
+    const diagnostics = await Tester.diagnose(`
+      @patch(#{ implicitOptionality: true }) op test(): string;
+      `);
+
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/http/deprecated-implicit-optionality",
+      message:
+        "The implicitOptionality option is deprecated. To preserve previous behavior, use an explicit patch model with optional properties. For actual merge-patch semantics, use MergePatchUpdate<T> for the @body type.",
+    });
+  });
+
+  it(`@patch does not emit deprecation warning when implicitOptionality: false`, async () => {
+    const diagnostics = await Tester.diagnose(`
+      @patch(#{ implicitOptionality: false }) op test(): string;
+      `);
+
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it(`@patch does not emit deprecation warning when inherited via 'op is'`, async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("/base") #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
+      @patch(#{ implicitOptionality: true }) op base(): string;
+      @route("/derived") op derived is base;
+      `);
+
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it(`@patch does not emit deprecation warning when inherited via 'interface extends'`, async () => {
+    const diagnostics = await Tester.diagnose(`
+      #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
+      interface Base {
+        @route("/test") @patch(#{ implicitOptionality: true }) test(): string;
+      }
+      @route("/derived")
+      interface Derived extends Base {}
+      `);
+
+    expectDiagnosticEmpty(diagnostics);
+  });
+});
+
+describe("@header", () => {
+  it("emit diagnostics when @header is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @header op test(): string;
+
+        @header model Foo {}
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
         message:
-          "The implicitOptionality option is deprecated. To preserve previous behavior, use an explicit patch model with optional properties. For actual merge-patch semantics, use MergePatchUpdate<T> for the @body type.",
-      });
-    });
-
-    it(`@patch does not emit deprecation warning when implicitOptionality: false`, async () => {
-      const diagnostics = await Tester.diagnose(`
-        @patch(#{ implicitOptionality: false }) op test(): string;
-        `);
-
-      expectDiagnosticEmpty(diagnostics);
-    });
-
-    it(`@patch does not emit deprecation warning when inherited via 'op is'`, async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("/base") #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
-        @patch(#{ implicitOptionality: true }) op base(): string;
-        @route("/derived") op derived is base;
-        `);
-
-      expectDiagnosticEmpty(diagnostics);
-    });
-
-    it(`@patch does not emit deprecation warning when inherited via 'interface extends'`, async () => {
-      const diagnostics = await Tester.diagnose(`
-        #suppress "@typespec/http/deprecated-implicit-optionality" "testing"
-        interface Base {
-          @route("/test") @patch(#{ implicitOptionality: true }) test(): string;
-        }
-        @route("/derived")
-        interface Derived extends Base {}
-        `);
-
-      expectDiagnosticEmpty(diagnostics);
-    });
+          "Cannot apply @header decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @header decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
   });
 
-  describe("@header", () => {
-    it("emit diagnostics when @header is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @header op test(): string;
-
-          @header model Foo {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @header decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @header decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
-    });
-
-    it("emit diagnostics when header name is not a string or of value HeaderOptions", async () => {
-      const diagnostics = await Tester.diagnose(`
-          op test(@header(123) MyHeader: string): string;
-          op test2(@header(#{ name: 123 }) MyHeader: string): string;
-          op test3(@header(#{ format: "invalid" }) MyHeader: string): string;
-          op test4(@header(#{ explode: "invalid" }) MyHeader: string): string;
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-      ]);
-    });
-
-    it("generate header name from property name", async () => {
-      const { MyHeader, program } = await Tester.compile(t.code`
-          op test(@header ${t.modelProperty("MyHeader")}: string): string;
-        `);
-
-      ok(isHeader(program, MyHeader));
-      strictEqual(getHeaderFieldName(program, MyHeader), "my-header");
-    });
-
-    it("override header name with 1st parameter", async () => {
-      const { MyHeader, program } = await Tester.compile(t.code`
-          op test( @header("x-my-header") ${t.modelProperty("MyHeader")}: string): string;
-        `);
-
-      strictEqual(getHeaderFieldName(program, MyHeader), "x-my-header");
-    });
-
-    it("override header with HeaderOptions", async () => {
-      const { SingleString, program } = await Tester.compile(t.code`
-          @put op test(@header(#{name: "x-single-string"}) ${t.modelProperty("SingleString")}: string): string;
-        `);
-
-      deepStrictEqual(getHeaderFieldOptions(program, SingleString), {
-        type: "header",
-        name: "x-single-string",
-      });
-      strictEqual(getHeaderFieldName(program, SingleString), "x-single-string");
-    });
-
-    it("specify explode", async () => {
-      const { MyHeader, program } = await Tester.compile(t.code`
-        @put op test(@header(#{ explode: true }) ${t.modelProperty("MyHeader")}: string): string;
+  it("emit diagnostics when header name is not a string or of value HeaderOptions", async () => {
+    const diagnostics = await Tester.diagnose(`
+        op test(@header(123) MyHeader: string): string;
+        op test2(@header(#{ name: 123 }) MyHeader: string): string;
+        op test3(@header(#{ format: "invalid" }) MyHeader: string): string;
+        op test4(@header(#{ explode: "invalid" }) MyHeader: string): string;
       `);
 
-      deepStrictEqual(getHeaderFieldOptions(program, MyHeader), {
-        type: "header",
-        name: "my-header",
-        explode: true,
-      });
-      strictEqual(getHeaderFieldName(program, MyHeader), "my-header");
-    });
+    expectDiagnostics(diagnostics, [
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+    ]);
   });
 
-  describe("@cookie", () => {
-    it("emit diagnostics when @cookie is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @cookie op test(): string;
+  it("generate header name from property name", async () => {
+    const { MyHeader, program } = await Tester.compile(t.code`
+        op test(@header ${t.modelProperty("MyHeader")}: string): string;
+      `);
 
-          @cookie model Foo {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @cookie decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @cookie decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
-    });
-
-    it("emit diagnostics when cookie name is not a string or of type CookieOptions", async () => {
-      const diagnostics = await Tester.diagnose(`
-          op test(@cookie(123) myCookie: string): string;
-          op test2(@cookie(#{ name: 123 })myCookie: string): string;
-          op test3(@cookie(#{ format: "invalid" }) myCookie: string): string;
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-      ]);
-    });
-
-    it("generate cookie name from property name", async () => {
-      const { myCookie, program } = await Tester.compile(t.code`
-          op test(@cookie ${t.modelProperty("myCookie")}: string): string;
-        `);
-
-      ok(isCookieParam(program, myCookie));
-      strictEqual(getCookieParamOptions(program, myCookie)?.name, "my_cookie");
-    });
-
-    it("override cookie name with 1st parameter", async () => {
-      const { myCookie, program } = await Tester.compile(t.code`
-          op test(@cookie("my-cookie") ${t.modelProperty("myCookie")}: string): string;
-        `);
-
-      strictEqual(getCookieParamOptions(program, myCookie)?.name, "my-cookie");
-    });
-
-    it("override cookie with CookieOptions", async () => {
-      const { myCookie, program } = await Tester.compile(t.code`
-          op test(@cookie(#{name: "my-cookie"}) ${t.modelProperty("myCookie")}: string): string;
-        `);
-
-      strictEqual(getCookieParamOptions(program, myCookie)?.name, "my-cookie");
-    });
+    ok(isHeader(program, MyHeader));
+    strictEqual(getHeaderFieldName(program, MyHeader), "my-header");
   });
 
-  describe("@query", () => {
-    it("emit diagnostics when @query is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @query op test(): string;
-
-          @query model Foo {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @query decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @query decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
-    });
-
-    it("emit diagnostics when query name is not a string or of type QueryOptions", async () => {
-      const diagnostics = await Tester.diagnose(`
-          op test(@query(123) MyQuery: string): string;
-          op test2(@query(#{name: 123}) MyQuery: string): string;
-          op test3(@query(#{format: "invalid"}) MyQuery: string): string;
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-      ]);
-    });
-
-    it("generate query name from property name", async () => {
-      const { select, program } = await Tester.compile(t.code`
-          op test(@query ${t.modelProperty("select")}: string): string;
-        `);
-
-      ok(isQueryParam(program, select));
-      strictEqual(getQueryParamName(program, select), "select");
-    });
-
-    it("override query name with 1st parameter", async () => {
-      const { select, program } = await Tester.compile(t.code`
-          op test(@query("$select") ${t.modelProperty("select")}: string): string;
-        `);
-
-      strictEqual(getQueryParamName(program, select), "$select");
-    });
-
-    it("specify explode: true", async () => {
-      const { selects, program } = await Tester.compile(t.code`
-        op test(@query(#{ explode: true }) ${t.modelProperty("selects")}: string[]): string;
+  it("override header name with 1st parameter", async () => {
+    const { MyHeader, program } = await Tester.compile(t.code`
+        op test( @header("x-my-header") ${t.modelProperty("MyHeader")}: string): string;
       `);
-      expect(getQueryParamOptions(program, selects)).toEqual({
-        type: "query",
-        name: "selects",
-        explode: true,
-      });
-    });
+
+    strictEqual(getHeaderFieldName(program, MyHeader), "x-my-header");
   });
 
-  describe("@route", () => {
-    it("emit diagnostics when duplicated unshared routes are applied", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("/test") op test(): string;
-        @route("/test") op test2(): string;
+  it("override header with HeaderOptions", async () => {
+    const { SingleString, program } = await Tester.compile(t.code`
+        @put op test(@header(#{name: "x-single-string"}) ${t.modelProperty("SingleString")}: string): string;
       `);
 
-      expectDiagnostics(diagnostics, [
-        {
-          code: "@typespec/http/duplicate-operation",
-          message: `Duplicate operation "test" routed at "get /test".`,
-        },
-        {
-          code: "@typespec/http/duplicate-operation",
-          message: `Duplicate operation "test2" routed at "get /test".`,
-        },
-      ]);
+    deepStrictEqual(getHeaderFieldOptions(program, SingleString), {
+      type: "header",
+      name: "x-single-string",
     });
-
-    it("emit diagnostics when not all duplicated routes are declared shared on each op conflicting", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("/test") @sharedRoute op test(): string;
-        @route("/test") @sharedRoute op test2(): string;
-        @route("/test") op test3(): string;
-      `);
-      expectDiagnostics(diagnostics, [
-        {
-          code: "@typespec/http/shared-inconsistency",
-          message: `Each operation routed at "get /test" needs to have the @sharedRoute decorator.`,
-        },
-        {
-          code: "@typespec/http/shared-inconsistency",
-          message: `Each operation routed at "get /test" needs to have the @sharedRoute decorator.`,
-        },
-        {
-          code: "@typespec/http/shared-inconsistency",
-          message: `Each operation routed at "get /test" needs to have the @sharedRoute decorator.`,
-        },
-      ]);
-    });
-
-    it("do not emit diagnostics when duplicated shared routes are applied", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("/test") @sharedRoute op test(): string;
-        @route("/test") @sharedRoute op test2(): string;
-      `);
-
-      expectDiagnosticEmpty(diagnostics);
-    });
-
-    it("do not emit diagnostics routes sharing path but not same verb", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("/test") @sharedRoute op test(): string;
-        @route("/test") @sharedRoute op test2(): string;
-        @route("/test") @post op test3(): string;
-      `);
-      expectDiagnosticEmpty(diagnostics);
-    });
+    strictEqual(getHeaderFieldName(program, SingleString), "x-single-string");
   });
 
-  describe("@path", () => {
-    it("emit diagnostics when @path is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @path op test(): string;
+  it("specify explode", async () => {
+    const { MyHeader, program } = await Tester.compile(t.code`
+      @put op test(@header(#{ explode: true }) ${t.modelProperty("MyHeader")}: string): string;
+    `);
 
-          @path model Foo {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @path decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @path decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
+    deepStrictEqual(getHeaderFieldOptions(program, MyHeader), {
+      type: "header",
+      name: "my-header",
+      explode: true,
     });
+    strictEqual(getHeaderFieldName(program, MyHeader), "my-header");
+  });
+});
 
-    it("accept optional path when specified at the root of @route", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("{/myPath}") op test(@path myPath?: string): string;
+describe("@cookie", () => {
+  it("emit diagnostics when @cookie is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @cookie op test(): string;
+
+        @cookie model Foo {}
       `);
 
-      expectDiagnosticEmpty(diagnostics);
-    });
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @cookie decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @cookie decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
+  });
 
-    it("accept optional path when specified in route", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("base{/myPath}") op test(@path myPath?: string): string;
+  it("emit diagnostics when cookie name is not a string or of type CookieOptions", async () => {
+    const diagnostics = await Tester.diagnose(`
+        op test(@cookie(123) myCookie: string): string;
+        op test2(@cookie(#{ name: 123 })myCookie: string): string;
+        op test3(@cookie(#{ format: "invalid" }) myCookie: string): string;
       `);
 
-      expectDiagnosticEmpty(diagnostics);
-    });
+    expectDiagnostics(diagnostics, [
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+    ]);
+  });
 
-    it("accept optional path when not used as operation parameter", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @route("/") op test(): {@path myPath?: string};
+  it("generate cookie name from property name", async () => {
+    const { myCookie, program } = await Tester.compile(t.code`
+        op test(@cookie ${t.modelProperty("myCookie")}: string): string;
       `);
 
-      expectDiagnosticEmpty(diagnostics);
-    });
-
-    it("emit diagnostics when path name is not a string", async () => {
-      const diagnostics = await Tester.diagnose(`
-          op test(@path(123) MyPath: string): string;
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "invalid-argument",
-        },
-      ]);
-    });
-
-    it("generate path name from property name", async () => {
-      const { select, program } = await Tester.compile(t.code`
-          op test(@path ${t.modelProperty("select")}: string): string;
-        `);
-
-      ok(isPathParam(program, select));
-      strictEqual(getPathParamName(program, select), "select");
-    });
-
-    it("override path name with 1st parameter", async () => {
-      const { select, program } = await Tester.compile(t.code`
-          op test(@path("$select") ${t.modelProperty("select")}: string): string;
-        `);
-
-      deepStrictEqual(getPathParamOptions(program, select), {
-        type: "path",
-        name: "$select",
-        allowReserved: false,
-        explode: false,
-        style: "simple",
-      });
-      strictEqual(getPathParamName(program, select), "$select");
-    });
+    ok(isCookieParam(program, myCookie));
+    strictEqual(getCookieParamOptions(program, myCookie)?.name, "my_cookie");
   });
 
-  describe("@body", () => {
-    it("emit diagnostics when @body is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @body op test(): string;
+  it("override cookie name with 1st parameter", async () => {
+    const { myCookie, program } = await Tester.compile(t.code`
+        op test(@cookie("my-cookie") ${t.modelProperty("myCookie")}: string): string;
+      `);
 
-          @body model Foo {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @body decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @body decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
-    });
-
-    it("set the body with @body", async () => {
-      const { body, program } = await Tester.compile(t.code`
-          @post op test(@body ${t.modelProperty("body")}: string): string;
-        `);
-
-      ok(isBody(program, body));
-    });
+    strictEqual(getCookieParamOptions(program, myCookie)?.name, "my-cookie");
   });
 
-  describe("@bodyRoot", () => {
-    it("emit diagnostics when @body is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @bodyRoot op test(): string;
+  it("override cookie with CookieOptions", async () => {
+    const { myCookie, program } = await Tester.compile(t.code`
+        op test(@cookie(#{name: "my-cookie"}) ${t.modelProperty("myCookie")}: string): string;
+      `);
 
-          @bodyRoot model Foo {}
-        `);
+    strictEqual(getCookieParamOptions(program, myCookie)?.name, "my-cookie");
+  });
+});
 
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @bodyRoot decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @bodyRoot decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
-    });
+describe("@query", () => {
+  it("emit diagnostics when @query is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @query op test(): string;
 
-    it("set the body root with @bodyRoot", async () => {
-      const { body, program } = await Tester.compile(t.code`
-          @post op test(@bodyRoot ${t.modelProperty("body")}: string): string;
-        `);
+        @query model Foo {}
+      `);
 
-      ok(isBodyRoot(program, body));
-    });
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @query decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message: "Cannot apply @query decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
   });
 
-  describe("@bodyIgnore", () => {
-    it("emit diagnostics when @body is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @bodyIgnore op test(): string;
+  it("emit diagnostics when query name is not a string or of type QueryOptions", async () => {
+    const diagnostics = await Tester.diagnose(`
+        op test(@query(123) MyQuery: string): string;
+        op test2(@query(#{name: 123}) MyQuery: string): string;
+        op test3(@query(#{format: "invalid"}) MyQuery: string): string;
+      `);
 
-          @bodyIgnore model Foo {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @bodyIgnore decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @bodyIgnore decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
-    });
-
-    it("isBodyIgnore returns true on property decorated", async () => {
-      const { body, program } = await Tester.compile(t.code`
-          @post op test(@bodyIgnore ${t.modelProperty("body")}: string): string;
-        `);
-
-      ok(isBodyIgnore(program, body));
-    });
+    expectDiagnostics(diagnostics, [
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+    ]);
   });
 
-  describe("@statusCode", () => {
-    it("emit diagnostics when @statusCode is not used on model property", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @statusCode op test(): string;
+  it("generate query name from property name", async () => {
+    const { select, program } = await Tester.compile(t.code`
+        op test(@query ${t.modelProperty("select")}: string): string;
+      `);
 
-          @statusCode model Foo {}
-        `);
+    ok(isQueryParam(program, select));
+    strictEqual(getQueryParamName(program, select), "select");
+  });
 
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @statusCode decorator to test since it is not assignable to ModelProperty",
-        },
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @statusCode decorator to Foo since it is not assignable to ModelProperty",
-        },
-      ]);
+  it("override query name with 1st parameter", async () => {
+    const { select, program } = await Tester.compile(t.code`
+        op test(@query("$select") ${t.modelProperty("select")}: string): string;
+      `);
+
+    strictEqual(getQueryParamName(program, select), "$select");
+  });
+
+  it("specify explode: true", async () => {
+    const { selects, program } = await Tester.compile(t.code`
+      op test(@query(#{ explode: true }) ${t.modelProperty("selects")}: string[]): string;
+    `);
+    expect(getQueryParamOptions(program, selects)).toEqual({
+      type: "query",
+      name: "selects",
+      explode: true,
     });
+  });
+});
 
-    it("emits error if multiple properties are decorated with `@statusCode` in return type", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        model CreatedOrUpdatedResponse {
-          @statusCode ok: "200";
-          @statusCode created: "201";
-        }
-        model DateHeader {
-          @header date: utcDateTime;
-        }
-        model Key {
-          key: string;
-        }
-        @put op create(): CreatedOrUpdatedResponse & DateHeader & Key;
-        `,
-      );
-      expectDiagnostics(diagnostics, [{ code: "@typespec/http/multiple-status-codes" }]);
+describe("@route", () => {
+  it("emit diagnostics when duplicated unshared routes are applied", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("/test") op test(): string;
+      @route("/test") op test2(): string;
+    `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@typespec/http/duplicate-operation",
+        message: `Duplicate operation "test" routed at "get /test".`,
+      },
+      {
+        code: "@typespec/http/duplicate-operation",
+        message: `Duplicate operation "test2" routed at "get /test".`,
+      },
+    ]);
+  });
+
+  it("emit diagnostics when not all duplicated routes are declared shared on each op conflicting", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("/test") @sharedRoute op test(): string;
+      @route("/test") @sharedRoute op test2(): string;
+      @route("/test") op test3(): string;
+    `);
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@typespec/http/shared-inconsistency",
+        message: `Each operation routed at "get /test" needs to have the @sharedRoute decorator.`,
+      },
+      {
+        code: "@typespec/http/shared-inconsistency",
+        message: `Each operation routed at "get /test" needs to have the @sharedRoute decorator.`,
+      },
+      {
+        code: "@typespec/http/shared-inconsistency",
+        message: `Each operation routed at "get /test" needs to have the @sharedRoute decorator.`,
+      },
+    ]);
+  });
+
+  it("do not emit diagnostics when duplicated shared routes are applied", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("/test") @sharedRoute op test(): string;
+      @route("/test") @sharedRoute op test2(): string;
+    `);
+
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("do not emit diagnostics routes sharing path but not same verb", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("/test") @sharedRoute op test(): string;
+      @route("/test") @sharedRoute op test2(): string;
+      @route("/test") @post op test3(): string;
+    `);
+    expectDiagnosticEmpty(diagnostics);
+  });
+});
+
+describe("@path", () => {
+  it("emit diagnostics when @path is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @path op test(): string;
+
+        @path model Foo {}
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message: "Cannot apply @path decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message: "Cannot apply @path decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
+  });
+
+  it("accept optional path when specified at the root of @route", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("{/myPath}") op test(@path myPath?: string): string;
+    `);
+
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("accept optional path when specified in route", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("base{/myPath}") op test(@path myPath?: string): string;
+    `);
+
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("accept optional path when not used as operation parameter", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @route("/") op test(): {@path myPath?: string};
+    `);
+
+    expectDiagnosticEmpty(diagnostics);
+  });
+
+  it("emit diagnostics when path name is not a string", async () => {
+    const diagnostics = await Tester.diagnose(`
+        op test(@path(123) MyPath: string): string;
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "invalid-argument",
+      },
+    ]);
+  });
+
+  it("generate path name from property name", async () => {
+    const { select, program } = await Tester.compile(t.code`
+        op test(@path ${t.modelProperty("select")}: string): string;
+      `);
+
+    ok(isPathParam(program, select));
+    strictEqual(getPathParamName(program, select), "select");
+  });
+
+  it("override path name with 1st parameter", async () => {
+    const { select, program } = await Tester.compile(t.code`
+        op test(@path("$select") ${t.modelProperty("select")}: string): string;
+      `);
+
+    deepStrictEqual(getPathParamOptions(program, select), {
+      type: "path",
+      name: "$select",
+      allowReserved: false,
+      explode: false,
+      style: "simple",
     });
+    strictEqual(getPathParamName(program, select), "$select");
+  });
+});
 
-    it("emits error if multiple `@statusCode` decorators are composed together", async () => {
-      const diagnostics = await Tester.diagnose(
-        `      
-        model CustomUnauthorizedResponse {
-          @statusCode _: 401;
-          @bodyRoot body: UnauthorizedResponse;
-        }
-  
-        model Pet {
-          name: string;
-        }
-        
-        model PetList {
-          @statusCode _: 200;
-          @body body: Pet[];
-        }
-        
-        op list(): PetList | CustomUnauthorizedResponse;
-        `,
-      );
-      expectDiagnostics(diagnostics, [{ code: "@typespec/http/multiple-status-codes" }]);
-    });
+describe("@body", () => {
+  it("emit diagnostics when @body is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @body op test(): string;
 
-    it("set numeric statusCode with @statusCode", async () => {
-      const { code, program } = await Tester.compile(t.code`
-          op test(): {
-            @statusCode ${t.modelProperty("code")}: 201
-          };
-        `);
+        @body model Foo {}
+      `);
 
-      ok(isStatusCode(program, code));
-      deepStrictEqual(getStatusCodes(program, code), [201]);
-    });
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message: "Cannot apply @body decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message: "Cannot apply @body decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
+  });
 
-    it("set range statusCode with @statusCode", async () => {
-      const { code, program } = await Tester.compile(t.code`
-          op test(): {
-            @statusCode @minValue(200) @maxValue(299) ${t.modelProperty("code")}: int32;
-          };
-        `);
+  it("set the body with @body", async () => {
+    const { body, program } = await Tester.compile(t.code`
+        @post op test(@body ${t.modelProperty("body")}: string): string;
+      `);
 
-      ok(isStatusCode(program, code));
-      deepStrictEqual(getStatusCodes(program, code), [{ start: 200, end: 299 }]);
-    });
+    ok(isBody(program, body));
+  });
+});
 
-    describe("invalid status codes", () => {
-      async function checkInvalid(code: string, message: string) {
-        const diagnostics = await Tester.diagnose(`
+describe("@bodyRoot", () => {
+  it("emit diagnostics when @body is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @bodyRoot op test(): string;
+
+        @bodyRoot model Foo {}
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @bodyRoot decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @bodyRoot decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
+  });
+
+  it("set the body root with @bodyRoot", async () => {
+    const { body, program } = await Tester.compile(t.code`
+        @post op test(@bodyRoot ${t.modelProperty("body")}: string): string;
+      `);
+
+    ok(isBodyRoot(program, body));
+  });
+});
+
+describe("@bodyIgnore", () => {
+  it("emit diagnostics when @body is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @bodyIgnore op test(): string;
+
+        @bodyIgnore model Foo {}
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @bodyIgnore decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @bodyIgnore decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
+  });
+
+  it("isBodyIgnore returns true on property decorated", async () => {
+    const { body, program } = await Tester.compile(t.code`
+        @post op test(@bodyIgnore ${t.modelProperty("body")}: string): string;
+      `);
+
+    ok(isBodyIgnore(program, body));
+  });
+});
+
+describe("@statusCode", () => {
+  it("emit diagnostics when @statusCode is not used on model property", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @statusCode op test(): string;
+
+        @statusCode model Foo {}
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @statusCode decorator to test since it is not assignable to ModelProperty",
+      },
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @statusCode decorator to Foo since it is not assignable to ModelProperty",
+      },
+    ]);
+  });
+
+  it("emits error if multiple properties are decorated with `@statusCode` in return type", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      model CreatedOrUpdatedResponse {
+        @statusCode ok: "200";
+        @statusCode created: "201";
+      }
+      model DateHeader {
+        @header date: utcDateTime;
+      }
+      model Key {
+        key: string;
+      }
+      @put op create(): CreatedOrUpdatedResponse & DateHeader & Key;
+      `,
+    );
+    expectDiagnostics(diagnostics, [{ code: "@typespec/http/multiple-status-codes" }]);
+  });
+
+  it("emits error if multiple `@statusCode` decorators are composed together", async () => {
+    const diagnostics = await Tester.diagnose(
+      `      
+      model CustomUnauthorizedResponse {
+        @statusCode _: 401;
+        @bodyRoot body: UnauthorizedResponse;
+      }
+
+      model Pet {
+        name: string;
+      }
+      
+      model PetList {
+        @statusCode _: 200;
+        @body body: Pet[];
+      }
+      
+      op list(): PetList | CustomUnauthorizedResponse;
+      `,
+    );
+    expectDiagnostics(diagnostics, [{ code: "@typespec/http/multiple-status-codes" }]);
+  });
+
+  it("set numeric statusCode with @statusCode", async () => {
+    const { code, program } = await Tester.compile(t.code`
         op test(): {
-          @statusCode code: ${code}
+          @statusCode ${t.modelProperty("code")}: 201
         };
       `);
 
-        expectDiagnostics(diagnostics, { code: "@typespec/http/status-code-invalid", message });
-      }
+    ok(isStatusCode(program, code));
+    deepStrictEqual(getStatusCodes(program, code), [201]);
+  });
 
-      it("emit diagnostic if status code is not a number", () =>
-        checkInvalid(`"Ok"`, "statusCode value must be a three digit code between 100 and 599"));
-      it("emit diagnostic if status code is a number with more than 3 digit", () =>
-        checkInvalid("12345", "statusCode value must be a three digit code between 100 and 599"));
-      it("emit diagnostic if status code is not an integer", () =>
-        checkInvalid("200.3", "statusCode value must be a three digit code between 100 and 599"));
+  it("set range statusCode with @statusCode", async () => {
+    const { code, program } = await Tester.compile(t.code`
+        op test(): {
+          @statusCode @minValue(200) @maxValue(299) ${t.modelProperty("code")}: int32;
+        };
+      `);
+
+    ok(isStatusCode(program, code));
+    deepStrictEqual(getStatusCodes(program, code), [{ start: 200, end: 299 }]);
+  });
+
+  describe("invalid status codes", () => {
+    async function checkInvalid(code: string, message: string) {
+      const diagnostics = await Tester.diagnose(`
+      op test(): {
+        @statusCode code: ${code}
+      };
+    `);
+
+      expectDiagnostics(diagnostics, { code: "@typespec/http/status-code-invalid", message });
+    }
+
+    it("emit diagnostic if status code is not a number", () =>
+      checkInvalid(`"Ok"`, "statusCode value must be a three digit code between 100 and 599"));
+    it("emit diagnostic if status code is a number with more than 3 digit", () =>
+      checkInvalid("12345", "statusCode value must be a three digit code between 100 and 599"));
+    it("emit diagnostic if status code is not an integer", () =>
+      checkInvalid("200.3", "statusCode value must be a three digit code between 100 and 599"));
+  });
+});
+
+describe("@server", () => {
+  it("emit diagnostics when @server is not used on namespace", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @server("https://example.com", "MyServer") op test(): string;
+
+        @server("https://example.com", "MyServer") model Foo {}
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message: "Cannot apply @server decorator to test since it is not assignable to Namespace",
+      },
+      {
+        code: "decorator-wrong-target",
+        message: "Cannot apply @server decorator to Foo since it is not assignable to Namespace",
+      },
+    ]);
+  });
+
+  it("emit diagnostics when url is not a string", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @server(123, "MyServer")
+        namespace MyService {}
+      `);
+
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
     });
   });
 
-  describe("@server", () => {
-    it("emit diagnostics when @server is not used on namespace", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @server("https://example.com", "MyServer") op test(): string;
+  it("emit diagnostics when description is not a string", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @server("https://example.com", 123)
+      namespace MyService {}
+    `);
 
-          @server("https://example.com", "MyServer") model Foo {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message: "Cannot apply @server decorator to test since it is not assignable to Namespace",
-        },
-        {
-          code: "decorator-wrong-target",
-          message: "Cannot apply @server decorator to Foo since it is not assignable to Namespace",
-        },
-      ]);
-    });
-
-    it("emit diagnostics when url is not a string", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @server(123, "MyServer")
-          namespace MyService {}
-        `);
-
-      expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-      });
-    });
-
-    it("emit diagnostics when description is not a string", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @server("https://example.com", 123)
-        namespace MyService {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-      });
-    });
-
-    it("emit diagnostics when parameters is not a model", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @server("https://example.com", "My service url", 123)
-        namespace MyService {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-      });
-    });
-
-    it("emit diagnostics if url has parameters that is not specified in model", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @server("https://example.com/{name}/foo", "My service url", {other: string})
-        namespace MyService {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/http/missing-server-param",
-        message: "Server url contains parameter 'name' but wasn't found in given parameters",
-      });
-    });
-
-    it("define a simple server without description", async () => {
-      const { MyService, program } = await Tester.compile(t.code`
-        @server("https://example.com")
-        namespace ${t.namespace("MyService")} {}
-      `);
-
-      const servers = getServers(program, MyService);
-      deepStrictEqual(servers, [
-        {
-          description: undefined,
-          parameters: new Map(),
-          url: "https://example.com",
-        },
-      ]);
-    });
-
-    it("define a simple server with a fixed url", async () => {
-      const { MyService, program } = await Tester.compile(t.code`
-        @server("https://example.com", "My service url")
-        namespace ${t.namespace("MyService")} {}
-      `);
-
-      const servers = getServers(program, MyService);
-      deepStrictEqual(servers, [
-        {
-          description: "My service url",
-          parameters: new Map(),
-          url: "https://example.com",
-        },
-      ]);
-    });
-
-    it("define a server with parameters", async () => {
-      const { MyService, NameParam, program } = await Tester.compile(t.code`
-        @server("https://example.com/{name}/foo", "My service url", {@test("NameParam") name: string })
-        namespace ${t.namespace("MyService")} {}
-      `);
-
-      const servers = getServers(program, MyService);
-      deepStrictEqual(servers, [
-        {
-          description: "My service url",
-          parameters: new Map<string, ModelProperty>([["name", NameParam as any]]),
-          url: "https://example.com/{name}/foo",
-        },
-      ]);
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
     });
   });
 
-  describe("@useAuth", () => {
-    it("emit diagnostics when config is not a model, tuple or union", async () => {
-      const diagnostics = await Tester.diagnose(`
-          @useAuth(anOp)
-          namespace Foo {}
+  it("emit diagnostics when parameters is not a model", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @server("https://example.com", "My service url", 123)
+      namespace MyService {}
+    `);
 
-          op anOp(): void;
-        `);
-
-      expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-      });
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
     });
+  });
 
-    it("emit diagnostic when OAuth2 flow is not a valid model", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @useAuth(OAuth2Auth<["foo"]>)
+  it("emit diagnostics if url has parameters that is not specified in model", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @server("https://example.com/{name}/foo", "My service url", {other: string})
+      namespace MyService {}
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/http/missing-server-param",
+      message: "Server url contains parameter 'name' but wasn't found in given parameters",
+    });
+  });
+
+  it("define a simple server without description", async () => {
+    const { MyService, program } = await Tester.compile(t.code`
+      @server("https://example.com")
+      namespace ${t.namespace("MyService")} {}
+    `);
+
+    const servers = getServers(program, MyService);
+    deepStrictEqual(servers, [
+      {
+        description: undefined,
+        parameters: new Map(),
+        url: "https://example.com",
+      },
+    ]);
+  });
+
+  it("define a simple server with a fixed url", async () => {
+    const { MyService, program } = await Tester.compile(t.code`
+      @server("https://example.com", "My service url")
+      namespace ${t.namespace("MyService")} {}
+    `);
+
+    const servers = getServers(program, MyService);
+    deepStrictEqual(servers, [
+      {
+        description: "My service url",
+        parameters: new Map(),
+        url: "https://example.com",
+      },
+    ]);
+  });
+
+  it("define a server with parameters", async () => {
+    const { MyService, NameParam, program } = await Tester.compile(t.code`
+      @server("https://example.com/{name}/foo", "My service url", {@test("NameParam") name: string })
+      namespace ${t.namespace("MyService")} {}
+    `);
+
+    const servers = getServers(program, MyService);
+    deepStrictEqual(servers, [
+      {
+        description: "My service url",
+        parameters: new Map<string, ModelProperty>([["name", NameParam as any]]),
+        url: "https://example.com/{name}/foo",
+      },
+    ]);
+  });
+});
+
+describe("@useAuth", () => {
+  it("emit diagnostics when config is not a model, tuple or union", async () => {
+    const diagnostics = await Tester.diagnose(`
+        @useAuth(anOp)
         namespace Foo {}
 
-        model Flow { noscopes: "boom"; };
-        @useAuth(OAuth2Auth<[Flow]>)
-        namespace Bar {}
-        `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-      ]);
-    });
-
-    it("can specify BasicAuth", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @useAuth(BasicAuth)
-        namespace ${t.namespace("Foo")} {}
+        op anOp(): void;
       `);
 
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "BasicAuth",
-                type: "http",
-                scheme: "Basic",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify custom auth name with description", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @doc("My custom basic auth")
-        model MyAuth is BasicAuth;
-        @useAuth(MyAuth)
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "MyAuth",
-                description: "My custom basic auth",
-                type: "http",
-                scheme: "Basic",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify BearerAuth", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @useAuth(BearerAuth)
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "BearerAuth",
-                type: "http",
-                scheme: "Bearer",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify ApiKeyAuth", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @useAuth(ApiKeyAuth<ApiKeyLocation.header, "x-my-header">)
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "ApiKeyAuth",
-                type: "apiKey",
-                in: "header",
-                name: "x-my-header",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify OAuth2", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        model MyFlow {
-          type: OAuth2FlowType.implicit;
-          authorizationUrl: "https://api.example.com/oauth2/authorize";
-          refreshUrl: "https://api.example.com/oauth2/refresh";
-          scopes: ["read", "write"];
-        }
-        @useAuth(OAuth2Auth<[MyFlow]>)
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "OAuth2Auth",
-                type: "oauth2",
-                flows: [
-                  {
-                    type: "implicit",
-                    authorizationUrl: "https://api.example.com/oauth2/authorize",
-                    refreshUrl: "https://api.example.com/oauth2/refresh",
-                    scopes: [{ value: "read" }, { value: "write" }],
-                  },
-                ],
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify OAuth2 with scopes, which are default for every flow", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        alias MyAuth<T extends string[]> = OAuth2Auth<Flows=[{
-          type: OAuth2FlowType.implicit;
-          authorizationUrl: "https://api.example.com/oauth2/authorize";
-          refreshUrl: "https://api.example.com/oauth2/refresh";
-        }], Scopes=T>;
-
-        @useAuth(MyAuth<["read", "write"]>)
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "OAuth2Auth",
-                type: "oauth2",
-                flows: [
-                  {
-                    type: "implicit",
-                    authorizationUrl: "https://api.example.com/oauth2/authorize",
-                    refreshUrl: "https://api.example.com/oauth2/refresh",
-                    scopes: [{ value: "read" }, { value: "write" }],
-                  },
-                ],
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify NoAuth", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @useAuth(NoAuth)
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "NoAuth",
-                type: "noAuth",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify multiple auth options", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @useAuth(BasicAuth | BearerAuth)
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "BasicAuth",
-                type: "http",
-                scheme: "Basic",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-          {
-            schemes: [
-              {
-                id: "BearerAuth",
-                type: "http",
-                scheme: "Bearer",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify multiple auth schemes to be used together", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @useAuth([BasicAuth, BearerAuth])
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "BasicAuth",
-                type: "http",
-                scheme: "Basic",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-              {
-                id: "BearerAuth",
-                type: "http",
-                scheme: "Bearer",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can specify multiple auth schemes to be used together and multiple options", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        @useAuth(BearerAuth | [ApiKeyAuth<ApiKeyLocation.header, "x-my-header">, BasicAuth])
-        namespace ${t.namespace("Foo")} {}
-      `);
-
-      expect(getAuthentication(program, Foo)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "BearerAuth",
-                type: "http",
-                scheme: "Bearer",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-          {
-            schemes: [
-              {
-                id: "ApiKeyAuth",
-                type: "apiKey",
-                in: "header",
-                name: "x-my-header",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-              {
-                id: "BasicAuth",
-                type: "http",
-                scheme: "Basic",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can override auth schemes on interface", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        alias ServiceKeyAuth = ApiKeyAuth<ApiKeyLocation.header, "X-API-KEY">;
-        @useAuth(ServiceKeyAuth)
-        namespace ${t.namespace("Foo")} {
-          @useAuth(BasicAuth | BearerAuth)
-          interface Bar { }
-        }
-      `);
-
-      expect(getAuthentication(program, Foo.interfaces.get("Bar")!)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "BasicAuth",
-                type: "http",
-                scheme: "Basic",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-          {
-            schemes: [
-              {
-                id: "BearerAuth",
-                type: "http",
-                scheme: "Bearer",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it("can override auth schemes on operation", async () => {
-      const { Foo, program } = await Tester.compile(t.code`
-        alias ServiceKeyAuth = ApiKeyAuth<ApiKeyLocation.header, "X-API-KEY">;
-        @useAuth(ServiceKeyAuth)
-        namespace ${t.namespace("Foo")} {
-          @useAuth([BasicAuth, BearerAuth])
-          op bar(): void;
-        }
-      `);
-
-      expect(getAuthentication(program, Foo.operations.get("bar")!)).toEqual({
-        options: [
-          {
-            schemes: [
-              {
-                id: "BasicAuth",
-                type: "http",
-                scheme: "Basic",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-              {
-                id: "BearerAuth",
-                type: "http",
-                scheme: "Bearer",
-                model: expect.objectContaining({ kind: "Model" }),
-              },
-            ],
-          },
-        ],
-      });
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
     });
   });
 
-  describe("@includeInapplicableMetadataInPayload", () => {
-    it("defaults to true", async () => {
-      const { M, program } = await Tester.compile(t.code`
-        namespace Foo;
-        model ${t.model("M")} {p: string; }
+  it("emit diagnostic when OAuth2 flow is not a valid model", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @useAuth(OAuth2Auth<["foo"]>)
+      namespace Foo {}
+
+      model Flow { noscopes: "boom"; };
+      @useAuth(OAuth2Auth<[Flow]>)
+      namespace Bar {}
       `);
 
-      strictEqual(M.kind, "Model" as const);
-      strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), true);
-    });
-    it("can specify at namespace level", async () => {
-      const { M, program } = await Tester.compile(t.code`
-        @Private.includeInapplicableMetadataInPayload(false)
-        namespace Foo;
-        model ${t.model("M")} {p: string; }
-      `);
+    expectDiagnostics(diagnostics, [
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+    ]);
+  });
 
-      strictEqual(M.kind, "Model" as const);
-      strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), false);
-    });
-    it("can specify at model level", async () => {
-      const { M, program } = await Tester.compile(t.code`
-      namespace Foo;
-      @Private.includeInapplicableMetadataInPayload(false) model ${t.model("M")} { p: string; }
+  it("can specify BasicAuth", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @useAuth(BasicAuth)
+      namespace ${t.namespace("Foo")} {}
     `);
 
-      strictEqual(M.kind, "Model" as const);
-      strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), false);
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "BasicAuth",
+              type: "http",
+              scheme: "Basic",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
     });
-    it("can specify at property level", async () => {
-      const { M, program } = await Tester.compile(t.code`
-      namespace Foo;
-      model ${t.model("M")} { @Private.includeInapplicableMetadataInPayload(false) p: string; }
+  });
+
+  it("can specify custom auth name with description", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @doc("My custom basic auth")
+      model MyAuth is BasicAuth;
+      @useAuth(MyAuth)
+      namespace ${t.namespace("Foo")} {}
     `);
 
-      strictEqual(M.kind, "Model" as const);
-      strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), false);
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "MyAuth",
+              description: "My custom basic auth",
+              type: "http",
+              scheme: "Basic",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
     });
+  });
 
-    it("can be overridden", async () => {
-      const { M, program } = await Tester.compile(t.code`
+  it("can specify BearerAuth", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @useAuth(BearerAuth)
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "BearerAuth",
+              type: "http",
+              scheme: "Bearer",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can specify ApiKeyAuth", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @useAuth(ApiKeyAuth<ApiKeyLocation.header, "x-my-header">)
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "ApiKeyAuth",
+              type: "apiKey",
+              in: "header",
+              name: "x-my-header",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can specify OAuth2", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      model MyFlow {
+        type: OAuth2FlowType.implicit;
+        authorizationUrl: "https://api.example.com/oauth2/authorize";
+        refreshUrl: "https://api.example.com/oauth2/refresh";
+        scopes: ["read", "write"];
+      }
+      @useAuth(OAuth2Auth<[MyFlow]>)
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "OAuth2Auth",
+              type: "oauth2",
+              flows: [
+                {
+                  type: "implicit",
+                  authorizationUrl: "https://api.example.com/oauth2/authorize",
+                  refreshUrl: "https://api.example.com/oauth2/refresh",
+                  scopes: [{ value: "read" }, { value: "write" }],
+                },
+              ],
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can specify OAuth2 with scopes, which are default for every flow", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      alias MyAuth<T extends string[]> = OAuth2Auth<Flows=[{
+        type: OAuth2FlowType.implicit;
+        authorizationUrl: "https://api.example.com/oauth2/authorize";
+        refreshUrl: "https://api.example.com/oauth2/refresh";
+      }], Scopes=T>;
+
+      @useAuth(MyAuth<["read", "write"]>)
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "OAuth2Auth",
+              type: "oauth2",
+              flows: [
+                {
+                  type: "implicit",
+                  authorizationUrl: "https://api.example.com/oauth2/authorize",
+                  refreshUrl: "https://api.example.com/oauth2/refresh",
+                  scopes: [{ value: "read" }, { value: "write" }],
+                },
+              ],
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can specify NoAuth", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @useAuth(NoAuth)
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "NoAuth",
+              type: "noAuth",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can specify multiple auth options", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @useAuth(BasicAuth | BearerAuth)
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "BasicAuth",
+              type: "http",
+              scheme: "Basic",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+        {
+          schemes: [
+            {
+              id: "BearerAuth",
+              type: "http",
+              scheme: "Bearer",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can specify multiple auth schemes to be used together", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @useAuth([BasicAuth, BearerAuth])
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "BasicAuth",
+              type: "http",
+              scheme: "Basic",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+            {
+              id: "BearerAuth",
+              type: "http",
+              scheme: "Bearer",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can specify multiple auth schemes to be used together and multiple options", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      @useAuth(BearerAuth | [ApiKeyAuth<ApiKeyLocation.header, "x-my-header">, BasicAuth])
+      namespace ${t.namespace("Foo")} {}
+    `);
+
+    expect(getAuthentication(program, Foo)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "BearerAuth",
+              type: "http",
+              scheme: "Bearer",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+        {
+          schemes: [
+            {
+              id: "ApiKeyAuth",
+              type: "apiKey",
+              in: "header",
+              name: "x-my-header",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+            {
+              id: "BasicAuth",
+              type: "http",
+              scheme: "Basic",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can override auth schemes on interface", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      alias ServiceKeyAuth = ApiKeyAuth<ApiKeyLocation.header, "X-API-KEY">;
+      @useAuth(ServiceKeyAuth)
+      namespace ${t.namespace("Foo")} {
+        @useAuth(BasicAuth | BearerAuth)
+        interface Bar { }
+      }
+    `);
+
+    expect(getAuthentication(program, Foo.interfaces.get("Bar")!)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "BasicAuth",
+              type: "http",
+              scheme: "Basic",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+        {
+          schemes: [
+            {
+              id: "BearerAuth",
+              type: "http",
+              scheme: "Bearer",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("can override auth schemes on operation", async () => {
+    const { Foo, program } = await Tester.compile(t.code`
+      alias ServiceKeyAuth = ApiKeyAuth<ApiKeyLocation.header, "X-API-KEY">;
+      @useAuth(ServiceKeyAuth)
+      namespace ${t.namespace("Foo")} {
+        @useAuth([BasicAuth, BearerAuth])
+        op bar(): void;
+      }
+    `);
+
+    expect(getAuthentication(program, Foo.operations.get("bar")!)).toEqual({
+      options: [
+        {
+          schemes: [
+            {
+              id: "BasicAuth",
+              type: "http",
+              scheme: "Basic",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+            {
+              id: "BearerAuth",
+              type: "http",
+              scheme: "Bearer",
+              model: expect.objectContaining({ kind: "Model" }),
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("@includeInapplicableMetadataInPayload", () => {
+  it("defaults to true", async () => {
+    const { M, program } = await Tester.compile(t.code`
+      namespace Foo;
+      model ${t.model("M")} {p: string; }
+    `);
+
+    strictEqual(M.kind, "Model" as const);
+    strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), true);
+  });
+  it("can specify at namespace level", async () => {
+    const { M, program } = await Tester.compile(t.code`
       @Private.includeInapplicableMetadataInPayload(false)
       namespace Foo;
-      @Private.includeInapplicableMetadataInPayload(true) model ${t.model("M")} { p: string; }
+      model ${t.model("M")} {p: string; }
     `);
 
-      strictEqual(M.kind, "Model" as const);
-      strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), true);
-    });
+    strictEqual(M.kind, "Model" as const);
+    strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), false);
+  });
+  it("can specify at model level", async () => {
+    const { M, program } = await Tester.compile(t.code`
+    namespace Foo;
+    @Private.includeInapplicableMetadataInPayload(false) model ${t.model("M")} { p: string; }
+  `);
+
+    strictEqual(M.kind, "Model" as const);
+    strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), false);
+  });
+  it("can specify at property level", async () => {
+    const { M, program } = await Tester.compile(t.code`
+    namespace Foo;
+    model ${t.model("M")} { @Private.includeInapplicableMetadataInPayload(false) p: string; }
+  `);
+
+    strictEqual(M.kind, "Model" as const);
+    strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), false);
+  });
+
+  it("can be overridden", async () => {
+    const { M, program } = await Tester.compile(t.code`
+    @Private.includeInapplicableMetadataInPayload(false)
+    namespace Foo;
+    @Private.includeInapplicableMetadataInPayload(true) model ${t.model("M")} { p: string; }
+  `);
+
+    strictEqual(M.kind, "Model" as const);
+    strictEqual(includeInapplicableMetadataInPayload(program, M.properties.get("p")!), true);
   });
 });

--- a/packages/http/test/overloads.test.ts
+++ b/packages/http/test/overloads.test.ts
@@ -1,126 +1,124 @@
 import { expectDiagnostics, t } from "@typespec/compiler/testing";
 import { strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { getHttpOperation, listHttpOperationsIn } from "../src/index.js";
 import { Tester } from "./test-host.js";
 
-describe("http: overloads", () => {
-  it("overloads inherit base overload route and verb", async () => {
-    const { uploadString, uploadBytes, program } = await Tester.compile(t.code`
-      @route("/upload")
-      @put
-      op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
-      @overload(upload)
-      op ${t.op("uploadString")}(data: string, @header contentType: "text/plain" ): void;
-      @overload(upload)
-      op ${t.op("uploadBytes")}(data: bytes, @header contentType: "application/octet-stream"): void;
-    `);
+it("overloads inherit base overload route and verb", async () => {
+  const { uploadString, uploadBytes, program } = await Tester.compile(t.code`
+    @route("/upload")
+    @put
+    op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+    @overload(upload)
+    op ${t.op("uploadString")}(data: string, @header contentType: "text/plain" ): void;
+    @overload(upload)
+    op ${t.op("uploadBytes")}(data: bytes, @header contentType: "application/octet-stream"): void;
+  `);
 
-    const [uploadStringHttp] = getHttpOperation(program, uploadString);
-    const [uploadBytesHttp] = getHttpOperation(program, uploadBytes);
+  const [uploadStringHttp] = getHttpOperation(program, uploadString);
+  const [uploadBytesHttp] = getHttpOperation(program, uploadBytes);
 
-    strictEqual(uploadStringHttp.path, "/upload");
-    strictEqual(uploadStringHttp.verb, "put");
-    strictEqual(uploadBytesHttp.path, "/upload");
-    strictEqual(uploadBytesHttp.verb, "put");
-  });
+  strictEqual(uploadStringHttp.path, "/upload");
+  strictEqual(uploadStringHttp.verb, "put");
+  strictEqual(uploadBytesHttp.path, "/upload");
+  strictEqual(uploadBytesHttp.verb, "put");
+});
 
-  it("overloads can change their route or verb", async () => {
-    const { upload, uploadString, uploadBytes, program } = await Tester.compile(t.code`
-      @route("/upload")
-      @put
-      op ${t.op("upload")}(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
-      @overload(upload)
-      @route("/uploadString")
-      op ${t.op("uploadString")}(data: string, @header contentType: "text/plain" ): void;
-      @overload(upload)
-      @post op ${t.op("uploadBytes")}(data: bytes, @header contentType: "application/octet-stream"): void;
-    `);
+it("overloads can change their route or verb", async () => {
+  const { upload, uploadString, uploadBytes, program } = await Tester.compile(t.code`
+    @route("/upload")
+    @put
+    op ${t.op("upload")}(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+    @overload(upload)
+    @route("/uploadString")
+    op ${t.op("uploadString")}(data: string, @header contentType: "text/plain" ): void;
+    @overload(upload)
+    @post op ${t.op("uploadBytes")}(data: bytes, @header contentType: "application/octet-stream"): void;
+  `);
 
-    const [uploadHttp] = getHttpOperation(program, upload);
-    const [uploadStringHttp] = getHttpOperation(program, uploadString);
-    const [uploadBytesHttp] = getHttpOperation(program, uploadBytes);
+  const [uploadHttp] = getHttpOperation(program, upload);
+  const [uploadStringHttp] = getHttpOperation(program, uploadString);
+  const [uploadBytesHttp] = getHttpOperation(program, uploadBytes);
 
-    strictEqual(uploadHttp.path, "/upload");
-    strictEqual(uploadHttp.verb, "put");
+  strictEqual(uploadHttp.path, "/upload");
+  strictEqual(uploadHttp.verb, "put");
 
-    // Change to /uploadString
-    strictEqual(uploadStringHttp.path, "/uploadString");
-    strictEqual(uploadStringHttp.verb, "put");
+  // Change to /uploadString
+  strictEqual(uploadStringHttp.path, "/uploadString");
+  strictEqual(uploadStringHttp.verb, "put");
 
-    // Changed to post
-    strictEqual(uploadBytesHttp.path, "/upload");
-    strictEqual(uploadBytesHttp.verb, "post");
-  });
+  // Changed to post
+  strictEqual(uploadBytesHttp.path, "/upload");
+  strictEqual(uploadBytesHttp.verb, "post");
+});
 
-  it("links overloads", async () => {
-    const { program } = await Tester.compile(t.code`
-      @route("/upload")
-      @put
-      op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
-      @overload(upload)
-      op uploadString(data: string, @header contentType: "text/plain" ): void;
-      @overload(upload)
-      op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
-    `);
+it("links overloads", async () => {
+  const { program } = await Tester.compile(t.code`
+    @route("/upload")
+    @put
+    op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+    @overload(upload)
+    op uploadString(data: string, @header contentType: "text/plain" ): void;
+    @overload(upload)
+    op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+  `);
 
-    const [[overload, uploadString, uploadBytes]] = listHttpOperationsIn(
-      program,
-      program.getGlobalNamespaceType(),
-    );
+  const [[overload, uploadString, uploadBytes]] = listHttpOperationsIn(
+    program,
+    program.getGlobalNamespaceType(),
+  );
 
-    strictEqual(uploadString.overloading, overload);
-    strictEqual(uploadBytes.overloading, overload);
-    strictEqual(overload.overloads?.[0], uploadString);
-    strictEqual(overload.overloads?.[1], uploadBytes);
-  });
+  strictEqual(uploadString.overloading, overload);
+  strictEqual(uploadBytes.overloading, overload);
+  strictEqual(overload.overloads?.[0], uploadString);
+  strictEqual(overload.overloads?.[1], uploadBytes);
+});
 
-  it("overload base route should still be unique with other operations", async () => {
-    const diagnostics = await Tester.diagnose(`
-      @route("/upload")
-      op otherUpload(data: bytes): void;
+it("overload base route should still be unique with other operations", async () => {
+  const diagnostics = await Tester.diagnose(`
+    @route("/upload")
+    op otherUpload(data: bytes): void;
 
-      @route("/upload")
-      op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
-      @overload(upload)
-      op uploadString(data: string, @header contentType: "text/plain" ): void;
-      @overload(upload)
-      op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
-    `);
-    expectDiagnostics(diagnostics, [
-      {
-        code: "@typespec/http/duplicate-operation",
-        message: `Duplicate operation "otherUpload" routed at "post /upload".`,
-      },
-      {
-        code: "@typespec/http/duplicate-operation",
-        message: `Duplicate operation "upload" routed at "post /upload".`,
-      },
-    ]);
-  });
+    @route("/upload")
+    op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+    @overload(upload)
+    op uploadString(data: string, @header contentType: "text/plain" ): void;
+    @overload(upload)
+    op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+  `);
+  expectDiagnostics(diagnostics, [
+    {
+      code: "@typespec/http/duplicate-operation",
+      message: `Duplicate operation "otherUpload" routed at "post /upload".`,
+    },
+    {
+      code: "@typespec/http/duplicate-operation",
+      message: `Duplicate operation "upload" routed at "post /upload".`,
+    },
+  ]);
+});
 
-  it("overloads route should still be unique with other operations", async () => {
-    const diagnostics = await Tester.diagnose(`
-      @route("/uploadString")
-      op otherUploadString(data: string): void;
+it("overloads route should still be unique with other operations", async () => {
+  const diagnostics = await Tester.diagnose(`
+    @route("/uploadString")
+    op otherUploadString(data: string): void;
 
-      @route("/upload")
-      op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
-      @overload(upload)
-      @route("/uploadString")
-      op uploadString(data: string, @header contentType: "text/plain" ): void;
-      @overload(upload)
-      op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
-    `);
-    expectDiagnostics(diagnostics, [
-      {
-        code: "@typespec/http/duplicate-operation",
-        message: `Duplicate operation "otherUploadString" routed at "post /uploadString".`,
-      },
-      {
-        code: "@typespec/http/duplicate-operation",
-        message: `Duplicate operation "uploadString" routed at "post /uploadString".`,
-      },
-    ]);
-  });
+    @route("/upload")
+    op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+    @overload(upload)
+    @route("/uploadString")
+    op uploadString(data: string, @header contentType: "text/plain" ): void;
+    @overload(upload)
+    op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+  `);
+  expectDiagnostics(diagnostics, [
+    {
+      code: "@typespec/http/duplicate-operation",
+      message: `Duplicate operation "otherUploadString" routed at "post /uploadString".`,
+    },
+    {
+      code: "@typespec/http/duplicate-operation",
+      message: `Duplicate operation "uploadString" routed at "post /uploadString".`,
+    },
+  ]);
 });

--- a/packages/http/test/plaindata.test.ts
+++ b/packages/http/test/plaindata.test.ts
@@ -1,37 +1,35 @@
 import { t } from "@typespec/compiler/testing";
 import { ok, strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { isBody, isHeader, isPathParam, isQueryParam } from "../src/decorators.js";
 import { Tester } from "./test-host.js";
 
-describe("http: plain data", () => {
-  it("removes header/query/body/path", async () => {
-    const { Before, After, Spread, program } = await Tester.compile(t.code`
-      model ${t.model("Before")} {
-        @header a: string;
-        @query b: string;
-        @path c: string;
-        @body d: string;
-      }
-
-      model ${t.model("After")} is PlainData<Before> {}
-
-      model ${t.model("Spread")} {
-        ...After
-      }
-    `);
-
-    ok(isHeader(program, Before.properties.get("a")!), "header expected");
-    ok(isBody(program, Before.properties.get("d")!), "body expected");
-    ok(isQueryParam(program, Before.properties.get("b")!), "query expected");
-    ok(isPathParam(program, Before.properties.get("c")!), "path expected");
-
-    for (const model of [After, Spread]) {
-      strictEqual(model.kind, "Model" as const);
-      ok(!isHeader(program, model.properties.get("a")!), `header not expected in ${model.name}`);
-      ok(!isBody(program, model.properties.get("d")!), `body not expected in ${model.name}`);
-      ok(!isQueryParam(program, model.properties.get("b")!), `query not expected in ${model.name}`);
-      ok(!isPathParam(program, model.properties.get("c")!), `path not expected in ${model.name}`);
+it("removes header/query/body/path", async () => {
+  const { Before, After, Spread, program } = await Tester.compile(t.code`
+    model ${t.model("Before")} {
+      @header a: string;
+      @query b: string;
+      @path c: string;
+      @body d: string;
     }
-  });
+
+    model ${t.model("After")} is PlainData<Before> {}
+
+    model ${t.model("Spread")} {
+      ...After
+    }
+  `);
+
+  ok(isHeader(program, Before.properties.get("a")!), "header expected");
+  ok(isBody(program, Before.properties.get("d")!), "body expected");
+  ok(isQueryParam(program, Before.properties.get("b")!), "query expected");
+  ok(isPathParam(program, Before.properties.get("c")!), "path expected");
+
+  for (const model of [After, Spread]) {
+    strictEqual(model.kind, "Model" as const);
+    ok(!isHeader(program, model.properties.get("a")!), `header not expected in ${model.name}`);
+    ok(!isBody(program, model.properties.get("d")!), `body not expected in ${model.name}`);
+    ok(!isQueryParam(program, model.properties.get("b")!), `query not expected in ${model.name}`);
+    ok(!isPathParam(program, model.properties.get("c")!), `path not expected in ${model.name}`);
+  }
 });

--- a/packages/http/test/response-descriptions.test.ts
+++ b/packages/http/test/response-descriptions.test.ts
@@ -1,83 +1,81 @@
 import { expectDiagnosticEmpty } from "@typespec/compiler/testing";
 import { strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { getOperationsWithServiceNamespace } from "./test-host.js";
 
-describe("http: response descriptions", () => {
-  async function getHttpOp(code: string) {
-    const [ops, diagnostics] = await getOperationsWithServiceNamespace(code);
-    expectDiagnosticEmpty(diagnostics);
-    strictEqual(ops.length, 1);
-    return ops[0];
-  }
+async function getHttpOp(code: string) {
+  const [ops, diagnostics] = await getOperationsWithServiceNamespace(code);
+  expectDiagnosticEmpty(diagnostics);
+  strictEqual(ops.length, 1);
+  return ops[0];
+}
 
-  it("use a default message by status code if not specified", async () => {
-    const op = await getHttpOp(
-      `
-      op read(): {@statusCode _: 200, content: string};
-      `,
-    );
-    strictEqual(op.responses[0].description, "The request has succeeded.");
-  });
+it("use a default message by status code if not specified", async () => {
+  const op = await getHttpOp(
+    `
+    op read(): {@statusCode _: 200, content: string};
+    `,
+  );
+  strictEqual(op.responses[0].description, "The request has succeeded.");
+});
 
-  it("@returns set doc for all success responses", async () => {
-    const op = await getHttpOp(
-      `
-      @error model Error {}
-      @returnsDoc("A string")
-      op read(): { @statusCode _: 200, content: string } |  { @statusCode _: 201, content: string } | Error;
-      `,
-    );
-    strictEqual(op.responses[0].description, "A string");
-    strictEqual(op.responses[1].description, "A string");
-    strictEqual(op.responses[2].description, undefined);
-  });
+it("@returns set doc for all success responses", async () => {
+  const op = await getHttpOp(
+    `
+    @error model Error {}
+    @returnsDoc("A string")
+    op read(): { @statusCode _: 200, content: string } |  { @statusCode _: 201, content: string } | Error;
+    `,
+  );
+  strictEqual(op.responses[0].description, "A string");
+  strictEqual(op.responses[1].description, "A string");
+  strictEqual(op.responses[2].description, undefined);
+});
 
-  it("@errors set doc for all success responses", async () => {
-    const op = await getHttpOp(
-      `
-      @error model Error {}
-      @errorsDoc("Generic error")
-      op read(): { @statusCode _: 200, content: string } |  { @statusCode _: 201, content: string } | Error;
-      `,
-    );
-    strictEqual(op.responses[0].description, "The request has succeeded.");
-    strictEqual(
-      op.responses[1].description,
-      "The request has succeeded and a new resource has been created as a result.",
-    );
-    strictEqual(op.responses[2].description, "Generic error");
-  });
+it("@errors set doc for all success responses", async () => {
+  const op = await getHttpOp(
+    `
+    @error model Error {}
+    @errorsDoc("Generic error")
+    op read(): { @statusCode _: 200, content: string } |  { @statusCode _: 201, content: string } | Error;
+    `,
+  );
+  strictEqual(op.responses[0].description, "The request has succeeded.");
+  strictEqual(
+    op.responses[1].description,
+    "The request has succeeded and a new resource has been created as a result.",
+  );
+  strictEqual(op.responses[2].description, "Generic error");
+});
 
-  it("@doc explicitly on a response override the operation returns doc", async () => {
-    const op = await getHttpOp(
-      `
-      @error model Error {}
-      @error @doc("Not found model") model NotFound {@statusCode _: 404}
-      @errorsDoc("Generic error")
-      op read(): { @statusCode _: 200, content: string } |  { @statusCode _: 201, content: string } | NotFound | Error ;
-      `,
-    );
-    strictEqual(op.responses[0].description, "The request has succeeded.");
-    strictEqual(
-      op.responses[1].description,
-      "The request has succeeded and a new resource has been created as a result.",
-    );
-    strictEqual(op.responses[2].description, "Not found model");
-    strictEqual(op.responses[3].description, "Generic error");
-  });
+it("@doc explicitly on a response override the operation returns doc", async () => {
+  const op = await getHttpOp(
+    `
+    @error model Error {}
+    @error @doc("Not found model") model NotFound {@statusCode _: 404}
+    @errorsDoc("Generic error")
+    op read(): { @statusCode _: 200, content: string } |  { @statusCode _: 201, content: string } | NotFound | Error ;
+    `,
+  );
+  strictEqual(op.responses[0].description, "The request has succeeded.");
+  strictEqual(
+    op.responses[1].description,
+    "The request has succeeded and a new resource has been created as a result.",
+  );
+  strictEqual(op.responses[2].description, "Not found model");
+  strictEqual(op.responses[3].description, "Generic error");
+});
 
-  it("@doc on response model set response doc if model is an evelope with @statusCode", async () => {
-    const op = await getHttpOp(
-      `
-      /** Explicit doc */
-      model Result {
-        @statusCode _: 201;
-        implicit: 200;
-      }
-      op read(): Result;
-      `,
-    );
-    strictEqual(op.responses[0].description, "Explicit doc");
-  });
+it("@doc on response model set response doc if model is an evelope with @statusCode", async () => {
+  const op = await getHttpOp(
+    `
+    /** Explicit doc */
+    model Result {
+      @statusCode _: 201;
+      implicit: 200;
+    }
+    op read(): Result;
+    `,
+  );
+  strictEqual(op.responses[0].description, "Explicit doc");
 });

--- a/packages/http/test/rules/op-reference-container-route.test.ts
+++ b/packages/http/test/rules/op-reference-container-route.test.ts
@@ -1,95 +1,93 @@
 import { createLinterRuleTester, LinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { opReferenceContainerRouteRule } from "../../src/rules/op-reference-container-route.js";
 import { Tester } from "../test-host.js";
 
-describe("operation reference route container rule", () => {
-  let ruleTester: LinterRuleTester;
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    ruleTester = createLinterRuleTester(runner, opReferenceContainerRouteRule, "@typespec/http");
-  });
+let ruleTester: LinterRuleTester;
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  ruleTester = createLinterRuleTester(runner, opReferenceContainerRouteRule, "@typespec/http");
+});
 
-  it("emit a diagnostic when referenced op has a route prefix on its parent container", async () => {
-    // cspell:ignore IFoo
-    await ruleTester
-      .expect(
-        `
-        @route("/foo")
-        namespace Foo {
-          @route("/test")
+it("emit a diagnostic when referenced op has a route prefix on its parent container", async () => {
+  // cspell:ignore IFoo
+  await ruleTester
+    .expect(
+      `
+      @route("/foo")
+      namespace Foo {
+        @route("/test")
+        op get(): string;
+      }
+
+      @route("/ifoo")
+      interface IFoo {
+        op get(): string;
+      }
+
+      @route("/bar")
+      namespace Bar {
+        interface IBar {
           op get(): string;
         }
+      }
 
-        @route("/ifoo")
-        interface IFoo {
-          op get(): string;
-        }
+      namespace Test {
+        @route("/get1") op get1 is Foo.get;
+        @route("/get2") op get2 is IFoo.get;
+        @route("/get3") op get3 is Bar.IBar.get;
+        @route("/get4") op get4 is get3; // Follow reference chain to find parent container
+      }
+    `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@typespec/http/op-reference-container-route",
+        message:
+          'Operation get1 references an operation which has a @route prefix on its namespace or interface: "/foo".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
+      },
+      {
+        code: "@typespec/http/op-reference-container-route",
+        message:
+          'Operation get2 references an operation which has a @route prefix on its namespace or interface: "/ifoo".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
+      },
+      {
+        code: "@typespec/http/op-reference-container-route",
+        message:
+          'Operation get3 references an operation which has a @route prefix on its namespace or interface: "/bar".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
+      },
+      {
+        code: "@typespec/http/op-reference-container-route",
+        message:
+          'Operation get4 references an operation which has a @route prefix on its namespace or interface: "/bar".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
+      },
+    ]);
+});
 
-        @route("/bar")
-        namespace Bar {
-          interface IBar {
-            op get(): string;
-          }
-        }
+it("does not emit for references inside of the same container", async () => {
+  await ruleTester
+    .expect(
+      `
+      @route("/foo")
+      namespace Foo {
+        @route("/test")
+        op get(): string;
+      }
 
-        namespace Test {
-          @route("/get1") op get1 is Foo.get;
-          @route("/get2") op get2 is IFoo.get;
-          @route("/get3") op get3 is Bar.IBar.get;
-          @route("/get4") op get4 is get3; // Follow reference chain to find parent container
-        }
-      `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@typespec/http/op-reference-container-route",
-          message:
-            'Operation get1 references an operation which has a @route prefix on its namespace or interface: "/foo".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
-        },
-        {
-          code: "@typespec/http/op-reference-container-route",
-          message:
-            'Operation get2 references an operation which has a @route prefix on its namespace or interface: "/ifoo".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
-        },
-        {
-          code: "@typespec/http/op-reference-container-route",
-          message:
-            'Operation get3 references an operation which has a @route prefix on its namespace or interface: "/bar".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
-        },
-        {
-          code: "@typespec/http/op-reference-container-route",
-          message:
-            'Operation get4 references an operation which has a @route prefix on its namespace or interface: "/bar".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
-        },
-      ]);
-  });
+      namespace Bar {
+        @route("/get1") op get1 is Foo.get;
+      }
 
-  it("does not emit for references inside of the same container", async () => {
-    await ruleTester
-      .expect(
-        `
-        @route("/foo")
-        namespace Foo {
-          @route("/test")
-          op get(): string;
-        }
-
-        namespace Bar {
-          @route("/get1") op get1 is Foo.get;
-        }
-
-        namespace Foo {
-          @route("/get2") op get2 is Foo.get;
-        }
-      `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@typespec/http/op-reference-container-route",
-          message:
-            'Operation get1 references an operation which has a @route prefix on its namespace or interface: "/foo".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
-        },
-      ]);
-  });
+      namespace Foo {
+        @route("/get2") op get2 is Foo.get;
+      }
+    `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@typespec/http/op-reference-container-route",
+        message:
+          'Operation get1 references an operation which has a @route prefix on its namespace or interface: "/foo".  This operation will not carry forward the route prefix so the final route may be different than the referenced operation.',
+      },
+    ]);
 });

--- a/packages/http/test/utils.test.ts
+++ b/packages/http/test/utils.test.ts
@@ -1,31 +1,29 @@
 import { describe, expect, it } from "vitest";
 import { extractParamsFromPath } from "../src/utils.js";
 
-describe("utils", () => {
-  describe("extractParamsFromPath", () => {
-    it("parse single param", () => {
-      expect(extractParamsFromPath("foo/{name}/bar")).toEqual(["name"]);
-    });
+describe("extractParamsFromPath", () => {
+  it("parse single param", () => {
+    expect(extractParamsFromPath("foo/{name}/bar")).toEqual(["name"]);
+  });
 
-    it("parse param with -", () => {
-      expect(extractParamsFromPath("foo/{foo-bar}/bar")).toEqual(["foo-bar"]);
-    });
+  it("parse param with -", () => {
+    expect(extractParamsFromPath("foo/{foo-bar}/bar")).toEqual(["foo-bar"]);
+  });
 
-    it("parse multiple param", () => {
-      expect(extractParamsFromPath("foo/{name}/bar/{age}")).toEqual(["name", "age"]);
-    });
+  it("parse multiple param", () => {
+    expect(extractParamsFromPath("foo/{name}/bar/{age}")).toEqual(["name", "age"]);
+  });
 
-    it("parse single OData params", () => {
-      expect(extractParamsFromPath("/certificates(thumbprint={thumbprint})/canceldelete")).toEqual([
-        "thumbprint",
-      ]);
-    });
-    it("parse multiple OData params", () => {
-      expect(
-        extractParamsFromPath(
-          "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})/canceldelete",
-        ),
-      ).toEqual(["thumbprintAlgorithm", "thumbprint"]);
-    });
+  it("parse single OData params", () => {
+    expect(extractParamsFromPath("/certificates(thumbprint={thumbprint})/canceldelete")).toEqual([
+      "thumbprint",
+    ]);
+  });
+  it("parse multiple OData params", () => {
+    expect(
+      extractParamsFromPath(
+        "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})/canceldelete",
+      ),
+    ).toEqual(["thumbprintAlgorithm", "thumbprint"]);
   });
 });

--- a/packages/internal-build-utils/test/mics.test.ts
+++ b/packages/internal-build-utils/test/mics.test.ts
@@ -1,6 +1,4 @@
 import { ok } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 
-describe("internal-build-utils", () => {
-  it("todo", () => ok(true));
-});
+it("todo", () => ok(true));

--- a/packages/internal-build-utils/test/prerelease.test.ts
+++ b/packages/internal-build-utils/test/prerelease.test.ts
@@ -1,43 +1,41 @@
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { getNextVersion, getPrereleaseVersionRange } from "../src/prerelease.js";
 
-describe("getPrereleaseVersionRange", () => {
-  it.each([
-    {
-      currentVersion: "0.1.0",
-      preReleaseTag: "dev",
-      expectedRange: "^0.1.0 || >=0.2.0-dev <0.2.0",
-    },
-    {
-      currentVersion: "0.1.0-alpha.0",
-      preReleaseTag: "dev",
-      expectedRange: "^0.1.0-alpha.0 || >=0.1.0-alpha.1-dev <0.1.0-alpha.1",
-    },
-    {
-      currentVersion: "1.0.0-rc.0",
-      preReleaseTag: "dev",
-      expectedRange: "^1.0.0-rc.0",
-    },
-    {
-      currentVersion: "1.1.0",
-      preReleaseTag: "dev",
-      expectedRange: "^1.1.0",
-    },
-  ])(
-    "limits range to major version ($currentVersion)",
-    ({ currentVersion, preReleaseTag, expectedRange }) => {
-      const range = getPrereleaseVersionRange(
-        {
-          manifest: { name: "test", version: currentVersion },
-          oldVersion: currentVersion,
-          nextVersion: getNextVersion(currentVersion),
-          newVersion: `${getNextVersion(currentVersion)}-${preReleaseTag}.0`,
-          packageJsonPath: "test/package.json",
-        },
-        preReleaseTag,
-      );
+it.each([
+  {
+    currentVersion: "0.1.0",
+    preReleaseTag: "dev",
+    expectedRange: "^0.1.0 || >=0.2.0-dev <0.2.0",
+  },
+  {
+    currentVersion: "0.1.0-alpha.0",
+    preReleaseTag: "dev",
+    expectedRange: "^0.1.0-alpha.0 || >=0.1.0-alpha.1-dev <0.1.0-alpha.1",
+  },
+  {
+    currentVersion: "1.0.0-rc.0",
+    preReleaseTag: "dev",
+    expectedRange: "^1.0.0-rc.0",
+  },
+  {
+    currentVersion: "1.1.0",
+    preReleaseTag: "dev",
+    expectedRange: "^1.1.0",
+  },
+])(
+  "limits range to major version ($currentVersion)",
+  ({ currentVersion, preReleaseTag, expectedRange }) => {
+    const range = getPrereleaseVersionRange(
+      {
+        manifest: { name: "test", version: currentVersion },
+        oldVersion: currentVersion,
+        nextVersion: getNextVersion(currentVersion),
+        newVersion: `${getNextVersion(currentVersion)}-${preReleaseTag}.0`,
+        packageJsonPath: "test/package.json",
+      },
+      preReleaseTag,
+    );
 
-      expect(range).toBe(expectedRange);
-    },
-  );
-});
+    expect(range).toBe(expectedRange);
+  },
+);

--- a/packages/json-schema/test/arrays.test.ts
+++ b/packages/json-schema/test/arrays.test.ts
@@ -1,159 +1,157 @@
 import assert from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("arrays", () => {
-  it("works with declarations", async () => {
-    const schemas = await emitSchema(`
-      model Foo is Array<string>;
-      model Bar is Array<Foo>;
-    `);
+it("works with declarations", async () => {
+  const schemas = await emitSchema(`
+    model Foo is Array<string>;
+    model Bar is Array<Foo>;
+  `);
 
-    const Foo = schemas["Foo.json"];
-    const Bar = schemas["Bar.json"];
+  const Foo = schemas["Foo.json"];
+  const Bar = schemas["Bar.json"];
 
-    assert.strictEqual(Foo.$schema, "https://json-schema.org/draft/2020-12/schema");
-    assert.strictEqual(Foo.$id, "Foo.json");
-    assert.strictEqual(Foo.type, "array");
-    assert.deepStrictEqual(Foo.items, { type: "string" });
-    assert.deepStrictEqual(Bar.items, { $ref: "Foo.json" });
-  });
+  assert.strictEqual(Foo.$schema, "https://json-schema.org/draft/2020-12/schema");
+  assert.strictEqual(Foo.$id, "Foo.json");
+  assert.strictEqual(Foo.type, "array");
+  assert.deepStrictEqual(Foo.items, { type: "string" });
+  assert.deepStrictEqual(Bar.items, { $ref: "Foo.json" });
+});
 
-  it("works with literals", async () => {
-    const schemas = await emitSchema(`
-      model M { }
-      model Foo {
-        x: string[];
-        y: M[];
-      }
-    `);
+it("works with literals", async () => {
+  const schemas = await emitSchema(`
+    model M { }
+    model Foo {
+      x: string[];
+      y: M[];
+    }
+  `);
 
-    const Foo = schemas["Foo.json"];
+  const Foo = schemas["Foo.json"];
 
-    assert.strictEqual(Foo.properties.x.type, "array");
-    assert.deepStrictEqual(Foo.properties.x.items, { type: "string" });
+  assert.strictEqual(Foo.properties.x.type, "array");
+  assert.deepStrictEqual(Foo.properties.x.items, { type: "string" });
 
-    assert.strictEqual(Foo.properties.y.type, "array");
-    assert.deepStrictEqual(Foo.properties.y.items, { $ref: "M.json" });
-  });
+  assert.strictEqual(Foo.properties.y.type, "array");
+  assert.deepStrictEqual(Foo.properties.y.items, { $ref: "M.json" });
+});
 
-  it("works with minItems and maxItems", async () => {
-    const { "Foo.json": Foo, "Bar.json": Bar } = await emitSchema(`
+it("works with minItems and maxItems", async () => {
+  const { "Foo.json": Foo, "Bar.json": Bar } = await emitSchema(`
+    @minItems(1)
+    @maxItems(2)
+    model Foo is Array<string>;
+    model Bar {
       @minItems(1)
       @maxItems(2)
-      model Foo is Array<string>;
-      model Bar {
-        @minItems(1)
-        @maxItems(2)
-        x: string[];
-      }
-    `);
+      x: string[];
+    }
+  `);
 
-    assert.strictEqual(Foo.minItems, 1);
-    assert.strictEqual(Foo.maxItems, 2);
-    assert.strictEqual(Bar.properties.x.minItems, 1);
-    assert.strictEqual(Bar.properties.x.maxItems, 2);
-  });
+  assert.strictEqual(Foo.minItems, 1);
+  assert.strictEqual(Foo.maxItems, 2);
+  assert.strictEqual(Bar.properties.x.minItems, 1);
+  assert.strictEqual(Bar.properties.x.maxItems, 2);
+});
 
-  it("works with contains, minContains, and maxContains", async () => {
-    const { "Foo.json": Foo, "Bar.json": Bar } = await emitSchema(`
+it("works with contains, minContains, and maxContains", async () => {
+  const { "Foo.json": Foo, "Bar.json": Bar } = await emitSchema(`
+    @contains(string)
+    @minContains(1)
+    @maxContains(2)
+    @uniqueItems
+    model Foo is Array<unknown>;
+    model Bar {
       @contains(string)
       @minContains(1)
       @maxContains(2)
       @uniqueItems
-      model Foo is Array<unknown>;
-      model Bar {
-        @contains(string)
-        @minContains(1)
-        @maxContains(2)
-        @uniqueItems
-        x: unknown[];
-      }
-    `);
+      x: unknown[];
+    }
+  `);
 
-    assert.strictEqual(Foo.minContains, 1);
-    assert.strictEqual(Foo.maxContains, 2);
-    assert.deepStrictEqual(Foo.contains, { type: "string" });
-    assert.strictEqual(Foo.uniqueItems, true);
-    assert.strictEqual(Bar.properties.x.minContains, 1);
-    assert.strictEqual(Bar.properties.x.maxContains, 2);
-    assert.deepStrictEqual(Bar.properties.x.contains, { type: "string" });
-    assert.strictEqual(Bar.properties.x.uniqueItems, true);
-  });
+  assert.strictEqual(Foo.minContains, 1);
+  assert.strictEqual(Foo.maxContains, 2);
+  assert.deepStrictEqual(Foo.contains, { type: "string" });
+  assert.strictEqual(Foo.uniqueItems, true);
+  assert.strictEqual(Bar.properties.x.minContains, 1);
+  assert.strictEqual(Bar.properties.x.maxContains, 2);
+  assert.deepStrictEqual(Bar.properties.x.contains, { type: "string" });
+  assert.strictEqual(Bar.properties.x.uniqueItems, true);
+});
 
-  it("works with prefixItems", async () => {
-    const { "Foo.json": Foo, "Bar.json": Bar } = await emitSchema(`
+it("works with prefixItems", async () => {
+  const { "Foo.json": Foo, "Bar.json": Bar } = await emitSchema(`
+    @prefixItems([string, { x: string }, Foo])
+    model Foo is Array<unknown>;
+    model Bar {
       @prefixItems([string, { x: string }, Foo])
-      model Foo is Array<unknown>;
-      model Bar {
-        @prefixItems([string, { x: string }, Foo])
-        x: unknown[];
-      }
-    `);
+      x: unknown[];
+    }
+  `);
 
-    assert.strictEqual(Foo.prefixItems.length, 3);
-    assert.deepStrictEqual(Foo.prefixItems[0], { type: "string" });
-    assert.deepStrictEqual(Foo.prefixItems[1], {
-      type: "object",
-      properties: { x: { type: "string" } },
-      required: ["x"],
-    });
-    assert.deepStrictEqual(Foo.prefixItems[2], { $ref: "Foo.json" });
-    assert.strictEqual(Bar.properties.x.prefixItems.length, 3);
-    assert.deepStrictEqual(Bar.properties.x.prefixItems[0], { type: "string" });
-    assert.deepStrictEqual(Bar.properties.x.prefixItems[1], {
-      type: "object",
-      properties: { x: { type: "string" } },
-      required: ["x"],
-    });
-    assert.deepStrictEqual(Bar.properties.x.prefixItems[2], { $ref: "Foo.json" });
+  assert.strictEqual(Foo.prefixItems.length, 3);
+  assert.deepStrictEqual(Foo.prefixItems[0], { type: "string" });
+  assert.deepStrictEqual(Foo.prefixItems[1], {
+    type: "object",
+    properties: { x: { type: "string" } },
+    required: ["x"],
+  });
+  assert.deepStrictEqual(Foo.prefixItems[2], { $ref: "Foo.json" });
+  assert.strictEqual(Bar.properties.x.prefixItems.length, 3);
+  assert.deepStrictEqual(Bar.properties.x.prefixItems[0], { type: "string" });
+  assert.deepStrictEqual(Bar.properties.x.prefixItems[1], {
+    type: "object",
+    properties: { x: { type: "string" } },
+    required: ["x"],
+  });
+  assert.deepStrictEqual(Bar.properties.x.prefixItems[2], { $ref: "Foo.json" });
+});
+
+it("accepts a visibility transform", async () => {
+  const {
+    "Test.json": Test,
+    "Person.json": Person,
+    "Friend.json": Friend,
+    "CreatePerson.json": CreatePerson,
+    "CreateFriend.json": CreateFriend,
+  } = await emitSchema(`
+    model Friend {
+      name: string;
+    
+      @visibility(Lifecycle.Read)
+      age: integer;
+    }
+    
+    model Person {
+      friends: Friend[];
+    }
+    
+    model Test {
+      a: Create<Person>;
+    }
+  `);
+
+  assert.deepStrictEqual(Friend.properties, {
+    name: { type: "string" },
+    age: { type: "integer" },
   });
 
-  it("accepts a visibility transform", async () => {
-    const {
-      "Test.json": Test,
-      "Person.json": Person,
-      "Friend.json": Friend,
-      "CreatePerson.json": CreatePerson,
-      "CreateFriend.json": CreateFriend,
-    } = await emitSchema(`
-      model Friend {
-        name: string;
-      
-        @visibility(Lifecycle.Read)
-        age: integer;
-      }
-      
-      model Person {
-        friends: Friend[];
-      }
-      
-      model Test {
-        a: Create<Person>;
-      }
-    `);
+  assert.deepStrictEqual(CreateFriend.properties, {
+    name: { type: "string" },
+  });
 
-    assert.deepStrictEqual(Friend.properties, {
-      name: { type: "string" },
-      age: { type: "integer" },
-    });
+  assert.deepStrictEqual(CreatePerson.properties, {
+    friends: { type: "array", items: { $ref: "CreateFriend.json" } },
+  });
 
-    assert.deepStrictEqual(CreateFriend.properties, {
-      name: { type: "string" },
-    });
+  assert.deepStrictEqual(Person.properties, {
+    friends: { type: "array", items: { $ref: "Friend.json" } },
+  });
 
-    assert.deepStrictEqual(CreatePerson.properties, {
-      friends: { type: "array", items: { $ref: "CreateFriend.json" } },
-    });
-
-    assert.deepStrictEqual(Person.properties, {
-      friends: { type: "array", items: { $ref: "Friend.json" } },
-    });
-
-    assert.deepStrictEqual(Test.properties, {
-      a: {
-        $ref: "CreatePerson.json",
-      },
-    });
+  assert.deepStrictEqual(Test.properties, {
+    a: {
+      $ref: "CreatePerson.json",
+    },
   });
 });

--- a/packages/json-schema/test/built-ins.test.ts
+++ b/packages/json-schema/test/built-ins.test.ts
@@ -1,54 +1,52 @@
 import assert from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("emitting built-in types", () => {
-  const types = new Map([
-    // numeric types
-    ["numeric", { type: "number" }],
-    ["integer", { type: "integer" }],
-    ["float", { type: "number" }],
-    ["float32", { type: "number" }],
-    ["float64", { type: "number" }],
-    ["int8", { type: "integer", minimum: -128, maximum: 127 }],
-    ["int16", { type: "integer", minimum: -32768, maximum: 32767 }],
-    ["int32", { type: "integer", minimum: -2147483648, maximum: 2147483647 }],
-    ["unixTimestamp32", { type: "integer", minimum: -2147483648, maximum: 2147483647 }],
-    ["int64", { type: "string" }],
-    ["uint8", { type: "integer", minimum: 0, maximum: 255 }],
-    ["uint16", { type: "integer", minimum: 0, maximum: 65535 }],
-    ["uint32", { type: "integer", minimum: 0, maximum: 4294967295 }],
-    ["uint64", { type: "string" }],
-    ["safeint", { type: "integer" }],
-    ["decimal", { type: "string" }],
-    ["decimal128", { type: "string" }],
+const types = new Map([
+  // numeric types
+  ["numeric", { type: "number" }],
+  ["integer", { type: "integer" }],
+  ["float", { type: "number" }],
+  ["float32", { type: "number" }],
+  ["float64", { type: "number" }],
+  ["int8", { type: "integer", minimum: -128, maximum: 127 }],
+  ["int16", { type: "integer", minimum: -32768, maximum: 32767 }],
+  ["int32", { type: "integer", minimum: -2147483648, maximum: 2147483647 }],
+  ["unixTimestamp32", { type: "integer", minimum: -2147483648, maximum: 2147483647 }],
+  ["int64", { type: "string" }],
+  ["uint8", { type: "integer", minimum: 0, maximum: 255 }],
+  ["uint16", { type: "integer", minimum: 0, maximum: 65535 }],
+  ["uint32", { type: "integer", minimum: 0, maximum: 4294967295 }],
+  ["uint64", { type: "string" }],
+  ["safeint", { type: "integer" }],
+  ["decimal", { type: "string" }],
+  ["decimal128", { type: "string" }],
 
-    // date types
-    ["plainDate", { type: "string", format: "date" }],
-    ["plainTime", { type: "string", format: "time" }],
-    ["duration", { type: "string", format: "duration" }],
+  // date types
+  ["plainDate", { type: "string", format: "date" }],
+  ["plainTime", { type: "string", format: "time" }],
+  ["duration", { type: "string", format: "duration" }],
 
-    // this is technically incorrect, date-time is an offsetDateTime.
-    ["utcDateTime", { type: "string", format: "date-time" }],
-    ["offsetDateTime", { type: "string", format: "date-time" }],
+  // this is technically incorrect, date-time is an offsetDateTime.
+  ["utcDateTime", { type: "string", format: "date-time" }],
+  ["offsetDateTime", { type: "string", format: "date-time" }],
 
-    // others
-    ["string", { type: "string" }],
-    ["url", { type: "string", format: "uri" }],
-    ["null", { type: "null" }],
-    ["bytes", { type: "string", contentEncoding: "base64" }],
-    ["boolean", { type: "boolean" }],
-  ]);
+  // others
+  ["string", { type: "string" }],
+  ["url", { type: "string", format: "uri" }],
+  ["null", { type: "null" }],
+  ["bytes", { type: "string", contentEncoding: "base64" }],
+  ["boolean", { type: "boolean" }],
+]);
 
-  for (const [type, expectedSchema] of types) {
-    it(`handles ${type}`, async () => {
-      const schemas = await emitSchema(`
-        model Foo {
-          x: ${type}
-        };
-      `);
+for (const [type, expectedSchema] of types) {
+  it(`handles ${type}`, async () => {
+    const schemas = await emitSchema(`
+      model Foo {
+        x: ${type}
+      };
+    `);
 
-      assert.deepStrictEqual(schemas["Foo.json"].properties.x, expectedSchema);
-    });
-  }
-});
+    assert.deepStrictEqual(schemas["Foo.json"].properties.x, expectedSchema);
+  });
+}

--- a/packages/json-schema/test/bundling.test.ts
+++ b/packages/json-schema/test/bundling.test.ts
@@ -1,147 +1,145 @@
 import assert, { strictEqual } from "assert";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("bundling", () => {
-  it("works", async () => {
-    const schemas = await emitSchema(
-      `
-      model Foo { }
-      model Bar { }
-    `,
-      { bundleId: "test.json" },
-    );
+it("works", async () => {
+  const schemas = await emitSchema(
+    `
+    model Foo { }
+    model Bar { }
+  `,
+    { bundleId: "test.json" },
+  );
 
-    const types = schemas["test.json"];
-    assert.strictEqual(types.$defs.Foo.$id, "Foo.json");
-    assert.strictEqual(types.$defs.Bar.$id, "Bar.json");
+  const types = schemas["test.json"];
+  assert.strictEqual(types.$defs.Foo.$id, "Foo.json");
+  assert.strictEqual(types.$defs.Bar.$id, "Bar.json");
+});
+
+it("doesn't create bundled schemas for referenced non-JSON Schema types", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
+    @jsonSchema
+    model testArray is Array<nonModel>;
+    @jsonSchema
+    union testUnion { nonModel }
+    @jsonSchema
+    enum testEnum { a, b }
+    @jsonSchema
+    scalar testScalar extends nonScalar;
+    
+    model nonModel { b: Baz }
+    model Baz { }
+    model nonArray is Array<nonModel>;
+    scalar nonScalar extends string;
+    enum nonEnum { a, b }
+    union nonUnion { nonModel }
+
+  `,
+    { bundleId: "test.json" },
+    {
+      emitNamespace: false,
+    },
+  );
+
+  const defs = Object.keys(schemas["test.json"].$defs);
+  strictEqual(defs.length, 5);
+  ["testModel", "testArray", "testUnion", "testEnum", "testScalar"].forEach((name) => {
+    expect(defs).toContain(name);
   });
+});
+it("with emitAllRefs, creates bundled schemas for referenced non-JSON Schema types", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
+    @jsonSchema
+    model testArray is Array<nonModel>;
+    @jsonSchema
+    union testUnion { nonModel }
+    @jsonSchema
+    enum testEnum { a, b }
+    @jsonSchema
+    scalar testScalar extends nonScalar;
+    
+    model nonModel { b: Baz }
+    model Baz { }
+    model nonArray is Array<nonModel>;
+    scalar nonScalar extends string;
+    enum nonEnum { a, b }
+    union nonUnion { nonModel }
 
-  it("doesn't create bundled schemas for referenced non-JSON Schema types", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
-      @jsonSchema
-      model testArray is Array<nonModel>;
-      @jsonSchema
-      union testUnion { nonModel }
-      @jsonSchema
-      enum testEnum { a, b }
-      @jsonSchema
-      scalar testScalar extends nonScalar;
-      
-      model nonModel { b: Baz }
-      model Baz { }
-      model nonArray is Array<nonModel>;
-      scalar nonScalar extends string;
-      enum nonEnum { a, b }
-      union nonUnion { nonModel }
+  `,
+    { bundleId: "test.json", emitAllRefs: true },
+    {
+      emitNamespace: false,
+    },
+  );
 
-    `,
-      { bundleId: "test.json" },
-      {
-        emitNamespace: false,
-      },
-    );
-
-    const defs = Object.keys(schemas["test.json"].$defs);
-    strictEqual(defs.length, 5);
-    ["testModel", "testArray", "testUnion", "testEnum", "testScalar"].forEach((name) => {
-      expect(defs).toContain(name);
-    });
+  const defs = Object.keys(schemas["test.json"].$defs);
+  strictEqual(defs.length, 11);
+  [
+    "testModel",
+    "testArray",
+    "testUnion",
+    "testEnum",
+    "testScalar",
+    "nonModel",
+    "Baz",
+    "nonArray",
+    "nonScalar",
+    "nonEnum",
+    "nonUnion",
+  ].forEach((name) => {
+    expect(defs).toContain(name);
   });
-  it("with emitAllRefs, creates bundled schemas for referenced non-JSON Schema types", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
-      @jsonSchema
-      model testArray is Array<nonModel>;
-      @jsonSchema
-      union testUnion { nonModel }
-      @jsonSchema
-      enum testEnum { a, b }
-      @jsonSchema
-      scalar testScalar extends nonScalar;
-      
-      model nonModel { b: Baz }
-      model Baz { }
-      model nonArray is Array<nonModel>;
-      scalar nonScalar extends string;
-      enum nonEnum { a, b }
-      union nonUnion { nonModel }
+});
 
-    `,
-      { bundleId: "test.json", emitAllRefs: true },
-      {
-        emitNamespace: false,
-      },
-    );
+it("with emitAllModels, creates bundled schemas for all data types", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
+    @jsonSchema
+    model testArray is Array<nonModel>;
+    @jsonSchema
+    union testUnion { nonModel }
+    @jsonSchema
+    enum testEnum { a, b }
+    @jsonSchema
+    scalar testScalar extends nonScalar;
+    
+    model nonModel { b: Baz }
+    model Baz { }
+    model nonArray is Array<nonModel>;
+    scalar nonScalar extends string;
+    enum nonEnum { a, b }
+    union nonUnion { nonModel }
 
-    const defs = Object.keys(schemas["test.json"].$defs);
-    strictEqual(defs.length, 11);
-    [
-      "testModel",
-      "testArray",
-      "testUnion",
-      "testEnum",
-      "testScalar",
-      "nonModel",
-      "Baz",
-      "nonArray",
-      "nonScalar",
-      "nonEnum",
-      "nonUnion",
-    ].forEach((name) => {
-      expect(defs).toContain(name);
-    });
-  });
+  `,
+    { bundleId: "test.json", emitAllModels: true },
+    {
+      emitNamespace: false,
+    },
+  );
 
-  it("with emitAllModels, creates bundled schemas for all data types", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
-      @jsonSchema
-      model testArray is Array<nonModel>;
-      @jsonSchema
-      union testUnion { nonModel }
-      @jsonSchema
-      enum testEnum { a, b }
-      @jsonSchema
-      scalar testScalar extends nonScalar;
-      
-      model nonModel { b: Baz }
-      model Baz { }
-      model nonArray is Array<nonModel>;
-      scalar nonScalar extends string;
-      enum nonEnum { a, b }
-      union nonUnion { nonModel }
-
-    `,
-      { bundleId: "test.json", emitAllModels: true },
-      {
-        emitNamespace: false,
-      },
-    );
-
-    const defs = Object.keys(schemas["test.json"].$defs);
-    strictEqual(defs.length, 11);
-    [
-      "testModel",
-      "testArray",
-      "testUnion",
-      "testEnum",
-      "testScalar",
-      "nonModel",
-      "Baz",
-      "nonArray",
-      "nonScalar",
-      "nonEnum",
-      "nonUnion",
-    ].forEach((name) => {
-      expect(defs).toContain(name);
-    });
+  const defs = Object.keys(schemas["test.json"].$defs);
+  strictEqual(defs.length, 11);
+  [
+    "testModel",
+    "testArray",
+    "testUnion",
+    "testEnum",
+    "testScalar",
+    "nonModel",
+    "Baz",
+    "nonArray",
+    "nonScalar",
+    "nonEnum",
+    "nonUnion",
+  ].forEach((name) => {
+    expect(defs).toContain(name);
   });
 });

--- a/packages/json-schema/test/doc.test.ts
+++ b/packages/json-schema/test/doc.test.ts
@@ -1,31 +1,29 @@
 import assert from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("doc", () => {
-  it("sets description from doc comments", async () => {
-    const schemas = await emitSchema(`
-      /**
-       * \`\`\`toml
-       * deny = [
-       *     { name = "simple" },
-       *     { name = "simple", version = "*" },
-       *     { name = "simple", wrappers = ["example"] }
-       * ]
-       * \`\`\`
-       */
-      scalar PackageSpec extends string;
-    `);
+it("sets description from doc comments", async () => {
+  const schemas = await emitSchema(`
+    /**
+     * \`\`\`toml
+     * deny = [
+     *     { name = "simple" },
+     *     { name = "simple", version = "*" },
+     *     { name = "simple", wrappers = ["example"] }
+     * ]
+     * \`\`\`
+     */
+    scalar PackageSpec extends string;
+  `);
 
-    assert.deepStrictEqual(
-      schemas["PackageSpec.json"].description,
-      `\`\`\`toml
+  assert.deepStrictEqual(
+    schemas["PackageSpec.json"].description,
+    `\`\`\`toml
 deny = [
     { name = "simple" },
     { name = "simple", version = "*" },
     { name = "simple", wrappers = ["example"] }
 ]
 \`\`\``,
-    );
-  });
+  );
 });

--- a/packages/json-schema/test/enums.test.ts
+++ b/packages/json-schema/test/enums.test.ts
@@ -1,87 +1,85 @@
 import assert from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("emitting enums", () => {
-  it("is a proper schema", async () => {
-    const schemas = await emitSchema(`
-      enum Foo { }
-    `);
-    const Foo = schemas["Foo.json"];
+it("is a proper schema", async () => {
+  const schemas = await emitSchema(`
+    enum Foo { }
+  `);
+  const Foo = schemas["Foo.json"];
 
-    assert.strictEqual(Foo.$id, "Foo.json");
-    assert.strictEqual(Foo.$schema, "https://json-schema.org/draft/2020-12/schema");
-  });
+  assert.strictEqual(Foo.$id, "Foo.json");
+  assert.strictEqual(Foo.$schema, "https://json-schema.org/draft/2020-12/schema");
+});
 
-  it("handles numbers", async () => {
-    const schemas = await emitSchema(`
-      enum Foo {
-        a: 0;
-        b: 1;
-        c: 2;
-      }
-    `);
-    const Foo = schemas["Foo.json"];
+it("handles numbers", async () => {
+  const schemas = await emitSchema(`
+    enum Foo {
+      a: 0;
+      b: 1;
+      c: 2;
+    }
+  `);
+  const Foo = schemas["Foo.json"];
 
-    assert.deepEqual(Foo.type, "number");
-    assert.deepStrictEqual(Foo.enum, [0, 1, 2]);
-  });
+  assert.deepEqual(Foo.type, "number");
+  assert.deepStrictEqual(Foo.enum, [0, 1, 2]);
+});
 
-  it("handles strings", async () => {
-    const schemas = await emitSchema(`
-      enum Foo {
-        a: "hi";
-        b: "bye";
-      }
-    `);
-    const Foo = schemas["Foo.json"];
+it("handles strings", async () => {
+  const schemas = await emitSchema(`
+    enum Foo {
+      a: "hi";
+      b: "bye";
+    }
+  `);
+  const Foo = schemas["Foo.json"];
 
-    assert.deepEqual(Foo.type, "string");
-    assert.deepStrictEqual(Foo.enum, ["hi", "bye"]);
-  });
+  assert.deepEqual(Foo.type, "string");
+  assert.deepStrictEqual(Foo.enum, ["hi", "bye"]);
+});
 
-  it("handles both numbers and strings", async () => {
-    const schemas = await emitSchema(`
-      enum Foo {
-        a: "hi";
-        b: 2;
-      }
-    `);
-    const Foo = schemas["Foo.json"];
+it("handles both numbers and strings", async () => {
+  const schemas = await emitSchema(`
+    enum Foo {
+      a: "hi";
+      b: 2;
+    }
+  `);
+  const Foo = schemas["Foo.json"];
 
-    assert.deepStrictEqual(Foo.type, ["string", "number"]);
-    assert.deepStrictEqual(Foo.enum, ["hi", 2]);
-  });
+  assert.deepStrictEqual(Foo.type, ["string", "number"]);
+  assert.deepStrictEqual(Foo.enum, ["hi", 2]);
+});
 
-  it("handles extensions", async () => {
-    const schemas = await emitSchema(`
-      @extension("x-foo", Json<"foo">)
-      enum Foo {
-        a: "hi";
-        b: 2;
-      }
-    `);
-    const Foo = schemas["Foo.json"];
-    assert.strictEqual(Foo["x-foo"], "foo");
-  });
+it("handles extensions", async () => {
+  const schemas = await emitSchema(`
+    @extension("x-foo", Json<"foo">)
+    enum Foo {
+      a: "hi";
+      b: 2;
+    }
+  `);
+  const Foo = schemas["Foo.json"];
+  assert.strictEqual(Foo["x-foo"], "foo");
+});
 
-  it("handles enum member refs", async () => {
-    const schemas = await emitSchema(`
-      enum Foo {
-        a: "hi";
-        b: 2;
-        c;
-      }
+it("handles enum member refs", async () => {
+  const schemas = await emitSchema(`
+    enum Foo {
+      a: "hi";
+      b: 2;
+      c;
+    }
 
-      model Bar {
-        a: Foo.a;
-        b: Foo.b;
-        c: Foo.c;
-      }
-    `);
-    const Bar = schemas["Bar.json"];
-    assert.deepStrictEqual(Bar.properties.a, { type: "string", const: "hi" });
-    assert.deepStrictEqual(Bar.properties.b, { type: "number", const: 2 });
-    assert.deepStrictEqual(Bar.properties.c, { type: "string", const: "c" });
-  });
+    model Bar {
+      a: Foo.a;
+      b: Foo.b;
+      c: Foo.c;
+    }
+  `);
+  const Bar = schemas["Bar.json"];
+  assert.deepStrictEqual(Bar.properties.a, { type: "string", const: "hi" });
+  assert.deepStrictEqual(Bar.properties.b, { type: "number", const: 2 });
+  assert.deepStrictEqual(Bar.properties.c, { type: "string", const: "c" });
 });

--- a/packages/json-schema/test/interfaces.test.ts
+++ b/packages/json-schema/test/interfaces.test.ts
@@ -1,13 +1,11 @@
 import { deepStrictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("jsonschema: interfaces", () => {
-  it("emit nothing", async () => {
-    const schemas = await emitSchema(`
-      interface Foo {}
-    `);
+it("emit nothing", async () => {
+  const schemas = await emitSchema(`
+    interface Foo {}
+  `);
 
-    deepStrictEqual(schemas, {});
-  });
+  deepStrictEqual(schemas, {});
 });

--- a/packages/json-schema/test/literals.test.ts
+++ b/packages/json-schema/test/literals.test.ts
@@ -1,37 +1,35 @@
 import assert from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("literals", () => {
-  it("handles booleans", async () => {
-    const schemas = await emitSchema(`
-      model Test {
-        a: true,
-        b: false
-      }
-    `);
+it("handles booleans", async () => {
+  const schemas = await emitSchema(`
+    model Test {
+      a: true,
+      b: false
+    }
+  `);
 
-    assert.deepStrictEqual(schemas["Test.json"].properties.a, { type: "boolean", const: true });
-    assert.deepStrictEqual(schemas["Test.json"].properties.b, { type: "boolean", const: false });
-  });
+  assert.deepStrictEqual(schemas["Test.json"].properties.a, { type: "boolean", const: true });
+  assert.deepStrictEqual(schemas["Test.json"].properties.b, { type: "boolean", const: false });
+});
 
-  it("handles strings", async () => {
-    const schemas = await emitSchema(`
-      model Test {
-        a: "hi",
-      }
-    `);
+it("handles strings", async () => {
+  const schemas = await emitSchema(`
+    model Test {
+      a: "hi",
+    }
+  `);
 
-    assert.deepStrictEqual(schemas["Test.json"].properties.a, { type: "string", const: "hi" });
-  });
+  assert.deepStrictEqual(schemas["Test.json"].properties.a, { type: "string", const: "hi" });
+});
 
-  it("handles numbers", async () => {
-    const schemas = await emitSchema(`
-      model Test {
-        a: 1,
-      }
-    `);
+it("handles numbers", async () => {
+  const schemas = await emitSchema(`
+    model Test {
+      a: 1,
+    }
+  `);
 
-    assert.deepStrictEqual(schemas["Test.json"].properties.a, { type: "number", const: 1 });
-  });
+  assert.deepStrictEqual(schemas["Test.json"].properties.a, { type: "number", const: 1 });
 });

--- a/packages/json-schema/test/references.test.ts
+++ b/packages/json-schema/test/references.test.ts
@@ -1,222 +1,220 @@
 import assert, { strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("referencing non-JSON Schema types", () => {
-  it("inlines into the defs of each referencing schema by default", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
-      @jsonSchema
-      model testArray is Array<nonModel>;
-      @jsonSchema
-      union testUnion { nonModel }
-      @jsonSchema
-      enum testEnum { a, b }
-      @jsonSchema
-      scalar testScalar extends nonScalar;
-      
-      model nonModel { b: Baz }
-      model Baz { }
-      model nonArray is Array<nonModel>;
-      scalar nonScalar extends string;
-      enum nonEnum { a, b }
-      union nonUnion { nonModel }
+it("inlines into the defs of each referencing schema by default", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model testModel { a: nonModel, b: nonArray, c: nonUnion, d: nonEnum, e: nonScalar  }
+    @jsonSchema
+    model testArray is Array<nonModel>;
+    @jsonSchema
+    union testUnion { nonModel }
+    @jsonSchema
+    enum testEnum { a, b }
+    @jsonSchema
+    scalar testScalar extends nonScalar;
+    
+    model nonModel { b: Baz }
+    model Baz { }
+    model nonArray is Array<nonModel>;
+    scalar nonScalar extends string;
+    enum nonEnum { a, b }
+    union nonUnion { nonModel }
 
-    `,
-      {},
-      {
-        emitNamespace: false,
-      },
-    );
+  `,
+    {},
+    {
+      emitNamespace: false,
+    },
+  );
 
-    validateInlinedSchema(schemas["testModel.json"], [
-      "nonModel",
-      "Baz",
-      "nonArray",
-      "nonScalar",
-      "nonEnum",
-      "nonUnion",
-    ]);
-    validateInlinedSchema(schemas["testArray.json"], ["nonModel", "Baz"]);
-    validateInlinedSchema(schemas["testUnion.json"], ["nonModel", "Baz"]);
+  validateInlinedSchema(schemas["testModel.json"], [
+    "nonModel",
+    "Baz",
+    "nonArray",
+    "nonScalar",
+    "nonEnum",
+    "nonUnion",
+  ]);
+  validateInlinedSchema(schemas["testArray.json"], ["nonModel", "Baz"]);
+  validateInlinedSchema(schemas["testUnion.json"], ["nonModel", "Baz"]);
 
-    strictEqual(schemas["nonModel.json"], undefined);
-    strictEqual(schemas["nonArray.json"], undefined);
-    strictEqual(schemas["nonUnion.json"], undefined);
-    strictEqual(schemas["nonEnum.json"], undefined);
-    strictEqual(schemas["nonScalar.json"], undefined);
-    strictEqual(schemas["Baz.json"], undefined);
+  strictEqual(schemas["nonModel.json"], undefined);
+  strictEqual(schemas["nonArray.json"], undefined);
+  strictEqual(schemas["nonUnion.json"], undefined);
+  strictEqual(schemas["nonEnum.json"], undefined);
+  strictEqual(schemas["nonScalar.json"], undefined);
+  strictEqual(schemas["Baz.json"], undefined);
 
-    function validateInlinedSchema(schema: Record<string, any>, expectedDefs: string[]) {
-      const defs = schema.$defs;
+  function validateInlinedSchema(schema: Record<string, any>, expectedDefs: string[]) {
+    const defs = schema.$defs;
 
-      strictEqual(typeof defs, "object");
+    strictEqual(typeof defs, "object");
 
-      for (const expectedDef of expectedDefs) {
-        strictEqual(typeof defs[expectedDef], "object", `def ${expectedDef} should be present`);
-        strictEqual(defs[expectedDef].$id, undefined, `def ${expectedDef} shouldn't have id`);
-        strictEqual(defs[expectedDef].$schema, undefined, `def ${expectedDef} shouldn't have id`);
-      }
-
-      const unseenDefs = new Set(expectedDefs);
-      for (const ref of findRefs(schema)) {
-        const defNameMatch = /^#\/\$defs\/(\w+)$/.exec(ref);
-        assert(defNameMatch !== null, "Found bad ref to def - " + ref);
-        const defName = defNameMatch[1];
-        unseenDefs.delete(defName);
-      }
-
-      strictEqual(
-        unseenDefs.size,
-        0,
-        "Expected all defs to be referenced, left with " + [...unseenDefs].join(", "),
-      );
+    for (const expectedDef of expectedDefs) {
+      strictEqual(typeof defs[expectedDef], "object", `def ${expectedDef} should be present`);
+      strictEqual(defs[expectedDef].$id, undefined, `def ${expectedDef} shouldn't have id`);
+      strictEqual(defs[expectedDef].$schema, undefined, `def ${expectedDef} shouldn't have id`);
     }
 
-    function* findRefs(root: any) {
-      const stack = [root];
+    const unseenDefs = new Set(expectedDefs);
+    for (const ref of findRefs(schema)) {
+      const defNameMatch = /^#\/\$defs\/(\w+)$/.exec(ref);
+      assert(defNameMatch !== null, "Found bad ref to def - " + ref);
+      const defName = defNameMatch[1];
+      unseenDefs.delete(defName);
+    }
 
-      while (stack.length > 0) {
-        const current = stack.pop();
-        for (const [key, value] of Object.entries(current)) {
-          if (key === "$ref") {
-            yield value as string;
-          } else if (typeof value === "object" && value !== null) {
-            stack.push(value);
-          }
+    strictEqual(
+      unseenDefs.size,
+      0,
+      "Expected all defs to be referenced, left with " + [...unseenDefs].join(", "),
+    );
+  }
+
+  function* findRefs(root: any) {
+    const stack = [root];
+
+    while (stack.length > 0) {
+      const current = stack.pop();
+      for (const [key, value] of Object.entries(current)) {
+        if (key === "$ref") {
+          yield value as string;
+        } else if (typeof value === "object" && value !== null) {
+          stack.push(value);
         }
       }
     }
-  });
+  }
+});
 
-  it("with emitAllModels, creates schemas for all types", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model test { b: Bar }
-      model Bar { }
-    `,
-      { emitAllModels: true },
-      { emitNamespace: false },
-    );
+it("with emitAllModels, creates schemas for all types", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model test { b: Bar }
+    model Bar { }
+  `,
+    { emitAllModels: true },
+    { emitNamespace: false },
+  );
 
-    assert.strictEqual(schemas["test.json"].$id, "test.json");
-    assert.strictEqual(schemas["test.json"].$defs, undefined);
-    assert.strictEqual(schemas["Bar.json"].$id, "Bar.json");
-  });
+  assert.strictEqual(schemas["test.json"].$id, "test.json");
+  assert.strictEqual(schemas["test.json"].$defs, undefined);
+  assert.strictEqual(schemas["Bar.json"].$id, "Bar.json");
+});
 
-  it("with emitAllRefs, creates schemas for referenced types", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model test { b: Bar }
-      model Bar { }
-    `,
-      { emitAllRefs: true },
-      { emitNamespace: false },
-    );
+it("with emitAllRefs, creates schemas for referenced types", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model test { b: Bar }
+    model Bar { }
+  `,
+    { emitAllRefs: true },
+    { emitNamespace: false },
+  );
 
-    assert.strictEqual(schemas["test.json"].$id, "test.json");
-    assert.strictEqual(schemas["test.json"].$defs, undefined);
-    assert.strictEqual(schemas["Bar.json"].$id, "Bar.json");
-  });
+  assert.strictEqual(schemas["test.json"].$id, "test.json");
+  assert.strictEqual(schemas["test.json"].$defs, undefined);
+  assert.strictEqual(schemas["Bar.json"].$id, "Bar.json");
+});
 
-  it("doesn't create duplicate defs for transitive references", async () => {
-    const schemas = await emitSchema(
-      `
-      model A {}
-      
-      model B {
-        refA: A;
-      }
-      
-      @jsonSchema
-      model C {
-        refB: B;
-      }
-      
-      @jsonSchema
-      model D {
-        refB: B;
-      }
-    `,
-      {},
-      { emitNamespace: false },
-    );
+it("doesn't create duplicate defs for transitive references", async () => {
+  const schemas = await emitSchema(
+    `
+    model A {}
+    
+    model B {
+      refA: A;
+    }
+    
+    @jsonSchema
+    model C {
+      refB: B;
+    }
+    
+    @jsonSchema
+    model D {
+      refB: B;
+    }
+  `,
+    {},
+    { emitNamespace: false },
+  );
 
-    const depSchemas = {
-      B: {
-        type: "object",
-        properties: {
-          refA: {
-            $ref: "#/$defs/A",
-          },
+  const depSchemas = {
+    B: {
+      type: "object",
+      properties: {
+        refA: {
+          $ref: "#/$defs/A",
         },
-        required: ["refA"],
       },
-      A: {
-        type: "object",
-        properties: {},
-      },
-    };
-    assert.deepStrictEqual(schemas["C.json"].$defs, depSchemas);
-    assert.deepStrictEqual(schemas["D.json"].$defs, depSchemas);
-  });
+      required: ["refA"],
+    },
+    A: {
+      type: "object",
+      properties: {},
+    },
+  };
+  assert.deepStrictEqual(schemas["C.json"].$defs, depSchemas);
+  assert.deepStrictEqual(schemas["D.json"].$defs, depSchemas);
+});
 
-  it("doesn't include types which are not referenced, but does when getAllModels is set", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model A {}
-      
-      model B {}
-    `,
-      {},
-      { emitNamespace: false },
-    );
+it("doesn't include types which are not referenced, but does when getAllModels is set", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model A {}
+    
+    model B {}
+  `,
+    {},
+    { emitNamespace: false },
+  );
 
-    assert(schemas["A.json"] !== undefined);
-    assert(Object.keys(schemas).length === 1);
+  assert(schemas["A.json"] !== undefined);
+  assert(Object.keys(schemas).length === 1);
 
-    const amSchemas = await emitSchema(
-      `
-      @jsonSchema
-      model A {}
-      
-      model B {}
-    `,
-      { emitAllModels: true },
-      { emitNamespace: false },
-    );
+  const amSchemas = await emitSchema(
+    `
+    @jsonSchema
+    model A {}
+    
+    model B {}
+  `,
+    { emitAllModels: true },
+    { emitNamespace: false },
+  );
 
-    assert(amSchemas["A.json"] !== undefined);
-    assert(amSchemas["B.json"] !== undefined);
-    assert(Object.keys(amSchemas).length === 2);
-  });
+  assert(amSchemas["A.json"] !== undefined);
+  assert(amSchemas["B.json"] !== undefined);
+  assert(Object.keys(amSchemas).length === 2);
+});
 
-  it("handles circular refs among non-json schema types", async () => {
-    const schemas = await emitSchema(
-      `
-      @jsonSchema
-      model R {
-        test: A;
-      }
-      
-      model A {
-        a: B;
-      }
-      
-      model B {
-        a: A;
-      }
-    `,
-      {},
-      { emitNamespace: false },
-    );
-    assert(schemas["R.json"] !== undefined);
-    assert(Object.keys(schemas).length === 1);
-    assert(Object.keys(schemas["R.json"].$defs).length === 2);
-  });
+it("handles circular refs among non-json schema types", async () => {
+  const schemas = await emitSchema(
+    `
+    @jsonSchema
+    model R {
+      test: A;
+    }
+    
+    model A {
+      a: B;
+    }
+    
+    model B {
+      a: A;
+    }
+  `,
+    {},
+    { emitNamespace: false },
+  );
+  assert(schemas["R.json"] !== undefined);
+  assert(Object.keys(schemas).length === 1);
+  assert(Object.keys(schemas["R.json"].$defs).length === 2);
 });

--- a/packages/json-schema/test/scalar-constraints.test.ts
+++ b/packages/json-schema/test/scalar-constraints.test.ts
@@ -2,179 +2,177 @@ import assert, { strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("jsonschema: scalar constraints", () => {
-  describe("numeric constraints", () => {
-    const scalarNumberTypes = [
-      "int8",
-      "int16",
-      "int32",
-      "uint8",
-      "uint16",
-      "uint32",
-      "integer",
-      "float32",
-      "float64",
-      "numeric",
-      "float",
-      "safeint",
-    ];
+describe("numeric constraints", () => {
+  const scalarNumberTypes = [
+    "int8",
+    "int16",
+    "int32",
+    "uint8",
+    "uint16",
+    "uint32",
+    "integer",
+    "float32",
+    "float64",
+    "numeric",
+    "float",
+    "safeint",
+  ];
 
-    function assertNumericConstraints(schema: any) {
-      assert.strictEqual(schema.minimum, 1);
-      assert.strictEqual(schema.maximum, 2);
-      assert.strictEqual(schema.multipleOf, 10);
+  function assertNumericConstraints(schema: any) {
+    assert.strictEqual(schema.minimum, 1);
+    assert.strictEqual(schema.maximum, 2);
+    assert.strictEqual(schema.multipleOf, 10);
+  }
+
+  describe("on scalar declaration", () => {
+    for (const numType of scalarNumberTypes) {
+      it(`handles ${numType}`, async () => {
+        const schemas = await emitSchema(`
+        @minValue(1)
+        @maxValue(2)
+        @multipleOf(10)
+        scalar Test extends ${numType};
+      `);
+
+        assertNumericConstraints(schemas["Test.json"]);
+      });
     }
 
-    describe("on scalar declaration", () => {
-      for (const numType of scalarNumberTypes) {
-        it(`handles ${numType}`, async () => {
-          const schemas = await emitSchema(`
+    it("on a union", async () => {
+      const schemas = await emitSchema(`
+    @minValue(1)
+    @maxValue(2)
+    @multipleOf(10)
+    union Test {
+      int32,
+      string,
+      null
+    };
+  `);
+      assertNumericConstraints(schemas["Test.json"]);
+    });
+  });
+
+  describe("@minValueExclusive/@maxValueExclusive", () => {
+    for (const numType of scalarNumberTypes) {
+      it(numType, async () => {
+        const schemas = await emitSchema(
+          `
+          @minValueExclusive(1)
+          @maxValueExclusive(2)
+          scalar Test extends ${numType};
+        `,
+        );
+
+        strictEqual(schemas["Test.json"].exclusiveMinimum, 1);
+        strictEqual(schemas["Test.json"].exclusiveMaximum, 2);
+      });
+
+      it("can be applied on a union", async () => {
+        const schemas = await emitSchema(
+          `
+          @minValueExclusive(1)
+          @maxValueExclusive(2)
+          union Test {int32, string, null};
+        `,
+        );
+
+        strictEqual(schemas["Test.json"].exclusiveMinimum, 1);
+        strictEqual(schemas["Test.json"].exclusiveMaximum, 2);
+      });
+    }
+  });
+
+  describe("on property", () => {
+    for (const numType of [...scalarNumberTypes, "int32 | string | null"]) {
+      it(`handles ${numType} properties`, async () => {
+        const schemas = await emitSchema(`
+        model Test {
           @minValue(1)
           @maxValue(2)
           @multipleOf(10)
-          scalar Test extends ${numType};
-        `);
-
-          assertNumericConstraints(schemas["Test.json"]);
-        });
-      }
-
-      it("on a union", async () => {
-        const schemas = await emitSchema(`
-      @minValue(1)
-      @maxValue(2)
-      @multipleOf(10)
-      union Test {
-        int32,
-        string,
-        null
-      };
-    `);
-        assertNumericConstraints(schemas["Test.json"]);
-      });
-    });
-
-    describe("@minValueExclusive/@maxValueExclusive", () => {
-      for (const numType of scalarNumberTypes) {
-        it(numType, async () => {
-          const schemas = await emitSchema(
-            `
-            @minValueExclusive(1)
-            @maxValueExclusive(2)
-            scalar Test extends ${numType};
-          `,
-          );
-
-          strictEqual(schemas["Test.json"].exclusiveMinimum, 1);
-          strictEqual(schemas["Test.json"].exclusiveMaximum, 2);
-        });
-
-        it("can be applied on a union", async () => {
-          const schemas = await emitSchema(
-            `
-            @minValueExclusive(1)
-            @maxValueExclusive(2)
-            union Test {int32, string, null};
-          `,
-          );
-
-          strictEqual(schemas["Test.json"].exclusiveMinimum, 1);
-          strictEqual(schemas["Test.json"].exclusiveMaximum, 2);
-        });
-      }
-    });
-
-    describe("on property", () => {
-      for (const numType of [...scalarNumberTypes, "int32 | string | null"]) {
-        it(`handles ${numType} properties`, async () => {
-          const schemas = await emitSchema(`
-          model Test {
-            @minValue(1)
-            @maxValue(2)
-            @multipleOf(10)
-            prop: ${numType};
-          }
-        `);
-          assertNumericConstraints(schemas["Test.json"].properties.prop);
-        });
-      }
-    });
-  });
-
-  describe("string constraints", () => {
-    function assertStringConstraints(schema: any) {
-      assert.strictEqual(schema.minLength, 1);
-      assert.strictEqual(schema.maxLength, 2);
-      assert.strictEqual(schema.pattern, "a|b");
-      assert.strictEqual(schema.format, "ipv4");
-      assert.strictEqual(schema.contentEncoding, "base64url");
-      assert.strictEqual(schema.contentMediaType, "application/jwt");
-      assert.deepStrictEqual(schema.contentSchema, {
-        $ref: "JwtToken.json",
+          prop: ${numType};
+        }
+      `);
+        assertNumericConstraints(schemas["Test.json"].properties.prop);
       });
     }
-    it("on scalar declaration", async () => {
-      const schemas = await emitSchema(`
-      @minLength(1)
-      @maxLength(2)
-      @pattern("a|b")
-      @format("ipv4")
-      @contentEncoding("base64url")
-      @contentMediaType("application/jwt")
-      @contentSchema(JwtToken)
-      scalar shortString extends string;
-
-      model JwtToken is Array<Record<string>>;
-    `);
-      assertStringConstraints(schemas["shortString.json"]);
-    });
-
-    it("on union", async () => {
-      const schemas = await emitSchema(`
-      @minLength(1)
-      @maxLength(2)
-      @pattern("a|b")
-      @format("ipv4")
-      @contentEncoding("base64url")
-      @contentMediaType("application/jwt")
-      @contentSchema(JwtToken)
-      union Test {
-        string, int32, null
-      }
-
-      model JwtToken is Array<Record<string>>;
-    `);
-      assertStringConstraints(schemas["Test.json"]);
-    });
-
-    it("on property", async () => {
-      const schemas = await emitSchema(`
-      model Test {
-        @minLength(1)
-        @maxLength(2)
-        @pattern("a|b")
-        @format("ipv4")
-        @contentEncoding("base64url")
-        @contentMediaType("application/jwt")
-        @contentSchema(JwtToken)
-        prop: string;
-      }
-
-      model JwtToken is Array<Record<string>>;
-    `);
-      assertStringConstraints(schemas["Test.json"].properties.prop);
-    });
   });
+});
 
-  it("combine with constraint of base scalar", async () => {
+describe("string constraints", () => {
+  function assertStringConstraints(schema: any) {
+    assert.strictEqual(schema.minLength, 1);
+    assert.strictEqual(schema.maxLength, 2);
+    assert.strictEqual(schema.pattern, "a|b");
+    assert.strictEqual(schema.format, "ipv4");
+    assert.strictEqual(schema.contentEncoding, "base64url");
+    assert.strictEqual(schema.contentMediaType, "application/jwt");
+    assert.deepStrictEqual(schema.contentSchema, {
+      $ref: "JwtToken.json",
+    });
+  }
+  it("on scalar declaration", async () => {
     const schemas = await emitSchema(`
-        @minValue(1)
-        scalar base extends int32;
+    @minLength(1)
+    @maxLength(2)
+    @pattern("a|b")
+    @format("ipv4")
+    @contentEncoding("base64url")
+    @contentMediaType("application/jwt")
+    @contentSchema(JwtToken)
+    scalar shortString extends string;
 
-        @maxValue(2)
-        scalar test extends base;
-      `);
-    strictEqual(schemas["test.json"].minimum, 1);
-    strictEqual(schemas["test.json"].maximum, 2);
+    model JwtToken is Array<Record<string>>;
+  `);
+    assertStringConstraints(schemas["shortString.json"]);
   });
+
+  it("on union", async () => {
+    const schemas = await emitSchema(`
+    @minLength(1)
+    @maxLength(2)
+    @pattern("a|b")
+    @format("ipv4")
+    @contentEncoding("base64url")
+    @contentMediaType("application/jwt")
+    @contentSchema(JwtToken)
+    union Test {
+      string, int32, null
+    }
+
+    model JwtToken is Array<Record<string>>;
+  `);
+    assertStringConstraints(schemas["Test.json"]);
+  });
+
+  it("on property", async () => {
+    const schemas = await emitSchema(`
+    model Test {
+      @minLength(1)
+      @maxLength(2)
+      @pattern("a|b")
+      @format("ipv4")
+      @contentEncoding("base64url")
+      @contentMediaType("application/jwt")
+      @contentSchema(JwtToken)
+      prop: string;
+    }
+
+    model JwtToken is Array<Record<string>>;
+  `);
+    assertStringConstraints(schemas["Test.json"].properties.prop);
+  });
+});
+
+it("combine with constraint of base scalar", async () => {
+  const schemas = await emitSchema(`
+      @minValue(1)
+      scalar base extends int32;
+
+      @maxValue(2)
+      scalar test extends base;
+    `);
+  strictEqual(schemas["test.json"].minimum, 1);
+  strictEqual(schemas["test.json"].maximum, 2);
 });

--- a/packages/json-schema/test/scalars.test.ts
+++ b/packages/json-schema/test/scalars.test.ts
@@ -1,53 +1,51 @@
 import assert from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("emitting scalars", () => {
-  it("works with scalars extending built-in scalars", async () => {
-    const schemas = await emitSchema(`
-      scalar Test extends uint8;
-    `);
+it("works with scalars extending built-in scalars", async () => {
+  const schemas = await emitSchema(`
+    scalar Test extends uint8;
+  `);
 
-    assert.deepStrictEqual(schemas["Test.json"], {
-      $id: "Test.json",
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      type: "integer",
-      minimum: 0,
-      maximum: 255,
-    });
+  assert.deepStrictEqual(schemas["Test.json"], {
+    $id: "Test.json",
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "integer",
+    minimum: 0,
+    maximum: 255,
   });
+});
 
-  it("throws errors for scalars not extending built-in scalars", async () => {
-    await assert.rejects(async () => {
-      await emitSchema(`
-        scalar Test;
-      `);
-    });
-  });
-
-  it("handles extensions", async () => {
-    const schemas = await emitSchema(`
-      @extension("x-scalar", Json<true>)
-      scalar Test extends uint8;
+it("throws errors for scalars not extending built-in scalars", async () => {
+  await assert.rejects(async () => {
+    await emitSchema(`
+      scalar Test;
     `);
-
-    assert.strictEqual(schemas["Test.json"]["x-scalar"], true);
   });
+});
 
-  it("can use a scalar template", async () => {
-    const schemas = await emitSchema(`
-      scalar Test<T> extends uint8;
+it("handles extensions", async () => {
+  const schemas = await emitSchema(`
+    @extension("x-scalar", Json<true>)
+    scalar Test extends uint8;
+  `);
 
-      model TestModel {
-        test: Test<string>;
-      }
-    `);
-    assert.deepStrictEqual(schemas["TestString.json"], {
-      $id: "TestString.json",
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      type: "integer",
-      maximum: 255,
-      minimum: 0,
-    });
+  assert.strictEqual(schemas["Test.json"]["x-scalar"], true);
+});
+
+it("can use a scalar template", async () => {
+  const schemas = await emitSchema(`
+    scalar Test<T> extends uint8;
+
+    model TestModel {
+      test: Test<string>;
+    }
+  `);
+  assert.deepStrictEqual(schemas["TestString.json"], {
+    $id: "TestString.json",
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "integer",
+    maximum: 255,
+    minimum: 0,
   });
 });

--- a/packages/json-schema/test/string-template.test.ts
+++ b/packages/json-schema/test/string-template.test.ts
@@ -3,65 +3,63 @@ import { deepStrictEqual } from "assert";
 import { describe, it } from "vitest";
 import { emitSchema, emitSchemaWithDiagnostics } from "./utils.js";
 
-describe("json-schema: string templates", () => {
-  describe("handle interpolating literals", () => {
-    it("string", async () => {
-      const schemas = await emitSchema(`
-      model Test {
-        a: "Start \${"abc"} end",
-      }
-    `);
-
-      deepStrictEqual(schemas["Test.json"].properties.a, {
-        type: "string",
-        const: "Start abc end",
-      });
-    });
-
-    it("number", async () => {
-      const schemas = await emitSchema(`
-      model Test {
-        a: "Start \${123} end",
-      }
-    `);
-
-      deepStrictEqual(schemas["Test.json"].properties.a, {
-        type: "string",
-        const: "Start 123 end",
-      });
-    });
-
-    it("boolean", async () => {
-      const schemas = await emitSchema(`
-      model Test {
-        a: "Start \${true} end",
-      }
-    `);
-
-      deepStrictEqual(schemas["Test.json"].properties.a, {
-        type: "string",
-        const: "Start true end",
-      });
-    });
-  });
-
-  it("emit diagnostics if interpolation value are not literals", async () => {
-    const [schemas, diagnostics] = await emitSchemaWithDiagnostics(`
-      model Test {
-        a: "Start \${Bar} end",
-      }
-      model Bar {}
-    `);
+describe("handle interpolating literals", () => {
+  it("string", async () => {
+    const schemas = await emitSchema(`
+    model Test {
+      a: "Start \${"abc"} end",
+    }
+  `);
 
     deepStrictEqual(schemas["Test.json"].properties.a, {
       type: "string",
+      const: "Start abc end",
     });
+  });
 
-    expectDiagnostics(diagnostics, {
-      code: "non-literal-string-template",
-      severity: "warning",
-      message:
-        "Value interpolated in this string template cannot be converted to a string. Only literal types can be automatically interpolated.",
+  it("number", async () => {
+    const schemas = await emitSchema(`
+    model Test {
+      a: "Start \${123} end",
+    }
+  `);
+
+    deepStrictEqual(schemas["Test.json"].properties.a, {
+      type: "string",
+      const: "Start 123 end",
     });
+  });
+
+  it("boolean", async () => {
+    const schemas = await emitSchema(`
+    model Test {
+      a: "Start \${true} end",
+    }
+  `);
+
+    deepStrictEqual(schemas["Test.json"].properties.a, {
+      type: "string",
+      const: "Start true end",
+    });
+  });
+});
+
+it("emit diagnostics if interpolation value are not literals", async () => {
+  const [schemas, diagnostics] = await emitSchemaWithDiagnostics(`
+    model Test {
+      a: "Start \${Bar} end",
+    }
+    model Bar {}
+  `);
+
+  deepStrictEqual(schemas["Test.json"].properties.a, {
+    type: "string",
+  });
+
+  expectDiagnostics(diagnostics, {
+    code: "non-literal-string-template",
+    severity: "warning",
+    message:
+      "Value interpolated in this string template cannot be converted to a string. Only literal types can be automatically interpolated.",
   });
 });

--- a/packages/json-schema/test/tuples.test.ts
+++ b/packages/json-schema/test/tuples.test.ts
@@ -1,36 +1,34 @@
 import { deepStrictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("jsonschema: tuples", () => {
-  it("emit tuples as items", async () => {
-    const schemas = await emitSchema(`
-      model Foo {
-        a: [string, int32]
-      }
-    `);
-    deepStrictEqual(schemas, {
-      "Foo.json": {
-        $id: "Foo.json",
-        $schema: "https://json-schema.org/draft/2020-12/schema",
-        type: "object",
-        required: ["a"],
-        properties: {
-          a: {
-            type: "array",
-            prefixItems: [
-              {
-                type: "string",
-              },
-              {
-                type: "integer",
-                minimum: -2147483648,
-                maximum: 2147483647,
-              },
-            ],
-          },
+it("emit tuples as items", async () => {
+  const schemas = await emitSchema(`
+    model Foo {
+      a: [string, int32]
+    }
+  `);
+  deepStrictEqual(schemas, {
+    "Foo.json": {
+      $id: "Foo.json",
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      required: ["a"],
+      properties: {
+        a: {
+          type: "array",
+          prefixItems: [
+            {
+              type: "string",
+            },
+            {
+              type: "integer",
+              minimum: -2147483648,
+              maximum: 2147483647,
+            },
+          ],
         },
       },
-    });
+    },
   });
 });

--- a/packages/json-schema/test/yaml.test.ts
+++ b/packages/json-schema/test/yaml.test.ts
@@ -1,21 +1,19 @@
 import assert from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { emitSchema } from "./utils.js";
 
-describe("emitting models to yaml", () => {
-  it("works", async () => {
-    const schemas = await emitSchema(
-      `
-      model Foo {
-        x: string;
-      }
-    `,
-      { "file-type": "yaml" },
-    );
-    const Foo = schemas["Foo.yaml"];
+it("works", async () => {
+  const schemas = await emitSchema(
+    `
+    model Foo {
+      x: string;
+    }
+  `,
+    { "file-type": "yaml" },
+  );
+  const Foo = schemas["Foo.yaml"];
 
-    assert.strictEqual(Foo.$id, "Foo.yaml");
-    assert.strictEqual(Foo.$schema, "https://json-schema.org/draft/2020-12/schema");
-    assert.deepStrictEqual(Foo.properties, { x: { type: "string" } });
-  });
+  assert.strictEqual(Foo.$id, "Foo.yaml");
+  assert.strictEqual(Foo.$schema, "https://json-schema.org/draft/2020-12/schema");
+  assert.deepStrictEqual(Foo.properties, { x: { type: "string" } });
 });

--- a/packages/library-linter/test/linter.test.ts
+++ b/packages/library-linter/test/linter.test.ts
@@ -3,68 +3,66 @@ import { expectDiagnostics, mockFile } from "@typespec/compiler/testing";
 import { describe, it } from "vitest";
 import { Tester } from "./test-host.js";
 
-describe("library-linter", () => {
-  describe("missing namespace", () => {
-    it("emit diagnostics when model is missing namespace", async () => {
-      const diagnostics = await Tester.diagnose("model Foo {}");
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/library-linter/missing-namespace",
-        message: "Model 'Foo' is not in a namespace. This is bad practice for a published library.",
-        severity: "warning",
-      });
-    });
-
-    it("emit diagnostics when operation is missing namespace", async () => {
-      const diagnostics = await Tester.diagnose("op test(): string;");
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/library-linter/missing-namespace",
-        message:
-          "Operation 'test' is not in a namespace. This is bad practice for a published library.",
-        severity: "warning",
-      });
-    });
-
-    it("emit diagnostics when interface is missing namespace", async () => {
-      const diagnostics = await Tester.diagnose("interface Foo {}");
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/library-linter/missing-namespace",
-        message:
-          "Interface 'Foo' is not in a namespace. This is bad practice for a published library.",
-        severity: "warning",
-      });
-    });
-
-    it("emit diagnostics when decorator is missing namespace", async () => {
-      const diagnostics = await Tester.files({
-        "./mylib.js": mockFile.js({ $myDec: () => null }),
-      }).diagnose(`
-        import "./mylib.js";
-        extern dec myDec(target: unknown);
-        namespace Foo { model Bar {}}
-      `);
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/library-linter/missing-namespace",
-        message:
-          "Decorator '@myDec' is not in a namespace. This is bad practice for a published library.",
-        severity: "warning",
-      });
+describe("missing namespace", () => {
+  it("emit diagnostics when model is missing namespace", async () => {
+    const diagnostics = await Tester.diagnose("model Foo {}");
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/library-linter/missing-namespace",
+      message: "Model 'Foo' is not in a namespace. This is bad practice for a published library.",
+      severity: "warning",
     });
   });
 
-  describe("missing extern dec", () => {
-    it("emit diagnostics when decorator is missing extern dec", async () => {
-      const decorators = {
-        $foo: (...args: unknown[]) => null,
-      };
-      setTypeSpecNamespace("Testing", decorators.$foo);
-      const diagnostics = await Tester.files({
-        "dec.js": mockFile.js(decorators),
-      }).diagnose(`import "./dec.js";`);
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/library-linter/missing-signature",
-        message: `Decorator function $foo is missing a decorator declaration. Add "extern dec foo(...args);" to the library tsp.`,
-        severity: "warning",
-      });
+  it("emit diagnostics when operation is missing namespace", async () => {
+    const diagnostics = await Tester.diagnose("op test(): string;");
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/library-linter/missing-namespace",
+      message:
+        "Operation 'test' is not in a namespace. This is bad practice for a published library.",
+      severity: "warning",
+    });
+  });
+
+  it("emit diagnostics when interface is missing namespace", async () => {
+    const diagnostics = await Tester.diagnose("interface Foo {}");
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/library-linter/missing-namespace",
+      message:
+        "Interface 'Foo' is not in a namespace. This is bad practice for a published library.",
+      severity: "warning",
+    });
+  });
+
+  it("emit diagnostics when decorator is missing namespace", async () => {
+    const diagnostics = await Tester.files({
+      "./mylib.js": mockFile.js({ $myDec: () => null }),
+    }).diagnose(`
+      import "./mylib.js";
+      extern dec myDec(target: unknown);
+      namespace Foo { model Bar {}}
+    `);
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/library-linter/missing-namespace",
+      message:
+        "Decorator '@myDec' is not in a namespace. This is bad practice for a published library.",
+      severity: "warning",
+    });
+  });
+});
+
+describe("missing extern dec", () => {
+  it("emit diagnostics when decorator is missing extern dec", async () => {
+    const decorators = {
+      $foo: (...args: unknown[]) => null,
+    };
+    setTypeSpecNamespace("Testing", decorators.$foo);
+    const diagnostics = await Tester.files({
+      "dec.js": mockFile.js(decorators),
+    }).diagnose(`import "./dec.js";`);
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/library-linter/missing-signature",
+      message: `Decorator function $foo is missing a decorator declaration. Add "extern dec foo(...args);" to the library tsp.`,
+      severity: "warning",
     });
   });
 });

--- a/packages/openapi/test/decorators.test.ts
+++ b/packages/openapi/test/decorators.test.ts
@@ -11,630 +11,627 @@ import {
 } from "../src/decorators.js";
 import { Tester } from "./test-host.js";
 
-describe("openapi: decorators", () => {
-  describe("@extension", () => {
-    it("apply extension on model", async () => {
-      const { program, Foo } = await Tester.compile(t.code`
-        @extension("x-custom", "Bar")
-        model ${t.model("Foo")} {
-          prop: string
-        }
+describe("@extension", () => {
+  it("apply extension on model", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      @extension("x-custom", "Bar")
+      model ${t.model("Foo")} {
+        prop: string
+      }
+    `);
+
+    deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
+      "x-custom": "Bar",
+    });
+  });
+
+  it("apply extension with complex value", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      @extension("x-custom", #{foo: 123, bar: "string"})
+      model ${t.model("Foo")} {
+        prop: string
+      }
+    `);
+
+    deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
+      "x-custom": { foo: 123, bar: "string" },
+    });
+  });
+
+  it.each([
+    { value: `#{ name: "foo" }`, expected: { name: "foo" } },
+    { value: `#{ items: #[ #{foo: "bar" }]}`, expected: { items: [{ foo: "bar" }] } },
+    { value: `#["foo"]`, expected: ["foo"] },
+    { value: `true`, expected: true },
+    { value: `42`, expected: 42 },
+    { value: `"hi"`, expected: "hi" },
+    { value: `null`, expected: null },
+  ])("treats value $value as raw value", async ({ value, expected }) => {
+    const { program, Foo } = await Tester.compile(t.code`
+        @extension("x-custom", ${value})
+        model ${t.model("Foo")} {}  
       `);
 
-      deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
-        "x-custom": "Bar",
-      });
+    deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
+      "x-custom": expected,
     });
+  });
 
-    it("apply extension with complex value", async () => {
-      const { program, Foo } = await Tester.compile(t.code`
-        @extension("x-custom", #{foo: 123, bar: "string"})
-        model ${t.model("Foo")} {
-          prop: string
-        }
-      `);
+  it("supports extension key not starting with `x-`", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      @extension("foo", "Bar")
+      model ${t.model("Foo")} {
+        prop: string
+      }
+    `);
 
-      deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
-        "x-custom": { foo: 123, bar: "string" },
-      });
+    deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
+      foo: "Bar",
     });
+  });
 
+  it("emit diagnostics when passing non string extension key", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @extension(123, "Bar")
+      @test
+      model Foo {
+        prop: string
+      }
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
+    });
+  });
+});
+
+describe("@externalDocs", () => {
+  it("emit diagnostic if url is not a string", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @externalDocs(123)
+      model Foo {}
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
+    });
+  });
+
+  it("emit diagnostic if description is not a string", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @externalDocs("https://example.com", 123)
+      model Foo {}
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
+    });
+  });
+
+  it("set the external url", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      @externalDocs("https://example.com")
+      model ${t.model("Foo")} {}
+    `);
+
+    deepStrictEqual(getExternalDocs(program, Foo), { url: "https://example.com" });
+  });
+
+  it("set the external url with description", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      @externalDocs("https://example.com", "More info there")
+      model ${t.model("Foo")} {}
+    `);
+
+    deepStrictEqual(getExternalDocs(program, Foo), {
+      url: "https://example.com",
+      description: "More info there",
+    });
+  });
+});
+
+describe("@info", () => {
+  describe("emit diagnostics when passing extension key not starting with `x-` in additionalInfo", () => {
     it.each([
-      { value: `#{ name: "foo" }`, expected: { name: "foo" } },
-      { value: `#{ items: #[ #{foo: "bar" }]}`, expected: { items: [{ foo: "bar" }] } },
-      { value: `#["foo"]`, expected: ["foo"] },
-      { value: `true`, expected: true },
-      { value: `42`, expected: 42 },
-      { value: `"hi"`, expected: "hi" },
-      { value: `null`, expected: null },
-    ])("treats value $value as raw value", async ({ value, expected }) => {
-      const { program, Foo } = await Tester.compile(t.code`
-          @extension("x-custom", ${value})
-          model ${t.model("Foo")} {}  
-        `);
-
-      deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
-        "x-custom": expected,
-      });
-    });
-
-    it("supports extension key not starting with `x-`", async () => {
-      const { program, Foo } = await Tester.compile(t.code`
-        @extension("foo", "Bar")
-        model ${t.model("Foo")} {
-          prop: string
-        }
-      `);
-
-      deepStrictEqual(Object.fromEntries(getExtensions(program, Foo)), {
-        foo: "Bar",
-      });
-    });
-
-    it("emit diagnostics when passing non string extension key", async () => {
+      ["root", `#{ foo: "Bar" }`],
+      ["license", `#{ license: #{ name: "Apache 2.0", foo:"Bar"} }`],
+      ["contact", `#{ contact: #{ foo:"Bar"} }`],
+      ["complex", `#{ contact: #{ \`x-custom\`: "string" }, foo:"Bar" }`],
+    ])("%s", async (_, code) => {
       const diagnostics = await Tester.diagnose(`
-        @extension(123, "Bar")
-        @test
-        model Foo {
-          prop: string
-        }
-      `);
+      @info(${code})
+      @test namespace Service;
+    `);
 
       expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
+        code: "@typespec/openapi/invalid-extension-key",
+        message: `OpenAPI extension must start with 'x-' but was 'foo'`,
       });
     });
-  });
 
-  describe("@externalDocs", () => {
-    it("emit diagnostic if url is not a string", async () => {
+    it("multiple", async () => {
       const diagnostics = await Tester.diagnose(`
-        @externalDocs(123)
-        model Foo {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-      });
-    });
-
-    it("emit diagnostic if description is not a string", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @externalDocs("https://example.com", 123)
-        model Foo {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-      });
-    });
-
-    it("set the external url", async () => {
-      const { program, Foo } = await Tester.compile(t.code`
-        @externalDocs("https://example.com")
-        model ${t.model("Foo")} {}
-      `);
-
-      deepStrictEqual(getExternalDocs(program, Foo), { url: "https://example.com" });
-    });
-
-    it("set the external url with description", async () => {
-      const { program, Foo } = await Tester.compile(t.code`
-        @externalDocs("https://example.com", "More info there")
-        model ${t.model("Foo")} {}
-      `);
-
-      deepStrictEqual(getExternalDocs(program, Foo), {
-        url: "https://example.com",
-        description: "More info there",
-      });
-    });
-  });
-
-  describe("@info", () => {
-    describe("emit diagnostics when passing extension key not starting with `x-` in additionalInfo", () => {
-      it.each([
-        ["root", `#{ foo: "Bar" }`],
-        ["license", `#{ license: #{ name: "Apache 2.0", foo:"Bar"} }`],
-        ["contact", `#{ contact: #{ foo:"Bar"} }`],
-        ["complex", `#{ contact: #{ \`x-custom\`: "string" }, foo:"Bar" }`],
-      ])("%s", async (_, code) => {
-        const diagnostics = await Tester.diagnose(`
-        @info(${code})
+        @info(#{
+          license: #{ name: "Apache 2.0", foo1:"Bar"}, 
+          contact: #{ \`x-custom\`: "string", foo2:"Bar" }, 
+          foo3:"Bar" 
+        })
         @test namespace Service;
       `);
 
-        expectDiagnostics(diagnostics, {
+      expectDiagnostics(diagnostics, [
+        {
           code: "@typespec/openapi/invalid-extension-key",
-          message: `OpenAPI extension must start with 'x-' but was 'foo'`,
-        });
-      });
-
-      it("multiple", async () => {
-        const diagnostics = await Tester.diagnose(`
-          @info(#{
-            license: #{ name: "Apache 2.0", foo1:"Bar"}, 
-            contact: #{ \`x-custom\`: "string", foo2:"Bar" }, 
-            foo3:"Bar" 
-          })
-          @test namespace Service;
-        `);
-
-        expectDiagnostics(diagnostics, [
-          {
-            code: "@typespec/openapi/invalid-extension-key",
-            message: `OpenAPI extension must start with 'x-' but was 'foo1'`,
-          },
-          {
-            code: "@typespec/openapi/invalid-extension-key",
-            message: `OpenAPI extension must start with 'x-' but was 'foo2'`,
-          },
-          {
-            code: "@typespec/openapi/invalid-extension-key",
-            message: `OpenAPI extension must start with 'x-' but was 'foo3'`,
-          },
-        ]);
-      });
-    });
-
-    it("emit diagnostic if termsOfService is not a valid url", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @info(#{termsOfService:"notvalidurl"})
-        namespace Service {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/openapi/not-url",
-        message: "TermsOfService: notvalidurl is not a valid URL.",
-      });
-    });
-
-    it("emit diagnostic if use on non namespace", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @info(#{})
-        model Foo {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "decorator-wrong-target",
-        message: "Cannot apply @info decorator to Foo since it is not assignable to Namespace",
-      });
-    });
-
-    it("emit diagnostic if info parameter is not an object", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @info(123)
-        namespace Service {}
-      `);
-
-      expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
-      });
-    });
-
-    it("set all properties", async () => {
-      const { program, Service } = await Tester.compile(t.code`
-        @info(#{
-          title: "My API",
-          version: "1.0.0",
-          summary: "My API summary",
-          termsOfService: "http://example.com/terms/",
-          contact: #{
-            name: "API Support",
-            url: "http://www.example.com/support",
-            email: "support@example.com"
-          },
-          license: #{
-            name: "Apache 2.0",
-            url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-          },
-        })
-        namespace ${t.namespace("Service")} {}
-      `);
-
-      deepStrictEqual(getInfo(program, Service), {
-        title: "My API",
-        version: "1.0.0",
-        summary: "My API summary",
-        termsOfService: "http://example.com/terms/",
-        contact: {
-          name: "API Support",
-          url: "http://www.example.com/support",
-          email: "support@example.com",
+          message: `OpenAPI extension must start with 'x-' but was 'foo1'`,
         },
-        license: {
-          name: "Apache 2.0",
-          url: "http://www.apache.org/licenses/LICENSE-2.0.html",
+        {
+          code: "@typespec/openapi/invalid-extension-key",
+          message: `OpenAPI extension must start with 'x-' but was 'foo2'`,
         },
-      });
-    });
-
-    it("resolveInfo() merge with data from @service and @summary", async () => {
-      const { program, Service } = await Tester.compile(t.code`
-        @service(#{ 
-          title: "Service API", 
-        })
-        @summary("My summary")
-        @info(#{
-          version: "1.0.0",
-          termsOfService: "http://example.com/terms/",
-        })
-        namespace ${t.namespace("Service")} {}
-      `);
-
-      deepStrictEqual(resolveInfo(program, Service), {
-        title: "Service API",
-        version: "1.0.0",
-        summary: "My summary",
-        termsOfService: "http://example.com/terms/",
-      });
-    });
-
-    it("resolveInfo() returns empty object if nothing is provided", async () => {
-      const { program, Service } = await Tester.compile(t.code`
-        namespace ${t.namespace("Service")} {}
-      `);
-
-      deepStrictEqual(resolveInfo(program, Service), {});
-    });
-
-    it("setInfo() function for setting info object directly", async () => {
-      const { program, Service } = await Tester.compile(t.code`
-        namespace ${t.namespace("Service")} {}
-      `);
-      setInfo(program, Service, {
-        title: "My API",
-        version: "1.0.0",
-        summary: "My API summary",
-        termsOfService: "http://example.com/terms/",
-        contact: {
-          name: "API Support",
-          url: "http://www.example.com/support",
-          email: "support@example.com",
+        {
+          code: "@typespec/openapi/invalid-extension-key",
+          message: `OpenAPI extension must start with 'x-' but was 'foo3'`,
         },
-        license: {
-          name: "Apache 2.0",
-          url: "http://www.apache.org/licenses/LICENSE-2.0.html",
-        },
-        "x-custom": "Bar",
-      });
-      deepStrictEqual(getInfo(program, Service), {
-        title: "My API",
-        version: "1.0.0",
-        summary: "My API summary",
-        termsOfService: "http://example.com/terms/",
-        contact: {
-          name: "API Support",
-          url: "http://www.example.com/support",
-          email: "support@example.com",
-        },
-        license: {
-          name: "Apache 2.0",
-          url: "http://www.apache.org/licenses/LICENSE-2.0.html",
-        },
-        "x-custom": "Bar",
-      });
+      ]);
     });
   });
 
-  describe("@tagMetadata", () => {
-    it("emit an error if a non-service namespace", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        @tagMetadata("tagName", #{})
-        namespace Test {}
-      `,
-      );
-      expectDiagnostics(diagnostics, [
-        {
-          code: "@typespec/openapi/tag-metadata-target-service",
+  it("emit diagnostic if termsOfService is not a valid url", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @info(#{termsOfService:"notvalidurl"})
+      namespace Service {}
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi/not-url",
+      message: "TermsOfService: notvalidurl is not a valid URL.",
+    });
+  });
+
+  it("emit diagnostic if use on non namespace", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @info(#{})
+      model Foo {}
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "decorator-wrong-target",
+      message: "Cannot apply @info decorator to Foo since it is not assignable to Namespace",
+    });
+  });
+
+  it("emit diagnostic if info parameter is not an object", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @info(123)
+      namespace Service {}
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
+    });
+  });
+
+  it("set all properties", async () => {
+    const { program, Service } = await Tester.compile(t.code`
+      @info(#{
+        title: "My API",
+        version: "1.0.0",
+        summary: "My API summary",
+        termsOfService: "http://example.com/terms/",
+        contact: #{
+          name: "API Support",
+          url: "http://www.example.com/support",
+          email: "support@example.com"
         },
-      ]);
+        license: #{
+          name: "Apache 2.0",
+          url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+      })
+      namespace ${t.namespace("Service")} {}
+    `);
+
+    deepStrictEqual(getInfo(program, Service), {
+      title: "My API",
+      version: "1.0.0",
+      summary: "My API summary",
+      termsOfService: "http://example.com/terms/",
+      contact: {
+        name: "API Support",
+        url: "http://www.example.com/support",
+        email: "support@example.com",
+      },
+      license: {
+        name: "Apache 2.0",
+        url: "http://www.apache.org/licenses/LICENSE-2.0.html",
+      },
+    });
+  });
+
+  it("resolveInfo() merge with data from @service and @summary", async () => {
+    const { program, Service } = await Tester.compile(t.code`
+      @service(#{ 
+        title: "Service API", 
+      })
+      @summary("My summary")
+      @info(#{
+        version: "1.0.0",
+        termsOfService: "http://example.com/terms/",
+      })
+      namespace ${t.namespace("Service")} {}
+    `);
+
+    deepStrictEqual(resolveInfo(program, Service), {
+      title: "Service API",
+      version: "1.0.0",
+      summary: "My summary",
+      termsOfService: "http://example.com/terms/",
+    });
+  });
+
+  it("resolveInfo() returns empty object if nothing is provided", async () => {
+    const { program, Service } = await Tester.compile(t.code`
+      namespace ${t.namespace("Service")} {}
+    `);
+
+    deepStrictEqual(resolveInfo(program, Service), {});
+  });
+
+  it("setInfo() function for setting info object directly", async () => {
+    const { program, Service } = await Tester.compile(t.code`
+      namespace ${t.namespace("Service")} {}
+    `);
+    setInfo(program, Service, {
+      title: "My API",
+      version: "1.0.0",
+      summary: "My API summary",
+      termsOfService: "http://example.com/terms/",
+      contact: {
+        name: "API Support",
+        url: "http://www.example.com/support",
+        email: "support@example.com",
+      },
+      license: {
+        name: "Apache 2.0",
+        url: "http://www.apache.org/licenses/LICENSE-2.0.html",
+      },
+      "x-custom": "Bar",
+    });
+    deepStrictEqual(getInfo(program, Service), {
+      title: "My API",
+      version: "1.0.0",
+      summary: "My API summary",
+      termsOfService: "http://example.com/terms/",
+      contact: {
+        name: "API Support",
+        url: "http://www.example.com/support",
+        email: "support@example.com",
+      },
+      license: {
+        name: "Apache 2.0",
+        url: "http://www.apache.org/licenses/LICENSE-2.0.html",
+      },
+      "x-custom": "Bar",
+    });
+  });
+});
+
+describe("@tagMetadata", () => {
+  it("emit an error if a non-service namespace", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @tagMetadata("tagName", #{})
+      namespace Test {}
+    `,
+    );
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@typespec/openapi/tag-metadata-target-service",
+      },
+    ]);
+  });
+
+  it.each([
+    ["tagName is not a string", `@tagMetadata(123, #{})`],
+    ["tagMetdata parameter is not an object", `@tagMetadata("tagName", 123)`],
+    ["description is not a string", `@tagMetadata("tagName", #{ description: 123, })`],
+    ["externalDocs is not an object", `@tagMetadata("tagName", #{ externalDocs: 123, })`],
+  ])("%s", async (_, code) => {
+    const diagnostics = await Tester.diagnose(
+      `
+      ${code}
+      namespace PetStore{};
+      `,
+    );
+
+    expectDiagnostics(diagnostics, {
+      code: "invalid-argument",
+    });
+  });
+
+  it("emit diagnostic if dup tagName", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @service()
+      @tagMetadata("tagName", #{})
+      @tagMetadata("tagName", #{})
+      namespace PetStore{};
+      `,
+    );
+
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi/duplicate-tag",
+    });
+  });
+
+  it("emit diagnostic if dup tagName in array form", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @service()
+      @tagMetadata(#[
+        #{ name: "tagName" },
+        #{ name: "tagName" },
+      ])
+      namespace PetStore{};
+      `,
+    );
+
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi/duplicate-tag",
+    });
+  });
+
+  describe("emit diagnostics when passing extension key not starting with `x-` in metadata", () => {
+    it("reports the diagnostic on the invalid metadata property", async () => {
+      const [{ pos }, diagnostics] = await Tester.compileAndDiagnose(`
+        @service
+        @tagMetadata("tagName", #{ /*custom*/custom: "Bar" })
+        namespace PetStore{};
+      `);
+
+      expectDiagnostics(diagnostics, {
+        code: "@typespec/openapi/invalid-extension-key",
+        message: `OpenAPI extension must start with 'x-' but was 'custom'`,
+        pos: pos.custom.pos,
+      });
     });
 
     it.each([
-      ["tagName is not a string", `@tagMetadata(123, #{})`],
-      ["tagMetdata parameter is not an object", `@tagMetadata("tagName", 123)`],
-      ["description is not a string", `@tagMetadata("tagName", #{ description: 123, })`],
-      ["externalDocs is not an object", `@tagMetadata("tagName", #{ externalDocs: 123, })`],
+      ["root", `#{ foo:"Bar" }`],
+      ["externalDocs", `#{ externalDocs: #{ url: "https://example.com", foo:"Bar"} }`],
+      [
+        "complex",
+        `#{ externalDocs: #{ url: "https://example.com", \`x-custom\`: "string" }, foo:"Bar" }`,
+      ],
     ])("%s", async (_, code) => {
       const diagnostics = await Tester.diagnose(
         `
-        ${code}
+        @service()
+        @tagMetadata("tagName", ${code})
         namespace PetStore{};
         `,
       );
 
       expectDiagnostics(diagnostics, {
-        code: "invalid-argument",
+        code: "@typespec/openapi/invalid-extension-key",
+        message: `OpenAPI extension must start with 'x-' but was 'foo'`,
       });
     });
 
-    it("emit diagnostic if dup tagName", async () => {
+    it("multiple", async () => {
       const diagnostics = await Tester.diagnose(
         `
         @service()
-        @tagMetadata("tagName", #{})
-        @tagMetadata("tagName", #{})
-        namespace PetStore{};
-        `,
-      );
-
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/openapi/duplicate-tag",
-      });
-    });
-
-    it("emit diagnostic if dup tagName in array form", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        @service()
-        @tagMetadata(#[
-          #{ name: "tagName" },
-          #{ name: "tagName" },
-        ])
-        namespace PetStore{};
-        `,
-      );
-
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/openapi/duplicate-tag",
-      });
-    });
-
-    describe("emit diagnostics when passing extension key not starting with `x-` in metadata", () => {
-      it("reports the diagnostic on the invalid metadata property", async () => {
-        const [{ pos }, diagnostics] = await Tester.compileAndDiagnose(`
-          @service
-          @tagMetadata("tagName", #{ /*custom*/custom: "Bar" })
-          namespace PetStore{};
-        `);
-
-        expectDiagnostics(diagnostics, {
-          code: "@typespec/openapi/invalid-extension-key",
-          message: `OpenAPI extension must start with 'x-' but was 'custom'`,
-          pos: pos.custom.pos,
-        });
-      });
-
-      it.each([
-        ["root", `#{ foo:"Bar" }`],
-        ["externalDocs", `#{ externalDocs: #{ url: "https://example.com", foo:"Bar"} }`],
-        [
-          "complex",
-          `#{ externalDocs: #{ url: "https://example.com", \`x-custom\`: "string" }, foo:"Bar" }`,
-        ],
-      ])("%s", async (_, code) => {
-        const diagnostics = await Tester.diagnose(
-          `
-          @service()
-          @tagMetadata("tagName", ${code})
-          namespace PetStore{};
-          `,
-        );
-
-        expectDiagnostics(diagnostics, {
-          code: "@typespec/openapi/invalid-extension-key",
-          message: `OpenAPI extension must start with 'x-' but was 'foo'`,
-        });
-      });
-
-      it("multiple", async () => {
-        const diagnostics = await Tester.diagnose(
-          `
-          @service()
-          @tagMetadata("tagName", #{
-            externalDocs: #{ url: "https://example.com", foo1:"Bar" }, 
-            foo2:"Bar" 
-          })
-          @test namespace Service{};
-          `,
-        );
-
-        expectDiagnostics(diagnostics, [
-          {
-            code: "@typespec/openapi/invalid-extension-key",
-            message: `OpenAPI extension must start with 'x-' but was 'foo1'`,
-          },
-          {
-            code: "@typespec/openapi/invalid-extension-key",
-            message: `OpenAPI extension must start with 'x-' but was 'foo2'`,
-          },
-        ]);
-      });
-    });
-
-    it("emit diagnostic if externalDocs.url is not a valid url", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        @service
         @tagMetadata("tagName", #{
-            externalDocs: #{ url: "notvalidurl"}, 
+          externalDocs: #{ url: "https://example.com", foo1:"Bar" }, 
+          foo2:"Bar" 
         })
-        namespace Service {}
+        @test namespace Service{};
         `,
       );
 
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/openapi/not-url",
-        message: "externalDocs.url: notvalidurl is not a valid URL.",
-      });
-    });
-
-    it("emit diagnostic if use on non namespace", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        @tagMetadata("tagName", #{})
-        model Foo {}
-        `,
-      );
-
-      expectDiagnostics(diagnostics, {
-        code: "decorator-wrong-target",
-        message:
-          "Cannot apply @tagMetadata decorator to Foo since it is not assignable to Namespace",
-      });
-    });
-
-    const testCases: [string, string, any][] = [
-      [
-        "set tagMetadata without additionalInfo",
-        `@tagMetadata("tagName", #{})`,
-        [{ name: "tagName" }],
-      ],
-      [
-        "set tagMetadata without externalDocs",
-        `@tagMetadata("tagName", #{ description: "Pets operations" })`,
-        [{ name: "tagName", description: "Pets operations" }],
-      ],
-      [
-        "set tagMetadata additionalInfo",
-        `@tagMetadata("tagName", #{ \`x-custom\`: "string" })`,
-        [{ name: "tagName", "x-custom": "string" }],
-      ],
-      [
-        "set multiple tagsMetadata",
-        `@tagMetadata(
-            "tagName1",
-            #{
-              description: "Pets operations",
-              externalDocs: #{
-                url: "https://example.com",
-                \`x-custom\`: "string"
-              }        
-            }
-          )
-          @tagMetadata(
-            "tagName2",
-            #{
-              description: "Pets operations",
-              externalDocs: #{
-                url: "https://example.com",
-                description: "More info."        
-              },
-               \`x-custom\`: "string"
-            }
-          )`,
-        [
-          {
-            name: "tagName2",
-            description: "Pets operations",
-            externalDocs: {
-              url: "https://example.com",
-              description: "More info.",
-            },
-            "x-custom": "string",
-          },
-          {
-            name: "tagName1",
-            description: "Pets operations",
-            externalDocs: {
-              url: "https://example.com",
-              "x-custom": "string",
-            },
-          },
-        ],
-      ],
-      [
-        "set tagMetadata using array form",
-        `@tagMetadata(#[
-            #{ name: "tagName1", description: "First tag" },
-            #{ name: "tagName2", description: "Second tag" },
-          ])`,
-        [
-          { name: "tagName1", description: "First tag" },
-          { name: "tagName2", description: "Second tag" },
-        ],
-      ],
-    ];
-    it.each(testCases)("%s", async (_, tagMetaDecorator, expected) => {
-      const { program, PetStore } = await Tester.compile(t.code`
-        @service()
-        ${tagMetaDecorator}
-        namespace ${t.namespace("PetStore")} {}
-      `);
-      deepStrictEqual(getTagsMetadata(program, PetStore), expected);
-    });
-
-    it("emit diagnostic when mixing array form and inline form (array first)", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        @service()
-        @tagMetadata("tag2", #{})
-        @tagMetadata(#[#{ name: "tag1" }])
-        namespace PetStore{};
-        `,
-      );
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/openapi/mixed-tag-metadata-form",
-      });
-    });
-
-    it("emit diagnostic when mixing array form and inline form (inline first)", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        @service()
-        @tagMetadata(#[#{ name: "tag2" }])
-        @tagMetadata("tag1", #{})
-        namespace PetStore{};
-        `,
-      );
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/openapi/mixed-tag-metadata-form",
-      });
-    });
-
-    it("emit diagnostic when using array form with a tagMetadata second argument", async () => {
-      const diagnostics = await Tester.diagnose(
-        `
-        @service()
-        @tagMetadata(#[#{ name: "tag1" }], #{description: "not allowed"})
-        namespace PetStore{};
-        `,
-      );
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/openapi/tag-metadata-array-with-metadata-arg",
-      });
+      expectDiagnostics(diagnostics, [
+        {
+          code: "@typespec/openapi/invalid-extension-key",
+          message: `OpenAPI extension must start with 'x-' but was 'foo1'`,
+        },
+        {
+          code: "@typespec/openapi/invalid-extension-key",
+          message: `OpenAPI extension must start with 'x-' but was 'foo2'`,
+        },
+      ]);
     });
   });
 
-  describe("@defaultResponse", () => {
-    it("emits warning when used on a model with @statusCode", async () => {
-      const diagnostics = await Tester.diagnose(`
-        model MyResponse {
-          @TypeSpec.Http.statusCode _: 500;
-          message: string;
-        }
+  it("emit diagnostic if externalDocs.url is not a valid url", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @service
+      @tagMetadata("tagName", #{
+          externalDocs: #{ url: "notvalidurl"}, 
+      })
+      namespace Service {}
+      `,
+    );
 
-        @defaultResponse
-        model DefaultError is MyResponse {}
-      `);
-      expectDiagnostics(diagnostics, [
-        { code: "@typespec/openapi/default-response-with-status-code", message: /status code/ },
-      ]);
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi/not-url",
+      message: "externalDocs.url: notvalidurl is not a valid URL.",
     });
+  });
 
-    it("emits warning when used on a model marked with @error", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @error
-        @defaultResponse
-        model DefaultError {
-          message: string;
-        }
-      `);
-      expectDiagnostics(diagnostics, [
-        { code: "@typespec/openapi/default-response-with-status-code", message: /@error/ },
-      ]);
-    });
+  it("emit diagnostic if use on non namespace", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @tagMetadata("tagName", #{})
+      model Foo {}
+      `,
+    );
 
-    it("does not emit warning when used on a plain model", async () => {
-      const diagnostics = await Tester.diagnose(`
-        @defaultResponse
-        model DefaultError {
-          message: string;
-        }
-      `);
-      expectDiagnostics(diagnostics, []);
+    expectDiagnostics(diagnostics, {
+      code: "decorator-wrong-target",
+      message: "Cannot apply @tagMetadata decorator to Foo since it is not assignable to Namespace",
     });
+  });
+
+  const testCases: [string, string, any][] = [
+    [
+      "set tagMetadata without additionalInfo",
+      `@tagMetadata("tagName", #{})`,
+      [{ name: "tagName" }],
+    ],
+    [
+      "set tagMetadata without externalDocs",
+      `@tagMetadata("tagName", #{ description: "Pets operations" })`,
+      [{ name: "tagName", description: "Pets operations" }],
+    ],
+    [
+      "set tagMetadata additionalInfo",
+      `@tagMetadata("tagName", #{ \`x-custom\`: "string" })`,
+      [{ name: "tagName", "x-custom": "string" }],
+    ],
+    [
+      "set multiple tagsMetadata",
+      `@tagMetadata(
+          "tagName1",
+          #{
+            description: "Pets operations",
+            externalDocs: #{
+              url: "https://example.com",
+              \`x-custom\`: "string"
+            }        
+          }
+        )
+        @tagMetadata(
+          "tagName2",
+          #{
+            description: "Pets operations",
+            externalDocs: #{
+              url: "https://example.com",
+              description: "More info."        
+            },
+             \`x-custom\`: "string"
+          }
+        )`,
+      [
+        {
+          name: "tagName2",
+          description: "Pets operations",
+          externalDocs: {
+            url: "https://example.com",
+            description: "More info.",
+          },
+          "x-custom": "string",
+        },
+        {
+          name: "tagName1",
+          description: "Pets operations",
+          externalDocs: {
+            url: "https://example.com",
+            "x-custom": "string",
+          },
+        },
+      ],
+    ],
+    [
+      "set tagMetadata using array form",
+      `@tagMetadata(#[
+          #{ name: "tagName1", description: "First tag" },
+          #{ name: "tagName2", description: "Second tag" },
+        ])`,
+      [
+        { name: "tagName1", description: "First tag" },
+        { name: "tagName2", description: "Second tag" },
+      ],
+    ],
+  ];
+  it.each(testCases)("%s", async (_, tagMetaDecorator, expected) => {
+    const { program, PetStore } = await Tester.compile(t.code`
+      @service()
+      ${tagMetaDecorator}
+      namespace ${t.namespace("PetStore")} {}
+    `);
+    deepStrictEqual(getTagsMetadata(program, PetStore), expected);
+  });
+
+  it("emit diagnostic when mixing array form and inline form (array first)", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @service()
+      @tagMetadata("tag2", #{})
+      @tagMetadata(#[#{ name: "tag1" }])
+      namespace PetStore{};
+      `,
+    );
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi/mixed-tag-metadata-form",
+    });
+  });
+
+  it("emit diagnostic when mixing array form and inline form (inline first)", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @service()
+      @tagMetadata(#[#{ name: "tag2" }])
+      @tagMetadata("tag1", #{})
+      namespace PetStore{};
+      `,
+    );
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi/mixed-tag-metadata-form",
+    });
+  });
+
+  it("emit diagnostic when using array form with a tagMetadata second argument", async () => {
+    const diagnostics = await Tester.diagnose(
+      `
+      @service()
+      @tagMetadata(#[#{ name: "tag1" }], #{description: "not allowed"})
+      namespace PetStore{};
+      `,
+    );
+    expectDiagnostics(diagnostics, {
+      code: "@typespec/openapi/tag-metadata-array-with-metadata-arg",
+    });
+  });
+});
+
+describe("@defaultResponse", () => {
+  it("emits warning when used on a model with @statusCode", async () => {
+    const diagnostics = await Tester.diagnose(`
+      model MyResponse {
+        @TypeSpec.Http.statusCode _: 500;
+        message: string;
+      }
+
+      @defaultResponse
+      model DefaultError is MyResponse {}
+    `);
+    expectDiagnostics(diagnostics, [
+      { code: "@typespec/openapi/default-response-with-status-code", message: /status code/ },
+    ]);
+  });
+
+  it("emits warning when used on a model marked with @error", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @error
+      @defaultResponse
+      model DefaultError {
+        message: string;
+      }
+    `);
+    expectDiagnostics(diagnostics, [
+      { code: "@typespec/openapi/default-response-with-status-code", message: /@error/ },
+    ]);
+  });
+
+  it("does not emit warning when used on a plain model", async () => {
+    const diagnostics = await Tester.diagnose(`
+      @defaultResponse
+      model DefaultError {
+        message: string;
+      }
+    `);
+    expectDiagnostics(diagnostics, []);
   });
 });

--- a/packages/playground/test/get-changed-line-numbers.test.ts
+++ b/packages/playground/test/get-changed-line-numbers.test.ts
@@ -1,78 +1,76 @@
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { getChangedLineNumbers } from "../src/react/diff-utils.js";
 
-describe("getChangedLineNumbers", () => {
-  it("returns empty array when texts are identical", () => {
-    const text = "line1\nline2\nline3";
-    expect(getChangedLineNumbers(text, text)).toEqual([]);
-  });
+it("returns empty array when texts are identical", () => {
+  const text = "line1\nline2\nline3";
+  expect(getChangedLineNumbers(text, text)).toEqual([]);
+});
 
-  it("returns all line numbers when old text is empty", () => {
-    const result = getChangedLineNumbers("", "line1\nline2\nline3");
-    expect(result).toEqual([1, 2, 3]);
-  });
+it("returns all line numbers when old text is empty", () => {
+  const result = getChangedLineNumbers("", "line1\nline2\nline3");
+  expect(result).toEqual([1, 2, 3]);
+});
 
-  it("returns empty array when new text is empty", () => {
-    const result = getChangedLineNumbers("line1\nline2", "");
-    // The empty string splits into [""], which is 1 line that doesn't match any old line
-    expect(result).toEqual([1]);
-  });
+it("returns empty array when new text is empty", () => {
+  const result = getChangedLineNumbers("line1\nline2", "");
+  // The empty string splits into [""], which is 1 line that doesn't match any old line
+  expect(result).toEqual([1]);
+});
 
-  it("detects a single changed line", () => {
-    const oldText = "line1\nline2\nline3";
-    const newText = "line1\nmodified\nline3";
-    const result = getChangedLineNumbers(oldText, newText);
-    expect(result).toEqual([2]);
-  });
+it("detects a single changed line", () => {
+  const oldText = "line1\nline2\nline3";
+  const newText = "line1\nmodified\nline3";
+  const result = getChangedLineNumbers(oldText, newText);
+  expect(result).toEqual([2]);
+});
 
-  it("detects inserted lines", () => {
-    const oldText = "line1\nline3";
-    const newText = "line1\nline2\nline3";
-    const result = getChangedLineNumbers(oldText, newText);
-    expect(result).toEqual([2]);
-  });
+it("detects inserted lines", () => {
+  const oldText = "line1\nline3";
+  const newText = "line1\nline2\nline3";
+  const result = getChangedLineNumbers(oldText, newText);
+  expect(result).toEqual([2]);
+});
 
-  it("detects multiple changed lines", () => {
-    const oldText = "alpha\nbeta\ngamma\ndelta";
-    const newText = "alpha\nXXX\ngamma\nYYY";
-    const result = getChangedLineNumbers(oldText, newText);
-    expect(result).toEqual([2, 4]);
-  });
+it("detects multiple changed lines", () => {
+  const oldText = "alpha\nbeta\ngamma\ndelta";
+  const newText = "alpha\nXXX\ngamma\nYYY";
+  const result = getChangedLineNumbers(oldText, newText);
+  expect(result).toEqual([2, 4]);
+});
 
-  it("returns 1-based line numbers (Monaco convention)", () => {
-    const oldText = "unchanged";
-    const newText = "changed";
-    const result = getChangedLineNumbers(oldText, newText);
-    expect(result).toEqual([1]);
-  });
+it("returns 1-based line numbers (Monaco convention)", () => {
+  const oldText = "unchanged";
+  const newText = "changed";
+  const result = getChangedLineNumbers(oldText, newText);
+  expect(result).toEqual([1]);
+});
 
-  it("handles completely different content", () => {
-    const oldText = "apple\nbanana\ncherry";
-    const newText = "mango\norange\npeach";
-    const result = getChangedLineNumbers(oldText, newText);
-    expect(result).toEqual([1, 2, 3]);
-  });
+it("handles completely different content", () => {
+  const oldText = "apple\nbanana\ncherry";
+  const newText = "mango\norange\npeach";
+  const result = getChangedLineNumbers(oldText, newText);
+  expect(result).toEqual([1, 2, 3]);
+});
 
-  it("handles appended lines", () => {
-    const oldText = "line1\nline2";
-    const newText = "line1\nline2\nline3\nline4";
-    const result = getChangedLineNumbers(oldText, newText);
-    expect(result).toEqual([3, 4]);
-  });
+it("handles appended lines", () => {
+  const oldText = "line1\nline2";
+  const newText = "line1\nline2\nline3\nline4";
+  const result = getChangedLineNumbers(oldText, newText);
+  expect(result).toEqual([3, 4]);
+});
 
-  it("handles deleted lines (only remaining lines counted)", () => {
-    const oldText = "line1\nline2\nline3\nline4";
-    const newText = "line1\nline4";
-    const result = getChangedLineNumbers(oldText, newText);
-    // line1 and line4 are matched, nothing is "changed" in the new text
-    expect(result).toEqual([]);
-  });
+it("handles deleted lines (only remaining lines counted)", () => {
+  const oldText = "line1\nline2\nline3\nline4";
+  const newText = "line1\nline4";
+  const result = getChangedLineNumbers(oldText, newText);
+  // line1 and line4 are matched, nothing is "changed" in the new text
+  expect(result).toEqual([]);
+});
 
-  it("handles reordered lines as changes", () => {
-    const oldText = "apple\nbanana\ncherry";
-    const newText = "cherry\nbanana\napple";
-    // Greedy forward scan: cherry at index 0 matches old[2], then banana/apple can't match forward
-    const result = getChangedLineNumbers(oldText, newText);
-    expect(result).toEqual([2, 3]);
-  });
+it("handles reordered lines as changes", () => {
+  const oldText = "apple\nbanana\ncherry";
+  const newText = "cherry\nbanana\napple";
+  // Greedy forward scan: cherry at index 0 matches old[2], then banana/apple can't match forward
+  const result = getChangedLineNumbers(oldText, newText);
+  expect(result).toEqual([2, 3]);
 });

--- a/packages/playground/test/responsive-command-bar.test.tsx
+++ b/packages/playground/test/responsive-command-bar.test.tsx
@@ -14,188 +14,186 @@ function renderBar(items: CommandBarItem[], isMobile = false) {
   );
 }
 
-describe("ResponsiveCommandBar", () => {
-  describe("desktop mode", () => {
-    it("renders all items as toolbar buttons", () => {
-      const items: CommandBarItem[] = [
-        { id: "save", label: "Save", onClick: vi.fn() },
-        { id: "format", label: "Format", onClick: vi.fn() },
-      ];
-      renderBar(items, false);
-      expect(screen.getByLabelText("Save")).toBeInTheDocument();
-      expect(screen.getByLabelText("Format")).toBeInTheDocument();
-    });
-
-    it("renders left items before right items with a divider between", () => {
-      const items: CommandBarItem[] = [
-        { id: "left1", label: "Left One", onClick: vi.fn() },
-        { id: "right1", label: "Right One", onClick: vi.fn(), align: "right" },
-      ];
-      renderBar(items, false);
-      expect(screen.getByLabelText("Left One")).toBeInTheDocument();
-      expect(screen.getByLabelText("Right One")).toBeInTheDocument();
-    });
-
-    it("calls onClick when a toolbar button is clicked", () => {
-      const onClick = vi.fn();
-      renderBar([{ id: "action", label: "Action", onClick }], false);
-      fireEvent.click(screen.getByLabelText("Action"));
-      expect(onClick).toHaveBeenCalledOnce();
-    });
-
-    it("renders custom toolbarItem when provided", () => {
-      const items: CommandBarItem[] = [
-        {
-          id: "custom",
-          label: "Custom",
-          toolbarItem: <button data-testid="custom-btn">Custom Button</button>,
-        },
-      ];
-      renderBar(items, false);
-      expect(screen.getByTestId("custom-btn")).toBeInTheDocument();
-    });
-
-    it("renders children as a dropdown menu", () => {
-      const childClick = vi.fn();
-      const items: CommandBarItem[] = [
-        {
-          id: "parent",
-          label: "Parent",
-          children: [{ id: "child1", label: "Child One", onClick: childClick }],
-        },
-      ];
-      renderBar(items, false);
-      // The parent renders as a button with aria-label
-      const trigger = screen.getByLabelText("Parent");
-      fireEvent.click(trigger);
-      // After clicking, the dropdown should show the child
-      expect(screen.getByText("Child One")).toBeInTheDocument();
-      fireEvent.click(screen.getByText("Child One"));
-      expect(childClick).toHaveBeenCalledOnce();
-    });
+describe("desktop mode", () => {
+  it("renders all items as toolbar buttons", () => {
+    const items: CommandBarItem[] = [
+      { id: "save", label: "Save", onClick: vi.fn() },
+      { id: "format", label: "Format", onClick: vi.fn() },
+    ];
+    renderBar(items, false);
+    expect(screen.getByLabelText("Save")).toBeInTheDocument();
+    expect(screen.getByLabelText("Format")).toBeInTheDocument();
   });
 
-  describe("mobile mode", () => {
-    it("renders pinned items directly and overflow in a menu", () => {
-      const items: CommandBarItem[] = [
-        { id: "pinned", label: "Pinned", onClick: vi.fn(), pinned: true },
-        { id: "overflow", label: "Overflow Item", onClick: vi.fn() },
-      ];
-      renderBar(items, true);
-      // Pinned item is directly visible
-      expect(screen.getByLabelText("Pinned")).toBeInTheDocument();
-      // Overflow item is hidden behind the hamburger
-      expect(screen.queryByText("Overflow Item")).not.toBeInTheDocument();
-      // Open the hamburger menu
-      fireEvent.click(screen.getByLabelText("More actions"));
-      expect(screen.getByText("Overflow Item")).toBeInTheDocument();
-    });
-
-    it("calls onClick on overflow menu item click", () => {
-      const onClick = vi.fn();
-      const items: CommandBarItem[] = [{ id: "action", label: "Action", onClick }];
-      renderBar(items, true);
-      fireEvent.click(screen.getByLabelText("More actions"));
-      fireEvent.click(screen.getByText("Action"));
-      expect(onClick).toHaveBeenCalledOnce();
-    });
-
-    it("renders a divider between left and right overflow items", () => {
-      const items: CommandBarItem[] = [
-        { id: "left", label: "Left Item", onClick: vi.fn() },
-        { id: "right", label: "Right Item", onClick: vi.fn(), align: "right" },
-      ];
-      const { container } = renderBar(items, true);
-      fireEvent.click(screen.getByLabelText("More actions"));
-      // Both items should be visible in the menu
-      expect(screen.getByText("Left Item")).toBeInTheDocument();
-      expect(screen.getByText("Right Item")).toBeInTheDocument();
-      // MenuDivider renders as an element with role="separator"
-      const divider = container.ownerDocument.querySelector(
-        "[class*='fui-MenuDivider'], [role='separator']",
-      );
-      expect(divider).toBeTruthy();
-    });
-
-    it("does not render divider when all overflow items are on the same side", () => {
-      const items: CommandBarItem[] = [
-        { id: "a", label: "Item A", onClick: vi.fn() },
-        { id: "b", label: "Item B", onClick: vi.fn() },
-      ];
-      renderBar(items, true);
-      fireEvent.click(screen.getByLabelText("More actions"));
-      const menuPopover = screen.getByText("Item A").closest("[role='menu']");
-      expect(menuPopover?.querySelector("[role='separator']")).not.toBeInTheDocument();
-    });
-
-    it("renders custom menuItem when provided", () => {
-      const items: CommandBarItem[] = [
-        {
-          id: "custom",
-          label: "Custom",
-          menuItem: <div data-testid="custom-menu">Custom Menu Content</div>,
-        },
-      ];
-      renderBar(items, true);
-      fireEvent.click(screen.getByLabelText("More actions"));
-      expect(screen.getByTestId("custom-menu")).toBeInTheDocument();
-    });
-
-    it("does not show hamburger when all items are pinned", () => {
-      const items: CommandBarItem[] = [
-        { id: "a", label: "A", onClick: vi.fn(), pinned: true },
-        { id: "b", label: "B", onClick: vi.fn(), pinned: true },
-      ];
-      renderBar(items, true);
-      expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument();
-    });
-
-    it("renders children as a nested submenu in overflow", () => {
-      const childClick = vi.fn();
-      const items: CommandBarItem[] = [
-        {
-          id: "parent",
-          label: "Parent",
-          children: [{ id: "child", label: "Nested Child", onClick: childClick }],
-        },
-      ];
-      renderBar(items, true);
-      fireEvent.click(screen.getByLabelText("More actions"));
-      // Parent appears as a menu item that triggers a submenu
-      const parentItem = screen.getByText("Parent");
-      expect(parentItem).toBeInTheDocument();
-      fireEvent.click(parentItem);
-      expect(screen.getByText("Nested Child")).toBeInTheDocument();
-      fireEvent.click(screen.getByText("Nested Child"));
-      expect(childClick).toHaveBeenCalledOnce();
-    });
+  it("renders left items before right items with a divider between", () => {
+    const items: CommandBarItem[] = [
+      { id: "left1", label: "Left One", onClick: vi.fn() },
+      { id: "right1", label: "Right One", onClick: vi.fn(), align: "right" },
+    ];
+    renderBar(items, false);
+    expect(screen.getByLabelText("Left One")).toBeInTheDocument();
+    expect(screen.getByLabelText("Right One")).toBeInTheDocument();
   });
 
-  describe("content rendering", () => {
-    it("renders item content outside the toolbar", () => {
-      const items: CommandBarItem[] = [
-        {
-          id: "with-content",
-          label: "Item",
-          onClick: vi.fn(),
-          content: <div data-testid="extra-content">Extra</div>,
-        },
-      ];
-      renderBar(items, false);
-      expect(screen.getByTestId("extra-content")).toBeInTheDocument();
-    });
+  it("calls onClick when a toolbar button is clicked", () => {
+    const onClick = vi.fn();
+    renderBar([{ id: "action", label: "Action", onClick }], false);
+    fireEvent.click(screen.getByLabelText("Action"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
 
-    it("renders content in mobile mode too", () => {
-      const items: CommandBarItem[] = [
-        {
-          id: "with-content",
-          label: "Item",
-          onClick: vi.fn(),
-          content: <div data-testid="mobile-content">Mobile Extra</div>,
-        },
-      ];
-      renderBar(items, true);
-      expect(screen.getByTestId("mobile-content")).toBeInTheDocument();
-    });
+  it("renders custom toolbarItem when provided", () => {
+    const items: CommandBarItem[] = [
+      {
+        id: "custom",
+        label: "Custom",
+        toolbarItem: <button data-testid="custom-btn">Custom Button</button>,
+      },
+    ];
+    renderBar(items, false);
+    expect(screen.getByTestId("custom-btn")).toBeInTheDocument();
+  });
+
+  it("renders children as a dropdown menu", () => {
+    const childClick = vi.fn();
+    const items: CommandBarItem[] = [
+      {
+        id: "parent",
+        label: "Parent",
+        children: [{ id: "child1", label: "Child One", onClick: childClick }],
+      },
+    ];
+    renderBar(items, false);
+    // The parent renders as a button with aria-label
+    const trigger = screen.getByLabelText("Parent");
+    fireEvent.click(trigger);
+    // After clicking, the dropdown should show the child
+    expect(screen.getByText("Child One")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Child One"));
+    expect(childClick).toHaveBeenCalledOnce();
+  });
+});
+
+describe("mobile mode", () => {
+  it("renders pinned items directly and overflow in a menu", () => {
+    const items: CommandBarItem[] = [
+      { id: "pinned", label: "Pinned", onClick: vi.fn(), pinned: true },
+      { id: "overflow", label: "Overflow Item", onClick: vi.fn() },
+    ];
+    renderBar(items, true);
+    // Pinned item is directly visible
+    expect(screen.getByLabelText("Pinned")).toBeInTheDocument();
+    // Overflow item is hidden behind the hamburger
+    expect(screen.queryByText("Overflow Item")).not.toBeInTheDocument();
+    // Open the hamburger menu
+    fireEvent.click(screen.getByLabelText("More actions"));
+    expect(screen.getByText("Overflow Item")).toBeInTheDocument();
+  });
+
+  it("calls onClick on overflow menu item click", () => {
+    const onClick = vi.fn();
+    const items: CommandBarItem[] = [{ id: "action", label: "Action", onClick }];
+    renderBar(items, true);
+    fireEvent.click(screen.getByLabelText("More actions"));
+    fireEvent.click(screen.getByText("Action"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders a divider between left and right overflow items", () => {
+    const items: CommandBarItem[] = [
+      { id: "left", label: "Left Item", onClick: vi.fn() },
+      { id: "right", label: "Right Item", onClick: vi.fn(), align: "right" },
+    ];
+    const { container } = renderBar(items, true);
+    fireEvent.click(screen.getByLabelText("More actions"));
+    // Both items should be visible in the menu
+    expect(screen.getByText("Left Item")).toBeInTheDocument();
+    expect(screen.getByText("Right Item")).toBeInTheDocument();
+    // MenuDivider renders as an element with role="separator"
+    const divider = container.ownerDocument.querySelector(
+      "[class*='fui-MenuDivider'], [role='separator']",
+    );
+    expect(divider).toBeTruthy();
+  });
+
+  it("does not render divider when all overflow items are on the same side", () => {
+    const items: CommandBarItem[] = [
+      { id: "a", label: "Item A", onClick: vi.fn() },
+      { id: "b", label: "Item B", onClick: vi.fn() },
+    ];
+    renderBar(items, true);
+    fireEvent.click(screen.getByLabelText("More actions"));
+    const menuPopover = screen.getByText("Item A").closest("[role='menu']");
+    expect(menuPopover?.querySelector("[role='separator']")).not.toBeInTheDocument();
+  });
+
+  it("renders custom menuItem when provided", () => {
+    const items: CommandBarItem[] = [
+      {
+        id: "custom",
+        label: "Custom",
+        menuItem: <div data-testid="custom-menu">Custom Menu Content</div>,
+      },
+    ];
+    renderBar(items, true);
+    fireEvent.click(screen.getByLabelText("More actions"));
+    expect(screen.getByTestId("custom-menu")).toBeInTheDocument();
+  });
+
+  it("does not show hamburger when all items are pinned", () => {
+    const items: CommandBarItem[] = [
+      { id: "a", label: "A", onClick: vi.fn(), pinned: true },
+      { id: "b", label: "B", onClick: vi.fn(), pinned: true },
+    ];
+    renderBar(items, true);
+    expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument();
+  });
+
+  it("renders children as a nested submenu in overflow", () => {
+    const childClick = vi.fn();
+    const items: CommandBarItem[] = [
+      {
+        id: "parent",
+        label: "Parent",
+        children: [{ id: "child", label: "Nested Child", onClick: childClick }],
+      },
+    ];
+    renderBar(items, true);
+    fireEvent.click(screen.getByLabelText("More actions"));
+    // Parent appears as a menu item that triggers a submenu
+    const parentItem = screen.getByText("Parent");
+    expect(parentItem).toBeInTheDocument();
+    fireEvent.click(parentItem);
+    expect(screen.getByText("Nested Child")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Nested Child"));
+    expect(childClick).toHaveBeenCalledOnce();
+  });
+});
+
+describe("content rendering", () => {
+  it("renders item content outside the toolbar", () => {
+    const items: CommandBarItem[] = [
+      {
+        id: "with-content",
+        label: "Item",
+        onClick: vi.fn(),
+        content: <div data-testid="extra-content">Extra</div>,
+      },
+    ];
+    renderBar(items, false);
+    expect(screen.getByTestId("extra-content")).toBeInTheDocument();
+  });
+
+  it("renders content in mobile mode too", () => {
+    const items: CommandBarItem[] = [
+      {
+        id: "with-content",
+        label: "Item",
+        onClick: vi.fn(),
+        content: <div data-testid="mobile-content">Mobile Extra</div>,
+      },
+    ];
+    renderBar(items, true);
+    expect(screen.getByTestId("mobile-content")).toBeInTheDocument();
   });
 });

--- a/packages/playground/test/use-debounced-compile.test.ts
+++ b/packages/playground/test/use-debounced-compile.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
 import { useDebouncedCompile } from "../src/react/hooks/use-debounced-compile.js";
 
 function createMockModel() {
@@ -15,117 +15,115 @@ function createMockModel() {
   };
 }
 
-describe("useDebouncedCompile", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+it("triggers compile after debounce delay on content change", () => {
+  const model = createMockModel();
+  const doCompile = vi.fn(() => Promise.resolve());
+
+  renderHook(() =>
+    useDebouncedCompile({
+      typespecModel: model as any,
+      doCompile,
+      debounceDelay: 100,
+    }),
+  );
+
+  act(() => {
+    model.simulateChange();
   });
 
-  it("triggers compile after debounce delay on content change", () => {
-    const model = createMockModel();
-    const doCompile = vi.fn(() => Promise.resolve());
+  // Not called immediately
+  expect(doCompile).not.toHaveBeenCalled();
 
-    renderHook(() =>
-      useDebouncedCompile({
-        typespecModel: model as any,
-        doCompile,
-        debounceDelay: 100,
-      }),
-    );
+  // Called after delay
+  act(() => {
+    vi.advanceTimersByTime(100);
+  });
+  expect(doCompile).toHaveBeenCalledTimes(1);
+});
 
-    act(() => {
-      model.simulateChange();
-    });
+it("debounces rapid changes into a single compile", () => {
+  const model = createMockModel();
+  const doCompile = vi.fn(() => Promise.resolve());
 
-    // Not called immediately
-    expect(doCompile).not.toHaveBeenCalled();
+  renderHook(() =>
+    useDebouncedCompile({
+      typespecModel: model as any,
+      doCompile,
+      debounceDelay: 200,
+    }),
+  );
 
-    // Called after delay
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-    expect(doCompile).toHaveBeenCalledTimes(1);
+  act(() => {
+    model.simulateChange();
+  });
+  act(() => {
+    vi.advanceTimersByTime(50);
+  });
+  act(() => {
+    model.simulateChange();
+  });
+  act(() => {
+    vi.advanceTimersByTime(50);
+  });
+  act(() => {
+    model.simulateChange();
   });
 
-  it("debounces rapid changes into a single compile", () => {
-    const model = createMockModel();
-    const doCompile = vi.fn(() => Promise.resolve());
+  // Still no call
+  expect(doCompile).not.toHaveBeenCalled();
 
-    renderHook(() =>
-      useDebouncedCompile({
-        typespecModel: model as any,
-        doCompile,
-        debounceDelay: 200,
-      }),
-    );
+  // After full debounce from last change
+  act(() => {
+    vi.advanceTimersByTime(200);
+  });
+  expect(doCompile).toHaveBeenCalledTimes(1);
+});
 
-    act(() => {
-      model.simulateChange();
-    });
-    act(() => {
-      vi.advanceTimersByTime(50);
-    });
-    act(() => {
-      model.simulateChange();
-    });
-    act(() => {
-      vi.advanceTimersByTime(50);
-    });
-    act(() => {
-      model.simulateChange();
-    });
+it("uses default 200ms delay when debounceDelay is not provided", () => {
+  const model = createMockModel();
+  const doCompile = vi.fn(() => Promise.resolve());
 
-    // Still no call
-    expect(doCompile).not.toHaveBeenCalled();
+  renderHook(() =>
+    useDebouncedCompile({
+      typespecModel: model as any,
+      doCompile,
+    }),
+  );
 
-    // After full debounce from last change
-    act(() => {
-      vi.advanceTimersByTime(200);
-    });
-    expect(doCompile).toHaveBeenCalledTimes(1);
+  act(() => {
+    model.simulateChange();
   });
 
-  it("uses default 200ms delay when debounceDelay is not provided", () => {
-    const model = createMockModel();
-    const doCompile = vi.fn(() => Promise.resolve());
-
-    renderHook(() =>
-      useDebouncedCompile({
-        typespecModel: model as any,
-        doCompile,
-      }),
-    );
-
-    act(() => {
-      model.simulateChange();
-    });
-
-    act(() => {
-      vi.advanceTimersByTime(199);
-    });
-    expect(doCompile).not.toHaveBeenCalled();
-
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(doCompile).toHaveBeenCalledTimes(1);
+  act(() => {
+    vi.advanceTimersByTime(199);
   });
+  expect(doCompile).not.toHaveBeenCalled();
 
-  it("cleans up subscription on unmount", () => {
-    const disposeMock = vi.fn();
-    const model = {
-      onDidChangeContent: vi.fn(() => ({ dispose: disposeMock })),
-    };
-    const doCompile = vi.fn(() => Promise.resolve());
-
-    const { unmount } = renderHook(() =>
-      useDebouncedCompile({
-        typespecModel: model as any,
-        doCompile,
-        debounceDelay: 100,
-      }),
-    );
-
-    unmount();
-    expect(disposeMock).toHaveBeenCalled();
+  act(() => {
+    vi.advanceTimersByTime(1);
   });
+  expect(doCompile).toHaveBeenCalledTimes(1);
+});
+
+it("cleans up subscription on unmount", () => {
+  const disposeMock = vi.fn();
+  const model = {
+    onDidChangeContent: vi.fn(() => ({ dispose: disposeMock })),
+  };
+  const doCompile = vi.fn(() => Promise.resolve());
+
+  const { unmount } = renderHook(() =>
+    useDebouncedCompile({
+      typespecModel: model as any,
+      doCompile,
+      debounceDelay: 100,
+    }),
+  );
+
+  unmount();
+  expect(disposeMock).toHaveBeenCalled();
 });

--- a/packages/playground/test/use-editor-actions.test.ts
+++ b/packages/playground/test/use-editor-actions.test.ts
@@ -23,159 +23,157 @@ function createMockEditorRef(hasFormatAction = true) {
   return { ref, runMock };
 }
 
-describe("useEditorActions", () => {
-  const baseProps = {
-    selectedEmitter: "openapi3",
-    compilerOptions: {},
-    selectedSampleName: "basic",
-    isSampleUntouched: true,
-    selectedViewer: "openapi",
-    viewerState: {},
-  };
+const baseProps = {
+  selectedEmitter: "openapi3",
+  compilerOptions: {},
+  selectedSampleName: "basic",
+  isSampleUntouched: true,
+  selectedViewer: "openapi",
+  viewerState: {},
+};
 
-  describe("saveCode", () => {
-    it("calls onSave with current model content and state", () => {
-      const model = createMockModel("my content");
-      const { ref } = createMockEditorRef();
-      const onSave = vi.fn();
+describe("saveCode", () => {
+  it("calls onSave with current model content and state", () => {
+    const model = createMockModel("my content");
+    const { ref } = createMockEditorRef();
+    const onSave = vi.fn();
 
-      const { result } = renderHook(() =>
-        useEditorActions({
-          ...baseProps,
-          typespecModel: model as any,
-          editorRef: ref as any,
-          onSave,
-        }),
-      );
+    const { result } = renderHook(() =>
+      useEditorActions({
+        ...baseProps,
+        typespecModel: model as any,
+        editorRef: ref as any,
+        onSave,
+      }),
+    );
 
-      result.current.saveCode();
+    result.current.saveCode();
 
-      expect(onSave).toHaveBeenCalledWith({
-        content: "my content",
-        emitter: "openapi3",
-        compilerOptions: {},
-        sampleName: "basic",
-        selectedViewer: "openapi",
-        viewerState: {},
-      });
-    });
-
-    it("does not include sampleName when sample is modified", () => {
-      const model = createMockModel("modified");
-      const { ref } = createMockEditorRef();
-      const onSave = vi.fn();
-
-      const { result } = renderHook(() =>
-        useEditorActions({
-          ...baseProps,
-          typespecModel: model as any,
-          editorRef: ref as any,
-          isSampleUntouched: false,
-          onSave,
-        }),
-      );
-
-      result.current.saveCode();
-
-      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ sampleName: undefined }));
-    });
-
-    it("does nothing when onSave is not provided", () => {
-      const model = createMockModel();
-      const { ref } = createMockEditorRef();
-
-      const { result } = renderHook(() =>
-        useEditorActions({
-          ...baseProps,
-          typespecModel: model as any,
-          editorRef: ref as any,
-        }),
-      );
-
-      // Should not throw
-      expect(() => result.current.saveCode()).not.toThrow();
+    expect(onSave).toHaveBeenCalledWith({
+      content: "my content",
+      emitter: "openapi3",
+      compilerOptions: {},
+      sampleName: "basic",
+      selectedViewer: "openapi",
+      viewerState: {},
     });
   });
 
-  describe("formatCode", () => {
-    it("runs the format document action", () => {
-      const model = createMockModel();
-      const { ref, runMock } = createMockEditorRef();
+  it("does not include sampleName when sample is modified", () => {
+    const model = createMockModel("modified");
+    const { ref } = createMockEditorRef();
+    const onSave = vi.fn();
 
-      const { result } = renderHook(() =>
-        useEditorActions({
-          ...baseProps,
-          typespecModel: model as any,
-          editorRef: ref as any,
-        }),
-      );
+    const { result } = renderHook(() =>
+      useEditorActions({
+        ...baseProps,
+        typespecModel: model as any,
+        editorRef: ref as any,
+        isSampleUntouched: false,
+        onSave,
+      }),
+    );
 
-      result.current.formatCode();
+    result.current.saveCode();
 
-      expect(ref.current.getAction).toHaveBeenCalledWith("editor.action.formatDocument");
-      expect(runMock).toHaveBeenCalled();
-    });
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ sampleName: undefined }));
   });
 
-  describe("fileBug", () => {
-    it("calls saveCode then onFileBug", async () => {
-      const model = createMockModel();
-      const { ref } = createMockEditorRef();
-      const onSave = vi.fn();
-      const onFileBug = vi.fn();
+  it("does nothing when onSave is not provided", () => {
+    const model = createMockModel();
+    const { ref } = createMockEditorRef();
 
-      const { result } = renderHook(() =>
-        useEditorActions({
-          ...baseProps,
-          typespecModel: model as any,
-          editorRef: ref as any,
-          onSave,
-          onFileBug,
-        }),
-      );
+    const { result } = renderHook(() =>
+      useEditorActions({
+        ...baseProps,
+        typespecModel: model as any,
+        editorRef: ref as any,
+      }),
+    );
 
-      await result.current.fileBug();
+    // Should not throw
+    expect(() => result.current.saveCode()).not.toThrow();
+  });
+});
 
-      expect(onSave).toHaveBeenCalled();
-      expect(onFileBug).toHaveBeenCalled();
-    });
+describe("formatCode", () => {
+  it("runs the format document action", () => {
+    const model = createMockModel();
+    const { ref, runMock } = createMockEditorRef();
 
-    it("does nothing when onFileBug is not provided", async () => {
-      const model = createMockModel();
-      const { ref } = createMockEditorRef();
-      const onSave = vi.fn();
+    const { result } = renderHook(() =>
+      useEditorActions({
+        ...baseProps,
+        typespecModel: model as any,
+        editorRef: ref as any,
+      }),
+    );
 
-      const { result } = renderHook(() =>
-        useEditorActions({
-          ...baseProps,
-          typespecModel: model as any,
-          editorRef: ref as any,
-          onSave,
-        }),
-      );
+    result.current.formatCode();
 
-      await result.current.fileBug();
-      expect(onSave).not.toHaveBeenCalled();
-    });
+    expect(ref.current.getAction).toHaveBeenCalledWith("editor.action.formatDocument");
+    expect(runMock).toHaveBeenCalled();
+  });
+});
+
+describe("fileBug", () => {
+  it("calls saveCode then onFileBug", async () => {
+    const model = createMockModel();
+    const { ref } = createMockEditorRef();
+    const onSave = vi.fn();
+    const onFileBug = vi.fn();
+
+    const { result } = renderHook(() =>
+      useEditorActions({
+        ...baseProps,
+        typespecModel: model as any,
+        editorRef: ref as any,
+        onSave,
+        onFileBug,
+      }),
+    );
+
+    await result.current.fileBug();
+
+    expect(onSave).toHaveBeenCalled();
+    expect(onFileBug).toHaveBeenCalled();
   });
 
-  describe("editorActions", () => {
-    it("returns a save action with Ctrl+S keybinding", () => {
-      const model = createMockModel();
-      const { ref } = createMockEditorRef();
+  it("does nothing when onFileBug is not provided", async () => {
+    const model = createMockModel();
+    const { ref } = createMockEditorRef();
+    const onSave = vi.fn();
 
-      const { result } = renderHook(() =>
-        useEditorActions({
-          ...baseProps,
-          typespecModel: model as any,
-          editorRef: ref as any,
-        }),
-      );
+    const { result } = renderHook(() =>
+      useEditorActions({
+        ...baseProps,
+        typespecModel: model as any,
+        editorRef: ref as any,
+        onSave,
+      }),
+    );
 
-      expect(result.current.editorActions).toHaveLength(1);
-      expect(result.current.editorActions[0].id).toBe("save");
-      expect(result.current.editorActions[0].label).toBe("Save");
-      expect(result.current.editorActions[0].keybindings).toBeDefined();
-    });
+    await result.current.fileBug();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});
+
+describe("editorActions", () => {
+  it("returns a save action with Ctrl+S keybinding", () => {
+    const model = createMockModel();
+    const { ref } = createMockEditorRef();
+
+    const { result } = renderHook(() =>
+      useEditorActions({
+        ...baseProps,
+        typespecModel: model as any,
+        editorRef: ref as any,
+      }),
+    );
+
+    expect(result.current.editorActions).toHaveLength(1);
+    expect(result.current.editorActions[0].id).toBe("save");
+    expect(result.current.editorActions[0].label).toBe("Save");
+    expect(result.current.editorActions[0].keybindings).toBeDefined();
   });
 });

--- a/packages/playground/test/use-monaco-sync.test.ts
+++ b/packages/playground/test/use-monaco-sync.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 import { useMonacoSync } from "../src/react/hooks/use-monaco-sync.js";
 
 function createMockModel(initialValue = "") {
@@ -22,104 +22,102 @@ function createMockModel(initialValue = "") {
   };
 }
 
-describe("useMonacoSync", () => {
-  it("sets model value when content changes externally", () => {
-    const model = createMockModel("");
+it("sets model value when content changes externally", () => {
+  const model = createMockModel("");
 
-    const { rerender } = renderHook(
-      ({ content }) =>
-        useMonacoSync({
-          typespecModel: model as any,
-          content,
-          onContentChange: vi.fn(),
-        }),
-      { initialProps: { content: "initial" } },
-    );
-
-    expect(model.setValue).toHaveBeenCalledWith("initial");
-
-    rerender({ content: "updated" });
-    expect(model.setValue).toHaveBeenCalledWith("updated");
-  });
-
-  it("does not set model value when content matches model", () => {
-    const model = createMockModel("same");
-
-    renderHook(() =>
+  const { rerender } = renderHook(
+    ({ content }) =>
       useMonacoSync({
         typespecModel: model as any,
-        content: "same",
+        content,
         onContentChange: vi.fn(),
       }),
-    );
+    { initialProps: { content: "initial" } },
+  );
 
-    expect(model.setValue).not.toHaveBeenCalled();
+  expect(model.setValue).toHaveBeenCalledWith("initial");
+
+  rerender({ content: "updated" });
+  expect(model.setValue).toHaveBeenCalledWith("updated");
+});
+
+it("does not set model value when content matches model", () => {
+  const model = createMockModel("same");
+
+  renderHook(() =>
+    useMonacoSync({
+      typespecModel: model as any,
+      content: "same",
+      onContentChange: vi.fn(),
+    }),
+  );
+
+  expect(model.setValue).not.toHaveBeenCalled();
+});
+
+it("calls onContentChange when model content changes (user typing)", () => {
+  const model = createMockModel("hello");
+  const onContentChange = vi.fn();
+
+  renderHook(() =>
+    useMonacoSync({
+      typespecModel: model as any,
+      content: "hello",
+      onContentChange,
+    }),
+  );
+
+  act(() => {
+    model.simulateTyping("hello world");
   });
 
-  it("calls onContentChange when model content changes (user typing)", () => {
-    const model = createMockModel("hello");
-    const onContentChange = vi.fn();
+  expect(onContentChange).toHaveBeenCalledWith("hello world");
+});
 
-    renderHook(() =>
+it("does not call onContentChange when model value matches current content", () => {
+  const model = createMockModel("same");
+  const onContentChange = vi.fn();
+
+  renderHook(() =>
+    useMonacoSync({
+      typespecModel: model as any,
+      content: "same",
+      onContentChange,
+    }),
+  );
+
+  act(() => {
+    model.simulateTyping("same");
+  });
+
+  expect(onContentChange).not.toHaveBeenCalled();
+});
+
+it("does not reset model after model-driven content change", () => {
+  const model = createMockModel("initial");
+  const onContentChange = vi.fn();
+
+  const { rerender } = renderHook(
+    ({ content }) =>
       useMonacoSync({
         typespecModel: model as any,
-        content: "hello",
+        content,
         onContentChange,
       }),
-    );
+    { initialProps: { content: "initial" } },
+  );
 
-    act(() => {
-      model.simulateTyping("hello world");
-    });
-
-    expect(onContentChange).toHaveBeenCalledWith("hello world");
+  // Simulate typing which triggers onContentChange
+  act(() => {
+    model.simulateTyping("typed");
   });
 
-  it("does not call onContentChange when model value matches current content", () => {
-    const model = createMockModel("same");
-    const onContentChange = vi.fn();
+  expect(onContentChange).toHaveBeenCalledWith("typed");
+  model.setValue.mockClear();
 
-    renderHook(() =>
-      useMonacoSync({
-        typespecModel: model as any,
-        content: "same",
-        onContentChange,
-      }),
-    );
+  // Now React re-renders with the new content from state
+  rerender({ content: "typed" });
 
-    act(() => {
-      model.simulateTyping("same");
-    });
-
-    expect(onContentChange).not.toHaveBeenCalled();
-  });
-
-  it("does not reset model after model-driven content change", () => {
-    const model = createMockModel("initial");
-    const onContentChange = vi.fn();
-
-    const { rerender } = renderHook(
-      ({ content }) =>
-        useMonacoSync({
-          typespecModel: model as any,
-          content,
-          onContentChange,
-        }),
-      { initialProps: { content: "initial" } },
-    );
-
-    // Simulate typing which triggers onContentChange
-    act(() => {
-      model.simulateTyping("typed");
-    });
-
-    expect(onContentChange).toHaveBeenCalledWith("typed");
-    model.setValue.mockClear();
-
-    // Now React re-renders with the new content from state
-    rerender({ content: "typed" });
-
-    // Should NOT call setValue again since it was model-driven
-    expect(model.setValue).not.toHaveBeenCalled();
-  });
+  // Should NOT call setValue again since it was model-driven
+  expect(model.setValue).not.toHaveBeenCalled();
 });

--- a/packages/prettier-plugin-typespec/test/smoke.test.ts
+++ b/packages/prettier-plugin-typespec/test/smoke.test.ts
@@ -2,14 +2,12 @@
 import { strictEqual } from "assert";
 import { resolve } from "path";
 import prettier from "prettier";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 
-describe("prettier-plugin: smoke test", () => {
-  it("loads and formats", async () => {
-    const result = await prettier.format("alias   Foo   =   string;", {
-      parser: "typespec",
-      plugins: [resolve(__dirname, "../dist/index.js")],
-    });
-    strictEqual(result, "alias Foo = string;\n");
+it("loads and formats", async () => {
+  const result = await prettier.format("alias   Foo   =   string;", {
+    parser: "typespec",
+    plugins: [resolve(__dirname, "../dist/index.js")],
   });
+  strictEqual(result, "alias Foo = string;\n");
 });

--- a/packages/protobuf/test/scenarios.test.ts
+++ b/packages/protobuf/test/scenarios.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import path from "path";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 
 import micromatch from "micromatch";
 
@@ -20,90 +20,88 @@ const ProtobufTester = createTester(resolvePath(pkgRoot), {
   libraries: ["@typespec/protobuf"],
 });
 
-describe("protobuf scenarios", function () {
-  const scenarios = readdirSync(SCENARIOS_DIRECTORY)
-    .map((dn) => path.join(SCENARIOS_DIRECTORY, dn))
-    .filter((dn) => statSync(dn).isDirectory());
+const scenarios = readdirSync(SCENARIOS_DIRECTORY)
+  .map((dn) => path.join(SCENARIOS_DIRECTORY, dn))
+  .filter((dn) => statSync(dn).isDirectory());
 
-  for (const scenario of scenarios) {
-    const scenarioName = path.basename(scenario);
+for (const scenario of scenarios) {
+  const scenarioName = path.basename(scenario);
 
-    const shouldRun = micromatch.isMatch(scenarioName, patternsToRun);
+  const shouldRun = micromatch.isMatch(scenarioName, patternsToRun);
 
-    shouldRun &&
-      it(scenarioName, async function () {
-        const inputFiles = await readdirRecursive(path.join(scenario, "input"));
-        const options = await readFile(path.join(scenario, "options.json"), "utf-8")
-          .then((s) => JSON.parse(s) as ProtobufEmitterOptions)
-          .catch((e) => {
-            return {} as ProtobufEmitterOptions;
-          });
+  shouldRun &&
+    it(scenarioName, async function () {
+      const inputFiles = await readdirRecursive(path.join(scenario, "input"));
+      const options = await readFile(path.join(scenario, "options.json"), "utf-8")
+        .then((s) => JSON.parse(s) as ProtobufEmitterOptions)
+        .catch((e) => {
+          return {} as ProtobufEmitterOptions;
+        });
 
-        const emitResult = await doEmit(inputFiles, options);
+      const emitResult = await doEmit(inputFiles, options);
 
-        const expectationDirectory = path.resolve(scenario, "output");
-        const diagnosticsExpectationPath = path.resolve(scenario, "diagnostics.txt");
+      const expectationDirectory = path.resolve(scenario, "output");
+      const diagnosticsExpectationPath = path.resolve(scenario, "diagnostics.txt");
 
-        if (shouldRecord) {
-          // Write new output to the scenario's output folder.
+      if (shouldRecord) {
+        // Write new output to the scenario's output folder.
 
-          await writeExpectationDirectory(expectationDirectory, emitResult.files);
+        await writeExpectationDirectory(expectationDirectory, emitResult.files);
 
-          await rm(diagnosticsExpectationPath, { force: true });
+        await rm(diagnosticsExpectationPath, { force: true });
 
-          if (emitResult.diagnostics.length > 0) {
-            const diagnostics = removeCoreDiagnostics(emitResult.diagnostics).join("\n") + "\n";
+        if (emitResult.diagnostics.length > 0) {
+          const diagnostics = removeCoreDiagnostics(emitResult.diagnostics).join("\n") + "\n";
 
-            await writeFile(diagnosticsExpectationPath, diagnostics);
-          }
-        } else {
-          // It's an error if any file in the expected files is missing, if any file in the output files doesn't have a
-          // corresponding expectation, or if any file in the output files doesn't match its corresponding output file
-          // character for character.
-
-          let err: Error | undefined = undefined;
-
-          // `throwIfNoEntry` is not supported with promisified fs.promises.stat.
-          if (!statSync(expectationDirectory, { throwIfNoEntry: false })) {
-            assert.strictEqual(
-              Object.entries(emitResult.files).length,
-              0,
-              "no expectations exist, but output files were generated",
-            );
-          } else {
-            const expectedFiles = await readdirRecursive(expectationDirectory);
-
-            // Need to defer this error until we've checked for diagnostics below. If diagnostics were unexpectedly
-            // raised and inhibited emit, that should be the primary error, not this one.
-            try {
-              assertFilesAsExpected(emitResult.files, expectedFiles);
-            } catch (e: unknown) {
-              err = e as Error;
-            }
-          }
-
-          let expectedDiagnostics: string;
-          try {
-            expectedDiagnostics = (await readFile(diagnosticsExpectationPath)).toString("utf-8");
-          } catch {
-            expectedDiagnostics = "\n";
-          }
-
-          // Fix the start of lines on Windows
-          const processedDiagnostics =
-            process.platform === "win32"
-              ? emitResult.diagnostics.map((d) => d.replaceAll(/^(\s*)Z:/gm, "$1"))
-              : emitResult.diagnostics;
-
-          const diagnostics = removeCoreDiagnostics(processedDiagnostics).join("\n") + "\n";
-
-          assert.strictEqual(diagnostics, expectedDiagnostics, "expected equivalent diagnostics");
-
-          if (err) throw err;
+          await writeFile(diagnosticsExpectationPath, diagnostics);
         }
-      });
-  }
-});
+      } else {
+        // It's an error if any file in the expected files is missing, if any file in the output files doesn't have a
+        // corresponding expectation, or if any file in the output files doesn't match its corresponding output file
+        // character for character.
+
+        let err: Error | undefined = undefined;
+
+        // `throwIfNoEntry` is not supported with promisified fs.promises.stat.
+        if (!statSync(expectationDirectory, { throwIfNoEntry: false })) {
+          assert.strictEqual(
+            Object.entries(emitResult.files).length,
+            0,
+            "no expectations exist, but output files were generated",
+          );
+        } else {
+          const expectedFiles = await readdirRecursive(expectationDirectory);
+
+          // Need to defer this error until we've checked for diagnostics below. If diagnostics were unexpectedly
+          // raised and inhibited emit, that should be the primary error, not this one.
+          try {
+            assertFilesAsExpected(emitResult.files, expectedFiles);
+          } catch (e: unknown) {
+            err = e as Error;
+          }
+        }
+
+        let expectedDiagnostics: string;
+        try {
+          expectedDiagnostics = (await readFile(diagnosticsExpectationPath)).toString("utf-8");
+        } catch {
+          expectedDiagnostics = "\n";
+        }
+
+        // Fix the start of lines on Windows
+        const processedDiagnostics =
+          process.platform === "win32"
+            ? emitResult.diagnostics.map((d) => d.replaceAll(/^(\s*)Z:/gm, "$1"))
+            : emitResult.diagnostics;
+
+        const diagnostics = removeCoreDiagnostics(processedDiagnostics).join("\n") + "\n";
+
+        assert.strictEqual(diagnostics, expectedDiagnostics, "expected equivalent diagnostics");
+
+        if (err) throw err;
+      }
+    });
+}
 
 /**
  * Removes line number references from core diagnostics and replaces them with

--- a/packages/rest/test/rest-decorators.test.ts
+++ b/packages/rest/test/rest-decorators.test.ts
@@ -4,37 +4,35 @@ import { describe, it } from "vitest";
 import { getResourceLocationType } from "../src/rest.js";
 import { Tester } from "./test-host.js";
 
-describe("rest: rest decorators", () => {
-  describe("@resourceLocation", () => {
-    it("emit diagnostic when used on non-model", async () => {
-      const diagnostics = await Tester.diagnose(`
-        model Widget {};
+describe("@resourceLocation", () => {
+  it("emit diagnostic when used on non-model", async () => {
+    const diagnostics = await Tester.diagnose(`
+      model Widget {};
 
-        @TypeSpec.Rest.Private.resourceLocation(Widget)
-        op test(): string;
+      @TypeSpec.Rest.Private.resourceLocation(Widget)
+      op test(): string;
 
-        scalar WidgetLocation extends ResourceLocation<Widget>;
-      `);
+      scalar WidgetLocation extends ResourceLocation<Widget>;
+    `);
 
-      expectDiagnostics(diagnostics, [
-        {
-          code: "decorator-wrong-target",
-          message:
-            "Cannot apply @resourceLocation decorator to test since it is not assignable to string",
-        },
-      ]);
-    });
+    expectDiagnostics(diagnostics, [
+      {
+        code: "decorator-wrong-target",
+        message:
+          "Cannot apply @resourceLocation decorator to test since it is not assignable to string",
+      },
+    ]);
+  });
 
-    it("marks a model type as a resource location for a specific type", async () => {
-      const { WidgetLocation, program } = await Tester.compile(t.code`
-        model Widget {};
+  it("marks a model type as a resource location for a specific type", async () => {
+    const { WidgetLocation, program } = await Tester.compile(t.code`
+      model Widget {};
 
-        scalar ${t.scalar("WidgetLocation")} extends ResourceLocation<Widget>;
-      `);
+      scalar ${t.scalar("WidgetLocation")} extends ResourceLocation<Widget>;
+    `);
 
-      const resourceType = getResourceLocationType(program, WidgetLocation.baseScalar!);
-      ok(resourceType);
-      strictEqual(resourceType!.name, "Widget");
-    });
+    const resourceType = getResourceLocationType(program, WidgetLocation.baseScalar!);
+    ok(resourceType);
+    strictEqual(resourceType!.name, "Widget");
   });
 });

--- a/packages/samples/test/samples.test.ts
+++ b/packages/samples/test/samples.test.ts
@@ -1,6 +1,6 @@
 import { resolvePath } from "@typespec/compiler";
 import { findTestPackageRoot } from "@typespec/compiler/testing";
-import { describe } from "vitest";
+import {} from "vitest";
 import { defineSampleSnaphotTests } from "../src/sample-snapshot-testing.js";
 
 const excludedSamples = [
@@ -12,10 +12,8 @@ const pkgRoot = await findTestPackageRoot(import.meta.url);
 const samplesRoot = resolvePath(pkgRoot, "specs");
 const rootOutputDir = resolvePath(pkgRoot, "test/output");
 
-describe("TypeSpec Samples", () => {
-  defineSampleSnaphotTests({
-    sampleDir: samplesRoot,
-    outputDir: rootOutputDir,
-    exclude: excludedSamples,
-  });
+defineSampleSnaphotTests({
+  sampleDir: samplesRoot,
+  outputDir: rootOutputDir,
+  exclude: excludedSamples,
 });

--- a/packages/spec-api/test/expectation.test.ts
+++ b/packages/spec-api/test/expectation.test.ts
@@ -1,53 +1,45 @@
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { RequestExpectation } from "../src/expectation.js";
 import { RequestExt } from "../src/types.js";
 
-describe("containsQueryParam()", () => {
-  it("should validate successfully with correct input of multi collection", () => {
-    const requestExt = { query: { letter: ["a", "b", "c"] } } as unknown as RequestExt;
-    const requestExpectation = new RequestExpectation(requestExt);
-    expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "multi")).toBe(
-      undefined,
-    );
-  });
+it("should validate successfully with correct input of multi collection", () => {
+  const requestExt = { query: { letter: ["a", "b", "c"] } } as unknown as RequestExt;
+  const requestExpectation = new RequestExpectation(requestExt);
+  expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "multi")).toBe(undefined);
+});
 
-  it("should validate successfully with correct input of csv collection with common not encoded", () => {
-    const requestExt = { query: { letter: "a,b,c" } } as unknown as RequestExt;
-    const requestExpectation = new RequestExpectation(requestExt);
-    expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "csv")).toBe(undefined);
-  });
+it("should validate successfully with correct input of csv collection with common not encoded", () => {
+  const requestExt = { query: { letter: "a,b,c" } } as unknown as RequestExt;
+  const requestExpectation = new RequestExpectation(requestExt);
+  expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "csv")).toBe(undefined);
+});
 
-  it("should validate successfully with correct input of csv collection with common encoded", () => {
-    const requestExt = { query: { letter: "a%2Cb%2Cc" } } as unknown as RequestExt;
-    const requestExpectation = new RequestExpectation(requestExt);
-    expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "csv")).toBe(undefined);
-  });
+it("should validate successfully with correct input of csv collection with common encoded", () => {
+  const requestExt = { query: { letter: "a%2Cb%2Cc" } } as unknown as RequestExt;
+  const requestExpectation = new RequestExpectation(requestExt);
+  expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "csv")).toBe(undefined);
+});
 
-  it("should validate successfully with correct input of csv collection with common encoded and space", () => {
-    const requestExt = { query: { letter: "a%2Cb%2Cc%20" } } as unknown as RequestExt;
-    const requestExpectation = new RequestExpectation(requestExt);
-    expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c "], "csv")).toBe(
-      undefined,
-    );
-  });
+it("should validate successfully with correct input of csv collection with common encoded and space", () => {
+  const requestExt = { query: { letter: "a%2Cb%2Cc%20" } } as unknown as RequestExt;
+  const requestExpectation = new RequestExpectation(requestExt);
+  expect(requestExpectation.containsQueryParam("letter", ["a", "b", "c "], "csv")).toBe(undefined);
+});
 
-  it("should throw validation error with wrong input of multi collection", () => {
-    const requestExt = { query: { letter: ["a", "b", "d"] } } as unknown as RequestExt;
-    const requestExpectation = new RequestExpectation(requestExt);
-    expect(() =>
-      requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "multi"),
-    ).toThrow();
-  });
+it("should throw validation error with wrong input of multi collection", () => {
+  const requestExt = { query: { letter: ["a", "b", "d"] } } as unknown as RequestExt;
+  const requestExpectation = new RequestExpectation(requestExt);
+  expect(() => requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "multi")).toThrow();
+});
 
-  it("should throw validation error with wrong input of csv collection with common not encoded", () => {
-    const requestExt = { query: { letter: "a,b,d" } } as unknown as RequestExt;
-    const requestExpectation = new RequestExpectation(requestExt);
-    expect(() => requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "csv")).toThrow();
-  });
+it("should throw validation error with wrong input of csv collection with common not encoded", () => {
+  const requestExt = { query: { letter: "a,b,d" } } as unknown as RequestExt;
+  const requestExpectation = new RequestExpectation(requestExt);
+  expect(() => requestExpectation.containsQueryParam("letter", ["a", "b", "c"], "csv")).toThrow();
+});
 
-  it("should validate successfully with correct input", () => {
-    const requestExt = { query: { letter: "[a, b, c]" } } as unknown as RequestExt;
-    const requestExpectation = new RequestExpectation(requestExt);
-    expect(requestExpectation.containsQueryParam("letter", "[a, b, c]")).toBe(undefined);
-  });
+it("should validate successfully with correct input", () => {
+  const requestExt = { query: { letter: "[a, b, c]" } } as unknown as RequestExt;
+  const requestExpectation = new RequestExpectation(requestExt);
+  expect(requestExpectation.containsQueryParam("letter", "[a, b, c]")).toBe(undefined);
 });

--- a/packages/spec-api/test/matchers/local-url.test.ts
+++ b/packages/spec-api/test/matchers/local-url.test.ts
@@ -5,78 +5,72 @@ import { expectFail, expectPass } from "./matcher-test-utils.js";
 
 const config: MatcherConfig = { baseUrl: "http://localhost:3000" };
 
-describe("match.localUrl()", () => {
-  it("should be identified by isMatcher", () => {
-    expect(isMatcher(match.localUrl("/some/path"))).toBe(true);
+it("should be identified by isMatcher", () => {
+  expect(isMatcher(match.localUrl("/some/path"))).toBe(true);
+});
+
+describe("check()", () => {
+  const matcher = match.localUrl("/payload/pageable/next-page");
+
+  it("should match exact full URL", () => {
+    expectPass(matcher.check("http://localhost:3000/payload/pageable/next-page", config));
   });
 
-  describe("check()", () => {
-    const matcher = match.localUrl("/payload/pageable/next-page");
-
-    it("should match exact full URL", () => {
-      expectPass(matcher.check("http://localhost:3000/payload/pageable/next-page", config));
-    });
-
-    it("should not match a different base URL", () => {
-      expectFail(
-        matcher.check("http://localhost:4000/payload/pageable/next-page", config),
-        "match.localUrl",
-      );
-    });
-
-    it("should not match a different path", () => {
-      expectFail(
-        matcher.check("http://localhost:3000/payload/pageable/other-page", config),
-        "match.localUrl",
-      );
-    });
-
-    it("should not match non-string values", () => {
-      expectFail(matcher.check(42, config), "expected a string but got number");
-      expectFail(matcher.check(null, config), "expected a string but got object");
-      expectFail(matcher.check(undefined, config), "expected a string but got undefined");
-    });
+  it("should not match a different base URL", () => {
+    expectFail(
+      matcher.check("http://localhost:4000/payload/pageable/next-page", config),
+      "match.localUrl",
+    );
   });
 
-  describe("serialize()", () => {
-    it("should return the full URL with config", () => {
-      expect(match.localUrl("/some/path").serialize(config)).toBe(
-        "http://localhost:3000/some/path",
-      );
-    });
-
-    it("should serialize correctly in JSON.stringify", () => {
-      const obj = { nextLink: match.localUrl("/some/path") };
-      // toJSON() uses empty config, so just the path
-      expect(JSON.stringify(obj)).toBe('{"nextLink":"/some/path"}');
-    });
+  it("should not match a different path", () => {
+    expectFail(
+      matcher.check("http://localhost:3000/payload/pageable/other-page", config),
+      "match.localUrl",
+    );
   });
 
-  describe("resolution with different base URLs", () => {
-    const matcher = match.localUrl("/api/items");
+  it("should not match non-string values", () => {
+    expectFail(matcher.check(42, config), "expected a string but got number");
+    expectFail(matcher.check(null, config), "expected a string but got object");
+    expectFail(matcher.check(undefined, config), "expected a string but got undefined");
+  });
+});
 
-    it("should resolve with localhost", () => {
-      expectPass(
-        matcher.check("http://localhost:3000/api/items", { baseUrl: "http://localhost:3000" }),
-      );
-    });
-
-    it("should resolve with https URL", () => {
-      expectPass(
-        matcher.check("https://example.com/api/items", { baseUrl: "https://example.com" }),
-      );
-    });
-
-    it("should resolve with URL including port", () => {
-      expectPass(
-        matcher.check("http://127.0.0.1:8080/api/items", { baseUrl: "http://127.0.0.1:8080" }),
-      );
-    });
+describe("serialize()", () => {
+  it("should return the full URL with config", () => {
+    expect(match.localUrl("/some/path").serialize(config)).toBe("http://localhost:3000/some/path");
   });
 
-  describe("toString()", () => {
-    it("should return a descriptive string", () => {
-      expect(match.localUrl("/some/path").toString()).toBe('match.localUrl("/some/path")');
-    });
+  it("should serialize correctly in JSON.stringify", () => {
+    const obj = { nextLink: match.localUrl("/some/path") };
+    // toJSON() uses empty config, so just the path
+    expect(JSON.stringify(obj)).toBe('{"nextLink":"/some/path"}');
+  });
+});
+
+describe("resolution with different base URLs", () => {
+  const matcher = match.localUrl("/api/items");
+
+  it("should resolve with localhost", () => {
+    expectPass(
+      matcher.check("http://localhost:3000/api/items", { baseUrl: "http://localhost:3000" }),
+    );
+  });
+
+  it("should resolve with https URL", () => {
+    expectPass(matcher.check("https://example.com/api/items", { baseUrl: "https://example.com" }));
+  });
+
+  it("should resolve with URL including port", () => {
+    expectPass(
+      matcher.check("http://127.0.0.1:8080/api/items", { baseUrl: "http://127.0.0.1:8080" }),
+    );
+  });
+});
+
+describe("toString()", () => {
+  it("should return a descriptive string", () => {
+    expect(match.localUrl("/some/path").toString()).toBe('match.localUrl("/some/path")');
   });
 });

--- a/packages/spec-api/test/matchers/string.test.ts
+++ b/packages/spec-api/test/matchers/string.test.ts
@@ -3,55 +3,53 @@ import { isMatcher } from "../../src/match-engine.js";
 import { match } from "../../src/matchers/index.js";
 import { expectFail, expectPass } from "./matcher-test-utils.js";
 
-describe("match.string.caseInsensitive()", () => {
-  it("should be identified by isMatcher", () => {
-    expect(isMatcher(match.string.caseInsensitive("true"))).toBe(true);
+it("should be identified by isMatcher", () => {
+  expect(isMatcher(match.string.caseInsensitive("true"))).toBe(true);
+});
+
+describe("check()", () => {
+  it("should match lower-case true", () => {
+    expectPass(match.string.caseInsensitive("true").check("true"));
   });
 
-  describe("check()", () => {
-    it("should match lower-case true", () => {
-      expectPass(match.string.caseInsensitive("true").check("true"));
-    });
-
-    it("should match upper-case true", () => {
-      expectPass(match.string.caseInsensitive("true").check("TRUE"));
-    });
-
-    it("should match mixed-case false", () => {
-      expectPass(match.string.caseInsensitive("false").check("FaLsE"));
-    });
-
-    it("should reject a different string value", () => {
-      expectFail(
-        match.string.caseInsensitive("true").check("false"),
-        'expected case-insensitive "true"',
-      );
-    });
-
-    it("should reject non-string values", () => {
-      expectFail(
-        match.string.caseInsensitive("true").check(true),
-        "expected a string but got boolean",
-      );
-      expectFail(
-        match.string.caseInsensitive("false").check(null),
-        "expected a string but got object",
-      );
-    });
+  it("should match upper-case true", () => {
+    expectPass(match.string.caseInsensitive("true").check("TRUE"));
   });
 
-  describe("serialize()", () => {
-    it("should serialize the original value", () => {
-      expect(match.string.caseInsensitive("TrUe").serialize()).toBe("TrUe");
-      expect(match.string.caseInsensitive("FALSE").serialize()).toBe("FALSE");
-    });
+  it("should match mixed-case false", () => {
+    expectPass(match.string.caseInsensitive("false").check("FaLsE"));
   });
 
-  describe("toString()", () => {
-    it("should return a descriptive string", () => {
-      expect(match.string.caseInsensitive("true").toString()).toBe(
-        'match.string.caseInsensitive("true")',
-      );
-    });
+  it("should reject a different string value", () => {
+    expectFail(
+      match.string.caseInsensitive("true").check("false"),
+      'expected case-insensitive "true"',
+    );
+  });
+
+  it("should reject non-string values", () => {
+    expectFail(
+      match.string.caseInsensitive("true").check(true),
+      "expected a string but got boolean",
+    );
+    expectFail(
+      match.string.caseInsensitive("false").check(null),
+      "expected a string but got object",
+    );
+  });
+});
+
+describe("serialize()", () => {
+  it("should serialize the original value", () => {
+    expect(match.string.caseInsensitive("TrUe").serialize()).toBe("TrUe");
+    expect(match.string.caseInsensitive("FALSE").serialize()).toBe("FALSE");
+  });
+});
+
+describe("toString()", () => {
+  it("should return a descriptive string", () => {
+    expect(match.string.caseInsensitive("true").toString()).toBe(
+      'match.string.caseInsensitive("true")',
+    );
   });
 });

--- a/packages/spec-dashboard/src/apis.test.ts
+++ b/packages/spec-dashboard/src/apis.test.ts
@@ -1,355 +1,353 @@
 import { ScenarioManifest } from "@typespec/spec-coverage-sdk";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { splitManifestByTables, TableDefinition } from "./apis.js";
 
-describe("splitManifestByTables", () => {
-  const createManifest = (
-    packageName: string,
-    displayName?: string,
-    scenarioNames: string[] = [],
-  ): ScenarioManifest => ({
-    packageName,
-    displayName,
-    commit: "abc123",
-    version: "1.0.0",
-    scenarios: scenarioNames.map((name) => ({
-      name,
-      scenarioDoc: `Doc for ${name}`,
-      location: {
-        path: "test.tsp",
-        start: { line: 1, character: 1 },
-        end: { line: 2, character: 1 },
-      },
-    })),
-  });
+const createManifest = (
+  packageName: string,
+  displayName?: string,
+  scenarioNames: string[] = [],
+): ScenarioManifest => ({
+  packageName,
+  displayName,
+  commit: "abc123",
+  version: "1.0.0",
+  scenarios: scenarioNames.map((name) => ({
+    name,
+    scenarioDoc: `Doc for ${name}`,
+    location: {
+      path: "test.tsp",
+      start: { line: 1, character: 1 },
+      end: { line: 2, character: 1 },
+    },
+  })),
+});
 
-  it("should use displayName as default table name when no table definitions", () => {
-    const manifest = createManifest("test-package", "Test Display Name", ["scenario1"]);
-    const result = splitManifestByTables(manifest, []);
+it("should use displayName as default table name when no table definitions", () => {
+  const manifest = createManifest("test-package", "Test Display Name", ["scenario1"]);
+  const result = splitManifestByTables(manifest, []);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].tableName).toBe("Test Display Name");
-  });
+  expect(result).toHaveLength(1);
+  expect(result[0].tableName).toBe("Test Display Name");
+});
 
-  it("should fall back to packageName when displayName is empty", () => {
-    const manifest = createManifest("test-package", undefined, ["scenario1"]);
-    const result = splitManifestByTables(manifest, []);
+it("should fall back to packageName when displayName is empty", () => {
+  const manifest = createManifest("test-package", undefined, ["scenario1"]);
+  const result = splitManifestByTables(manifest, []);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].tableName).toBe("test-package");
-  });
+  expect(result).toHaveLength(1);
+  expect(result[0].tableName).toBe("test-package");
+});
 
-  it("should use table.name from table definition", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "prefix1_scenario1",
-      "prefix1_scenario2",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Custom Table Name",
-        packageName: "test-package",
-        prefixes: ["prefix1_"],
-      },
-    ];
+it("should use table.name from table definition", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "prefix1_scenario1",
+    "prefix1_scenario2",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Custom Table Name",
+      packageName: "test-package",
+      prefixes: ["prefix1_"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].tableName).toBe("Custom Table Name");
-    expect(result[0].manifest.scenarios).toHaveLength(2);
-  });
+  expect(result).toHaveLength(1);
+  expect(result[0].tableName).toBe("Custom Table Name");
+  expect(result[0].manifest.scenarios).toHaveLength(2);
+});
 
-  it("should not include scenarios in catch-all table if already assigned to specific table", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "prefix1_scenario1",
-      "prefix1_scenario2",
-      "other_scenario",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Prefix1 Table",
-        packageName: "test-package",
-        prefixes: ["prefix1_"],
-      },
-      {
-        name: "Catch All Table",
-        packageName: "test-package",
-        // No prefixes - catch-all table
-      },
-    ];
+it("should not include scenarios in catch-all table if already assigned to specific table", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "prefix1_scenario1",
+    "prefix1_scenario2",
+    "other_scenario",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Prefix1 Table",
+      packageName: "test-package",
+      prefixes: ["prefix1_"],
+    },
+    {
+      name: "Catch All Table",
+      packageName: "test-package",
+      // No prefixes - catch-all table
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(2);
+  expect(result).toHaveLength(2);
 
-    // First table should have prefix1 scenarios
-    const prefix1Table = result.find((r) => r.tableName === "Prefix1 Table");
-    expect(prefix1Table).toBeDefined();
-    expect(prefix1Table!.manifest.scenarios).toHaveLength(2);
-    expect(prefix1Table!.manifest.scenarios.map((s) => s.name)).toEqual([
-      "prefix1_scenario1",
-      "prefix1_scenario2",
-    ]);
+  // First table should have prefix1 scenarios
+  const prefix1Table = result.find((r) => r.tableName === "Prefix1 Table");
+  expect(prefix1Table).toBeDefined();
+  expect(prefix1Table!.manifest.scenarios).toHaveLength(2);
+  expect(prefix1Table!.manifest.scenarios.map((s) => s.name)).toEqual([
+    "prefix1_scenario1",
+    "prefix1_scenario2",
+  ]);
 
-    // Catch-all table should only have the remaining scenario
-    const catchAllTable = result.find((r) => r.tableName === "Catch All Table");
-    expect(catchAllTable).toBeDefined();
-    expect(catchAllTable!.manifest.scenarios).toHaveLength(1);
-    expect(catchAllTable!.manifest.scenarios[0].name).toBe("other_scenario");
-  });
+  // Catch-all table should only have the remaining scenario
+  const catchAllTable = result.find((r) => r.tableName === "Catch All Table");
+  expect(catchAllTable).toBeDefined();
+  expect(catchAllTable!.manifest.scenarios).toHaveLength(1);
+  expect(catchAllTable!.manifest.scenarios[0].name).toBe("other_scenario");
+});
 
-  it("should process tables with prefixes before catch-all tables", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "prefix1_scenario1",
-      "prefix2_scenario1",
-      "other_scenario",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Catch All Table",
-        packageName: "test-package",
-        // No prefixes - should be processed last
-      },
-      {
-        name: "Prefix1 Table",
-        packageName: "test-package",
-        prefixes: ["prefix1_"],
-      },
-      {
-        name: "Prefix2 Table",
-        packageName: "test-package",
-        prefixes: ["prefix2_"],
-      },
-    ];
+it("should process tables with prefixes before catch-all tables", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "prefix1_scenario1",
+    "prefix2_scenario1",
+    "other_scenario",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Catch All Table",
+      packageName: "test-package",
+      // No prefixes - should be processed last
+    },
+    {
+      name: "Prefix1 Table",
+      packageName: "test-package",
+      prefixes: ["prefix1_"],
+    },
+    {
+      name: "Prefix2 Table",
+      packageName: "test-package",
+      prefixes: ["prefix2_"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(3);
+  expect(result).toHaveLength(3);
 
-    // Verify each table got the correct scenarios
-    const prefix1Table = result.find((r) => r.tableName === "Prefix1 Table");
-    expect(prefix1Table!.manifest.scenarios).toHaveLength(1);
-    expect(prefix1Table!.manifest.scenarios[0].name).toBe("prefix1_scenario1");
+  // Verify each table got the correct scenarios
+  const prefix1Table = result.find((r) => r.tableName === "Prefix1 Table");
+  expect(prefix1Table!.manifest.scenarios).toHaveLength(1);
+  expect(prefix1Table!.manifest.scenarios[0].name).toBe("prefix1_scenario1");
 
-    const prefix2Table = result.find((r) => r.tableName === "Prefix2 Table");
-    expect(prefix2Table!.manifest.scenarios).toHaveLength(1);
-    expect(prefix2Table!.manifest.scenarios[0].name).toBe("prefix2_scenario1");
+  const prefix2Table = result.find((r) => r.tableName === "Prefix2 Table");
+  expect(prefix2Table!.manifest.scenarios).toHaveLength(1);
+  expect(prefix2Table!.manifest.scenarios[0].name).toBe("prefix2_scenario1");
 
-    const catchAllTable = result.find((r) => r.tableName === "Catch All Table");
-    expect(catchAllTable!.manifest.scenarios).toHaveLength(1);
-    expect(catchAllTable!.manifest.scenarios[0].name).toBe("other_scenario");
-  });
+  const catchAllTable = result.find((r) => r.tableName === "Catch All Table");
+  expect(catchAllTable!.manifest.scenarios).toHaveLength(1);
+  expect(catchAllTable!.manifest.scenarios[0].name).toBe("other_scenario");
+});
 
-  it("should handle unmatched scenarios in default table when no catch-all", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "prefix1_scenario1",
-      "other_scenario",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Prefix1 Table",
-        packageName: "test-package",
-        prefixes: ["prefix1_"],
-      },
-    ];
+it("should handle unmatched scenarios in default table when no catch-all", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "prefix1_scenario1",
+    "other_scenario",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Prefix1 Table",
+      packageName: "test-package",
+      prefixes: ["prefix1_"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(2);
+  expect(result).toHaveLength(2);
 
-    // Prefix table
-    const prefix1Table = result.find((r) => r.tableName === "Prefix1 Table");
-    expect(prefix1Table!.manifest.scenarios).toHaveLength(1);
-    expect(prefix1Table!.manifest.scenarios[0].name).toBe("prefix1_scenario1");
+  // Prefix table
+  const prefix1Table = result.find((r) => r.tableName === "Prefix1 Table");
+  expect(prefix1Table!.manifest.scenarios).toHaveLength(1);
+  expect(prefix1Table!.manifest.scenarios[0].name).toBe("prefix1_scenario1");
 
-    // Default table with displayName
-    const defaultTable = result.find((r) => r.tableName === "Display Name");
-    expect(defaultTable).toBeDefined();
-    expect(defaultTable!.manifest.scenarios).toHaveLength(1);
-    expect(defaultTable!.manifest.scenarios[0].name).toBe("other_scenario");
-  });
+  // Default table with displayName
+  const defaultTable = result.find((r) => r.tableName === "Display Name");
+  expect(defaultTable).toBeDefined();
+  expect(defaultTable!.manifest.scenarios).toHaveLength(1);
+  expect(defaultTable!.manifest.scenarios[0].name).toBe("other_scenario");
+});
 
-  it("should handle multiple prefixes in a single table", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "prefix1_scenario1",
-      "prefix2_scenario1",
-      "prefix1_scenario2",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Combined Table",
-        packageName: "test-package",
-        prefixes: ["prefix1_", "prefix2_"],
-      },
-    ];
+it("should handle multiple prefixes in a single table", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "prefix1_scenario1",
+    "prefix2_scenario1",
+    "prefix1_scenario2",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Combined Table",
+      packageName: "test-package",
+      prefixes: ["prefix1_", "prefix2_"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].tableName).toBe("Combined Table");
-    expect(result[0].manifest.scenarios).toHaveLength(3);
-  });
+  expect(result).toHaveLength(1);
+  expect(result[0].tableName).toBe("Combined Table");
+  expect(result[0].manifest.scenarios).toHaveLength(3);
+});
 
-  it("should not duplicate scenarios across tables", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "shared_scenario1",
-      "unique_scenario",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Table 1",
-        packageName: "test-package",
-        prefixes: ["shared_"],
-      },
-      {
-        name: "Table 2",
-        packageName: "test-package",
-        prefixes: ["shared_"], // Same prefix - should not get scenarios already in Table 1
-      },
-    ];
+it("should not duplicate scenarios across tables", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "shared_scenario1",
+    "unique_scenario",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Table 1",
+      packageName: "test-package",
+      prefixes: ["shared_"],
+    },
+    {
+      name: "Table 2",
+      packageName: "test-package",
+      prefixes: ["shared_"], // Same prefix - should not get scenarios already in Table 1
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    // First table gets the shared scenario
-    const table1 = result.find((r) => r.tableName === "Table 1");
-    expect(table1!.manifest.scenarios).toHaveLength(1);
-    expect(table1!.manifest.scenarios[0].name).toBe("shared_scenario1");
+  // First table gets the shared scenario
+  const table1 = result.find((r) => r.tableName === "Table 1");
+  expect(table1!.manifest.scenarios).toHaveLength(1);
+  expect(table1!.manifest.scenarios[0].name).toBe("shared_scenario1");
 
-    // Second table should be empty (no scenarios left with shared_ prefix)
-    const table2 = result.find((r) => r.tableName === "Table 2");
-    expect(table2).toBeUndefined(); // Table 2 shouldn't be in results if it has no scenarios
+  // Second table should be empty (no scenarios left with shared_ prefix)
+  const table2 = result.find((r) => r.tableName === "Table 2");
+  expect(table2).toBeUndefined(); // Table 2 shouldn't be in results if it has no scenarios
 
-    // Unmatched scenario goes to default table
-    const defaultTable = result.find((r) => r.tableName === "Display Name");
-    expect(defaultTable!.manifest.scenarios).toHaveLength(1);
-    expect(defaultTable!.manifest.scenarios[0].name).toBe("unique_scenario");
-  });
+  // Unmatched scenario goes to default table
+  const defaultTable = result.find((r) => r.tableName === "Display Name");
+  expect(defaultTable!.manifest.scenarios).toHaveLength(1);
+  expect(defaultTable!.manifest.scenarios[0].name).toBe("unique_scenario");
+});
 
-  it("should include emitterNames from table definition", () => {
-    const manifest = createManifest("test-package", "Display Name", ["scenario1"]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Test Table",
-        packageName: "test-package",
-        emitterNames: ["@typespec/emitter-1", "@typespec/emitter-2"],
-      },
-    ];
+it("should include emitterNames from table definition", () => {
+  const manifest = createManifest("test-package", "Display Name", ["scenario1"]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Test Table",
+      packageName: "test-package",
+      emitterNames: ["@typespec/emitter-1", "@typespec/emitter-2"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].emitterNames).toEqual(["@typespec/emitter-1", "@typespec/emitter-2"]);
-  });
+  expect(result).toHaveLength(1);
+  expect(result[0].emitterNames).toEqual(["@typespec/emitter-1", "@typespec/emitter-2"]);
+});
 
-  it("should return undefined emitterNames when not specified in table definition", () => {
-    const manifest = createManifest("test-package", "Display Name", ["scenario1"]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Test Table",
-        packageName: "test-package",
-      },
-    ];
+it("should return undefined emitterNames when not specified in table definition", () => {
+  const manifest = createManifest("test-package", "Display Name", ["scenario1"]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Test Table",
+      packageName: "test-package",
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].emitterNames).toBeUndefined();
-  });
+  expect(result).toHaveLength(1);
+  expect(result[0].emitterNames).toBeUndefined();
+});
 
-  it("should handle different emitterNames for different tables", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "mgmt_scenario1",
-      "dataplane_scenario1",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Management Table",
-        packageName: "test-package",
-        prefixes: ["mgmt_"],
-        emitterNames: ["@azure-tools/typespec-csharp-mgmt"],
-      },
-      {
-        name: "Data Plane Table",
-        packageName: "test-package",
-        prefixes: ["dataplane_"],
-        emitterNames: ["@azure-tools/typespec-csharp"],
-      },
-    ];
+it("should handle different emitterNames for different tables", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "mgmt_scenario1",
+    "dataplane_scenario1",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Management Table",
+      packageName: "test-package",
+      prefixes: ["mgmt_"],
+      emitterNames: ["@azure-tools/typespec-csharp-mgmt"],
+    },
+    {
+      name: "Data Plane Table",
+      packageName: "test-package",
+      prefixes: ["dataplane_"],
+      emitterNames: ["@azure-tools/typespec-csharp"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(2);
+  expect(result).toHaveLength(2);
 
-    const mgmtTable = result.find((r) => r.tableName === "Management Table");
-    expect(mgmtTable!.emitterNames).toEqual(["@azure-tools/typespec-csharp-mgmt"]);
+  const mgmtTable = result.find((r) => r.tableName === "Management Table");
+  expect(mgmtTable!.emitterNames).toEqual(["@azure-tools/typespec-csharp-mgmt"]);
 
-    const dataPlaneTable = result.find((r) => r.tableName === "Data Plane Table");
-    expect(dataPlaneTable!.emitterNames).toEqual(["@azure-tools/typespec-csharp"]);
-  });
+  const dataPlaneTable = result.find((r) => r.tableName === "Data Plane Table");
+  expect(dataPlaneTable!.emitterNames).toEqual(["@azure-tools/typespec-csharp"]);
+});
 
-  it("should preserve order of tableDefinitions in the result", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "prefix1_scenario1",
-      "prefix2_scenario1",
-      "prefix3_scenario1",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Third Table",
-        packageName: "test-package",
-        prefixes: ["prefix3_"],
-      },
-      {
-        name: "First Table",
-        packageName: "test-package",
-        prefixes: ["prefix1_"],
-      },
-      {
-        name: "Second Table",
-        packageName: "test-package",
-        prefixes: ["prefix2_"],
-      },
-    ];
+it("should preserve order of tableDefinitions in the result", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "prefix1_scenario1",
+    "prefix2_scenario1",
+    "prefix3_scenario1",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Third Table",
+      packageName: "test-package",
+      prefixes: ["prefix3_"],
+    },
+    {
+      name: "First Table",
+      packageName: "test-package",
+      prefixes: ["prefix1_"],
+    },
+    {
+      name: "Second Table",
+      packageName: "test-package",
+      prefixes: ["prefix2_"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(3);
-    // Results should be in the same order as tableDefinitions
-    expect(result[0].tableName).toBe("Third Table");
-    expect(result[1].tableName).toBe("First Table");
-    expect(result[2].tableName).toBe("Second Table");
-  });
+  expect(result).toHaveLength(3);
+  // Results should be in the same order as tableDefinitions
+  expect(result[0].tableName).toBe("Third Table");
+  expect(result[1].tableName).toBe("First Table");
+  expect(result[2].tableName).toBe("Second Table");
+});
 
-  it("should preserve order when mixing tables with prefixes and catch-all tables", () => {
-    const manifest = createManifest("test-package", "Display Name", [
-      "prefix1_scenario1",
-      "prefix2_scenario1",
-      "other_scenario",
-    ]);
-    const tables: TableDefinition[] = [
-      {
-        name: "Second Table (Prefix2)",
-        packageName: "test-package",
-        prefixes: ["prefix2_"],
-      },
-      {
-        name: "First Table (Catch-All)",
-        packageName: "test-package",
-        // No prefixes - catch-all table
-      },
-      {
-        name: "Third Table (Prefix1)",
-        packageName: "test-package",
-        prefixes: ["prefix1_"],
-      },
-    ];
+it("should preserve order when mixing tables with prefixes and catch-all tables", () => {
+  const manifest = createManifest("test-package", "Display Name", [
+    "prefix1_scenario1",
+    "prefix2_scenario1",
+    "other_scenario",
+  ]);
+  const tables: TableDefinition[] = [
+    {
+      name: "Second Table (Prefix2)",
+      packageName: "test-package",
+      prefixes: ["prefix2_"],
+    },
+    {
+      name: "First Table (Catch-All)",
+      packageName: "test-package",
+      // No prefixes - catch-all table
+    },
+    {
+      name: "Third Table (Prefix1)",
+      packageName: "test-package",
+      prefixes: ["prefix1_"],
+    },
+  ];
 
-    const result = splitManifestByTables(manifest, tables);
+  const result = splitManifestByTables(manifest, tables);
 
-    expect(result).toHaveLength(3);
-    // Results should be in the same order as tableDefinitions, not grouped by type
-    expect(result[0].tableName).toBe("Second Table (Prefix2)");
-    expect(result[1].tableName).toBe("First Table (Catch-All)");
-    expect(result[2].tableName).toBe("Third Table (Prefix1)");
-  });
+  expect(result).toHaveLength(3);
+  // Results should be in the same order as tableDefinitions, not grouped by type
+  expect(result[0].tableName).toBe("Second Table (Prefix2)");
+  expect(result[1].tableName).toBe("First Table (Catch-All)");
+  expect(result[2].tableName).toBe("Third Table (Prefix1)");
 });

--- a/packages/spector/src/utils/body-utils.test.ts
+++ b/packages/spector/src/utils/body-utils.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { cleanupBody } from "./body-utils.js";
 
-describe("BodyUtils", () => {
-  describe("cleanupBody()", () => {
-    it("remove trailing whitespaces", () => {
-      expect(cleanupBody("  foo     ")).toEqual("foo");
-    });
+describe("cleanupBody()", () => {
+  it("remove trailing whitespaces", () => {
+    expect(cleanupBody("  foo     ")).toEqual("foo");
+  });
 
-    it("remove trailing new lines", () => {
-      expect(cleanupBody("\nfoo\nbar\n")).toEqual("foo\nbar");
-    });
+  it("remove trailing new lines", () => {
+    expect(cleanupBody("\nfoo\nbar\n")).toEqual("foo\nbar");
+  });
 
-    it("replace windows line endings", () => {
-      expect(cleanupBody("foo\r\nbar")).toEqual("foo\nbar");
-    });
+  it("replace windows line endings", () => {
+    expect(cleanupBody("foo\r\nbar")).toEqual("foo\nbar");
   });
 });

--- a/packages/spector/test/coverage-tracker.test.ts
+++ b/packages/spector/test/coverage-tracker.test.ts
@@ -1,29 +1,27 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, expect, it } from "vitest";
 import { CoverageTracker } from "../src/coverage/coverage-tracker.js";
 
-describe("CoverageTracker", () => {
-  let tempDir: string;
+let tempDir: string;
 
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), "spector-coverage-"));
-  });
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "spector-coverage-"));
+});
 
-  afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
-  });
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
 
-  it("creates missing parent directories before writing the coverage file", () => {
-    const coverageFile = join(tempDir, "nested", "dir", "coverage.json");
-    const tracker = new CoverageTracker(coverageFile);
-    tracker.setScenarios([]);
+it("creates missing parent directories before writing the coverage file", () => {
+  const coverageFile = join(tempDir, "nested", "dir", "coverage.json");
+  const tracker = new CoverageTracker(coverageFile);
+  tracker.setScenarios([]);
 
-    // saveCoverageSync is private and normally runs on process exit.
-    (tracker as any).saveCoverageSync();
+  // saveCoverageSync is private and normally runs on process exit.
+  (tracker as any).saveCoverageSync();
 
-    expect(existsSync(coverageFile)).toBe(true);
-    expect(JSON.parse(readFileSync(coverageFile, "utf-8"))).toEqual([]);
-  });
+  expect(existsSync(coverageFile)).toBe(true);
+  expect(JSON.parse(readFileSync(coverageFile, "utf-8"))).toEqual([]);
 });

--- a/packages/spector/test/xml-validation.test.ts
+++ b/packages/spector/test/xml-validation.test.ts
@@ -16,137 +16,135 @@ function makeRequest(rawBody: string): RequestExt {
   return { rawBody } as unknown as RequestExt;
 }
 
-describe("validateXmlBodyEquals", () => {
-  describe("with plain string (no matchers)", () => {
-    it("should accept matching XML", () => {
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><a>1</a></Root>`),
-          "<Root><a>1</a></Root>",
-        ),
-      ).not.toThrow();
-    });
-
-    it("should reject mismatched XML", () => {
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><a>2</a></Root>`),
-          "<Root><a>1</a></Root>",
-        ),
-      ).toThrow("Body provided doesn't match expected body");
-    });
-
-    it("should reject empty body", () => {
-      expect(() => validateXmlBodyEquals(makeRequest(""), "<Root/>")).toThrow("Body should exists");
-    });
+describe("with plain string (no matchers)", () => {
+  it("should accept matching XML", () => {
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><a>1</a></Root>`),
+        "<Root><a>1</a></Root>",
+      ),
+    ).not.toThrow();
   });
 
-  describe("with Resolver containing matchers", () => {
-    it("should use matcher check instead of strict equality", () => {
-      // A custom matcher that accepts any number
-      const anyNumber = createMatcher<string>({
-        check(actual) {
-          return typeof actual === "string" && /^\d+$/.test(actual)
-            ? ok()
-            : err("expected a number string");
-        },
-        serialize: () => "PLACEHOLDER",
-      });
+  it("should reject mismatched XML", () => {
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><a>2</a></Root>`),
+        "<Root><a>1</a></Root>",
+      ),
+    ).toThrow("Body provided doesn't match expected body");
+  });
 
-      const body = xml`<Root><val>${anyNumber}</val></Root>`;
+  it("should reject empty body", () => {
+    expect(() => validateXmlBodyEquals(makeRequest(""), "<Root/>")).toThrow("Body should exists");
+  });
+});
 
-      // "42" is a number string → should pass
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><val>42</val></Root>`),
-          body.rawContent as any,
-          config,
-        ),
-      ).not.toThrow();
-
-      // "abc" is not a number → should fail
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><val>abc</val></Root>`),
-          body.rawContent as any,
-          config,
-        ),
-      ).toThrow("Body provided doesn't match expected body");
+describe("with Resolver containing matchers", () => {
+  it("should use matcher check instead of strict equality", () => {
+    // A custom matcher that accepts any number
+    const anyNumber = createMatcher<string>({
+      check(actual) {
+        return typeof actual === "string" && /^\d+$/.test(actual)
+          ? ok()
+          : err("expected a number string");
+      },
+      serialize: () => "PLACEHOLDER",
     });
 
-    it("should validate plain elements strictly alongside matchers", () => {
-      const anyNumber = createMatcher<string>({
-        check(actual) {
-          return typeof actual === "string" && /^\d+$/.test(actual)
-            ? ok()
-            : err("expected a number string");
-        },
-        serialize: () => "0",
-      });
+    const body = xml`<Root><val>${anyNumber}</val></Root>`;
 
-      const body = xml`<Item><name>test</name><count>${anyNumber}</count></Item>`;
+    // "42" is a number string → should pass
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><val>42</val></Root>`),
+        body.rawContent as any,
+        config,
+      ),
+    ).not.toThrow();
 
-      // Both correct
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(
-            `<?xml version='1.0' encoding='UTF-8'?><Item><name>test</name><count>5</count></Item>`,
-          ),
-          body.rawContent as any,
-          config,
-        ),
-      ).not.toThrow();
+    // "abc" is not a number → should fail
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(`<?xml version='1.0' encoding='UTF-8'?><Root><val>abc</val></Root>`),
+        body.rawContent as any,
+        config,
+      ),
+    ).toThrow("Body provided doesn't match expected body");
+  });
 
-      // Plain element wrong
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(
-            `<?xml version='1.0' encoding='UTF-8'?><Item><name>wrong</name><count>5</count></Item>`,
-          ),
-          body.rawContent as any,
-          config,
-        ),
-      ).toThrow("Body provided doesn't match expected body");
+  it("should validate plain elements strictly alongside matchers", () => {
+    const anyNumber = createMatcher<string>({
+      check(actual) {
+        return typeof actual === "string" && /^\d+$/.test(actual)
+          ? ok()
+          : err("expected a number string");
+      },
+      serialize: () => "0",
     });
 
-    it("should work with datetime matchers", () => {
-      const body = xml`<Event><when>${match.dateTime.rfc3339("2022-08-26T18:38:00.000Z")}</when></Event>`;
+    const body = xml`<Item><name>test</name><count>${anyNumber}</count></Item>`;
 
-      // Without fractional seconds — same point in time
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(
-            `<?xml version='1.0' encoding='UTF-8'?><Event><when>2022-08-26T18:38:00Z</when></Event>`,
-          ),
-          body.rawContent as any,
-          config,
+    // Both correct
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(
+          `<?xml version='1.0' encoding='UTF-8'?><Item><name>test</name><count>5</count></Item>`,
         ),
-      ).not.toThrow();
+        body.rawContent as any,
+        config,
+      ),
+    ).not.toThrow();
 
-      // Different time
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(
-            `<?xml version='1.0' encoding='UTF-8'?><Event><when>2023-01-01T00:00:00Z</when></Event>`,
-          ),
-          body.rawContent as any,
-          config,
+    // Plain element wrong
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(
+          `<?xml version='1.0' encoding='UTF-8'?><Item><name>wrong</name><count>5</count></Item>`,
         ),
-      ).toThrow("Body provided doesn't match expected body");
-    });
+        body.rawContent as any,
+        config,
+      ),
+    ).toThrow("Body provided doesn't match expected body");
+  });
 
-    it("should work with multiple matchers", () => {
-      const body = xml`<Model><a>${match.dateTime.utcRfc3339("2022-08-26T18:38:00.000Z")}</a><b>${match.dateTime.rfc7231("Fri, 26 Aug 2022 14:38:00 GMT")}</b></Model>`;
+  it("should work with datetime matchers", () => {
+    const body = xml`<Event><when>${match.dateTime.rfc3339("2022-08-26T18:38:00.000Z")}</when></Event>`;
 
-      expect(() =>
-        validateXmlBodyEquals(
-          makeRequest(
-            `<?xml version='1.0' encoding='UTF-8'?><Model><a>2022-08-26T18:38:00.0000000Z</a><b>Fri, 26 Aug 2022 14:38:00 GMT</b></Model>`,
-          ),
-          body.rawContent as any,
-          config,
+    // Without fractional seconds — same point in time
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(
+          `<?xml version='1.0' encoding='UTF-8'?><Event><when>2022-08-26T18:38:00Z</when></Event>`,
         ),
-      ).not.toThrow();
-    });
+        body.rawContent as any,
+        config,
+      ),
+    ).not.toThrow();
+
+    // Different time
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(
+          `<?xml version='1.0' encoding='UTF-8'?><Event><when>2023-01-01T00:00:00Z</when></Event>`,
+        ),
+        body.rawContent as any,
+        config,
+      ),
+    ).toThrow("Body provided doesn't match expected body");
+  });
+
+  it("should work with multiple matchers", () => {
+    const body = xml`<Model><a>${match.dateTime.utcRfc3339("2022-08-26T18:38:00.000Z")}</a><b>${match.dateTime.rfc7231("Fri, 26 Aug 2022 14:38:00 GMT")}</b></Model>`;
+
+    expect(() =>
+      validateXmlBodyEquals(
+        makeRequest(
+          `<?xml version='1.0' encoding='UTF-8'?><Model><a>2022-08-26T18:38:00.0000000Z</a><b>Fri, 26 Aug 2022 14:38:00 GMT</b></Model>`,
+        ),
+        body.rawContent as any,
+        config,
+      ),
+    ).not.toThrow();
   });
 });

--- a/packages/sse/test/decorators.test.ts
+++ b/packages/sse/test/decorators.test.ts
@@ -1,42 +1,40 @@
 import type { UnionVariant } from "@typespec/compiler";
 import { expectDiagnostics, t } from "@typespec/compiler/testing";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { isTerminalEvent } from "../src/decorators.js";
 import { Tester } from "./test-host.js";
 
-describe("@terminalEvent", () => {
-  it("marks the model as a terminal event", async () => {
-    const { TerminalEvent, program } = await Tester.compile(
-      t.code`
+it("marks the model as a terminal event", async () => {
+  const { TerminalEvent, program } = await Tester.compile(
+    t.code`
 @events
 union TestEvents {
-  { done: false, @data message: string},
+{ done: false, @data message: string},
 
-  @test("TerminalEvent")
-  @terminalEvent
-  { done: true }
+@test("TerminalEvent")
+@terminalEvent
+{ done: true }
 }
-      `,
-    );
+    `,
+  );
 
-    expect(isTerminalEvent(program, TerminalEvent as UnionVariant)).toBe(true);
-  });
+  expect(isTerminalEvent(program, TerminalEvent as UnionVariant)).toBe(true);
+});
 
-  it("can only be applied to union variants within a union decorated with @events", async () => {
-    const diagnostics = await Tester.diagnose(
-      `
+it("can only be applied to union variants within a union decorated with @events", async () => {
+  const diagnostics = await Tester.diagnose(
+    `
 union TestEvents {
-  { done: false, @data message: string},
+{ done: false, @data message: string},
 
-  @terminalEvent
-  { done: true }
+@terminalEvent
+{ done: true }
 }
-      `,
-    );
+    `,
+  );
 
-    expectDiagnostics(diagnostics, {
-      code: "@typespec/sse/terminal-event-not-in-events",
-      severity: "error",
-    });
+  expectDiagnostics(diagnostics, {
+    code: "@typespec/sse/terminal-event-not-in-events",
+    severity: "error",
   });
 });

--- a/packages/sse/test/models.test.ts
+++ b/packages/sse/test/models.test.ts
@@ -1,111 +1,109 @@
 import { expectDiagnostics, t } from "@typespec/compiler/testing";
 import { getContentTypes } from "@typespec/http";
 import { getStreamOf } from "@typespec/streams";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { Tester } from "./test-host.js";
 
-describe("SSEStream", () => {
-  it("sets streamOf, contentType ('text/event-stream'), and body", async () => {
-    const { Foo, TestEvents, program } = await Tester.compile(t.code`
-      @events
-      union ${t.union("TestEvents")} { 
-        foo: string,
+it("sets streamOf, contentType ('text/event-stream'), and body", async () => {
+  const { Foo, TestEvents, program } = await Tester.compile(t.code`
+    @events
+    union ${t.union("TestEvents")} { 
+      foo: string,
 
-        bar: string,
-      }
+      bar: string,
+    }
 
-      model ${t.model("Foo")} is SSEStream<TestEvents>;
-    `);
-    expect(getStreamOf(program, Foo)).toBe(TestEvents);
-    expect(getContentTypes(Foo.properties.get("contentType")!)[0]).toEqual(["text/event-stream"]);
-    expect(Foo.properties.get("body")!.type).toMatchObject({
-      kind: "Scalar",
-      name: "string",
-    });
+    model ${t.model("Foo")} is SSEStream<TestEvents>;
+  `);
+  expect(getStreamOf(program, Foo)).toBe(TestEvents);
+  expect(getContentTypes(Foo.properties.get("contentType")!)[0]).toEqual(["text/event-stream"]);
+  expect(Foo.properties.get("body")!.type).toMatchObject({
+    kind: "Scalar",
+    name: "string",
   });
+});
 
-  it("should fail when union is not decorated with @events", async () => {
-    const diagnostics = await Tester.diagnose(`
-      model UserConnect {
-        name: string;
-      }
+it("should fail when union is not decorated with @events", async () => {
+  const diagnostics = await Tester.diagnose(`
+    model UserConnect {
+      name: string;
+    }
 
-      union BasicUnion {
-        userconnect: UserConnect,
-      }
+    union BasicUnion {
+      userconnect: UserConnect,
+    }
 
-      op subscribe(): SSEStream<BasicUnion>;
-    `);
+    op subscribe(): SSEStream<BasicUnion>;
+  `);
 
-    expectDiagnostics(diagnostics, {
-      code: "@typespec/sse/sse-stream-union-not-events",
-      severity: "error",
-    });
+  expectDiagnostics(diagnostics, {
+    code: "@typespec/sse/sse-stream-union-not-events",
+    severity: "error",
   });
+});
 
-  it("should pass when union is decorated with @events", async () => {
-    const diagnostics = await Tester.diagnose(`
-      model UserConnect {
-        name: string;
-      }
+it("should pass when union is decorated with @events", async () => {
+  const diagnostics = await Tester.diagnose(`
+    model UserConnect {
+      name: string;
+    }
 
-      @events
-      union BasicUnion {
-        userconnect: UserConnect,
-      }
+    @events
+    union BasicUnion {
+      userconnect: UserConnect,
+    }
 
-      op subscribe(): SSEStream<BasicUnion>;
-    `);
+    op subscribe(): SSEStream<BasicUnion>;
+  `);
 
-    expectDiagnostics(diagnostics, []);
+  expectDiagnostics(diagnostics, []);
+});
+
+it("should fail when HttpStream with text/event-stream is used without @events", async () => {
+  const diagnostics = await Tester.diagnose(`
+    model UserConnect {
+      name: string;
+    }
+
+    union BasicUnion {
+      userconnect: UserConnect,
+    }
+
+    model MyStream is Http.Streams.HttpStream<BasicUnion, "text/event-stream">;
+  `);
+
+  expectDiagnostics(diagnostics, {
+    code: "@typespec/sse/sse-stream-union-not-events",
+    severity: "error",
   });
+});
 
-  it("should fail when HttpStream with text/event-stream is used without @events", async () => {
-    const diagnostics = await Tester.diagnose(`
-      model UserConnect {
-        name: string;
-      }
+it("should fail when HttpStream with text/event-stream is a model", async () => {
+  const diagnostics = await Tester.diagnose(`
+    model UserConnect {
+      name: string;
+    }
 
-      union BasicUnion {
-        userconnect: UserConnect,
-      }
+    model MyStream is Http.Streams.HttpStream<UserConnect, "text/event-stream">;
+  `);
 
-      model MyStream is Http.Streams.HttpStream<BasicUnion, "text/event-stream">;
-    `);
-
-    expectDiagnostics(diagnostics, {
-      code: "@typespec/sse/sse-stream-union-not-events",
-      severity: "error",
-    });
+  expectDiagnostics(diagnostics, {
+    code: "@typespec/sse/sse-stream-union-not-events",
+    severity: "error",
   });
+});
 
-  it("should fail when HttpStream with text/event-stream is a model", async () => {
-    const diagnostics = await Tester.diagnose(`
-      model UserConnect {
-        name: string;
-      }
+it("should fail when SSEStream is used with a model", async () => {
+  const diagnostics = await Tester.diagnose(`
+    model UserConnect {
+      name: string;
+    }
 
-      model MyStream is Http.Streams.HttpStream<UserConnect, "text/event-stream">;
-    `);
+    model MyStream is SSEStream<UserConnect>;
+  `);
 
-    expectDiagnostics(diagnostics, {
-      code: "@typespec/sse/sse-stream-union-not-events",
-      severity: "error",
-    });
-  });
-
-  it("should fail when SSEStream is used with a model", async () => {
-    const diagnostics = await Tester.diagnose(`
-      model UserConnect {
-        name: string;
-      }
-
-      model MyStream is SSEStream<UserConnect>;
-    `);
-
-    expectDiagnostics(diagnostics, {
-      code: "invalid-argument",
-      severity: "error",
-    });
+  expectDiagnostics(diagnostics, {
+    code: "invalid-argument",
+    severity: "error",
   });
 });

--- a/packages/streams/test/decorators.test.ts
+++ b/packages/streams/test/decorators.test.ts
@@ -1,36 +1,34 @@
 import type { Model } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { getStreamOf } from "../src/decorators.js";
 import { Tester } from "./test-host.js";
 
-describe("@streamOf", () => {
-  it("provides stream protocol type", async () => {
-    const { Blob, program } = await Tester.compile(t.code`
-      @streamOf(string)
-      model ${t.model("Blob")} {}
-    `);
+it("provides stream protocol type", async () => {
+  const { Blob, program } = await Tester.compile(t.code`
+    @streamOf(string)
+    model ${t.model("Blob")} {}
+  `);
 
-    expect(getStreamOf(program, Blob as Model)).toMatchObject({
-      kind: "Scalar",
-      name: "string",
-    });
+  expect(getStreamOf(program, Blob as Model)).toMatchObject({
+    kind: "Scalar",
+    name: "string",
   });
+});
 
-  it("returns undefined if model is not decorated", async () => {
-    const { Blob, program } = await Tester.compile(t.code`
-      model ${t.model("Blob")} {}
-    `);
+it("returns undefined if model is not decorated", async () => {
+  const { Blob, program } = await Tester.compile(t.code`
+    model ${t.model("Blob")} {}
+  `);
 
-    expect(getStreamOf(program, Blob as Model)).toBeUndefined();
-  });
+  expect(getStreamOf(program, Blob as Model)).toBeUndefined();
+});
 
-  it("is automatically set on the Stream model", async () => {
-    const { CustomStream, Message, program } = await Tester.compile(t.code`
-      model ${t.model("Message")} { id: string, text: string }
-      model ${t.model("CustomStream")} is Stream<Message> {}
-    `);
+it("is automatically set on the Stream model", async () => {
+  const { CustomStream, Message, program } = await Tester.compile(t.code`
+    model ${t.model("Message")} { id: string, text: string }
+    model ${t.model("CustomStream")} is Stream<Message> {}
+  `);
 
-    expect(getStreamOf(program, CustomStream as Model)).toBe(Message);
-  });
+  expect(getStreamOf(program, CustomStream as Model)).toBe(Message);
 });

--- a/packages/tspd/test/ref-doc/markdown.test.ts
+++ b/packages/tspd/test/ref-doc/markdown.test.ts
@@ -1,29 +1,27 @@
 import { strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { table } from "../../src/ref-doc/utils/markdown.js";
 
-describe("ref-doc: markdown", () => {
-  it("escapes table content", () => {
-    const t = table([
-      [
-        "Header 1\n\nThe first header",
-        "Header 2\n\nThe second header",
-        "Header 3\n\nThe third header",
-      ],
-      [
-        "First row\nFirst column\nhas\nlots of newlines\n!!!",
-        "First row\nSecond column\nhas\nlots of newlines\n!!!",
-        "First row\nThird column\nhas\nlots of newlines\n!!!",
-      ],
-    ]);
+it("escapes table content", () => {
+  const t = table([
+    [
+      "Header 1\n\nThe first header",
+      "Header 2\n\nThe second header",
+      "Header 3\n\nThe third header",
+    ],
+    [
+      "First row\nFirst column\nhas\nlots of newlines\n!!!",
+      "First row\nSecond column\nhas\nlots of newlines\n!!!",
+      "First row\nThird column\nhas\nlots of newlines\n!!!",
+    ],
+  ]);
 
-    strictEqual(
-      t,
-      `
+  strictEqual(
+    t,
+    `
 | Header 1<br /><br />The first header | Header 2<br /><br />The second header | Header 3<br /><br />The third header |
 |----------------------------|-----------------------------|----------------------------|
 | First row<br />First column<br />has<br />lots of newlines<br />!!! | First row<br />Second column<br />has<br />lots of newlines<br />!!! | First row<br />Third column<br />has<br />lots of newlines<br />!!! |
-      `.trim(),
-    );
-  });
+    `.trim(),
+  );
 });

--- a/packages/typespec-vscode/test/unit/extension.test.ts
+++ b/packages/typespec-vscode/test/unit/extension.test.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from "assert";
-import { assert, beforeAll, describe, it } from "vitest";
+import { assert, beforeAll, it } from "vitest";
 import { InitTemplateSchema } from "../../../compiler/dist/src/init/init-template.js";
 import { ConsoleLogLogger } from "../../src/log/console-log-listener.js";
 import logger from "../../src/log/logger.js";
@@ -9,16 +9,14 @@ beforeAll(() => {
   logger.registerLogListener("test", new ConsoleLogLogger());
 });
 
-describe("Hello world test", () => {
-  it("should pass", () => {
-    assert(true, "test sample");
-  });
+it("should pass", () => {
+  assert(true, "test sample");
+});
 
-  it("Check inputs type supported in InitTemplate", () => {
-    // Add this test to ensure we won't forget to add the support in VS/VSCode extension of typespec
-    // when we add more input types support in InitTemplate.inputs
-    const schema = InitTemplateSchema;
-    strictEqual(schema.properties.inputs.additionalProperties.properties.type.enum.length, 1);
-    strictEqual(schema.properties.inputs.additionalProperties.properties.type.enum[0], "text");
-  });
+it("Check inputs type supported in InitTemplate", () => {
+  // Add this test to ensure we won't forget to add the support in VS/VSCode extension of typespec
+  // when we add more input types support in InitTemplate.inputs
+  const schema = InitTemplateSchema;
+  strictEqual(schema.properties.inputs.additionalProperties.properties.type.enum.length, 1);
+  strictEqual(schema.properties.inputs.additionalProperties.properties.type.enum[0], "text");
 });

--- a/packages/versioning/test/versioning-timeline.test.ts
+++ b/packages/versioning/test/versioning-timeline.test.ts
@@ -1,132 +1,130 @@
 import type { Namespace } from "@typespec/compiler";
 import { deepStrictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { VersioningTimeline } from "../src/versioning-timeline.js";
 import { resolveVersions } from "../src/versioning.js";
 import { Tester } from "./test-host.js";
 
-describe("versioning: VersioningTimeline", () => {
-  function generateLibraryNamespace(name: string, versions: string[]) {
-    return `@versioned(Versions) namespace ${name} { enum Versions {${versions.join(",")}} } `;
-  }
+function generateLibraryNamespace(name: string, versions: string[]) {
+  return `@versioned(Versions) namespace ${name} { enum Versions {${versions.join(",")}} } `;
+}
 
-  async function resolveTimelineMatrix(
-    serviceMapping: Record<string, string[]>,
-    ...libraryVersions: string[][]
-  ): Promise<string[][]> {
-    function generateVersionMember(name: string, mapping: string[]) {
-      return [
-        ...mapping.map((x, i) => `@useDependency(${libNamespaceNames[i]}.Versions.${x})`),
-        name,
-      ].join("\n");
-    }
-
-    const libNamespaceNames = libraryVersions.map((_, i) => `TestLibNs_${i}`);
-    const content = [
-      `@versioned(Versions) namespace TestServiceNs {
-          enum Versions {
-            ${Object.entries(serviceMapping)
-              .map(([k, v]) => generateVersionMember(k, v))
-              .join(",\n")}
-          }
-      }`,
-      ...libraryVersions.map((x, i) => generateLibraryNamespace(libNamespaceNames[i], x)),
+async function resolveTimelineMatrix(
+  serviceMapping: Record<string, string[]>,
+  ...libraryVersions: string[][]
+): Promise<string[][]> {
+  function generateVersionMember(name: string, mapping: string[]) {
+    return [
+      ...mapping.map((x, i) => `@useDependency(${libNamespaceNames[i]}.Versions.${x})`),
+      name,
     ].join("\n");
-    const { program } = await Tester.compile(content);
-
-    const serviceNamespace = program.getGlobalNamespaceType().namespaces.get("TestServiceNs")!;
-    const libNamespaces: Namespace[] = libNamespaceNames.map(
-      (x) => program.getGlobalNamespaceType().namespaces.get(x)!,
-    );
-    const resolutions = resolveVersions(program, serviceNamespace);
-    const timeline = new VersioningTimeline(
-      program,
-      resolutions.map((x) => x.versions),
-    );
-    const timelineMatrix: string[][] = [];
-
-    for (const moment of timeline) {
-      const cells: string[] = [moment.getVersion(serviceNamespace)?.name ?? ""];
-      for (let i = 0; i < libraryVersions.length; i++) {
-        cells.push(moment.getVersion(libNamespaces[i])?.name ?? "");
-      }
-      timelineMatrix.push(cells);
-    }
-
-    return timelineMatrix;
   }
-  it("generate timeline where each service version map to a different library version", async () => {
-    const timeline = await resolveTimelineMatrix({ v1: ["l1"], v2: ["l2"], v3: ["l3"] }, [
-      "l1",
-      "l2",
-      "l3",
-    ]);
-    deepStrictEqual(timeline, [
-      ["v1", "l1"],
-      ["v2", "l2"],
-      ["v3", "l3"],
-    ]);
-  });
 
-  it("generate timeline where each service version map to a single library version", async () => {
-    const timeline = await resolveTimelineMatrix({ v1: ["l1"], v2: ["l1"], v3: ["l1"] }, ["l1"]);
-    deepStrictEqual(timeline, [
-      ["v1", "l1"],
-      ["v2", "l1"],
-      ["v3", "l1"],
-    ]);
-  });
+  const libNamespaceNames = libraryVersions.map((_, i) => `TestLibNs_${i}`);
+  const content = [
+    `@versioned(Versions) namespace TestServiceNs {
+        enum Versions {
+          ${Object.entries(serviceMapping)
+            .map(([k, v]) => generateVersionMember(k, v))
+            .join(",\n")}
+        }
+    }`,
+    ...libraryVersions.map((x, i) => generateLibraryNamespace(libNamespaceNames[i], x)),
+  ].join("\n");
+  const { program } = await Tester.compile(content);
 
-  it("generate timeline where each service version map to a one of the library versions", async () => {
-    const timeline = await resolveTimelineMatrix({ v1: ["l2"], v2: ["l2"] }, [
-      "l1",
-      "l2",
-      "l3",
-      "l4",
-    ]);
-    deepStrictEqual(timeline, [
-      ["", "l1"],
-      ["v1", "l2"],
-      ["v2", "l2"],
-      ["", "l3"],
-      ["", "l4"],
-    ]);
-  });
+  const serviceNamespace = program.getGlobalNamespaceType().namespaces.get("TestServiceNs")!;
+  const libNamespaces: Namespace[] = libNamespaceNames.map(
+    (x) => program.getGlobalNamespaceType().namespaces.get(x)!,
+  );
+  const resolutions = resolveVersions(program, serviceNamespace);
+  const timeline = new VersioningTimeline(
+    program,
+    resolutions.map((x) => x.versions),
+  );
+  const timelineMatrix: string[][] = [];
 
-  it("generate timeline where service versions skip library versions", async () => {
-    const timeline = await resolveTimelineMatrix({ v1: ["l2"], v2: ["l5"] }, [
-      "l1",
-      "l2",
-      "l3",
-      "l4",
-      "l5",
-      "l6",
-    ]);
-    deepStrictEqual(timeline, [
-      ["", "l1"],
-      ["v1", "l2"],
-      ["", "l3"],
-      ["", "l4"],
-      ["v2", "l5"],
-      ["", "l6"],
-    ]);
-  });
+  for (const moment of timeline) {
+    const cells: string[] = [moment.getVersion(serviceNamespace)?.name ?? ""];
+    for (let i = 0; i < libraryVersions.length; i++) {
+      cells.push(moment.getVersion(libNamespaces[i])?.name ?? "");
+    }
+    timelineMatrix.push(cells);
+  }
 
-  it("generate timeline with multiple libraries", async () => {
-    const timeline = await resolveTimelineMatrix(
-      { v1: ["l2", "k1"], v2: ["l5", "k1"] },
-      ["l1", "l2", "l3", "l4", "l5", "l6"],
-      ["k1", "k2", "k3"],
-    );
-    deepStrictEqual(timeline, [
-      ["", "l1", ""],
-      ["v1", "l2", "k1"],
-      ["", "l3", ""],
-      ["", "l4", ""],
-      ["v2", "l5", "k1"],
-      ["", "", "k2"],
-      ["", "", "k3"],
-      ["", "l6", ""],
-    ]);
-  });
+  return timelineMatrix;
+}
+it("generate timeline where each service version map to a different library version", async () => {
+  const timeline = await resolveTimelineMatrix({ v1: ["l1"], v2: ["l2"], v3: ["l3"] }, [
+    "l1",
+    "l2",
+    "l3",
+  ]);
+  deepStrictEqual(timeline, [
+    ["v1", "l1"],
+    ["v2", "l2"],
+    ["v3", "l3"],
+  ]);
+});
+
+it("generate timeline where each service version map to a single library version", async () => {
+  const timeline = await resolveTimelineMatrix({ v1: ["l1"], v2: ["l1"], v3: ["l1"] }, ["l1"]);
+  deepStrictEqual(timeline, [
+    ["v1", "l1"],
+    ["v2", "l1"],
+    ["v3", "l1"],
+  ]);
+});
+
+it("generate timeline where each service version map to a one of the library versions", async () => {
+  const timeline = await resolveTimelineMatrix({ v1: ["l2"], v2: ["l2"] }, [
+    "l1",
+    "l2",
+    "l3",
+    "l4",
+  ]);
+  deepStrictEqual(timeline, [
+    ["", "l1"],
+    ["v1", "l2"],
+    ["v2", "l2"],
+    ["", "l3"],
+    ["", "l4"],
+  ]);
+});
+
+it("generate timeline where service versions skip library versions", async () => {
+  const timeline = await resolveTimelineMatrix({ v1: ["l2"], v2: ["l5"] }, [
+    "l1",
+    "l2",
+    "l3",
+    "l4",
+    "l5",
+    "l6",
+  ]);
+  deepStrictEqual(timeline, [
+    ["", "l1"],
+    ["v1", "l2"],
+    ["", "l3"],
+    ["", "l4"],
+    ["v2", "l5"],
+    ["", "l6"],
+  ]);
+});
+
+it("generate timeline with multiple libraries", async () => {
+  const timeline = await resolveTimelineMatrix(
+    { v1: ["l2", "k1"], v2: ["l5", "k1"] },
+    ["l1", "l2", "l3", "l4", "l5", "l6"],
+    ["k1", "k2", "k3"],
+  );
+  deepStrictEqual(timeline, [
+    ["", "l1", ""],
+    ["v1", "l2", "k1"],
+    ["", "l3", ""],
+    ["", "l4", ""],
+    ["v2", "l5", "k1"],
+    ["", "", "k2"],
+    ["", "", "k3"],
+    ["", "l6", ""],
+  ]);
 });


### PR DESCRIPTION
## Summary

Cleanup of a legacy test pattern documented in `CONTRIBUTING.md`:

> Do **not** wrap tests in a top-level `describe`. The test file name already provides context. Use `it()` directly at the top level. Only use `describe()` for sub-groups within a file.

This PR removes the redundant single top-level `describe(...)` wrappers that span an entire test file, dedenting the contents and lifting any hooks/consts to module scope. Genuine sub-group describes (files with multiple sibling top-level describes, or `it()` alongside sub-groups) are preserved.

## Packages (24, ~90 files)

http (6), json-schema (13), rest (1), versioning (1), openapi (1), sse (2), emitter-framework (15), http-server-csharp (7), spec-api (3), http-server-js (3), asset-emitter (3), internal-build-utils (2), html-program-viewer (2), streams (1), library-linter (1), bundler (1), playground (5), spector (3), prettier-plugin-typespec (1), samples (1), spec-dashboard (1), tspd (1), typespec-vscode (1), protobuf (1).

Files that already follow the convention (multiple sibling top-level describes, or top-level `it()` alongside sub-group describes) were reviewed and left unchanged.

## Not in this PR

The three largest test suites are deliberately left for dedicated PRs to keep this reviewable: **compiler** (~75 files), **http-client-js** (~48), **openapi3** (~28). The separate legacy `createTestHost`/`createTestRunner` → `createTester` migration (~8 files) and `test()` → `it()` (~10 files) are also follow-ups.

## Validation

- Per-package `vitest run`: **all tests pass**
- Prettier: clean
- oxlint: clean