### PR TITLE
fix(http-client-python): avoid _enums import for constant enum values in typeddict mode

### DIFF
--- a/.chronus/changes/fix-typeddict-constant-enum-literal-2026-07-08.md
+++ b/.chronus/changes/fix-typeddict-constant-enum-literal-2026-07-08.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix constant enum values referencing the nonexistent `_enums` module in `models-mode: typeddict`. In typeddict mode enums are emitted as `Literal` aliases in `types.py` and `_enums.py` is never generated, so a single constant enum value now annotates with its literal value (e.g. `Literal["red"]`) and no longer imports from `_enums`.

--- a/packages/http-client-python/generator/pygen/codegen/models/enum_type.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/enum_type.py
@@ -40,6 +40,10 @@ class EnumValue(BaseType):
 
     def type_annotation(self, **kwargs: Any) -> str:
         """The python type used for type annotation"""
+        if self.code_model.options["models-mode"] == "typeddict":
+            # A single constant enum value must be
+            # annotated with its literal value directly (e.g. ``Literal["red"]``).
+            return f"Literal[{self.value_type.get_declaration(self.value)}]"
         return f"Literal[{self.enum_type.name}.{self.name}]"
 
     def get_declaration(self, value=None):
@@ -79,6 +83,9 @@ class EnumValue(BaseType):
         file_import = FileImport(self.code_model)
         file_import.merge(self.value_type.imports(**kwargs))
         file_import.add_submodule_import("typing", "Literal", ImportType.STDLIB, TypingSection.REGULAR)
+        if self.code_model.options["models-mode"] == "typeddict":
+            # In typeddict mode the enums module (``_enums.py``) is never generated
+            return file_import
         serialize_namespace = kwargs.get("serialize_namespace", self.code_model.namespace)
         file_import.add_submodule_import(
             self.code_model.get_relative_import_path(

--- a/packages/http-client-python/tests/unit/test_typeddict.py
+++ b/packages/http-client-python/tests/unit/test_typeddict.py
@@ -8,7 +8,8 @@
 
 from jinja2 import PackageLoader, Environment
 
-from pygen.codegen.models import CodeModel, JSONModelType, DPGModelType
+from pygen.codegen.models import CodeModel, JSONModelType, DPGModelType, build_type
+from pygen.codegen.models.imports import ImportType
 from pygen.codegen.models.model_type import TypedDictModelType
 from pygen.codegen.serializers.types_serializer import TypesSerializer
 from pygen.codegen.serializers.unions_serializer import UnionsSerializer
@@ -252,3 +253,67 @@ def test_typed_dict_only_docstring_type():
     docstring = model.docstring_type()
     assert "types.Foo" in docstring
     assert "models.Foo" not in docstring
+
+
+# ---------- constant enum value (EnumValue) annotation & imports ----------
+
+
+def _make_enum_value(code_model, enum_name="Color", member_name="RED", value="red"):
+    """Build a single constant EnumValue attached to code_model."""
+    value_type_yaml = {"type": "string"}
+    enum_yaml = {
+        "type": "enum",
+        "name": enum_name,
+        "valueType": value_type_yaml,
+        "values": [],
+    }
+    enum_value_yaml = {
+        "type": "enumvalue",
+        "name": member_name,
+        "value": value,
+        "enumType": enum_yaml,
+        "valueType": value_type_yaml,
+    }
+    return build_type(enum_value_yaml, code_model)
+
+
+def _local_import_modules(file_import):
+    """Collect all LOCAL import module names from a FileImport."""
+    modules = set()
+    for section in file_import.to_dict().values():
+        modules.update(section.get(ImportType.LOCAL, {}).keys())
+    return modules
+
+
+def test_enum_value_dpg_annotation_uses_enum_member():
+    """In dpg mode a constant enum value annotates as ``Literal[Color.RED]``."""
+    code_model = _make_code_model(models_mode="dpg")
+    enum_value = _make_enum_value(code_model)
+    assert enum_value.type_annotation() == "Literal[Color.RED]"
+
+
+def test_enum_value_typeddict_annotation_uses_literal_value():
+    """In typeddict mode a constant enum value annotates with its literal value.
+
+    Enums are ``Literal`` aliases in types.py with no member attributes, so the
+    annotation must be ``Literal["red"]`` rather than ``Literal[Color.RED]``.
+    """
+    code_model = _make_code_model(models_mode="typeddict")
+    enum_value = _make_enum_value(code_model)
+    assert enum_value.type_annotation() == 'Literal["red"]'
+
+
+def test_enum_value_typeddict_does_not_import_enums_module():
+    """In typeddict mode ``_enums.py`` is never generated, so no import of it."""
+    code_model = _make_code_model(models_mode="typeddict")
+    enum_value = _make_enum_value(code_model)
+    modules = _local_import_modules(enum_value.imports())
+    assert not any("_enums" in module for module in modules)
+
+
+def test_enum_value_dpg_imports_enums_module():
+    """In dpg mode a constant enum value imports the enum from ``_enums.py``."""
+    code_model = _make_code_model(models_mode="dpg")
+    enum_value = _make_enum_value(code_model)
+    modules = _local_import_modules(enum_value.imports())
+    assert any("_enums" in module for module in modules)


### PR DESCRIPTION
## Problem

In `models-mode: typeddict`, enums are emitted as `Literal` aliases in `types.py` (e.g. `Color = Literal["red", "blue"]`) and `_enums.py` is **never generated**. However, a single constant enum value (`EnumValue`) still used the dpg-style annotation `Literal[Color.RED]` and imported `Color` from `..models._enums` — a module that does not exist in typeddict mode, and an attribute (`Color.RED`) that a `Literal` alias does not have.

## Fix

`EnumValue`, in typeddict mode only:

- `type_annotation` returns the raw literal value — `Literal["red"]` — instead of `Literal[Color.RED]`.
- `imports` skips the `_enums` import (only `typing.Literal` is needed).

dpg / msrest behavior is unchanged. `ConstantType` is unaffected (it already uses primitive value types).

```python
# models-mode: typeddict — before (broken)
from ..models._enums import Color   # _enums.py never generated
x: Literal[Color.RED]               # Color is a Literal alias, has no .RED

# after
from typing import Literal
x: Literal["red"]
```


This scenario is what I have a question on:


```python
# models-mode: typeddict — before (broken)
from ..models._enums import Foo  # _enums.py never generated
Foo = Literal["bar"]
x: Literal[Foo.BAR]              

# after
from typing import Literal
Foo = Literal["bar"]   # enums are extensible so at any time Foo could become Foo = Literal["bar", "bar2"]????
x: Literal["bar"]
```

versus where it is the whole enum type

```python
# models-mode: typeddict — before (broken)
from ..models._enums import Foo  # _enums.py never generated
Foo = Literal["bar"]
x: Foo        

# after
from typing import Literal
Foo = Literal["bar"]  
x: Foo
```

