### PR TITLE
fix: variable scope in regenpreview script

### DIFF
--- a/packages/http-client-csharp/eng/scripts/RegenPreview.psm1
+++ b/packages/http-client-csharp/eng/scripts/RegenPreview.psm1
@@ -1,7 +1,5 @@
 Import-Module "$PSScriptRoot\Generation.psm1" -DisableNameChecking -Force -Global
 
-$script:PublicNpmRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
-
 function Update-GeneratorPackage {
     <#
     .SYNOPSIS
@@ -83,25 +81,25 @@ function Update-GeneratorPackage {
             Write-Host "  Updated dependencies to local packages" -ForegroundColor Green
         }
 
-        # Step 2: Install dependencies, clean, and build
+        # Step 2: Install dependencies, clean, and build.
         # Force the default registry to the public azure-sdk-for-js feed.
         Push-Location $GeneratorPath
         try {
             Write-Host "Installing dependencies..." -ForegroundColor Gray
             if ($UseNpmCi) {
-                $installOutput = & npm install --package-lock-only --registry $script:PublicNpmRegistry 2>&1
+                $installOutput = & npm install --package-lock-only --registry https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ 2>&1
                 if ($LASTEXITCODE -ne 0) {
                     Write-Host $installOutput -ForegroundColor Red
                     throw "Failed to update package-lock.json"
                 }
                 
-                $ciOutput = & npm ci --registry $script:PublicNpmRegistry 2>&1
+                $ciOutput = & npm ci --registry https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ 2>&1
                 if ($LASTEXITCODE -ne 0) {
                     Write-Host $ciOutput -ForegroundColor Red
                     throw "Failed to install dependencies"
                 }
             } else {
-                $installOutput = & npm install --registry $script:PublicNpmRegistry 2>&1
+                $installOutput = & npm install --registry https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ 2>&1
                 if ($LASTEXITCODE -ne 0) {
                     Write-Host $installOutput -ForegroundColor Red
                     throw "Failed to run npm install"
@@ -267,7 +265,7 @@ function Update-MgmtGenerator {
     # Point the default registry at the public azure-sdk-for-js feed so dependency
     # resolution doesn't fall back to the authenticated machine-global proxy
     # (packagefeedproxy), which fails with E401 for @typespec/@azure-tools packages.
-    Set-Content (Join-Path $tempDir ".npmrc") "registry=$script:PublicNpmRegistry`n" -Encoding utf8
+    Set-Content (Join-Path $tempDir ".npmrc") "registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/`n" -Encoding utf8
     
     try {
         $tempPackageJson = Join-Path $tempDir "package.json"
@@ -909,9 +907,7 @@ function Update-AzureSpectorScenarios {
         Write-Host "Installing dependencies..." -ForegroundColor Gray
         Push-Location $AzureGeneratorPath
         try {
-            # Use the public azure-sdk-for-js feed to avoid the authenticated
-            # machine-global proxy (packagefeedproxy) failing on uncached deps.
-            $installOutput = & npm install --registry $script:PublicNpmRegistry 2>&1
+            $installOutput = & npm install --registry https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ 2>&1
             if ($LASTEXITCODE -ne 0) {
                 Write-Host $installOutput -ForegroundColor Red
                 throw "npm install failed in Azure generator"


### PR DESCRIPTION
The script was failing since the variable set at the script level was not resolving. To avoid overcomplicating these changes, this PR simply reverts to using the registry string value directly.