### PR TITLE
[http-client-csharp] Isolate plugin build output per process to fix parallel build race

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
@@ -198,7 +198,7 @@ namespace Microsoft.TypeSpec.Generator
                 return null;
             }
 
-            return BuildPlugin(csprojPath, directory, emitter);
+            return BuildPlugin(csprojPath, emitter);
         }
 
         /// <summary>
@@ -256,25 +256,52 @@ namespace Microsoft.TypeSpec.Generator
             paths.OrderBy(path => path, StringComparer.Ordinal).FirstOrDefault();
 
         /// <summary>
-        /// Builds a plugin .csproj and returns the path to the output DLL by scanning
-        /// <paramref name="scanDirectory"/> for the built assembly.
+        /// Builds a plugin .csproj into a process-isolated output directory and returns the path
+        /// to the built assembly, or <see langword="null"/> if the build failed or no assembly
+        /// could be located.
         /// </summary>
-        internal static string? BuildPlugin(string csprojPath, string scanDirectory, Emitter emitter)
+        /// <remarks>
+        /// Within a single solution folder the emitter runs once per referenced project, so the
+        /// same plugin can be built concurrently by multiple processes. Sharing the plugin's
+        /// 'bin'/'obj' output across those processes races: the assembly can be truncated
+        /// mid-write, restore can corrupt 'project.assets.json', or a stale assembly from a
+        /// previous run can be loaded — which silently drops the plugin's behavior (for example,
+        /// visitors that add attributes). Redirecting each process to its own output directory
+        /// removes the shared resource entirely, so builds stay fully parallel and the loaded
+        /// assembly is always the one this process just built.
+        /// </remarks>
+        internal static string? BuildPlugin(string csprojPath, Emitter emitter)
         {
             emitter.Info($"Building plugin: {csprojPath}");
+
+            var outputRoot = CreateIsolatedPluginOutputDirectory(csprojPath);
+            var binDirectory = EnsureTrailingSeparator(Path.Combine(outputRoot, "bin"));
+            var objDirectory = EnsureTrailingSeparator(Path.Combine(outputRoot, "obj"));
 
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "dotnet",
-                    Arguments = $"build \"{csprojPath}\" -c Release",
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 }
             };
+
+            // Override the *base* output/intermediate paths (rather than 'OutputPath'/'--output')
+            // so that multi-targeted plugin projects keep their per-framework subfolders and any
+            // project that derives its output location from these base paths is still honored.
+            // Command-line global properties take precedence over values set within the project or
+            // its imports, so this reliably redirects the build regardless of repository layout.
+            // ArgumentList is used to avoid the Windows trailing-backslash quoting pitfall.
+            process.StartInfo.ArgumentList.Add("build");
+            process.StartInfo.ArgumentList.Add(csprojPath);
+            process.StartInfo.ArgumentList.Add("-c");
+            process.StartInfo.ArgumentList.Add("Release");
+            process.StartInfo.ArgumentList.Add($"-p:BaseOutputPath={binDirectory}");
+            process.StartInfo.ArgumentList.Add($"-p:BaseIntermediateOutputPath={objDirectory}");
 
             process.Start();
             // Read both streams to avoid deadlocks. 'dotnet build' writes build/compiler
@@ -284,36 +311,66 @@ namespace Microsoft.TypeSpec.Generator
             var stderr = process.StandardError.ReadToEnd();
             process.WaitForExit();
 
-            var buildSucceeded = process.ExitCode == 0;
-            if (!buildSucceeded)
+            if (process.ExitCode != 0)
             {
-                // Log a warning instead of an error so that a failed plugin build does not abort
-                // the entire generation. The build may fail when the same plugin is being built
-                // in parallel for multiple referenced projects within a single solution folder,
-                // in which case a previously built assembly may already exist and can still be
-                // reused below.
+                // Report a warning rather than an error so that a failed plugin build does not
+                // abort the entire generation; callers treat a null result as "no assembly to
+                // load" and continue. Because the output directory is isolated per process, there
+                // is no shared artifact to fall back to, so a failed build simply yields no plugin.
                 emitter.ReportDiagnostic(
                     DiagnosticCodes.PluginBuildFailed,
                     $"Failed to build plugin '{csprojPath}'. Exit code: {process.ExitCode}\n{stdout}\n{stderr}",
                     severity: EmitterDiagnosticSeverity.Warning);
+                return null;
             }
 
-            var dllPath = FindPluginAssembly(csprojPath, scanDirectory);
+            // Scan only this process's isolated output directory so we never pick up an assembly
+            // produced by a concurrent build of the same plugin.
+            var dllPath = FindPluginAssembly(csprojPath, binDirectory);
             if (dllPath != null)
             {
-                emitter.Info(buildSucceeded
-                    ? $"Plugin built: {dllPath}"
-                    : $"Using existing plugin artifact (not re-built): {dllPath}");
+                emitter.Info($"Plugin built: {dllPath}");
                 return dllPath;
             }
 
-            if (buildSucceeded)
-            {
-                emitter.Info($"Warning: Build succeeded but could not locate the output DLL for '{csprojPath}'");
-            }
-
+            emitter.Info($"Warning: Build succeeded but could not locate the output DLL for '{csprojPath}'");
             return null;
         }
+
+        /// <summary>
+        /// Creates a unique, process-isolated directory to hold a plugin build's 'bin' and 'obj'
+        /// output. The directory is keyed on the process id and a GUID so that concurrent
+        /// generations never share build output for the same plugin.
+        /// </summary>
+        private static string CreateIsolatedPluginOutputDirectory(string csprojPath)
+        {
+            var directory = Path.Combine(
+                Path.GetTempPath(),
+                "typespec-generator-plugins",
+                GetAssemblyName(csprojPath),
+                $"{Environment.ProcessId}-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+
+            // Best-effort cleanup when the process exits. The built assembly may still be loaded
+            // (and therefore locked) at that point, so any failure to delete is ignored; the
+            // operating system reclaims the temporary directory eventually.
+            AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // Best effort only.
+                }
+            };
+
+            return directory;
+        }
+
+        private static string EnsureTrailingSeparator(string path) =>
+            path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
 
         /// <summary>
         /// Locates the assembly produced by building a plugin .csproj by scanning

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
@@ -20,6 +20,7 @@ namespace Microsoft.TypeSpec.Generator
     {
         private const string NodeModulesDir = "node_modules";
         private const string SrcDir = "src";
+        private const string PluginOutputRootDirName = "typespec-generator-plugins";
 
         public void LoadGenerator(CommandLineOptions options)
         {
@@ -346,7 +347,7 @@ namespace Microsoft.TypeSpec.Generator
         {
             var directory = Path.Combine(
                 Path.GetTempPath(),
-                "typespec-generator-plugins",
+                PluginOutputRootDirName,
                 GetAssemblyName(csprojPath),
                 $"{Environment.ProcessId}-{Guid.NewGuid():N}");
             Directory.CreateDirectory(directory);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
@@ -211,12 +211,14 @@ namespace TestPlugin
                 using var emitter = new Emitter(Stream.Null);
                 var result = GeneratorHandler.BuildPlugin(
                     Path.Combine(testDir, "TestPlugin.csproj"),
-                    testDir,
                     emitter);
 
                 Assert.IsNotNull(result, "BuildPlugin should return a DLL path");
                 Assert.IsTrue(result!.EndsWith("TestPlugin.dll", StringComparison.OrdinalIgnoreCase));
                 Assert.IsTrue(File.Exists(result), $"Built DLL should exist at {result}");
+                // The plugin is built into a process-isolated directory, not under the project.
+                StringAssert.DoesNotContain(testDir, result,
+                    "Plugin output should be redirected to an isolated directory, not the project directory");
             }
             finally
             {
@@ -241,7 +243,6 @@ namespace TestPlugin
                 // generation is not aborted (e.g. when the plugin is built in parallel across projects).
                 var result = GeneratorHandler.BuildPlugin(
                     Path.Combine(testDir, "Bad.csproj"),
-                    testDir,
                     emitter);
 
                 Assert.IsNull(result);
@@ -253,30 +254,28 @@ namespace TestPlugin
         }
 
         [Test]
-        public void BuildPlugin_ReusesExistingArtifactWhenBuildFails()
+        public void BuildPlugin_ReturnsNullWhenBuildFails()
         {
             var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
             try
             {
                 Directory.CreateDirectory(testDir);
 
-                // Create an invalid .csproj so the build fails. GetAssemblyName falls back to the
-                // project file name ("Bad"), so an existing "Bad.dll" simulates an artifact that was
-                // already produced by a parallel build for another project in the solution.
+                // Create an invalid .csproj so the build fails. Because each generation builds the
+                // plugin into its own isolated output directory, there is no shared artifact from a
+                // parallel build to fall back to: a failed build yields no plugin (null) instead of
+                // silently reusing a possibly-stale assembly.
                 File.WriteAllText(Path.Combine(testDir, "Bad.csproj"), "not valid xml");
                 var existingDll = Path.Combine(testDir, "Bad.dll");
                 File.Copy(typeof(GeneratorHandlerTests).Assembly.Location, existingDll);
 
                 using var emitter = new Emitter(Stream.Null);
 
-                // Even though the build fails, the existing artifact should be reused rather than
-                // aborting generation.
                 var result = GeneratorHandler.BuildPlugin(
                     Path.Combine(testDir, "Bad.csproj"),
-                    testDir,
                     emitter);
 
-                Assert.AreEqual(existingDll, result);
+                Assert.IsNull(result, "A failed build should not reuse an unrelated assembly next to the project");
             }
             finally
             {
@@ -354,7 +353,7 @@ namespace TypedPlugin { public class MyType { public int Value => 42; } }");
 
                 using var emitter = new Emitter(Stream.Null);
                 var dllPath = GeneratorHandler.BuildPlugin(
-                    Path.Combine(testDir, "TypedPlugin.csproj"), testDir, emitter);
+                    Path.Combine(testDir, "TypedPlugin.csproj"), emitter);
 
                 Assert.IsNotNull(dllPath);
                 var asm = System.Reflection.Assembly.LoadFrom(dllPath!);
@@ -745,16 +744,16 @@ namespace Plugin2 { public class Dummy { } }");
         }
 
         [Test]
-        public void BuildPlugin_FindsOutputWhenRedirectedToCustomLocation()
+        public void BuildPlugin_IsolatesOutputEvenWhenProjectRedirectsIt()
         {
             var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
             try
             {
                 Directory.CreateDirectory(testDir);
 
-                // Use <TargetFrameworks> (plural) and redirect build output to a custom
-                // folder, mirroring repositories that send output to an 'artifacts'-style
-                // location. The previous path-computation logic failed in this scenario.
+                // The project tries to redirect its build output to a custom folder. The plugin
+                // build must override this and write to its own process-isolated directory so that
+                // concurrent builds of the same plugin never share output.
                 File.WriteAllText(Path.Combine(testDir, "Redirected.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
@@ -767,13 +766,16 @@ namespace Redirected { public class Dummy { } }");
 
                 using var emitter = new Emitter(Stream.Null);
                 var result = GeneratorHandler.BuildPlugin(
-                    Path.Combine(testDir, "Redirected.csproj"), testDir, emitter);
+                    Path.Combine(testDir, "Redirected.csproj"), emitter);
 
-                Assert.IsNotNull(result, "Should locate the DLL even when output is redirected");
+                Assert.IsNotNull(result, "Should locate the built DLL");
                 Assert.IsTrue(result!.EndsWith("Redirected.dll", StringComparison.OrdinalIgnoreCase));
                 Assert.IsTrue(File.Exists(result), $"Built DLL should exist at {result}");
-                StringAssert.Contains("artifacts-bin", result,
-                    "DLL should be located in the redirected output folder");
+                // The project's own output redirection is overridden by the isolated build.
+                StringAssert.DoesNotContain("artifacts-bin", result,
+                    "The project's output redirection should be overridden by the isolated build");
+                StringAssert.DoesNotContain(testDir, result,
+                    "Plugin output should be redirected outside the project directory");
             }
             finally
             {
@@ -803,7 +805,7 @@ namespace MultiTarget { public class Dummy { } }");
 
                 using var emitter = new Emitter(Stream.Null);
                 var result = GeneratorHandler.BuildPlugin(
-                    Path.Combine(testDir, "MultiTarget.csproj"), testDir, emitter);
+                    Path.Combine(testDir, "MultiTarget.csproj"), emitter);
 
                 Assert.IsNotNull(result, "Should locate the DLL for a multi-targeted project");
                 Assert.IsTrue(result!.EndsWith("MultiTarget.dll", StringComparison.OrdinalIgnoreCase));
@@ -813,6 +815,45 @@ namespace MultiTarget { public class Dummy { } }");
                     result.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                         .Contains("obj", StringComparer.OrdinalIgnoreCase),
                     $"Should not return a metadata-only reference assembly under obj: {result}");
+            }
+            finally
+            {
+                try { Directory.Delete(testDir, true); } catch { }
+            }
+        }
+
+        [Test]
+        public void BuildPlugin_UsesADistinctOutputDirectoryPerCall()
+        {
+            var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-plugin-" + Guid.NewGuid().ToString("N")[..8]);
+            try
+            {
+                Directory.CreateDirectory(testDir);
+
+                // Building the *same* project twice must produce assemblies in different
+                // directories. This is what allows concurrent generations to build a shared
+                // plugin without racing on the same 'bin'/'obj' output.
+                File.WriteAllText(Path.Combine(testDir, "Isolated.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>");
+
+                File.WriteAllText(Path.Combine(testDir, "Plugin.cs"), @"
+namespace Isolated { public class Dummy { } }");
+
+                using var emitter = new Emitter(Stream.Null);
+                var csproj = Path.Combine(testDir, "Isolated.csproj");
+
+                var first = GeneratorHandler.BuildPlugin(csproj, emitter);
+                var second = GeneratorHandler.BuildPlugin(csproj, emitter);
+
+                Assert.IsNotNull(first);
+                Assert.IsNotNull(second);
+                Assert.AreNotEqual(
+                    Path.GetDirectoryName(first),
+                    Path.GetDirectoryName(second),
+                    "Each build should write to its own isolated output directory");
             }
             finally
             {


### PR DESCRIPTION
## Problem

When multiple projects in a single solution folder are generated concurrently, the emitter runs once **per referenced project** and can build the same configured plugin (`plugins: [...]`) at the same time. Those parallel builds share the plugin's `bin`/`obj` output, which races:

- the plugin assembly can be truncated while another process is mid-write,
- `restore` can corrupt `project.assets.json`,
- or a **stale** assembly from a previous run can be loaded.

The last two are silent-correctness bugs: the plugin loads but its behavior is missing. In the Azure SDK this surfaced as generated code losing an `[Experimental]` attribute added by a plugin visitor, which then failed the build. `GeneratorHandler.BuildPlugin` already tolerates a failed build (warn + reuse), but reusing a stale artifact is exactly the hazard.

## Fix (isolate the shared resource)

Build each plugin into a **process-isolated output directory** under the temp folder, then load only from that directory:

- Override `BaseOutputPath` and `BaseIntermediateOutputPath` via command-line global properties (which take precedence over project/import values). Using the *base* paths — rather than `--output`/`OutputPath` — preserves the per-framework subfolders for multi-targeted plugin projects.
- Isolating `obj` as well removes the restore/`project.assets.json` race.
- On build failure, return `null` (warn) instead of reusing whatever DLL happens to be on disk, closing the stale-assembly hole.
- Best-effort cleanup of the temp directory on process exit.

This removes the shared mutable resource entirely, so concurrent plugin builds stay fully parallel and the loaded assembly is always the one the current process just built — no locks or retries needed.

## Tests

- Updated `BuildPlugin` tests for the new signature/behavior.
- `BuildPlugin_ReturnsNullWhenBuildFails` replaces the reuse-on-failure test.
- Existing multi-target and output-redirection tests updated to assert isolation.
- Added `BuildPlugin_UsesADistinctOutputDirectoryPerCall` verifying two builds of the same project write to different directories.

All 33 `GeneratorHandler` tests pass.
