### PR TITLE
fix(http-client-python): honor models-mode=none passed to OptionsDict constructor

### DIFF
--- a/.chronus/changes/fix-models-mode-none-constructor-2026-7-10-9-46-0.md
+++ b/.chronus/changes/fix-models-mode-none-constructor-2026-7-10-9-46-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix crash when generating with `models-mode=none`. Options passed to the `OptionsDict` constructor are now normalized through the same validation/transform path as `__setitem__`, so `models-mode=none` is correctly treated as falsy and a modelless client is produced instead of crashing.

--- a/packages/http-client-python/generator/pygen/__init__.py
+++ b/packages/http-client-python/generator/pygen/__init__.py
@@ -46,7 +46,7 @@ class OptionsDict(MutableMapping):
     def __init__(self, options: Optional[dict[str, Any]] = None) -> None:
         self._data = options.copy() if options else {}
         for key in list(self._data):
-                        self._data[key] = self._validate_and_transform(key, self._data[key])
+            self._data[key] = self._validate_and_transform(key, self._data[key])
         self._validate_combinations()
 
     def __getitem__(self, key: str) -> Any:  # pylint: disable=too-many-return-statements

--- a/packages/http-client-python/generator/pygen/__init__.py
+++ b/packages/http-client-python/generator/pygen/__init__.py
@@ -46,7 +46,7 @@ class OptionsDict(MutableMapping):
     def __init__(self, options: Optional[dict[str, Any]] = None) -> None:
         self._data = options.copy() if options else {}
         for key in list(self._data):
-          self._data[key] = self._validate_and_transform(key, self._data[key])
+                        self._data[key] = self._validate_and_transform(key, self._data[key])
         self._validate_combinations()
 
     def __getitem__(self, key: str) -> Any:  # pylint: disable=too-many-return-statements

--- a/packages/http-client-python/generator/pygen/__init__.py
+++ b/packages/http-client-python/generator/pygen/__init__.py
@@ -44,10 +44,9 @@ class OptionsDict(MutableMapping):
     }
 
     def __init__(self, options: Optional[dict[str, Any]] = None) -> None:
-        self._data = {}
-        if options:
-            for key, value in options.items():
-                self._data[key] = self._validate_and_transform(key, value)
+        self._data = options.copy() if options else {}
+        for key in list(self._data):
+          self._data[key] = self._validate_and_transform(key, self._data[key])
         self._validate_combinations()
 
     def __getitem__(self, key: str) -> Any:  # pylint: disable=too-many-return-statements

--- a/packages/http-client-python/generator/pygen/__init__.py
+++ b/packages/http-client-python/generator/pygen/__init__.py
@@ -44,7 +44,10 @@ class OptionsDict(MutableMapping):
     }
 
     def __init__(self, options: Optional[dict[str, Any]] = None) -> None:
-        self._data = options.copy() if options else {}
+        self._data = {}
+        if options:
+            for key, value in options.items():
+                self._data[key] = self._validate_and_transform(key, value)
         self._validate_combinations()
 
     def __getitem__(self, key: str) -> Any:  # pylint: disable=too-many-return-statements

--- a/packages/http-client-python/tests/unit/test_options_dict.py
+++ b/packages/http-client-python/tests/unit/test_options_dict.py
@@ -4,6 +4,8 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import pytest
+
 from pygen import OptionsDict
 
 
@@ -25,3 +27,26 @@ def test_constructor_and_setitem_agree():
     options["models-mode"] = "none"
     via_setitem = options["models-mode"]
     assert via_ctor == via_setitem
+
+
+def test_package_mode_validation_uses_from_typespec_from_constructor_any_order():
+    with pytest.raises(ValueError):
+        OptionsDict({"from-typespec": True, "package-mode": "dataplane", "package-version": "1.0.0"})
+
+    with pytest.raises(ValueError):
+        OptionsDict({"package-mode": "dataplane", "from-typespec": True, "package-version": "1.0.0"})
+
+
+def test_package_mode_typespec_value_succeeds_in_any_constructor_order():
+    assert (
+        OptionsDict({"from-typespec": True, "package-mode": "azure-dataplane", "package-version": "1.0.0"})[
+            "package-mode"
+        ]
+        == "azure-dataplane"
+    )
+    assert (
+        OptionsDict({"package-mode": "azure-dataplane", "from-typespec": True, "package-version": "1.0.0"})[
+            "package-mode"
+        ]
+        == "azure-dataplane"
+    )

--- a/packages/http-client-python/tests/unit/test_options_dict.py
+++ b/packages/http-client-python/tests/unit/test_options_dict.py
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from pygen import OptionsDict
+
+
+def test_models_mode_none_normalized_via_constructor():
+    # models-mode=none must be normalized to falsy False, even when passed
+    # through the constructor (not just __setitem__).
+    assert OptionsDict({"models-mode": "none"})["models-mode"] is False
+
+
+def test_models_mode_none_normalized_via_setitem():
+    options = OptionsDict()
+    options["models-mode"] = "none"
+    assert options["models-mode"] is False
+
+
+def test_constructor_and_setitem_agree():
+    via_ctor = OptionsDict({"models-mode": "none"})["models-mode"]
+    options = OptionsDict()
+    options["models-mode"] = "none"
+    via_setitem = options["models-mode"]
+    assert via_ctor == via_setitem


### PR DESCRIPTION
Fixes #11046  ----> No generated code diff

## Problem

Running the Python emitter with `--option "@azure-tools/typespec-python.models-mode=none"` crashes instead of producing a modelless client:

```
jinja2.exceptions.UndefinedError: 'pygen.codegen.serializers.model_serializer.MsrestModelSerializer object' has no attribute 'get_properties_to_declare'
```

## Root cause

`OptionsDict.__init__` stored constructor-supplied options directly (`self._data = options.copy()`), bypassing the `_validate_and_transform` step that `__setitem__` uses. That transform is what converts the string `"none"` into falsy `False`. Skipping it left `models-mode` as the truthy string `"none"`, so serialization wrongly entered the `_serialize_and_write_models_folder` path with `MsrestModelSerializer` (which has no `get_properties_to_declare`), crashing the render.

## Fix

Route constructor-supplied options through the same `_validate_and_transform` used by `__setitem__`, so both write paths agree and `models-mode=none` is honored.

## Tests

Added `tests/unit/test_options_dict.py` verifying `models-mode=none` normalizes to `False` via both the constructor and `__setitem__`.