### PR TITLE
fix(compiler): enable compiler feature flags for library code

### DIFF
--- a/.chronus/changes/fix-entrypoint-tspmain-2026-6-13.md
+++ b/.chronus/changes/fix-entrypoint-tspmain-2026-6-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix directory entrypoint resolution ignoring `package.json` `tspMain` when a `tspconfig.yaml` with `kind: project` is present but does not specify an `entrypoint`. The resolution order is now: explicit config `entrypoint`, then `package.json` `tspMain`, then `main.tsp`.

--- a/.chronus/changes/fix-library-feature-flags-2026-6-13.md
+++ b/.chronus/changes/fix-library-feature-flags-2026-6-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix compiler feature flags (e.g. `auto-decorators`) not being enablable for library code. A library can now opt into a feature via its own `tspconfig.yaml` `features`, enabling it only for that library's source files without requiring the consuming project to enable it.

--- a/.chronus/changes/fix-library-feature-flags-2026-6-13.md
+++ b/.chronus/changes/fix-library-feature-flags-2026-6-13.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/compiler"
 ---
 
-Fix compiler feature flags (e.g. `auto-decorators`) not being enablable for library code. A library can now opt into a feature via its own `tspconfig.yaml` `features`, enabling it only for that library's source files without requiring the consuming project to enable it.
+Fix compiler feature flags (e.g. `auto-decorators`) not being enabled for library code. A library can now opt into a feature via its own `tspconfig.yaml` `features`, enabling it only for that library's source files without requiring the consuming project to enable it.

--- a/packages/compiler/src/core/entrypoint-resolution.ts
+++ b/packages/compiler/src/core/entrypoint-resolution.ts
@@ -33,13 +33,14 @@ export async function resolveTypeSpecEntrypointForDir(
   dir: string,
   reportDiagnostic: DiagnosticHandler,
 ): Promise<string> {
-  // Check for project tspconfig first
+  // An explicit entrypoint in the project config takes precedence.
   const config = await loadTypeSpecConfigForPath(host, dir, false, false);
-  if (config.kind === "project") {
-    const entrypoint = config.entrypoint ?? "main.tsp";
-    return resolvePath(dir, entrypoint);
+  if (config.kind === "project" && config.entrypoint !== undefined) {
+    return resolvePath(dir, config.entrypoint);
   }
 
+  // Otherwise fall back to the `tspMain` declared in package.json. A `tspconfig.yaml`
+  // without an explicit `entrypoint` must not override `tspMain`.
   const pkgJsonPath = resolvePath(dir, "package.json");
   const [pkg] = await loadFile(host, pkgJsonPath, JSON.parse, reportDiagnostic, {
     allowFileNotFound: true,

--- a/packages/compiler/src/core/features.ts
+++ b/packages/compiler/src/core/features.ts
@@ -32,13 +32,22 @@ export function isCompilerFeatureEnabled(
   feature: CompilerFeatureName,
   target?: DiagnosticTarget,
 ): boolean {
-  if (!program.compilerOptions.configFile?.features?.includes(feature)) {
-    return false;
-  }
-
+  // Without a target, fall back to the root project config (e.g. global feature checks).
   if (target === undefined) {
-    return true;
+    return program.compilerOptions.configFile?.features?.includes(feature) ?? false;
   }
 
-  return getLocationContext(program, target).type === "project";
+  // Resolve the feature set from the package that owns the source file so that a library
+  // can enable a feature for its own code via its own `tspconfig.yaml`, independently of
+  // the consuming project's config.
+  const context = getLocationContext(program, target);
+  switch (context.type) {
+    case "project":
+      return program.compilerOptions.configFile?.features?.includes(feature) ?? false;
+    case "library":
+      return context.features?.includes(feature) ?? false;
+    default:
+      // compiler (standard library) and synthetic code are never gated.
+      return false;
+  }
 }

--- a/packages/compiler/src/core/source-loader.ts
+++ b/packages/compiler/src/core/source-loader.ts
@@ -1,3 +1,4 @@
+import { loadTypeSpecConfigForPath } from "../config/config-loader.js";
 import {
   ModuleResolutionResult,
   ResolvedModule,
@@ -96,6 +97,9 @@ export async function createSourceLoader(
   const jsSourceFiles = new Map<string, JsSourceFileNode>();
   const loadedLibraries = new Map<string, TypeSpecLibraryReference>();
   const externals: string[] = [];
+  // Cache of resolved feature lists from each library's own tspconfig.yaml, keyed by the
+  // library root directory, to avoid re-reading the config for every import of the library.
+  const libraryFeaturesCache = new Map<string, readonly string[] | undefined>();
 
   const externalsOpts = options?.externals;
   const isExternal = externalsOpts
@@ -280,9 +284,11 @@ export async function createSourceLoader(
       );
 
       const metadata = computeModuleMetadata(library);
+      const features = await resolveLibraryFeatures(library.path);
       locationContext = {
         type: "library",
         metadata,
+        ...(features && { features }),
       };
     }
 
@@ -356,6 +362,27 @@ export async function createSourceLoader(
       jsSourceFiles.set(path, file);
     }
     return file;
+  }
+
+  /**
+   * Resolve the compiler features a library opted into via its own `tspconfig.yaml`.
+   * Features are only honored when the library config is a project config (`kind: "project"`),
+   * matching the rule that `features` is only meaningful in a project config.
+   * @param libraryRoot Absolute path to the library root directory (containing `package.json`).
+   */
+  async function resolveLibraryFeatures(
+    libraryRoot: string,
+  ): Promise<readonly string[] | undefined> {
+    if (libraryFeaturesCache.has(libraryRoot)) {
+      return libraryFeaturesCache.get(libraryRoot);
+    }
+    // `lookup: false` restricts the search to the library root only, so we never pick up the
+    // consuming project's config by walking up the directory tree.
+    const config = await loadTypeSpecConfigForPath(host, libraryRoot, false, false);
+    const features =
+      config.diagnostics.length === 0 && config.kind === "project" ? config.features : undefined;
+    libraryFeaturesCache.set(libraryRoot, features);
+    return features;
   }
 }
 

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2093,6 +2093,13 @@ export interface LibraryLocationContext {
 
   /** Module definition */
   readonly flags?: PackageFlags;
+
+  /**
+   * Compiler features enabled for this library, as declared in the library's own
+   * `tspconfig.yaml` `features`. Used to gate experimental features (e.g. `auto-decorators`)
+   * for the library's own source files, independently of the consuming project's config.
+   */
+  readonly features?: readonly string[];
 }
 
 export interface LibraryInstance {

--- a/packages/compiler/test/checker/auto-decorator-library.test.ts
+++ b/packages/compiler/test/checker/auto-decorator-library.test.ts
@@ -1,0 +1,100 @@
+import { expect, it } from "vitest";
+import type { TypeSpecConfig } from "../../src/config/types.js";
+import type { CompilerOptions } from "../../src/core/options.js";
+import {
+  createTestHost,
+  expectDiagnostics,
+  resolveVirtualPath,
+  type TestHost,
+} from "../../src/testing/index.js";
+
+const libFeaturesConfig: TypeSpecConfig = {
+  projectRoot: resolveVirtualPath("node_modules/my-lib"),
+  kind: "project",
+  features: ["auto-decorators"],
+  diagnostics: [],
+  outputDir: "tsp-output",
+};
+
+/** Add a virtual `my-lib` library that declares an `auto` decorator. */
+function addAutoDecoratorLibrary(host: TestHost, config?: TypeSpecConfig) {
+  host.addTypeSpecFile(
+    resolveVirtualPath("node_modules/my-lib/package.json"),
+    JSON.stringify({ name: "my-lib", tspMain: "main.tsp", main: "main.tsp" }),
+  );
+  host.addTypeSpecFile(
+    resolveVirtualPath("node_modules/my-lib/main.tsp"),
+    `namespace MyLib;
+    auto dec myFlag(target: unknown);`,
+  );
+  if (config) {
+    host.addTypeSpecFile(
+      resolveVirtualPath("node_modules/my-lib/tspconfig.yaml"),
+      `kind: project
+features:
+${config.features?.map((f) => `  - ${f}`).join("\n") ?? ""}`,
+    );
+  }
+}
+
+/** Root project config enabling the given features for the consumer's own files. */
+function projectOptions(features: string[]): CompilerOptions {
+  return {
+    configFile: {
+      projectRoot: ".",
+      kind: "project",
+      features,
+      diagnostics: [],
+      outputDir: "tsp-output",
+    },
+  };
+}
+
+it("library can declare an auto decorator by enabling the feature in its own tspconfig.yaml", async () => {
+  const host = await createTestHost();
+  addAutoDecoratorLibrary(host, libFeaturesConfig);
+  host.addTypeSpecFile(
+    "main.tsp",
+    `import "my-lib";
+    using MyLib;
+    @myFlag model Foo {}`,
+  );
+
+  // Consumer does NOT enable the feature; it should still compile.
+  const diagnostics = await host.diagnose("main.tsp");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("library auto decorator still errors when the library does not enable the feature", async () => {
+  const host = await createTestHost();
+  addAutoDecoratorLibrary(host); // no tspconfig.yaml -> feature not enabled
+  host.addTypeSpecFile(
+    "main.tsp",
+    `import "my-lib";
+    using MyLib;
+    @myFlag model Foo {}`,
+  );
+
+  const diagnostics = await host.diagnose("main.tsp");
+  expectDiagnostics(diagnostics, {
+    code: "auto-decorator-disabled",
+  });
+});
+
+it("feature is scoped per package: enabling it in the consumer project does not enable it for library code", async () => {
+  const host = await createTestHost();
+  addAutoDecoratorLibrary(host); // library does not opt in
+  host.addTypeSpecFile(
+    "main.tsp",
+    `import "my-lib";
+    using MyLib;
+    @myFlag model Foo {}`,
+  );
+
+  // Consumer enables the feature in its own project config, but that must not
+  // enable the feature for the library's source files.
+  const diagnostics = await host.diagnose("main.tsp", projectOptions(["auto-decorators"]));
+  expectDiagnostics(diagnostics, {
+    code: "auto-decorator-disabled",
+  });
+});

--- a/packages/compiler/test/core/entrypoint-resolution.test.ts
+++ b/packages/compiler/test/core/entrypoint-resolution.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, expect, it } from "vitest";
+import { resolveTypeSpecEntrypointForDir } from "../../src/core/entrypoint-resolution.js";
+import type { CompilerHost } from "../../src/core/types.js";
+import {
+  createTestFileSystem,
+  resolveVirtualPath,
+  type TestFileSystem,
+} from "../../src/testing/index.js";
+
+let fs: TestFileSystem;
+let host: CompilerHost;
+
+beforeEach(async () => {
+  fs = await createTestFileSystem();
+  host = fs.compilerHost;
+});
+
+const dir = resolveVirtualPath("my-lib");
+
+it("uses package.json tspMain when there is no tspconfig.yaml", async () => {
+  fs.add("my-lib/package.json", JSON.stringify({ name: "my-lib", tspMain: "lib/main.tsp" }));
+  const entrypoint = await resolveTypeSpecEntrypointForDir(host, dir, () => {});
+  expect(entrypoint).toBe(resolveVirtualPath("my-lib/lib/main.tsp"));
+});
+
+it("uses package.json tspMain when tspconfig.yaml has no explicit entrypoint", async () => {
+  fs.add("my-lib/package.json", JSON.stringify({ name: "my-lib", tspMain: "lib/main.tsp" }));
+  fs.add("my-lib/tspconfig.yaml", `kind: project`);
+  const entrypoint = await resolveTypeSpecEntrypointForDir(host, dir, () => {});
+  expect(entrypoint).toBe(resolveVirtualPath("my-lib/lib/main.tsp"));
+});
+
+it("an explicit entrypoint in tspconfig.yaml takes precedence over package.json tspMain", async () => {
+  fs.add("my-lib/package.json", JSON.stringify({ name: "my-lib", tspMain: "lib/main.tsp" }));
+  fs.add("my-lib/tspconfig.yaml", `kind: project\nentrypoint: other.tsp`);
+  const entrypoint = await resolveTypeSpecEntrypointForDir(host, dir, () => {});
+  expect(entrypoint).toBe(resolveVirtualPath("my-lib/other.tsp"));
+});
+
+it("defaults to main.tsp when neither tspconfig entrypoint nor package.json tspMain is set", async () => {
+  fs.add("my-lib/package.json", JSON.stringify({ name: "my-lib" }));
+  fs.add("my-lib/tspconfig.yaml", `kind: project`);
+  const entrypoint = await resolveTypeSpecEntrypointForDir(host, dir, () => {});
+  expect(entrypoint).toBe(resolveVirtualPath("my-lib/main.tsp"));
+});


### PR DESCRIPTION
## Summary

Two related compiler fixes that make it possible for a **library** to opt into an experimental compiler feature (e.g. `auto-decorators`) via its own `tspconfig.yaml`.

## 1. Enable compiler feature flags for library code

`isCompilerFeatureEnabled` only read the single root project config and required `getLocationContext(...).type === "project"`, so library-owned files could **never** enable a feature — even when the consumer opted in. The library's own `tspconfig.yaml` was never consulted.

**Fix:** resolve feature enablement from the package that owns the source file:
- **project** files → root project config (unchanged)
- **library** files → the features declared in *that library's own* `tspconfig.yaml` (only when `kind: project`), carried on `LibraryLocationContext`
- **compiler / synthetic** → never gated

Changes: `core/features.ts`, `core/source-loader.ts`, `core/types.ts` + `test/checker/auto-decorator-library.test.ts`.

## 2. Respect `package.json` `tspMain` when tspconfig has no entrypoint

Adding a `tspconfig.yaml` with `kind: project` (as needed to opt into a feature) caused directory entrypoint resolution to force `main.tsp` and ignore `package.json` `tspMain`, breaking libraries whose entry is e.g. `lib/main.tsp`.

**Fix:** resolution order is now explicit config `entrypoint` → `package.json` `tspMain` → `main.tsp`.

Changes: `core/entrypoint-resolution.ts` + `test/core/entrypoint-resolution.test.ts`.

## Notes for library authors
For a published library, its `tspconfig.yaml` must be included in `package.json` `files`, otherwise the opt-in won't ship in the npm tarball.

## Validation
- Full compiler suite: 4014 passed / 6 skipped.
- tsc build + oxlint + cspell clean.