### PR TITLE
[http-client-csharp] Fix options-bag override convenience for renamed grouped query params

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1622,7 +1622,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         }
 
         [Test]
-        public async Task MethodParameterSegments_RenamedGroupedQueryParam_MapsByWireName()
+        public async Task MethodParameterSegments_RenamedGroupedQueryParam_MapsByClientName()
         {
             // Options-bag override where a grouped query property has a client name ("bandIndex")
             // that differs from its wire name ("band_index"), e.g. @query("band_index") bandIndex.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1622,6 +1622,66 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         }
 
         [Test]
+        public async Task MethodParameterSegments_RenamedGroupedQueryParam_MapsByWireName()
+        {
+            // Options-bag override where a grouped query property has a client name ("bidx")
+            // that differs from its wire name ("asset_bidx"), e.g. @query("asset_bidx") bidx.
+            // The convenience body must resolve the property by wire name; otherwise the emitter
+            // throws "Property with serialized name 'bidx' not found in model 'GetPointOptions'".
+            var optionsModel = InputFactory.Model(
+                "GetPointOptions",
+                properties:
+                [
+                    InputFactory.Property(
+                        "bidx",
+                        InputPrimitiveType.String,
+                        isRequired: false,
+                        isHttpMetadata: true,
+                        wireName: "asset_bidx"),
+                ]);
+
+            var collectionIdParam = InputFactory.PathParameter("collectionId", InputPrimitiveType.String, isRequired: true);
+            var bidxParam = InputFactory.QueryParameter("bidx", InputPrimitiveType.String, isRequired: false);
+            bidxParam.Update(methodParameterSegments:
+            [
+                InputFactory.MethodParameter("options", optionsModel, isRequired: true, location: InputRequestLocation.Query),
+                // Segments carry the client name ("bidx"); the property's wire name is "asset_bidx".
+                InputFactory.MethodParameter("bidx", InputPrimitiveType.String, isRequired: false),
+            ]);
+
+            var serviceMethod = InputFactory.BasicServiceMethod(
+                "GetPoint",
+                InputFactory.Operation(
+                    "GetPoint",
+                    parameters: [collectionIdParam, bidxParam],
+                    responses: [InputFactory.OperationResponse([200])]),
+                parameters:
+                [
+                    InputFactory.MethodParameter("collectionId", InputPrimitiveType.String, isRequired: true, location: InputRequestLocation.Path),
+                    InputFactory.MethodParameter("options", optionsModel, isRequired: true, location: InputRequestLocation.Query),
+                ]);
+
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+            await MockHelpers.LoadMockGeneratorAsync(clients: () => [inputClient], inputModels: () => [optionsModel]);
+
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+            Assert.IsNotNull(methodCollection);
+
+            var convenienceMethod = methodCollection.FirstOrDefault(m =>
+                m.Signature.Name == "GetPoint" &&
+                m.Signature.Parameters.Any(p => p.Type.Name == "CancellationToken"));
+            Assert.IsNotNull(convenienceMethod);
+
+            // Before the fix, building the body threw because the grouped query property was
+            // looked up by client name ("bidx") instead of wire name ("asset_bidx").
+            var methodBody = convenienceMethod!.BodyStatements!.ToDisplayString();
+            Assert.That(methodBody, Does.Contain(".Bidx"));
+        }
+
+        [Test]
         public async Task MethodParameterSegments_BodyParameterSerialization()
         {
             // Test scenario: Body parameter with MethodParameterSegments should be serialized

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1641,7 +1641,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
                 ]);
 
             var collectionIdParam = InputFactory.PathParameter("collectionId", InputPrimitiveType.String, isRequired: true);
-            var bandIndexParam = InputFactory.QueryParameter("bandIndex", InputPrimitiveType.String, isRequired: false);
+            var bandIndexParam = InputFactory.QueryParameter("bandIndex", InputPrimitiveType.String, isRequired: false, serializedName: "band_index");
             bandIndexParam.Update(methodParameterSegments:
             [
                 InputFactory.MethodParameter("options", optionsModel, isRequired: true, location: InputRequestLocation.Query),

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1679,7 +1679,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             // looked up only by wire name ("band_index") while the segment carried the client
             // name ("bandIndex").
             var methodBody = convenienceMethod!.BodyStatements!.ToDisplayString();
-            Assert.That(methodBody, Does.Contain(".BandIndex"));
+            Assert.AreEqual(Helpers.GetExpectedFromFile(), methodBody);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1624,36 +1624,36 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         [Test]
         public async Task MethodParameterSegments_RenamedGroupedQueryParam_MapsByWireName()
         {
-            // Options-bag override where a grouped query property has a client name ("bidx")
-            // that differs from its wire name ("asset_bidx"), e.g. @query("asset_bidx") bidx.
-            // The convenience body must resolve the property by wire name; otherwise the emitter
-            // throws "Property with serialized name 'bidx' not found in model 'GetPointOptions'".
+            // Options-bag override where a grouped query property has a client name ("bandIndex")
+            // that differs from its wire name ("band_index"), e.g. @query("band_index") bandIndex.
+            // The convenience body must still resolve the property; otherwise the emitter throws
+            // "Property with name 'bandIndex' not found in model 'GetPointOptions'".
             var optionsModel = InputFactory.Model(
                 "GetPointOptions",
                 properties:
                 [
                     InputFactory.Property(
-                        "bidx",
+                        "bandIndex",
                         InputPrimitiveType.String,
                         isRequired: false,
                         isHttpMetadata: true,
-                        wireName: "asset_bidx"),
+                        wireName: "band_index"),
                 ]);
 
             var collectionIdParam = InputFactory.PathParameter("collectionId", InputPrimitiveType.String, isRequired: true);
-            var bidxParam = InputFactory.QueryParameter("bidx", InputPrimitiveType.String, isRequired: false);
-            bidxParam.Update(methodParameterSegments:
+            var bandIndexParam = InputFactory.QueryParameter("bandIndex", InputPrimitiveType.String, isRequired: false);
+            bandIndexParam.Update(methodParameterSegments:
             [
                 InputFactory.MethodParameter("options", optionsModel, isRequired: true, location: InputRequestLocation.Query),
-                // Segments carry the client name ("bidx"); the property's wire name is "asset_bidx".
-                InputFactory.MethodParameter("bidx", InputPrimitiveType.String, isRequired: false),
+                // Segments carry the client name ("bandIndex"); the property's wire name is "band_index".
+                InputFactory.MethodParameter("bandIndex", InputPrimitiveType.String, isRequired: false),
             ]);
 
             var serviceMethod = InputFactory.BasicServiceMethod(
                 "GetPoint",
                 InputFactory.Operation(
                     "GetPoint",
-                    parameters: [collectionIdParam, bidxParam],
+                    parameters: [collectionIdParam, bandIndexParam],
                     responses: [InputFactory.OperationResponse([200])]),
                 parameters:
                 [
@@ -1676,9 +1676,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             Assert.IsNotNull(convenienceMethod);
 
             // Before the fix, building the body threw because the grouped query property was
-            // looked up by client name ("bidx") instead of wire name ("asset_bidx").
+            // looked up only by wire name ("band_index") while the segment carried the client
+            // name ("bandIndex").
             var methodBody = convenienceMethod!.BodyStatements!.ToDisplayString();
-            Assert.That(methodBody, Does.Contain(".Bidx"));
+            Assert.That(methodBody, Does.Contain(".BandIndex"));
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/MethodParameterSegments_RenamedGroupedQueryParam_MapsByClientName.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/MethodParameterSegments_RenamedGroupedQueryParam_MapsByClientName.cs
@@ -1,0 +1,4 @@
+global::Sample.Argument.AssertNotNullOrEmpty(collectionId, nameof(collectionId));
+global::Sample.Argument.AssertNotNull(options, nameof(options));
+
+return this.GetPoint(collectionId, options.BandIndex, cancellationToken.ToRequestOptions());

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
@@ -23,7 +23,7 @@ namespace Microsoft.TypeSpec.Generator.Snippets
 
         private static ValueExpression BuildPropertyAccessExpression(this ModelProvider model, ValueExpression modelVariable, IReadOnlyList<string> propertySegments)
         {
-            TypeProvider currentModel = model;
+            ModelProvider currentModel = model;
             ValueExpression propertyAccessExpression = modelVariable;
 
             for (int i = 0; i < propertySegments.Count; i++)
@@ -38,7 +38,7 @@ namespace Microsoft.TypeSpec.Generator.Snippets
                     {
                         propertyAccessExpression = propertyAccessExpression.NullConditional();
                     }
-                    currentModel = CodeModelGenerator.Instance.TypeFactory.CSharpTypeMap[property.Type]!;
+                    currentModel = (ModelProvider)CodeModelGenerator.Instance.TypeFactory.CSharpTypeMap[property.Type]!;
                 }
             }
 
@@ -50,10 +50,10 @@ namespace Microsoft.TypeSpec.Generator.Snippets
         /// property's serialized (wire) name or its client name. Method-parameter segments carry
         /// the client name, which can differ from the wire name (e.g. <c>@query("band_index") bandIndex</c>).
         /// </summary>
-        private static PropertyProvider FindPropertyInModelHierarchy(TypeProvider model, string segmentName)
+        private static PropertyProvider FindPropertyInModelHierarchy(ModelProvider model, string segmentName)
         {
             // Properties may only be populated on the canonical view at this stage.
-            var properties = (model as ModelProvider)?.CanonicalView.Properties ?? model.Properties;
+            var properties = model.CanonicalView.Properties;
 
             // Try to find the property by wire name, then by client name (segments carry the
             // camelCase client name; the C# property name is PascalCase).
@@ -66,9 +66,9 @@ namespace Microsoft.TypeSpec.Generator.Snippets
             }
 
             // If not found, search in the base model hierarchy
-            if (model is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
+            if (model.BaseModelProvider != null)
             {
-                return FindPropertyInModelHierarchy(modelProvider.BaseModelProvider, segmentName);
+                return FindPropertyInModelHierarchy(model.BaseModelProvider, segmentName);
             }
 
             // If not found anywhere, throw an exception with a helpful message

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
@@ -38,7 +38,8 @@ namespace Microsoft.TypeSpec.Generator.Snippets
                     {
                         propertyAccessExpression = propertyAccessExpression.NullConditional();
                     }
-                    currentModel = (ModelProvider)CodeModelGenerator.Instance.TypeFactory.CSharpTypeMap[property.Type]!;
+                    currentModel = CodeModelGenerator.Instance.TypeFactory.CSharpTypeMap[property.Type] as ModelProvider
+                        ?? throw new System.InvalidOperationException($"Cannot navigate the property path through '{property.Name}' because its type is not a model.");
                 }
             }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
@@ -46,12 +46,20 @@ namespace Microsoft.TypeSpec.Generator.Snippets
         }
 
         /// <summary>
-        /// Searches for a property with the specified serialized name in the model and its base models.
+        /// Searches for a property in the model and its base models by matching either the
+        /// property's serialized (wire) name or its client name. Method-parameter segments carry
+        /// the client name, which can differ from the wire name (e.g. <c>@query("asset_bidx") bidx</c>).
         /// </summary>
-        private static PropertyProvider FindPropertyInModelHierarchy(TypeProvider model, string serializedName)
+        private static PropertyProvider FindPropertyInModelHierarchy(TypeProvider model, string segmentName)
         {
-            // First, try to find the property in the current model
-            var property = model.Properties.FirstOrDefault(p => p.WireInfo?.SerializedName == serializedName);
+            // Properties may only be populated on the canonical view at this stage.
+            var properties = (model as ModelProvider)?.CanonicalView.Properties ?? model.Properties;
+
+            // Try to find the property by wire name, then by client name (segments carry the
+            // camelCase client name; the C# property name is PascalCase).
+            var property = properties.FirstOrDefault(p => p.WireInfo?.SerializedName == segmentName)
+                ?? properties.FirstOrDefault(p => p.InputProperty?.Name == segmentName)
+                ?? properties.FirstOrDefault(p => string.Equals(p.Name, segmentName, System.StringComparison.OrdinalIgnoreCase));
             if (property != null)
             {
                 return property;
@@ -60,12 +68,12 @@ namespace Microsoft.TypeSpec.Generator.Snippets
             // If not found, search in the base model hierarchy
             if (model is ModelProvider modelProvider && modelProvider.BaseModelProvider != null)
             {
-                return FindPropertyInModelHierarchy(modelProvider.BaseModelProvider, serializedName);
+                return FindPropertyInModelHierarchy(modelProvider.BaseModelProvider, segmentName);
             }
 
             // If not found anywhere, throw an exception with a helpful message
             throw new System.InvalidOperationException(
-                $"Property with serialized name '{serializedName}' not found in model '{model.Name}' or its base models.");
+                $"Property with name '{segmentName}' not found in model '{model.Name}' or its base models.");
         }
 
         private static bool NeedsNullableConditional(PropertyProvider property)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TypeSpec.Generator.Snippets
         /// <summary>
         /// Searches for a property in the model and its base models by matching either the
         /// property's serialized (wire) name or its client name. Method-parameter segments carry
-        /// the client name, which can differ from the wire name (e.g. <c>@query("asset_bidx") bidx</c>).
+        /// the client name, which can differ from the wire name (e.g. <c>@query("band_index") bandIndex</c>).
         /// </summary>
         private static PropertyProvider FindPropertyInModelHierarchy(TypeProvider model, string segmentName)
         {


### PR DESCRIPTION
## Problem

When an `@@override` groups operation parameters into an options-bag model, the generated convenience method delegates to the protocol method by reading each argument off the options model (`options.Foo`). The emitter walks the protocol parameter's `MethodParameterSegments` and looks the property up on the options `ModelProvider`.

That lookup (`ModelProviderSnippets.FindPropertyInModelHierarchy`) had two issues:

1. It searched `model.Properties`, which is empty at this point — the properties live on `CanonicalView.Properties`.
2. It matched only by `WireInfo.SerializedName`. The segments, however, carry the **client** name (from `SdkMethodParameter.name`), which differs from the wire name whenever the query parameter is renamed, e.g. `@query("asset_bidx") bidx`.

So generating an options-bag convenience for a renamed grouped query parameter throws and crashes the emitter:

```
Property with serialized name 'bidx' not found in model 'GetItemPointOptions' or its base models.
```

Stack:

```
ModelProviderSnippets.FindPropertyInModelHierarchy
ModelProviderSnippets.BuildPropertyAccessExpression
ScmMethodProviderCollection.GetProtocolMethodArguments
ScmMethodProviderCollection.BuildConvenienceMethod
```

## Fix

`FindPropertyInModelHierarchy` now:

- searches `CanonicalView.Properties` (falling back to `Properties`), and
- matches by wire name, then client (input) name, then case-insensitively by the C# property name.

This mirrors the existing paging property-path navigation, which already resolves segments against `SerializedName`. When client name == wire name (the case that already worked) behavior is unchanged.

## Tests

- New regression test `MethodParameterSegments_RenamedGroupedQueryParam_MapsByWireName` — reproduces the crash without the fix, passes with it.
- Full `Microsoft.TypeSpec.Generator.ClientModel` (1459) and `Microsoft.TypeSpec.Generator` (1587) suites pass.
