### PR TITLE
fix(csharp): prevent plugin build output deadlock

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/StartUp/GeneratorHandler.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Microsoft.TypeSpec.Generator.Utilities;
@@ -308,9 +309,7 @@ namespace Microsoft.TypeSpec.Generator
             // Read both streams to avoid deadlocks. 'dotnet build' writes build/compiler
             // errors to standard output rather than standard error, so we include both when
             // reporting a failure.
-            var stdout = process.StandardOutput.ReadToEnd();
-            var stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
+            var (stdout, stderr) = ReadProcessOutput(process);
 
             if (process.ExitCode != 0)
             {
@@ -336,6 +335,15 @@ namespace Microsoft.TypeSpec.Generator
 
             emitter.Info($"Warning: Build succeeded but could not locate the output DLL for '{csprojPath}'");
             return null;
+        }
+
+        internal static (string StandardOutput, string StandardError) ReadProcessOutput(Process process)
+        {
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            process.WaitForExit();
+            Task.WaitAll(stdoutTask, stderrTask);
+            return (stdoutTask.Result, stderrTask.Result);
         }
 
         /// <summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/StartUp/GeneratorHandlerTests.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Moq;
 using NUnit.Framework;
@@ -219,6 +221,76 @@ namespace TestPlugin
                 // The plugin is built into a process-isolated directory, not under the project.
                 StringAssert.DoesNotContain(testDir, result,
                     "Plugin output should be redirected to an isolated directory, not the project directory");
+            }
+            finally
+            {
+                try { Directory.Delete(testDir, true); } catch { }
+            }
+        }
+
+        [Test]
+        public void ReadProcessOutput_DrainsStandardOutputAndErrorConcurrently()
+        {
+            var testDir = Path.Combine(Path.GetTempPath(), "typespec-test-process-output-" + Guid.NewGuid().ToString("N")[..8]);
+            try
+            {
+                Directory.CreateDirectory(testDir);
+                var projectPath = Path.Combine(testDir, "OutputFlood.csproj");
+                File.WriteAllText(projectPath, """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <TargetFramework>net10.0</TargetFramework>
+                      </PropertyGroup>
+                    </Project>
+                    """);
+                File.WriteAllText(Path.Combine(testDir, "Program.cs"), """
+                    using System;
+
+                    Console.Error.Write(new string('e', 1_000_000));
+                    Console.Out.Write("stdout");
+                    """);
+
+                using var buildProcess = Process.Start(new ProcessStartInfo("dotnet")
+                {
+                    UseShellExecute = false,
+                    ArgumentList =
+                    {
+                        "build",
+                        projectPath,
+                        "-c",
+                        "Release",
+                        "--nologo",
+                        "--verbosity",
+                        "quiet"
+                    }
+                });
+                Assert.IsNotNull(buildProcess);
+                buildProcess!.WaitForExit();
+                Assert.AreEqual(0, buildProcess.ExitCode);
+
+                using var process = Process.Start(new ProcessStartInfo("dotnet")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    ArgumentList =
+                    {
+                        Path.Combine(testDir, "bin", "Release", "net10.0", "OutputFlood.dll")
+                    }
+                });
+                Assert.IsNotNull(process);
+
+                var readTask = Task.Run(() => GeneratorHandler.ReadProcessOutput(process!));
+                if (!readTask.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    process!.Kill(entireProcessTree: true);
+                    Assert.Fail("Reading redirected output deadlocked when stderr filled its pipe before stdout closed.");
+                }
+
+                var (stdout, stderr) = readTask.Result;
+                Assert.AreEqual("stdout", stdout);
+                Assert.AreEqual(1_000_000, stderr.Length);
             }
             finally
             {
@@ -888,4 +960,3 @@ namespace Isolated { public class Dummy { } }");
         }
     }
 }
-


### PR DESCRIPTION
## Summary

- drain plugin-build stdout and stderr concurrently to prevent redirected pipe deadlocks
- add a deterministic regression that fills stderr before writing stdout

## Validation

- `npm run build`
- `npm run cop`
- `dotnet test ./generator/Microsoft.TypeSpec.Generator/test/Microsoft.TypeSpec.Generator.Tests.csproj --filter FullyQualifiedName~GeneratorHandlerTests`

No changelog entry is required for the C# emitter package.