### PR TITLE
fix(http-client-csharp): preserve serialization owner accessibility

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/ReferenceMap/ProviderReferenceMapAnalyzer.Helpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/ReferenceMap/ProviderReferenceMapAnalyzer.Helpers.cs
@@ -874,6 +874,11 @@ namespace Microsoft.TypeSpec.Generator
             var nonInternalDeclarations = new HashSet<string>(StringComparer.Ordinal);
             foreach (var provider in GetGeneratedProviders(providers))
             {
+                if (provider.SerializationProviderOwner != null)
+                {
+                    continue;
+                }
+
                 if (provider.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Internal))
                 {
                     AddTypeReference(declarations, provider.Type, generatedTypeNames);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/ReferenceMap/ProviderReferenceMapAnalyzerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/ReferenceMap/ProviderReferenceMapAnalyzerTests.cs
@@ -1098,6 +1098,31 @@ namespace Microsoft.TypeSpec.Generator.Tests.ReferenceMap
         }
 
         [Test]
+        public void PublicSerializationPartialDoesNotPublicizeInternalOwner()
+        {
+            var model = new GeneratedModelTestTypeProvider(
+                "InternalModel",
+                TypeSignatureModifiers.Internal,
+                ns: "Sample.Models");
+            var serialization = new TestTypeProvider(
+                "InternalModel",
+                TypeSignatureModifiers.Public,
+                ns: "Sample.Models");
+            model.Update(serializations: [serialization]);
+            MockHelpers.LoadMockGenerator(
+                createOutputLibrary: () => new TestOutputLibrary(model),
+                configuration: "{\"unreferenced-types-handling\":\"removeOrInternalize\"}");
+            CodeModelGenerator.Instance.AddTypeToKeep(model.Type.FullyQualifiedName);
+
+            ProviderReferenceMapAnalyzer.ApplyPreWriteAccessibility([model]);
+
+            Assert.IsTrue(model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Internal));
+            Assert.IsFalse(model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public));
+            Assert.IsTrue(serialization.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Internal));
+            Assert.IsFalse(serialization.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public));
+        }
+
+        [Test]
         public void InternalizedGenericModelRemovesAritylessModelFactoryMethod()
         {
             var genericArgument = CreateNamedType("T", string.Empty);


### PR DESCRIPTION
## Summary

- preserve the owning model's declared accessibility when it has serialization partial providers
- prevent public-default serialization partials from publicizing internal generated models
- add a regression test covering an internal owner with a public serialization partial

## Context

Azure/azure-sdk-for-net#61069 regenerates `Azure.AI.Projects.Agents` with public `InternalComparisonFilter` and `InternalCompoundFilter` classes that expose internal enum types, causing CS0051 and CS0053 across all target frameworks. Serialization partial providers were participating in declared-accessibility detection even though their owner is authoritative.

## Validation

- `dotnet test packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Microsoft.TypeSpec.Generator.Tests.csproj --filter FullyQualifiedName~ProviderReferenceMapAnalyzerTests` (53 passed)
- `npm run cop`
- `npm run build`