### PR TITLE
Enable QueryTests dollar-sign test for http-client-java

### DIFF
--- a/.chronus/changes/http-client-java-enable-query-dollarsign-2026-7-20-16-28-0.md
+++ b/.chronus/changes/http-client-java-enable-query-dollarsign-2026-7-20-16-28-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-java"
+---
+
+Enable the `parameters.query.QueryTests` dollar-sign test in the clientcore test module now that the `@typespec/http-specs` dollar-sign route fix is published.

--- a/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/parameters/query/QueryTests.java
+++ b/packages/http-client-java/generator/http-client-generator-clientcore-test/src/test/java/parameters/query/QueryTests.java
@@ -3,7 +3,6 @@
 
 package parameters.query;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class QueryTests {
@@ -17,7 +16,6 @@ public class QueryTests {
     }
 
     @Test
-    @Disabled("Blocked until @typespec/http-specs publishes the dollar-sign route fix")
     public void testDollarSign() {
         specialCharClient.dollarSign("status eq 'active'");
     }


### PR DESCRIPTION
## Summary

The `parameters.query.QueryTests#testDollarSign` test in `http-client-generator-clientcore-test` was disabled pending the `@typespec/http-specs` dollar-sign route fix. That fix is now published (http-specs `0.1.0-alpha.38`), and the already-generated `SpecialCharClient.dollarSign` code matches the current spec (route `/parameters/query/special-char/dollar-sign`, `@QueryParam("$filter")`).

This PR removes the `@Disabled` annotation (and its now-unused import) to enable the test.

## Validation

`mvn test -Dtest=parameters.query.QueryTests` against the spector mock server: **2 run, 0 failures, 0 skipped**.