### PR TITLE
refactor(compiler): remove unused runScript backupPath fallback

### DIFF
--- a/.chronus/changes/runner-remove-backup-path-2026-7-20-13-30-0.md
+++ b/.chronus/changes/runner-remove-backup-path-2026-7-20-13-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/compiler"
+---
+
+Remove the unused `backupPath` fallback argument from the internal `runScript` helper

--- a/packages/compiler/cmd/tsp-server.js
+++ b/packages/compiler/cmd/tsp-server.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 import { runScript } from "../dist/src/runner.js";
-await runScript("entrypoints/server.js", "dist/server/server.js");
+await runScript("entrypoints/server.js");

--- a/packages/compiler/cmd/tsp.js
+++ b/packages/compiler/cmd/tsp.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 import { runScript } from "../dist/src/runner.js";
-await runScript("entrypoints/cli.js", "dist/core/cli/cli.js");
+await runScript("entrypoints/cli.js");

--- a/packages/compiler/src/runner.ts
+++ b/packages/compiler/src/runner.ts
@@ -1,4 +1,4 @@
-import { access, readFile, realpath, stat } from "fs/promises";
+import { readFile, realpath, stat } from "fs/promises";
 import { join, resolve } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { ResolveModuleHost, resolveModule } from "./module-resolver/index.js";
@@ -10,14 +10,11 @@ import { ResolveModuleHost, resolveModule } from "./module-resolver/index.js";
  * Prevents loading two conflicting copies of TypeSpec modules from global and
  * local package locations.
  */
-export async function runScript(relativePath: string, backupPath: string): Promise<void> {
+export async function runScript(relativePath: string): Promise<void> {
   const packageRoot = await resolvePackageRoot();
 
   if (packageRoot) {
-    let script = join(packageRoot, relativePath);
-    if (!(await checkFileExists(script)) && backupPath) {
-      script = join(packageRoot, backupPath);
-    }
+    const script = join(packageRoot, relativePath);
     const scriptUrl = pathToFileURL(script).toString();
     await import(scriptUrl);
   } else {
@@ -25,12 +22,6 @@ export async function runScript(relativePath: string, backupPath: string): Promi
       "Couldn't resolve TypeSpec compiler root. This is unexpected. Please file an issue at https://github.com/microsoft/typespec.",
     );
   }
-}
-
-function checkFileExists(file: string) {
-  return access(file)
-    .then(() => true)
-    .catch(() => false);
 }
 
 async function resolvePackageRoot(): Promise<string> {


### PR DESCRIPTION
## Summary

Removes the unused `backupPath` fallback argument from the internal `runScript` helper (`packages/compiler/src/runner.ts`) and its two callers.

`runScript(relativePath, backupPath)` used to fall back to `backupPath` when `relativePath` did not exist under the resolved package root. Both call sites (`cmd/tsp.js`, `cmd/tsp-server.js`) always pass a `relativePath` that exists, so the fallback (and its `checkFileExists` helper + `access` import) is dead code.

This is a pure, self-contained cleanup extracted out of #11299 (standalone SEA rewrite) so that PR stays focused on the feature. The standalone CLI does not use `runScript`.

## History / why it is safe to remove

The `backupPath` fallback was added in #1410 and shipped in `@cadl-lang/compiler` **0.38.2** (Dec 2022) as a patch: _"Revert breaking change to global cli usage."_

That PR introduced the stable indirection entrypoints `entrypoints/cli.js` and `entrypoints/server.js`. Before 0.38.2 the global CLI booted the compiler directly at `dist/core/cli/cli.js` (and `dist/server/server.js`). Because a **globally-installed** CLI resolves and runs the **locally-installed** compiler, a global 0.38.2 CLI could hit an older local compiler that did not yet have the `entrypoints/` files. The `backupPath` (`dist/core/cli/cli.js` / `dist/server/server.js`) was the fallback so the global CLI could still boot those pre-0.38.2 local installs.

Every supported compiler version has shipped `entrypoints/cli.js` / `entrypoints/server.js` since 0.38.2, so the fallback branch is now unreachable dead code.

## Changes
- `runner.ts`: `runScript(relativePath)` — dropped `backupPath` param, `checkFileExists`, and the now-unused `access` import.
- `cmd/tsp.js` / `cmd/tsp-server.js`: drop the second argument.

## Validation
- `tsc -p packages/compiler/tsconfig.build.json` passes.