### PR TITLE
perf: optimize linter event emission and diagnostic reporting

### DIFF
--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -252,15 +252,15 @@ export function createLinterRuleContext<N extends string, DM extends DiagnosticM
   }
 
   function reportDiagnostic<M extends keyof DM>(diag: LinterRuleDiagnosticReport<DM, M>): void {
-    const diagnostic = createDiagnostic(diag);
-    if (diagnostic.target !== NoTarget) {
-      const context = getLocationContext(program, diagnostic.target);
+    if (diag.target !== NoTarget) {
+      const context = getLocationContext(program, diag.target);
       // Only report diagnostic in the user project.
       // See for showing diagnostic in library at point of usage https://github.com/microsoft/typespec/issues/1997
-      if (context.type === "project") {
-        diagnosticCollector.add(diagnostic);
+      if (context.type !== "project") {
+        return;
       }
     }
+    diagnosticCollector.add(createDiagnostic(diag));
   }
 }
 

--- a/packages/compiler/src/core/semantic-walker.ts
+++ b/packages/compiler/src/core/semantic-walker.ts
@@ -485,16 +485,19 @@ export class EventEmitter<T extends { [key: string]: (...args: any) => any }> {
 
   /**
    * Emit an event with a single argument (optimized hot path avoiding spread).
-   * Returns the first non-undefined ListenerFlow value from any listener.
+   * Calls all listeners and returns ListenerFlow.NoRecursion if any listener returns it.
    */
   public emitOne<K extends keyof T>(name: K, arg: any): any {
     const listeners = this.listeners.get(name);
     if (listeners) {
-      let result: any;
+      let flow: any;
       for (let i = 0; i < listeners.length; i++) {
-        result = listeners[i](arg);
-        if (result !== undefined) return result;
+        const result = listeners[i](arg);
+        if (result !== undefined) {
+          flow = result;
+        }
       }
+      return flow;
     }
     return undefined;
   }

--- a/packages/compiler/src/core/semantic-walker.ts
+++ b/packages/compiler/src/core/semantic-walker.ts
@@ -116,6 +116,8 @@ export function navigateTypesInNamespace(
 
 /**
  * Create a Semantic node listener from an event emitter.
+ * Only creates handlers for events that have registered listeners,
+ * allowing the navigation context to skip unlistened events via optional chaining.
  * @param eventEmitter Event emitter.
  * @returns Semantic node listener.
  */
@@ -124,9 +126,11 @@ export function mapEventEmitterToNodeListener(
 ): SemanticNodeListener {
   const listener: SemanticNodeListener = {};
   for (const eventName of eventNames) {
-    listener[eventName] = (...args) => {
-      eventEmitter.emit(eventName, ...(args as [any]));
-    };
+    if (eventEmitter.hasListeners(eventName)) {
+      listener[eventName] = (arg: any) => {
+        return eventEmitter.emitOne(eventName, arg);
+      };
+    }
   }
 
   return listener;
@@ -148,7 +152,7 @@ function createNavigationContext(
 ): NavigationContext {
   return {
     visited: new Set(),
-    emit: (key, ...args) => (listeners as any)[key]?.(...(args as [any])),
+    emit: (key, arg) => (listeners as any)[key]?.(arg),
     options: computeOptions(options),
   };
 }
@@ -164,7 +168,7 @@ interface NavigationContext<
 > {
   options: ResolvedNavigationOptions;
   visited: Set<Type>;
-  emit<K extends keyof T>(name: K, ...args: Parameters<T[K]>): ListenerFlow | undefined | void;
+  emit<K extends keyof T>(name: K, arg: Parameters<T[K]>[0]): ListenerFlow | undefined | void;
 }
 
 function navigateNamespaceType(namespace: Namespace, context: NavigationContext) {
@@ -464,13 +468,35 @@ export class EventEmitter<T extends { [key: string]: (...args: any) => any }> {
     }
   }
 
+  /** Check if any listeners are registered for the given event. */
+  public hasListeners<K extends keyof T>(name: K): boolean {
+    const listeners = this.listeners.get(name);
+    return listeners !== undefined && listeners.length > 0;
+  }
+
   public emit<K extends keyof T>(name: K, ...args: Parameters<T[K]>) {
     const listeners = this.listeners.get(name);
     if (listeners) {
-      for (const listener of listeners) {
-        listener(...(args as any));
+      for (let i = 0; i < listeners.length; i++) {
+        listeners[i](...(args as any));
       }
     }
+  }
+
+  /**
+   * Emit an event with a single argument (optimized hot path avoiding spread).
+   * Returns the first non-undefined ListenerFlow value from any listener.
+   */
+  public emitOne<K extends keyof T>(name: K, arg: any): any {
+    const listeners = this.listeners.get(name);
+    if (listeners) {
+      let result: any;
+      for (let i = 0; i < listeners.length; i++) {
+        result = listeners[i](arg);
+        if (result !== undefined) return result;
+      }
+    }
+    return undefined;
   }
 }
 


### PR DESCRIPTION
Feedback from teams working on large TypeSpec conversions (e.g. ARM specs) indicates that linter delays can be long enough that authors give up waiting for results. As we plan to add more rules, this will get worse. This PR targets the hot path in the linter's AST traversal with low-risk, surgical optimizations.

## Approach

The linter works by registering rule listeners on an `EventEmitter`, then doing a single-pass AST traversal via `navigateProgram` that emits events at each node. With 60+ rules enabled across Azure rulesets and thousands of types in a large spec, the per-node overhead adds up.

**1. Skip unlistened events entirely** -- `mapEventEmitterToNodeListener` now only creates handler functions for events that have registered listeners. Most rules listen to only 2-3 of 30+ event types, so ~90% of events short-circuit via optional chaining (`?.`) in the navigation context instead of calling into an empty handler.

**2. Eliminate rest/spread overhead** -- All `SemanticNodeListener` callbacks take a single argument, but the emit path previously used `...args` rest parameters and `...(args as [any])` spread on every node visit. Replaced with direct single-arg calls and a new `emitOne()` method on `EventEmitter`.

**3. Use indexed loops** -- `EventEmitter.emit` now uses `for (let i = ...)` instead of `for...of`, avoiding iterator protocol overhead in the hot loop.

**4. Defer diagnostic message formatting** -- `reportDiagnostic` now checks `getLocationContext` before calling `createDiagnostic`. Previously it formatted the full message string (including `paramMessage` interpolation) then discarded the result for library types. Since the linter only reports diagnostics for project files, this avoids wasted string formatting for all library-sourced types.

## Notes

- `emitOne` calls all listeners before returning a `ListenerFlow` value, ensuring multiple rules listening to the same event type all process the node before the walker decides whether to recurse into children.
- The `EventEmitter.hasListeners` method is new public API on the class, used by `mapEventEmitterToNodeListener` at setup time (not on the hot path).
- These changes are purely in the compiler core; no rule implementations are modified.