### PR TITLE
fix(eng): skip generating empty external-reviewers policy when no external owners

### DIFF
--- a/eng/common/scripts/labels/automation.ts
+++ b/eng/common/scripts/labels/automation.ts
@@ -1,6 +1,6 @@
 import { resolve } from "path";
 import { stringify } from "yaml";
-import { CheckOptions, syncFile } from "../utils/common.js";
+import { CheckOptions, removeFile, syncFile } from "../utils/common.js";
 import { expandFolder } from "../utils/find-area-changed.js";
 import {
   PolicyServiceConfig,
@@ -26,11 +26,15 @@ export interface SyncLabelAutomationOptions extends CheckOptions {}
 export async function syncLabelAutomation(config: RepoConfig, options: SyncLabelAutomationOptions) {
   await syncPolicyFile(createIssueTriageConfig(config), options);
   await syncPolicyFile(createPrTriageConfig(config), options);
-  await syncPolicyFile(
-    createExternalReviewersConfig(config),
-    options,
-    collectExternalOwners(config),
-  );
+
+  const externalOwners = collectExternalOwners(config);
+  if (externalOwners.length > 0) {
+    await syncPolicyFile(createExternalReviewersConfig(config), options, externalOwners);
+  } else {
+    // No external owners to ping means the policy would have no tasks, so avoid
+    // emitting an empty generated file (and remove any stale one).
+    await removeFile(resolve(policyFolder, "prs.external-reviewers.generated.yml"), options);
+  }
 }
 
 async function syncPolicyFile(

--- a/eng/common/scripts/utils/common.ts
+++ b/eng/common/scripts/utils/common.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from "fs/promises";
+import { existsSync } from "fs";
+import { readFile, rm, writeFile } from "fs/promises";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -25,5 +26,16 @@ export async function syncFile(filename: string, newContent: string, options: Ch
     }
   } else {
     await writeFile(filename, newContent);
+  }
+}
+
+export async function removeFile(filename: string, options: CheckOptions) {
+  if (!existsSync(filename)) {
+    console.log(`${filename} is correctly absent.`);
+  } else if (options.check) {
+    console.error(`${filename} should not exist, run pnpm sync-labels to remove it`);
+    process.exit(1);
+  } else {
+    await rm(filename);
   }
 }


### PR DESCRIPTION
## Problem

The `sync-labels` script always writes `.github/policies/prs.external-reviewers.generated.yml`, even when a repo has no `externalOwners` configured. This produces a taskless, effectively-empty policy file that downstream repos (e.g. `typespec-azure`, whose `externalOwners` is `{}`) then have to `.gitignore` because it has no useful content and cannot be meaningfully committed.

## Change

- `syncLabelAutomation` now only generates the external-reviewers policy when there is at least one external owner.
- When there are no external owners, any stale generated file is removed (and in `--check` mode the script errors if one still exists), via a new `removeFile` helper in `utils/common.ts`.

Repos that do configure `externalOwners` (like this one) are unaffected — the file continues to be generated as before.

## Verification

Ran `sync-labels` across all code paths:
- External owners present → file generated ✅
- No external owners, stale file present → removed (write mode) ✅
- No external owners, file absent → "correctly absent", passes ✅
- No external owners, stale file + `--check` → exits 1 with an actionable message ✅
