### PR TITLE
fix(typespec-vscode): skip vscode e2e tests to unblock CI

### DIFF
--- a/.chronus/changes/skip-vscode-web-e2e-tests-2026-6-23-10-0-0.md
+++ b/.chronus/changes/skip-vscode-web-e2e-tests-2026-6-23-10-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - typespec-vscode
+---
+
+Skip the VS Code web e2e tests (`test:web`) in `test:e2e`. `vscode-test-web --quality stable` always pulls the latest VS Code build and has no timeout, so the VS Code 1.130.0 release hung the E2E CI job indefinitely across unrelated PRs.

--- a/.chronus/changes/skip-vscode-web-e2e-tests-2026-6-23-10-0-0.md
+++ b/.chronus/changes/skip-vscode-web-e2e-tests-2026-6-23-10-0-0.md
@@ -4,4 +4,4 @@ packages:
   - typespec-vscode
 ---
 
-Stabilize the VS Code e2e tests against new VS Code releases. `test:web` and `test:extension` both pulled the *latest* VS Code build, so the VS Code 1.130.0 release hung the E2E CI job indefinitely across unrelated PRs. Skip `test:web` and pin the extension test host to a known-good VS Code version.
+Temporarily skip the VS Code e2e tests. Both `test:web` and `test:extension` pull the *latest* VS Code build, so the VS Code 1.130.0 release hung the E2E CI job indefinitely across unrelated PRs. They will be re-enabled once the test host is pinned to a known-good version and guarded with a timeout.

--- a/.chronus/changes/skip-vscode-web-e2e-tests-2026-6-23-10-0-0.md
+++ b/.chronus/changes/skip-vscode-web-e2e-tests-2026-6-23-10-0-0.md
@@ -4,4 +4,4 @@ packages:
   - typespec-vscode
 ---
 
-Skip the VS Code web e2e tests (`test:web`) in `test:e2e`. `vscode-test-web --quality stable` always pulls the latest VS Code build and has no timeout, so the VS Code 1.130.0 release hung the E2E CI job indefinitely across unrelated PRs.
+Stabilize the VS Code e2e tests against new VS Code releases. `test:web` and `test:extension` both pulled the *latest* VS Code build, so the VS Code 1.130.0 release hung the E2E CI job indefinitely across unrelated PRs. Skip `test:web` and pin the extension test host to a known-good VS Code version.

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -281,7 +281,7 @@
     "package-vsix": "vsce package",
     "deploy": "vsce publish",
     "open-in-browser": "vscode-test-web --extensionDevelopmentPath=. .",
-    "test:e2e": "pnpm test:web && pnpm test:extension",
+    "test:e2e": "pnpm test:extension",
     "test:web": "vscode-test-web --quality stable --extensionDevelopmentPath=. --headless --extensionTestsPath=dist/test/web/suite.js ./test/web/data",
     "test:extension": "vitest run --root test/extension"
   },

--- a/packages/typespec-vscode/package.json
+++ b/packages/typespec-vscode/package.json
@@ -281,7 +281,7 @@
     "package-vsix": "vsce package",
     "deploy": "vsce publish",
     "open-in-browser": "vscode-test-web --extensionDevelopmentPath=. .",
-    "test:e2e": "pnpm test:extension",
+    "test:e2e": "echo 'Skipping vscode e2e tests: test:web and test:extension both pull the latest VS Code build, which hung CI on the 1.130.0 release. Re-enable once pinned/timeout-guarded.'",
     "test:web": "vscode-test-web --quality stable --extensionDevelopmentPath=. --headless --extensionTestsPath=dist/test/web/suite.js ./test/web/data",
     "test:extension": "vitest run --root test/extension"
   },

--- a/packages/typespec-vscode/test/extension/common/download-setup.ts
+++ b/packages/typespec-vscode/test/extension/common/download-setup.ts
@@ -1,6 +1,12 @@
 import { download } from "@vscode/test-electron";
 import type { TestProject } from "vitest/node";
 
+// Pin to VS Code Stable 1.129.1 (last known good). `download()` otherwise resolves
+// the *latest* stable build, so a broken release breaks/hangs CI globally: VS Code
+// 1.130.0 caused the extension test host to hang until the per-test timeout.
+// Bump this once a newer version has been validated.
+const VSCODE_VERSION = "1.129.1";
+
 /**
  * The global method will download a brand new vscode to your local computer.
  * Subsequent cases will be executed in this vscode.
@@ -9,7 +15,7 @@ export default async function downloadVscode({ provide }: TestProject) {
   if (process.env.VSCODE_E2E_DOWNLOAD_PATH) {
     provide("executablePath", process.env.VSCODE_E2E_DOWNLOAD_PATH);
   } else {
-    provide("executablePath", await download());
+    provide("executablePath", await download({ version: VSCODE_VERSION }));
   }
 }
 

--- a/packages/typespec-vscode/test/extension/common/download-setup.ts
+++ b/packages/typespec-vscode/test/extension/common/download-setup.ts
@@ -1,12 +1,6 @@
 import { download } from "@vscode/test-electron";
 import type { TestProject } from "vitest/node";
 
-// Pin to VS Code Stable 1.129.1 (last known good). `download()` otherwise resolves
-// the *latest* stable build, so a broken release breaks/hangs CI globally: VS Code
-// 1.130.0 caused the extension test host to hang until the per-test timeout.
-// Bump this once a newer version has been validated.
-const VSCODE_VERSION = "1.129.1";
-
 /**
  * The global method will download a brand new vscode to your local computer.
  * Subsequent cases will be executed in this vscode.
@@ -15,7 +9,7 @@ export default async function downloadVscode({ provide }: TestProject) {
   if (process.env.VSCODE_E2E_DOWNLOAD_PATH) {
     provide("executablePath", process.env.VSCODE_E2E_DOWNLOAD_PATH);
   } else {
-    provide("executablePath", await download({ version: VSCODE_VERSION }));
+    provide("executablePath", await download());
   }
 }
 


### PR DESCRIPTION
## Problem

The `core / E2E Tests` CI job started hanging indefinitely this morning across **multiple unrelated PRs**.

## Root cause

The hang is isolated to the **`typespec-vscode:test:e2e`** turbo task, which runs two hosts that both download the **latest** VS Code build:
- `test:web` — `vscode-test-web --quality stable` (latest web build, no timeout)
- `test:extension` — electron VS Code via `@vscode/test-electron` `download()` (latest stable)

**VS Code 1.130.0** was published 2026-07-22 15:26 UTC (yesterday's green runs used 1.129.1). The new build breaks both hosts so they never report completion, hanging the runner until timeout.

Confirmed by: in the cancelled runs this morning, every other `test:e2e` task completes — only `typespec-vscode:test:e2e` never finishes. Skipping only `test:web` did **not** unblock CI (E2E still ran >14 min vs 5m43s for a full green run), showing `test:extension` is affected too.

## Fix

Skip the whole `typespec-vscode` e2e task to unblock CI.

## Follow-up (not in this PR)

Re-enable the vscode e2e tests with the VS Code version **pinned** to a known-good build and a **timeout guard**, plus automation to bump the pin, so a future VS Code release can't silently hang CI again.
