### PR TITLE
[python-integration] Build mock specs from source to fix client/mock skew

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -67,12 +67,15 @@ jobs:
       - name: Build
         run: pnpm turbo run --filter "@azure-tools/typespec-python..." build
 
-      - name: Use pinned http-specs versions
-        run: |
-          rm -rf core/packages/http-specs/dist
-          cp -r core/packages/http-client-python/node_modules/@typespec/http-specs/dist core/packages/http-specs/dist
-          rm -rf packages/azure-http-specs/dist
-          cp -r core/packages/http-client-python/node_modules/@azure-tools/azure-http-specs/dist packages/azure-http-specs/dist
+      - name: Build http-specs and azure-http-specs from source
+        # Build the mock servers from the checked-out typespec-azure (+ PR core)
+        # source, so the mock stays in lockstep with the client that is
+        # regenerated from the same source below. Previously these build outputs
+        # were overwritten with the versions resolved via http-client-python's
+        # package.json pin, which caused client/mock spec skew whenever
+        # typespec-azure main advanced a spec beyond the pinned bundle and failed
+        # otherwise-green PRs. See microsoft/typespec#11348.
+        run: pnpm turbo run build --filter "@typespec/http-specs..." --filter "@azure-tools/azure-http-specs..."
 
       - name: Prepare Python environment
         run: pnpm run prepare


### PR DESCRIPTION
Do we even need to pin devDep for http-specs then?


## Summary

The **Python Integration → Mock API Tests** job (`.github/workflows/python-integration.yml`) can fail on http-client-python PRs with body-validation errors **unrelated to the PR under test**, due to a client/mock spec skew.

## Root cause

The job:
- **regenerates the client** from the freshly checked-out `Azure/typespec-azure` `main` `.tsp` source, but
- **overwrites the mock server dist** (`azure-http-specs` / `http-specs`) with the versions resolved via `http-client-python`'s `package.json` pin (`@azure-tools/azure-http-specs@0.1.0-alpha.43`).

Whenever `typespec-azure` `main` advances a spec beyond the pinned bundle, client and mock disagree. After [Azure/typespec-azure#4891](https://github.com/Azure/typespec-azure/pull/4891) added the `armIdWithGroupScope` ARM common property, the regenerated client sends 5 `properties` but the pinned alpha.43 mock expects 4 → the 4 `test_arm_resource_identifiers_*` failures on every Python PR.

## The change

Build the mock servers from the **same checked-out source** used to regenerate the client, instead of pinning them to the http-client-python-resolved version. Client and mock stay in lockstep, removing this entire class of failure (issue #11348, option 3).

```yaml
- name: Build http-specs and azure-http-specs from source
  run: pnpm turbo run build --filter "@typespec/http-specs..." --filter "@azure-tools/azure-http-specs..."
```

The `@azure-tools/azure-http-specs` devDependency pin is intentionally **left at `alpha.43`** — it is still needed by the emitter's own `npm run regenerate` (which resolves specs from `node_modules/@azure-tools/azure-http-specs/specs`) and its RegenCheck. This change only decouples the *mock server* from that pin.

Because this PR edits `python-integration.yml` (a trigger path), the workflow's own run here validates the fix.

## Why not just bump the `azure-http-specs` pin?

Tried and rejected. Bumping to `0.1.0-alpha.44-dev.5` makes Mock API Tests pass, but **breaks the blocking `typespec - ci … RegenCheck`**: the emitter's `npm run regenerate` compiles specs from the bundle against its pinned `@azure-tools/typespec-azure-*: ~0.70.0`, and every published alpha.44 build also pulls in the new `service-group` spec / `ServiceGroup` scope, which requires **typespec-azure 0.71-dev** (only dev pre-releases exist; no stable 0.71). RegenCheck failed on both linux and windows in that attempt. This workflow-only fix avoids that skew entirely and leaves the pin untouched.

## Fixes

Closes #11348 — including the 4 `test_arm_resource_identifiers_*` Mock API failures.