### PR TITLE
feat(http-client-java): expose required-fields-as-ctor-args option to tspconfig

### DIFF
--- a/.chronus/changes/expose-required-fields-as-ctor-args-2026-7-24-10-11-0.md
+++ b/.chronus/changes/expose-required-fields-as-ctor-args-2026-7-24-10-11-0.md
@@ -1,0 +1,13 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-java"
+---
+
+Expose the `required-fields-as-ctor-args` emitter option in `tspconfig.yaml`. It controls whether required model properties are generated as constructor arguments. The default remains `true`.
+
+```yaml
+options:
+  "@typespec/http-client-java":
+    required-fields-as-ctor-args: false
+```

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -191,7 +191,6 @@ export interface EmitterOptionsDev {
   "generate-tests"?: boolean;
 
   // customization
-  "required-fields-as-ctor-args"?: boolean;
   "partial-update"?: boolean;
   "models-subpackage"?: string;
   "custom-types"?: string;
@@ -204,6 +203,7 @@ export interface EmitterOptionsDev {
   "enable-subclient"?: boolean;
 
   // not recommended to set
+  "required-fields-as-ctor-args"?: boolean;
   "group-etag-headers"?: boolean;
   "enable-sync-stack"?: boolean;
   "stream-style-serialization"?: boolean;

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -191,6 +191,7 @@ export interface EmitterOptionsDev {
   "generate-tests"?: boolean;
 
   // customization
+  "required-fields-as-ctor-args"?: boolean;
   "partial-update"?: boolean;
   "models-subpackage"?: string;
   "custom-types"?: string;

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/TypeSpecPlugin.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/TypeSpecPlugin.java
@@ -224,6 +224,9 @@ public class TypeSpecPlugin extends Javagen {
         if (options.getPartialUpdate() != null) {
             SETTINGS_MAP.put("partial-update", options.getPartialUpdate());
         }
+        if (options.getRequiredFieldsAsConstructorArgs() != null) {
+            SETTINGS_MAP.put("required-fields-as-ctor-args", options.getRequiredFieldsAsConstructorArgs());
+        }
         if (!CoreUtils.isNullOrEmpty(options.getServiceVersions())) {
             SETTINGS_MAP.put("service-versions", options.getServiceVersions());
         }

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/model/EmitterOptions.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/model/EmitterOptions.java
@@ -28,6 +28,7 @@ public class EmitterOptions implements JsonSerializable<EmitterOptions> {
     private Boolean enableSyncStack = true;
     private Boolean streamStyleSerialization = true;
     private Boolean partialUpdate;
+    private Boolean requiredFieldsAsConstructorArgs;
     private String customTypes;
     private String customTypeSubpackage;
     private String customizationClass;
@@ -83,6 +84,10 @@ public class EmitterOptions implements JsonSerializable<EmitterOptions> {
 
     public Boolean getPartialUpdate() {
         return partialUpdate;
+    }
+
+    public Boolean getRequiredFieldsAsConstructorArgs() {
+        return requiredFieldsAsConstructorArgs;
     }
 
     public Boolean getGenerateTests() {
@@ -237,6 +242,8 @@ public class EmitterOptions implements JsonSerializable<EmitterOptions> {
                 options.streamStyleSerialization = reader.getNullable(EmitterOptions::getBoolean);
             } else if ("partial-update".equals(fieldName)) {
                 options.partialUpdate = reader.getNullable(EmitterOptions::getBoolean);
+            } else if ("required-fields-as-ctor-args".equals(fieldName)) {
+                options.requiredFieldsAsConstructorArgs = reader.getNullable(EmitterOptions::getBoolean);
             } else if ("custom-types".equals(fieldName)) {
                 options.customTypes = emptyToNull(reader.getString());
             } else if ("custom-types-subpackage".equals(fieldName)) {


### PR DESCRIPTION
Expose the `required-fields-as-ctor-args` emitter option to `tspconfig.yaml` for data-plane. Previously it was hard-coded to `true` in `TypeSpecPlugin`. The default remains `true`; users can now opt out.

```yaml
options:
  "@typespec/http-client-java":
    required-fields-as-ctor-args: false
```

## Changes
- `emitter/src/code-model-builder.ts` — add `required-fields-as-ctor-args` to `EmitterOptionsDev` so the option flows from tspconfig into the JSON passed to the Java generator.
- `generator/.../model/EmitterOptions.java` — add field, getter, and JSON parsing.
- `generator/.../TypeSpecPlugin.java` — override the setting only when the user sets it; the static default stays `true`.