### PR TITLE
Fix C# spread conversion for custom constructors

### DIFF
--- a/.chronus/changes/fix-csharp-custom-spread-constructor-2026-7-24.md
+++ b/.chronus/changes/fix-csharp-custom-spread-constructor-2026-7-24.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@typespec/http-client-csharp"
----
-
-Fix C# generation for spread models with custom constructors whose collection parameters are not linked to generated properties.

--- a/.chronus/changes/fix-csharp-custom-spread-constructor-2026-7-24.md
+++ b/.chronus/changes/fix-csharp-custom-spread-constructor-2026-7-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Fix C# generation for spread models with custom constructors whose collection parameters are not linked to generated properties.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -457,10 +457,17 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             {
                 // Get wire name from the parameter's property if available, otherwise resolve
                 // from the model's properties by matching the parameter name to a property name.
-                var wireName = param.Property?.WireInfo?.SerializedName;
+                var property = param.Property;
+                var wireName = property?.WireInfo?.SerializedName;
                 if (wireName == null)
                 {
                     propertyWireNames.TryGetValue(param.Name, out wireName);
+                }
+
+                if (property == null && wireName != null)
+                {
+                    property = spreadSource.CanonicalView.Properties.FirstOrDefault(
+                        p => string.Equals(p.WireInfo?.SerializedName, wireName, StringComparison.OrdinalIgnoreCase));
                 }
 
                 ParameterProvider? convenienceParam = null;
@@ -473,7 +480,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 {
                     if (convenienceParam.Type.IsList)
                     {
-                        var interfaceType = param.Property!.WireInfo?.IsReadOnly == true
+                        var interfaceType = property?.WireInfo?.IsReadOnly == true
                             ? new CSharpType(typeof(IReadOnlyList<>), convenienceParam.Type.Arguments)
                             : new CSharpType(typeof(IList<>), convenienceParam.Type.Arguments);
                         expressions.Add(new AsExpression(convenienceParam.NullConditional().ToList(), interfaceType)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -217,6 +217,55 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
 
         }
 
+        [Test]
+        public async Task SpreadListUsesCanonicalPropertyWhenCustomConstructorParameterHasNoProperty()
+        {
+            var spreadModel = InputFactory.Model(
+                "listSpreadModel",
+                usage: InputModelTypeUsage.Spread,
+                properties:
+                [
+                    InputFactory.Property("items", InputFactory.Array(InputPrimitiveType.String), isRequired: true),
+                ]);
+            var serviceMethod = InputFactory.BasicServiceMethod(
+                "CreateMessage",
+                InputFactory.Operation(
+                    "CreateMessage",
+                    parameters:
+                    [
+                        InputFactory.BodyParameter(
+                            "spread",
+                            spreadModel,
+                            isRequired: true,
+                            scope: InputParameterScope.Spread),
+                    ]),
+                parameters:
+                [
+                    InputFactory.MethodParameter(
+                        "items",
+                        InputFactory.Array(InputPrimitiveType.String),
+                        isRequired: true,
+                        scope: InputParameterScope.Spread),
+                ]);
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+            await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [inputClient],
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+
+            var convenienceMethods = methodCollection.Where(m => m.Signature.Parameters.All(p => p.Name != "content")).ToList();
+            Assert.AreEqual(2, convenienceMethods.Count);
+            foreach (var method in convenienceMethods)
+            {
+                StringAssert.Contains(
+                    "global::Sample.Models.ListSpreadModel spreadModel = new global::Sample.Models.ListSpreadModel((items?.ToList() as global::System.Collections.Generic.IList<string> ?? new global::Sample.ChangeTrackingList<string>()), default);",
+                    method.BodyStatements!.ToDisplayString());
+            }
+        }
+
         // Validate that spread model correctly instantiates optional dictionary properties
         [Test]
         public async Task SpreadModelWithOptionalDictionaryIsNotNull()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/SpreadListUsesCanonicalPropertyWhenCustomConstructorParameterHasNoProperty/ListSpreadModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/SpreadListUsesCanonicalPropertyWhenCustomConstructorParameterHasNoProperty/ListSpreadModel.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace Sample.Models
+{
+    internal class ListSpreadModel
+    {
+        internal ListSpreadModel(IList<string> items)
+        {
+            Items = items;
+        }
+
+        internal ListSpreadModel(IList<string> items, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        {
+            Items = items;
+            _additionalBinaryDataProperties = additionalBinaryDataProperties;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- resolve canonical spread properties by wire name when custom constructor parameters are not linked to generated properties
- avoid null dereferences when converting collection-valued spread parameters
- add regression coverage for custom spread-model constructors

## Validation

- `ScmMethodProviderCollectionTests`: 101 passed
- generated `Azure.AI.Vision.Face` from `Azure/azure-rest-api-specs#42486`
- built the generated Face SDK for `netstandard2.0`, `net8.0`, and `net10.0`