### PR TITLE
Fix C# private protected accessibility promotion

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -524,9 +524,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
             };
 
         private static bool IsPublic(SyntaxTokenList modifiers)
-            => modifiers.Any(static modifier =>
-                modifier.IsKind(SyntaxKind.PublicKeyword) ||
-                modifier.IsKind(SyntaxKind.ProtectedKeyword));
+            => modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.PublicKeyword)) ||
+                (modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.ProtectedKeyword)) &&
+                 !modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.PrivateKeyword)));
 
         private static bool IsImplicitPublicInterfaceMember(MemberDeclarationSyntax member)
             => member.Parent is InterfaceDeclarationSyntax &&

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/ReferenceMap/ProviderReferenceMapAnalyzerTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/ReferenceMap/ProviderReferenceMapAnalyzerTests.cs
@@ -953,6 +953,51 @@ namespace Microsoft.TypeSpec.Generator.Tests.ReferenceMap
         }
 
         [Test]
+        public async Task PrivateProtectedCustomSignatureDoesNotPublicizeGeneratedType()
+        {
+            MockHelpers.LoadMockGenerator();
+            var customization = await Helpers.GetCompilationFromDirectoryAsync();
+            var customSymbol = CompilationHelper.GetSymbol(
+                customization.Assembly.Modules.First().GlobalNamespace,
+                "AdvancedFilter");
+            Assert.IsNotNull(customSymbol);
+
+            var customCodeView = new NamedTypeSymbolProvider(customSymbol!, customization);
+            var publicSignatureDependencies = customCodeView.SignatureDependencyTypes.Select(type => type.Name).ToArray();
+            CollectionAssert.DoesNotContain(publicSignatureDependencies, "AdvancedFilterOperatorType");
+            CollectionAssert.Contains(publicSignatureDependencies, "PublicFilterOperatorType");
+
+            var customType = new CustomizableTestTypeProvider(
+                "AdvancedFilter",
+                TypeSignatureModifiers.Public,
+                customCodeView,
+                ns: "Sample");
+            var privateProtectedParameterType = new TestTypeProvider(
+                "AdvancedFilterOperatorType",
+                TypeSignatureModifiers.Internal,
+                ns: "Sample");
+            var protectedParameterType = new TestTypeProvider(
+                "PublicFilterOperatorType",
+                TypeSignatureModifiers.Internal,
+                ns: "Sample");
+            await MockHelpers.LoadMockGeneratorAsync(
+                createOutputLibrary: () => new TestOutputLibrary(customType, privateProtectedParameterType, protectedParameterType),
+                configuration: "{\"unreferenced-types-handling\":\"removeOrInternalize\"}",
+                compilation: () => Task.FromResult<Compilation>(customization));
+            CodeModelGenerator.Instance.AddTypeToKeep(customType);
+            CodeModelGenerator.Instance.AddTypeToKeep(privateProtectedParameterType.Type.FullyQualifiedName, isRoot: false);
+            CodeModelGenerator.Instance.AddTypeToKeep(protectedParameterType.Type.FullyQualifiedName, isRoot: false);
+
+            ProviderReferenceMapAnalyzer.ApplyPreWriteAccessibility(
+                [customType, privateProtectedParameterType, protectedParameterType]);
+
+            Assert.IsTrue(privateProtectedParameterType.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Internal));
+            Assert.IsFalse(privateProtectedParameterType.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public));
+            Assert.IsTrue(protectedParameterType.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public));
+            Assert.IsFalse(protectedParameterType.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Internal));
+        }
+
+        [Test]
         public void InternalizeModeDoesNotRemoveUnreferencedProviders()
         {
             var context = new TestTypeProvider("SampleContext", TypeSignatureModifiers.Public);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/ReferenceMap/TestData/ProviderReferenceMapAnalyzerTests/PrivateProtectedCustomSignatureDoesNotPublicizeGeneratedType/Customization.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/ReferenceMap/TestData/ProviderReferenceMapAnalyzerTests/PrivateProtectedCustomSignatureDoesNotPublicizeGeneratedType/Customization.cs
@@ -1,0 +1,21 @@
+namespace Sample
+{
+    internal readonly struct AdvancedFilterOperatorType
+    {
+    }
+
+    public readonly struct PublicFilterOperatorType
+    {
+    }
+
+    public partial class AdvancedFilter
+    {
+        private protected AdvancedFilter(AdvancedFilterOperatorType operatorType)
+        {
+        }
+
+        protected AdvancedFilter(PublicFilterOperatorType operatorType)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- exclude private protected custom members from public signature dependency analysis
- continue treating protected members as public API roots
- add regression coverage for discriminator parameter accessibility propagation

Fixes #11381