### PR TITLE
Support XML ApiCompat baselines in C# generator

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/PostProcessing/GeneratedCodeWorkspace.cs
@@ -342,8 +342,10 @@ namespace Microsoft.TypeSpec.Generator
 
         /// <summary>
         /// Locates and parses the ApiCompat baseline (suppression) file for the current library, if
-        /// present. The file is expected at <c>eng/apicompatbaselines/&lt;AssemblyName&gt;.txt</c>
-        /// relative to a repository root discovered by walking up from the project directory.
+        /// present. The file is expected at <c>eng/apicompatbaselines/&lt;AssemblyName&gt;.xml</c> or
+        /// <c>eng/apicompatbaselines/&lt;AssemblyName&gt;.txt</c> relative to a repository root
+        /// discovered by walking up from the project directory. The XML format is preferred when both
+        /// files exist.
         /// Returns <see cref="ApiCompatBaseline.Empty"/> when no baseline file is found.
         /// </summary>
         internal static ApiCompatBaseline LoadApiCompatBaseline()
@@ -353,11 +355,15 @@ namespace Microsoft.TypeSpec.Generator
 
             while (directory != null)
             {
-                var candidate = Path.Combine(directory.FullName, "eng", "apicompatbaselines", $"{packageName}.txt");
-                if (File.Exists(candidate))
+                var baselineDirectory = Path.Combine(directory.FullName, "eng", "apicompatbaselines");
+                foreach (var extension in new[] { ".xml", ".txt" })
                 {
-                    CodeModelGenerator.Instance.Emitter.Debug($"Loading ApiCompat baseline from {candidate}");
-                    return ApiCompatBaseline.FromFile(candidate);
+                    var candidate = Path.Combine(baselineDirectory, $"{packageName}{extension}");
+                    if (File.Exists(candidate))
+                    {
+                        CodeModelGenerator.Instance.Emitter.Debug($"Loading ApiCompat baseline from {candidate}");
+                        return ApiCompatBaseline.FromFile(candidate);
+                    }
                 }
 
                 directory = directory.Parent;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
@@ -32,6 +32,7 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
         private const string EnumValuesMustMatch = "EnumValuesMustMatch";
         private const string TypeMustExistDiagnostic = "CP0001";
         private const string MemberMustExistDiagnostic = "CP0002";
+        private const string EnumValueMustMatchDiagnostic = "CP0011";
 
         private readonly HashSet<string> _suppressedTypes;
         private readonly HashSet<MemberKey> _suppressedMembers;
@@ -177,6 +178,7 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
                         }
                         break;
                     case MemberMustExistDiagnostic:
+                    case EnumValueMustMatchDiagnostic:
                         if (TryParseXmlMember(target, out var memberKey, out var methodKey))
                         {
                             suppressedMembers.Add(memberKey);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/ApiCompatBaseline.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Xml.Linq;
 using Microsoft.TypeSpec.Generator.Primitives;
 
 namespace Microsoft.TypeSpec.Generator.SourceInput
@@ -12,6 +13,7 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
     /// <summary>
     /// Represents the set of intentional, already-accepted breaking changes recorded in an
     /// <c>ApiCompat</c> baseline (suppression) file (for example the files under
+    /// <c>eng/apicompatbaselines/&lt;AssemblyName&gt;.xml</c> or
     /// <c>eng/apicompatbaselines/&lt;AssemblyName&gt;.txt</c>).
     /// <para>
     /// The backward-compatibility system resurrects any public member that exists in the previous
@@ -28,6 +30,8 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
         private const string TypesMustExist = "TypesMustExist";
         private const string MembersMustExist = "MembersMustExist";
         private const string EnumValuesMustMatch = "EnumValuesMustMatch";
+        private const string TypeMustExistDiagnostic = "CP0001";
+        private const string MemberMustExistDiagnostic = "CP0002";
 
         private readonly HashSet<string> _suppressedTypes;
         private readonly HashSet<MemberKey> _suppressedMembers;
@@ -62,7 +66,9 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
                 return Empty;
             }
 
-            return Parse(File.ReadAllLines(path));
+            return string.Equals(Path.GetExtension(path), ".xml", StringComparison.OrdinalIgnoreCase)
+                ? ParseXml(XDocument.Load(path))
+                : Parse(File.ReadAllLines(path));
         }
 
         /// <summary>
@@ -122,6 +128,63 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
                     // Other rule ids (e.g. CannotRemoveAttribute) do not describe a removed
                     // member/type that the back-compat system would resurrect, so they are ignored.
                     default:
+                        break;
+                }
+            }
+
+            return new ApiCompatBaseline(suppressedTypes, suppressedMembers, suppressedMethods);
+        }
+
+        private static ApiCompatBaseline ParseXml(XDocument document)
+        {
+            var suppressedTypes = new HashSet<string>(StringComparer.Ordinal);
+            var suppressedMembers = new HashSet<MemberKey>();
+            var suppressedMethods = new HashSet<MethodKey>();
+
+            foreach (var suppression in document.Descendants())
+            {
+                if (suppression.Name.LocalName != "Suppression")
+                {
+                    continue;
+                }
+
+                string? diagnosticId = null;
+                string? target = null;
+                foreach (var element in suppression.Elements())
+                {
+                    switch (element.Name.LocalName)
+                    {
+                        case "DiagnosticId":
+                            diagnosticId = element.Value.Trim();
+                            break;
+                        case "Target":
+                            target = element.Value.Trim();
+                            break;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(target))
+                {
+                    continue;
+                }
+
+                switch (diagnosticId)
+                {
+                    case TypeMustExistDiagnostic:
+                        if (target.StartsWith("T:", StringComparison.Ordinal))
+                        {
+                            suppressedTypes.Add(RemoveGenericArity(target.Substring(2)));
+                        }
+                        break;
+                    case MemberMustExistDiagnostic:
+                        if (TryParseXmlMember(target, out var memberKey, out var methodKey))
+                        {
+                            suppressedMembers.Add(memberKey);
+                            if (methodKey.HasValue)
+                            {
+                                suppressedMethods.Add(methodKey.Value);
+                            }
+                        }
                         break;
                 }
             }
@@ -333,6 +396,116 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
             return true;
         }
 
+        private static bool TryParseXmlMember(string target, out MemberKey memberKey, out MethodKey? methodKey)
+        {
+            memberKey = default;
+            methodKey = null;
+
+            if (target.Length < 3 || target[1] != ':')
+            {
+                return false;
+            }
+
+            var symbolKind = target[0];
+            var symbol = target.Substring(2);
+            if (symbolKind == 'M')
+            {
+                var parenIndex = symbol.IndexOf('(');
+                if (parenIndex >= 0 && !symbol.EndsWith(")", StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                var memberPath = parenIndex >= 0 ? symbol.Substring(0, parenIndex) : symbol;
+                var parameterList = parenIndex >= 0
+                    ? symbol.Substring(parenIndex + 1, symbol.Length - parenIndex - 2)
+                    : string.Empty;
+
+                if (!TrySplitXmlMemberPath(memberPath, out var declaringTypeFullName, out var memberName))
+                {
+                    return false;
+                }
+
+                memberName = NormalizeXmlMemberName(memberName);
+                var normalizedParameters = NormalizeXmlParameterList(parameterList);
+                memberKey = new MemberKey(declaringTypeFullName, memberName, CountParameters(normalizedParameters));
+                methodKey = new MethodKey(declaringTypeFullName, memberName, normalizedParameters);
+                return true;
+            }
+
+            if (symbolKind is 'F' or 'P' or 'E'
+                && TrySplitXmlMemberPath(symbol, out var declaringType, out var name))
+            {
+                memberKey = new MemberKey(declaringType, NormalizeXmlMemberName(name), 0);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TrySplitXmlMemberPath(
+            string memberPath,
+            out string declaringTypeFullName,
+            out string memberName)
+        {
+            declaringTypeFullName = string.Empty;
+            memberName = string.Empty;
+
+            var lastDot = memberPath.LastIndexOf('.');
+            if (lastDot <= 0 || lastDot == memberPath.Length - 1)
+            {
+                return false;
+            }
+
+            declaringTypeFullName = RemoveGenericArity(memberPath.Substring(0, lastDot));
+            memberName = memberPath.Substring(lastDot + 1);
+            return true;
+        }
+
+        private static string NormalizeXmlMemberName(string memberName)
+        {
+            if (memberName.StartsWith('#'))
+            {
+                memberName = $".{memberName.Substring(1)}";
+            }
+
+            if (memberName.StartsWith("get_", StringComparison.Ordinal)
+                || memberName.StartsWith("set_", StringComparison.Ordinal)
+                || memberName.StartsWith("add_", StringComparison.Ordinal)
+                || memberName.StartsWith("remove_", StringComparison.Ordinal))
+            {
+                memberName = memberName.Substring(memberName.IndexOf('_') + 1);
+            }
+
+            return RemoveGenericArity(memberName);
+        }
+
+        private static string NormalizeXmlParameterList(string parameterList)
+            => NormalizeParameterList(parameterList)
+                .Replace('{', '<')
+                .Replace('}', '>')
+                .Replace('+', '.');
+
+        private static string RemoveGenericArity(string name)
+        {
+            var builder = new StringBuilder(name.Length);
+            for (int i = 0; i < name.Length; i++)
+            {
+                if (name[i] == '`')
+                {
+                    while (i + 1 < name.Length && char.IsDigit(name[i + 1]))
+                    {
+                        i++;
+                    }
+                    continue;
+                }
+
+                builder.Append(name[i] == '+' ? '.' : name[i]);
+            }
+
+            return builder.ToString();
+        }
+
         private static int CountParameters(string parameterList)
         {
             var trimmed = parameterList.Trim();
@@ -415,6 +588,13 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
 
         private static void AppendTypeName(StringBuilder builder, CSharpType type)
         {
+            if (type.IsFrameworkType && type.FrameworkType.IsGenericParameter)
+            {
+                builder.Append('`');
+                builder.Append(type.FrameworkType.GenericParameterPosition);
+                return;
+            }
+
             // Nullable value types are rendered by ApiCompat as System.Nullable<T>.
             if (type.IsNullable && type.IsValueType)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
@@ -38,6 +38,35 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         }
 
         [Test]
+        public void ParsesXmlSuppressions()
+        {
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: ".xml", method: "Baseline");
+
+            Assert.IsTrue(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol"));
+            Assert.IsTrue(baseline.IsMemberSuppressed(
+                "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
+                "ProtocolVersionRecord",
+                2));
+            Assert.IsTrue(baseline.IsMethodRemovalSuppressed(
+                "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
+                "ProtocolVersionRecord",
+                [
+                    new CSharpType(typeof(string)),
+                    new CSharpType(typeof(IEnumerable<string>))
+                ]));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", ".ctor", 0));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 0));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 1));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "LegacyField", 0));
+            Assert.IsTrue(baseline.IsTypeSuppressed("Ns.Outer.Inner"));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Outer.Inner", "Reset", 0));
+
+            var genericParameter = new CSharpType(typeof(IEnumerable<>).GetGenericArguments()[0]);
+            Assert.IsTrue(baseline.IsMethodRemovalSuppressed("Ns.Foo", "Generic", [genericParameter]));
+            Assert.IsFalse(baseline.IsMemberSuppressed("Ns.Foo", "ParameterRename", 1));
+        }
+
+        [Test]
         public void TypeSuppressionImpliesAllMembersSuppressed()
         {
             var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/ApiCompatBaselineTests.cs
@@ -10,8 +10,17 @@ using NUnit.Framework;
 
 namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
 {
+    [TestFixture(".txt")]
+    [TestFixture(".xml")]
     public class ApiCompatBaselineTests
     {
+        private readonly string _fileExtension;
+
+        public ApiCompatBaselineTests(string fileExtension)
+        {
+            _fileExtension = fileExtension;
+        }
+
         [SetUp]
         public void Setup()
         {
@@ -31,45 +40,33 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesTypesMustExist()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol"));
             Assert.IsFalse(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.SomethingElse"));
         }
 
         [Test]
-        public void ParsesXmlSuppressions()
+        public void ParsesSuppressions()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: ".xml", method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsTypeSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol"));
             Assert.IsTrue(baseline.IsMemberSuppressed(
                 "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
                 "ProtocolVersionRecord",
                 2));
-            Assert.IsTrue(baseline.IsMethodRemovalSuppressed(
-                "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
-                "ProtocolVersionRecord",
-                [
-                    new CSharpType(typeof(string)),
-                    new CSharpType(typeof(IEnumerable<string>))
-                ]));
-            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", ".ctor", 0));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", ".ctor", 2));
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 0));
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 1));
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "LegacyField", 0));
-            Assert.IsTrue(baseline.IsTypeSuppressed("Ns.Outer.Inner"));
-            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Outer.Inner", "Reset", 0));
-
-            var genericParameter = new CSharpType(typeof(IEnumerable<>).GetGenericArguments()[0]);
-            Assert.IsTrue(baseline.IsMethodRemovalSuppressed("Ns.Foo", "Generic", [genericParameter]));
-            Assert.IsFalse(baseline.IsMemberSuppressed("Ns.Foo", "ParameterRename", 1));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.CapacityLevel", "FiftyThousand", 0));
         }
 
         [Test]
         public void TypeSuppressionImpliesAllMembersSuppressed()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Azure.AI.Projects.Agents.ProjectsAgentProtocol", "AnyMember", 3));
         }
@@ -77,7 +74,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesMembersMustExistMethod()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed(
                 "Azure.AI.Projects.Agents.ProjectsAgentsModelFactory",
@@ -98,7 +95,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesParameterlessMember()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Reset", 0));
         }
@@ -106,7 +103,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesConstructor()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", ".ctor", 2));
         }
@@ -114,7 +111,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesPropertyAccessorOntoOwner()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 0));
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Kind", 1));
@@ -123,7 +120,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void CountsGenericParametersAsSingleArgument()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "Configure", 2));
         }
@@ -131,7 +128,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesMembersMustExistField()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // A removed field/enum member has no parameter list; it is recorded with arity 0.
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Foo", "LegacyField", 0));
@@ -140,7 +137,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ParsesEnumValuesMustMatch()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // An accepted enum value difference suppresses back-compat handling for that member.
             Assert.IsTrue(baseline.IsMemberSuppressed("Ns.CapacityLevel", "FiftyThousand", 0));
@@ -151,7 +148,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IgnoresUnknownRulesAndMalformedLines()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile();
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension);
 
             Assert.IsTrue(baseline.IsEmpty);
         }
@@ -159,7 +156,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedDistinguishesOverloadsByParameterType()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // The baseline accepts removal of Get(string). Only that overload is suppressed; a Get(int)
             // overload with the same arity must NOT be treated as suppressed.
@@ -174,7 +171,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesGenericParameterTypes()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Foo.Configure(IDictionary<string, int>, string) is suppressed; the query builds the same
             // canonical signature from CSharpType parameters (including nested generic arguments).
@@ -195,7 +192,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedHonorsTypeSuppression()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // The whole type is suppressed via TypesMustExist, so any method on it is suppressed
             // regardless of parameter types.
@@ -208,7 +205,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesNullableValueTypeParameter()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithNullable(System.Nullable<System.Int32>) is suppressed. A nullable value type
             // is rendered as System.Nullable<T> on both sides.
@@ -221,7 +218,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesArrayParameter()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithArray(System.String[]) is suppressed.
             Assert.IsTrue(baseline.IsMethodRemovalSuppressed("Ns.Types", "WithArray", [new CSharpType(typeof(string[]))]));
@@ -236,7 +233,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesGenericListParameter()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithList(System.Collections.Generic.List<System.String>) is suppressed.
             var listOfString = new CSharpType(typeof(List<>), new CSharpType(typeof(string)));
@@ -250,7 +247,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesNestedGenericParameter()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithNestedGeneric(IList<IDictionary<string, int>>) is suppressed; nested generic
             // arguments are rendered recursively on both sides.
@@ -269,7 +266,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesMultipleParametersInOrder()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithMany(int, string, bool) is suppressed.
             Assert.IsTrue(baseline.IsMethodRemovalSuppressed(
@@ -293,7 +290,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesParameterlessOverload()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Foo.Reset() has no parameters; the canonical signature is empty on both sides.
             Assert.IsTrue(baseline.IsMethodRemovalSuppressed("Ns.Foo", "Reset", []));
@@ -305,7 +302,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesEnumParameter()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithEnum(Sample.Models.MyKind) is suppressed. The enum's output type is produced
             // by the TypeFactory from the input enum and renders as its fully-qualified name.
@@ -321,7 +318,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesNullableEnumParameter()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithNullableEnum(System.Nullable<Sample.Models.MyKind>) is suppressed. A nullable
             // enum renders as System.Nullable<Sample.Models.MyKind>.
@@ -338,7 +335,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesModelParameter()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithModel(Sample.Models.MyModel) is suppressed. The model's output type is produced
             // by the TypeFactory and renders as its fully-qualified name.
@@ -354,7 +351,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void IsMethodRemovalSuppressedMatchesDictionaryWithModelValue()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "Baseline");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "Baseline");
 
             // Ns.Types.WithDictionary(Dictionary<string, Sample.Models.MyModel>) is suppressed. The model
             // appears as a generic argument and is rendered recursively.
@@ -371,7 +368,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ReferencesSuppressedTypeMatchesDirectType()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "SuppressedString");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "SuppressedString");
 
             Assert.IsTrue(baseline.ReferencesSuppressedType(new CSharpType(typeof(string))));
             Assert.IsFalse(baseline.ReferencesSuppressedType(new CSharpType(typeof(int))));
@@ -380,7 +377,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         [Test]
         public void ReferencesSuppressedTypeMatchesNestedGenericArgument()
         {
-            var baseline = Helpers.GetApiCompatBaselineFromFile(method: "SuppressedString");
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: _fileExtension, method: "SuppressedString");
 
             // IList<string> -- the suppressed type is nested as a generic argument.
             var listOfString = new CSharpType(typeof(IList<>), new CSharpType(typeof(string)));
@@ -395,6 +392,28 @@ namespace Microsoft.TypeSpec.Generator.Tests.SourceInput
         {
             Assert.IsFalse(ApiCompatBaseline.Empty.ReferencesSuppressedType(new CSharpType(typeof(string))));
             Assert.IsFalse(ApiCompatBaseline.Empty.ReferencesSuppressedType(null));
+        }
+    }
+
+    public class ApiCompatBaselineXmlTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            MockHelpers.LoadMockGenerator();
+        }
+
+        [Test]
+        public void ParsesXmlDocumentationSymbolFormats()
+        {
+            var baseline = Helpers.GetApiCompatBaselineFromFile(fileExtension: ".xml", method: "XmlDocumentationSymbols");
+
+            Assert.IsTrue(baseline.IsTypeSuppressed("Ns.Outer.Inner"));
+            Assert.IsTrue(baseline.IsMemberSuppressed("Ns.Outer.Inner", "Reset", 0));
+
+            var genericParameter = new CSharpType(typeof(IEnumerable<>).GetGenericArguments()[0]);
+            Assert.IsTrue(baseline.IsMethodRemovalSuppressed("Ns.Foo", "Generic", [genericParameter]));
+            Assert.IsFalse(baseline.IsMemberSuppressed("Ns.Foo", "ParameterRename", 1));
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/Baseline.xml
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/Baseline.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Azure.AI.Projects.Agents.ProjectsAgentProtocol</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ProtocolVersionRecord(System.String,System.Collections.Generic.IEnumerable{System.String})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Foo.#ctor</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Foo.get_Kind</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Foo.set_Kind(Ns.Kind)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Ns.Foo.LegacyField</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Ns.Outer`1+Inner</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Outer`1+Inner.Reset</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Foo.Generic`1(`0)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0017</DiagnosticId>
+    <Target>M:Ns.Foo.ParameterRename(System.String)$0</Target>
+  </Suppression>
+</Suppressions>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/Baseline.xml
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/Baseline.xml
@@ -1,16 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Suppressions>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>T:Azure.AI.Projects.Agents.HostedAgentDefinition</Target>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Azure.AI.Projects.Agents.ProjectsAgentProtocol</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ProtocolVersionRecord(System.String,System.Collections.Generic.IEnumerable{System.String})</Target>
+    <Target>M:Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ProtocolVersionRecord(Azure.AI.Projects.Agents.ProjectsAgentProtocol,System.String)</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Ns.Foo.#ctor</Target>
+    <Target>M:Ns.Foo.Reset</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Foo.#ctor(Ns.Kind,System.String)</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
@@ -22,22 +30,54 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Foo.Configure(System.Collections.Generic.IDictionary{System.String,System.Int32},System.String)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Ns.Foo.LegacyField</Target>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Ns.Outer`1+Inner</Target>
+    <DiagnosticId>CP0011</DiagnosticId>
+    <Target>F:Ns.CapacityLevel.FiftyThousand</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Ns.Outer`1+Inner.Reset</Target>
+    <Target>M:Ns.Overloads.Get(System.String)</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Ns.Foo.Generic`1(`0)</Target>
+    <Target>M:Ns.Types.WithNullable(System.Nullable{System.Int32})</Target>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0017</DiagnosticId>
-    <Target>M:Ns.Foo.ParameterRename(System.String)$0</Target>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithArray(System.String[])</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithList(System.Collections.Generic.List{System.String})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithNestedGeneric(System.Collections.Generic.IList{System.Collections.Generic.IDictionary{System.String,System.Int32}})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithMany(System.Int32,System.String,System.Boolean)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithEnum(Sample.Models.MyKind)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithNullableEnum(System.Nullable{Sample.Models.MyKind})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithModel(Sample.Models.MyModel)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Types.WithDictionary(System.Collections.Generic.Dictionary{System.String,Sample.Models.MyModel})</Target>
   </Suppression>
 </Suppressions>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/IgnoresUnknownRulesAndMalformedLines.xml
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/IgnoresUnknownRulesAndMalformedLines.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Suppressions>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>T:Ns.Foo</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+  </Suppression>
+  <Suppression>
+    <Target>M:Ns.Foo.Reset</Target>
+  </Suppression>
+</Suppressions>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/SuppressedString.xml
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/SuppressedString.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Suppressions>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.String</Target>
+  </Suppression>
+</Suppressions>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/XmlDocumentationSymbols.xml
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/SourceInput/TestData/ApiCompatBaselineTests/XmlDocumentationSymbols.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Suppressions>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Ns.Outer`1+Inner</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Outer`1+Inner.Reset</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ns.Foo.Generic`1(`0)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0017</DiagnosticId>
+    <Target>M:Ns.Foo.ParameterRename(System.String)$0</Target>
+  </Suppression>
+</Suppressions>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/Helpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/Helpers.cs
@@ -27,16 +27,17 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
         }
 
         /// <summary>
-        /// Loads an <see cref="ApiCompatBaseline"/> from a <c>.txt</c> baseline asset file located at
-        /// <c>TestData/&lt;CallingClass&gt;/&lt;method&gt;.txt</c> next to the calling test.
+        /// Loads an <see cref="ApiCompatBaseline"/> from a baseline asset file located under
+        /// <c>TestData/&lt;CallingClass&gt;</c> next to the calling test.
         /// </summary>
         public static ApiCompatBaseline GetApiCompatBaselineFromFile(
             string? parameters = null,
+            string fileExtension = ".txt",
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "")
         {
             return ApiCompatBaseline.FromFile(
-                GetAssetFileOrDirectoryPath(true, parameters, method, filePath, fileExtension: ".txt"));
+                GetAssetFileOrDirectoryPath(true, parameters, method, filePath, fileExtension));
         }
 
         public static string GetAssetFileOrDirectoryPath(


### PR DESCRIPTION
## Summary
- support modern XML ApiCompat suppression baselines while retaining legacy text baseline support
- recognize CP0001 type and CP0002 member removals, including constructors, accessors, generic methods, and nested types
- prefer XML when both baseline formats exist and ignore parameter-name suppressions that do not require API resurrection

This is required by Azure/azure-sdk-for-net#61353, which migrates the repository baselines to XML.

## Validation
- `dotnet test ...Microsoft.TypeSpec.Generator.Tests.csproj --filter FullyQualifiedName~ApiCompatBaselineTests` (28 passed)
- stacked the change on the exact `@typespec/http-client-csharp@1.0.0-alpha.20260722.4` generator embedded by `Azure.ResourceManager.AppService` in Azure/azure-sdk-for-net#61353; regeneration produced no tracked SDK diffs