### PR TITLE
[http-client-csharp] Keep MRW builders for system types referenced by generated serialization

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/Definitions/ModelReaderWriterContextDefinitionTests.cs
@@ -227,6 +227,53 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
         }
 
         [Test]
+        public void SystemObjectModelProvidersSupportingMrwRemainBuildable()
+        {
+            // A framework type represented by a SystemObjectModelProvider (e.g. an ARM common type such as
+            // ManagedServiceIdentity) is still deserialized by generated serialization code through
+            // ModelReaderWriter.Read<T>(..., Context.Default), so it must keep its buildable entry.
+            var systemInputModel = InputFactory.Model("SystemMrwModel", properties: []);
+            var referencingInputModel = InputFactory.Model("ReferencingModel", properties: []);
+            MockHelpers.LoadMockGenerator(createOutputLibrary: () => new TestOutputLibrary(
+            [
+                new SystemTypeReferencingProvider(referencingInputModel),
+                new SystemObjectModelProvider(new CSharpType(typeof(SystemMrwModel)), systemInputModel)
+            ]));
+
+            var contextDefinition = new ModelReaderWriterContextDefinition();
+            var buildableAttributes = contextDefinition.Attributes
+                .Where(a => a.Type.IsFrameworkType && a.Type.FrameworkType == typeof(ModelReaderWriterBuildableAttribute))
+                .Select(a => a.Arguments.First().ToDisplayString())
+                .ToList();
+
+            Assert.IsTrue(
+                buildableAttributes.Contains("typeof(global::Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions.SystemMrwModel)"),
+                "Framework types wrapped by a SystemObjectModelProvider must remain buildable when the wrapped system type supports MRW.");
+        }
+
+        [Test]
+        public void SystemObjectModelProvidersWithoutMrwSupportAreNotBuildable()
+        {
+            var systemInputModel = InputFactory.Model("SystemNonMrwModel", properties: []);
+            var referencingInputModel = InputFactory.Model("ReferencingModel", properties: []);
+            MockHelpers.LoadMockGenerator(createOutputLibrary: () => new TestOutputLibrary(
+            [
+                new SystemTypeReferencingProvider(referencingInputModel, useMrwSystemType: false),
+                new SystemObjectModelProvider(new CSharpType(typeof(SystemNonMrwModel)), systemInputModel)
+            ]));
+
+            var contextDefinition = new ModelReaderWriterContextDefinition();
+            var buildableAttributes = contextDefinition.Attributes
+                .Where(a => a.Type.IsFrameworkType && a.Type.FrameworkType == typeof(ModelReaderWriterBuildableAttribute))
+                .Select(a => a.Arguments.First().ToDisplayString())
+                .ToList();
+
+            Assert.IsFalse(
+                buildableAttributes.Contains("typeof(global::Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions.SystemNonMrwModel)"),
+                "System types that do not support MRW must not get a buildable entry.");
+        }
+
+        [Test]
         public void ValidateModelReaderWriterBuildableAttributesIncludeNestedModels()
         {
             // Create a model with a property that references another model
@@ -2082,6 +2129,64 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.Definitions
 
                 return [new MethodProvider(signature, Statements.MethodBodyStatement.Empty, this)];
             }
+        }
+    }
+
+    internal class SystemTypeReferencingProvider : ModelProvider
+    {
+        private readonly bool _useMrwSystemType;
+
+        public SystemTypeReferencingProvider(InputModelType inputModelType, bool useMrwSystemType = true) : base(inputModelType)
+        {
+            _useMrwSystemType = useMrwSystemType;
+        }
+
+        protected override string BuildName() => "SystemTypeReferencingModel";
+
+        protected internal override PropertyProvider[] BuildProperties() =>
+        [
+            new PropertyProvider(
+                null,
+                MethodSignatureModifiers.Public,
+                new CSharpType(_useMrwSystemType ? typeof(SystemMrwModel) : typeof(SystemNonMrwModel)),
+                "SystemProperty",
+                new AutoPropertyBody(false),
+                this)
+        ];
+    }
+
+    public class SystemNonMrwModel
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    public class SystemMrwModel : IJsonModel<SystemMrwModel>, IPersistableModel<SystemMrwModel>
+    {
+        public string Value { get; set; } = string.Empty;
+
+        SystemMrwModel? IJsonModel<SystemMrwModel>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        SystemMrwModel? IPersistableModel<SystemMrwModel>.Create(BinaryData data, ModelReaderWriterOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IPersistableModel<SystemMrwModel>.GetFormatFromOptions(ModelReaderWriterOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IJsonModel<SystemMrwModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        BinaryData IPersistableModel<SystemMrwModel>.Write(ModelReaderWriterOptions options)
+        {
+            throw new NotImplementedException();
         }
     }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/ReferenceMap/ProviderReferenceMapAnalyzer.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/ReferenceMap/ProviderReferenceMapAnalyzer.cs
@@ -56,9 +56,32 @@ namespace Microsoft.TypeSpec.Generator
         }
 
         private static bool IsResolvableBuildableProvider(TypeProvider provider) =>
-            provider is not SystemObjectModelProvider &&
-            provider is not ModelProvider { IsExternal: true } &&
-            ShouldWriteProvider(provider);
+            provider switch
+            {
+                // A system type is not generated, but generated serialization code still reads it through
+                // ModelReaderWriter.Read<T>(..., Context.Default), so it stays buildable when it supports MRW.
+                SystemObjectModelProvider systemModel => SupportsModelReaderWriter(systemModel.SystemType),
+                ModelProvider { IsExternal: true } => false,
+                _ => ShouldWriteProvider(provider)
+            };
+
+        private static bool SupportsModelReaderWriter(CSharpType type)
+        {
+            if (!type.IsFrameworkType)
+            {
+                return false;
+            }
+
+            foreach (var @interface in type.FrameworkType.GetInterfaces())
+            {
+                if (@interface.Name is "IPersistableModel`1" or "IJsonModel`1")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private static bool TryGetProvider(CSharpType type, bool exact, out TypeProvider provider)
         {


### PR DESCRIPTION
## Summary

`ProviderReferenceMapAnalyzer.IsResolvableBuildableProvider()` rejected every `SystemObjectModelProvider`, so `ModelReaderWriterContextDefinition` pruned `[ModelReaderWriterBuildable(...)]` entries for ARM framework types (`ManagedServiceIdentity`, `ResponseError`, `SystemData`, ...) while generated serialization still deserializes them via `ModelReaderWriter.Read<T>(data, options, Context.Default)`. That path calls `context.GetTypeBuilder(returnType)` and threw `InvalidOperationException: No ModelReaderWriterTypeBuilder found ...` at runtime.

Regression from #11288 (`89f388c40`).

## Change

A `SystemObjectModelProvider` is now considered resolvable for MRW context generation when its wrapped `SystemType` implements `IPersistableModel<T>` or `IJsonModel<T>`. External `ModelProvider`s and providers removed by the reference map remain excluded.

## Tests

- `SystemObjectModelProvidersSupportingMrwRemainBuildable` — regression coverage; fails on `main` with the buildable attribute missing, passes with the fix.
- `SystemObjectModelProvidersWithoutMrwSupportAreNotBuildable` — negative coverage so non-MRW system types stay excluded.

## Validation

- `Microsoft.TypeSpec.Generator.ClientModel.Tests`: 1515/1515 passed
- `Microsoft.TypeSpec.Generator.Tests`: 1720/1720 passed

Fixes #11396.