### PR TITLE
fix(website): give docs sidebar navigation a proper landmark box

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -327,6 +327,7 @@ words:
   - Vsts
   - vswhere
   - wday
+  - WCAG
   - weidxu
   - westus
   - WHATWG

--- a/website/src/components/starlight-overrides/PageFrame.astro
+++ b/website/src/components/starlight-overrides/PageFrame.astro
@@ -42,4 +42,27 @@ import Footer from "../footer/footer.astro";
     z-index: 100;
     width: 100%;
   }
+
+  /*
+   * Starlight wraps the docs sidebar in `<nav class="sidebar" aria-label>` but
+   * makes the inner `.sidebar-pane` `position: fixed`. On desktop that leaves
+   * the `<nav>` landmark element itself with an empty, collapsed layout box, so
+   * assistive tech / landmark tools report the visible left navigation as not
+   * belonging to any landmark region (#10793, WCAG 1.3.1). Move the fixed
+   * positioning onto the `<nav>` landmark itself so its bounding box coincides
+   * with the visible sidebar, and let the pane fill it.
+   */
+  @media (min-width: 50rem) {
+    :global(nav.sidebar) {
+      position: fixed;
+      inset-block: var(--sl-nav-height) 0;
+      inset-inline-start: 0;
+      width: var(--sl-sidebar-width);
+    }
+    :global(nav.sidebar > .sidebar-pane) {
+      position: static;
+      width: 100%;
+      height: 100%;
+    }
+  }
 </style>


### PR DESCRIPTION
Fixes #10793

## Problem

On the Docs pages, screen-reader / landmark tools report the left docs navigation as **not belonging to any landmark region** (WCAG 1.3.1). This was not resolved by the previous accessibility pass (#11292), which added the `aria-label="Documentation"` label but not the structural fix.

Root cause: Starlight wraps the docs sidebar in `<nav class="sidebar" aria-label="Documentation">`, but its inner `.sidebar-pane` is `position: fixed`. On desktop that leaves the `<nav>` **landmark element itself with an empty, collapsed layout box**, so Accessibility Insights draws the "Documentation navigation" landmark up near the header and the visible left sidebar appears outside any landmark.

![reported issue](https://github.com/user-attachments/assets/0dad989a-b8ee-45f9-9066-d1a7e0f36c2b)

## Fix

In our existing `PageFrame.astro` Starlight override, move the fixed positioning onto the `<nav>` landmark itself (desktop only, `min-width: 50rem`) and let `.sidebar-pane` fill it. The navigation landmark's bounding box now coincides with the visible sidebar.

## Verification

Measured with Playwright at 1365×755 (the reporter's environment):

- `nav.sidebar` bounding box is now `x:0, y:58, w:300, h:697` — covering the full visible sidebar, with all sidebar links contained inside it.
- Sidebar stays fixed while the main content scrolls, and scrolls independently when its content overflows.
- Main content offset unchanged (`x:300`); no visual regression.
- Mobile menu toggle behavior unchanged (the change is scoped to desktop widths).

`@typespec/website` is a private package, so no changelog entry is required (consistent with #11292).
