### PR TITLE
docs(http-client-java): document how to inspect TCGC SDK output for a spec

### DIFF
--- a/.github/instructions/http-client-java.instructions.md
+++ b/.github/instructions/http-client-java.instructions.md
@@ -69,6 +69,23 @@ The code generator has two connected parts, linked by a `code-model.yaml`:
 
 After a compile, inspect `tsp-output/**/code-model.yaml` in the test module to see what the emitter passed to the generator.
 
+## Inspect the TCGC output (SDK model) for a spec
+
+The emitter is built on top of TCGC (`@azure-tools/typespec-client-generator-core`), which turns the raw TypeSpec compiler output into an SDK model (`SdkPackage`: clients, operation groups, methods, parameters, responses, models, enums, …). When you need to understand what TCGC hands to the emitter — for example, to check how a type is named, whether a response has a body vs. only headers, or how an operation is nested under a client — dump the TCGC output and read it directly, rather than adding debug logging in the emitter.
+
+Run TCGC as the emitter for the spec (TCGC is already installed in the test module's `node_modules`, so no extra install is needed):
+
+```
+npx tsp compile <path-to-tsp> --emit @azure-tools/typespec-client-generator-core --option "@azure-tools/typespec-client-generator-core.emitter-output-dir=$PWD/tcgc-output"
+```
+
+This writes `tcgc-output/tcgc-output.yaml` — the serialized `SdkPackage` (keys starting with `__` are omitted). Notes:
+
+- This is the same SDK model the http-client-java emitter consumes; it is upstream of `code-model.yaml`. Use `tcgc-output.yaml` to inspect the TCGC/SDK view and `code-model.yaml` to inspect what the emitter produced from it.
+- It requires no changes to the http-client-java emitter or generator — it invokes TCGC's own emitter directly.
+- The dump is generated for verification only. Do NOT commit `tcgc-output.yaml` (or its output folder); delete it when done.
+- The mechanism is TCGC's `exportTCGCoutput` (see `packages/typespec-client-generator-core/src/context.ts` in the `microsoft/typespec-azure` repo, typically checked out as a sibling folder).
+
 ## Edit → update emitter → test loop
 
 1. Make the emitter (TypeScript) and/or generator (Java) changes.

--- a/.github/instructions/http-client-java.instructions.md
+++ b/.github/instructions/http-client-java.instructions.md
@@ -69,23 +69,6 @@ The code generator has two connected parts, linked by a `code-model.yaml`:
 
 After a compile, inspect `tsp-output/**/code-model.yaml` in the test module to see what the emitter passed to the generator.
 
-## Inspect the TCGC output (SDK model) for a spec
-
-The emitter is built on top of TCGC (`@azure-tools/typespec-client-generator-core`), which turns the raw TypeSpec compiler output into an SDK model (`SdkPackage`: clients, operation groups, methods, parameters, responses, models, enums, …). When you need to understand what TCGC hands to the emitter — for example, to check how a type is named, whether a response has a body vs. only headers, or how an operation is nested under a client — dump the TCGC output and read it directly, rather than adding debug logging in the emitter.
-
-Run TCGC as the emitter for the spec (TCGC is already installed in the test module's `node_modules`, so no extra install is needed):
-
-```
-npx tsp compile <path-to-tsp> --emit @azure-tools/typespec-client-generator-core --option "@azure-tools/typespec-client-generator-core.emitter-output-dir=$PWD/tcgc-output"
-```
-
-This writes `tcgc-output/tcgc-output.yaml` — the serialized `SdkPackage` (keys starting with `__` are omitted). Notes:
-
-- This is the same SDK model the http-client-java emitter consumes; it is upstream of `code-model.yaml`. Use `tcgc-output.yaml` to inspect the TCGC/SDK view and `code-model.yaml` to inspect what the emitter produced from it.
-- It requires no changes to the http-client-java emitter or generator — it invokes TCGC's own emitter directly.
-- The dump is generated for verification only. Do NOT commit `tcgc-output.yaml` (or its output folder); delete it when done.
-- The mechanism is TCGC's `exportTCGCoutput` (see `packages/typespec-client-generator-core/src/context.ts` in the `microsoft/typespec-azure` repo, typically checked out as a sibling folder).
-
 ## Edit → update emitter → test loop
 
 1. Make the emitter (TypeScript) and/or generator (Java) changes.
@@ -98,6 +81,16 @@ This writes `tcgc-output/tcgc-output.yaml` — the serialized `SdkPackage` (keys
    (Optionally add `--option "@typespec/http-client-java.emitter-output-dir=$PWD/tsp-output/<name>"` to isolate output into a subfolder for an easier diff.)
 7. Verify the generated code under `tsp-output/**/src` is as expected. When the spec corresponds to sources tracked in `src/main/java`, compare against them and, if correct, copy the generated files into `src` (replacing existing files) but EXCLUDE `module-info.java`. Some specs do not map to `src` — in that case just verify the output, without comparing or copying.
 8. When the spec maps to `src` and you copied the generated code in, run the tests (`mvn test`, or a targeted `--define "test=<pkg>.<Class>"`). Restart the Spector server if needed (`npm run spector-stop` then `npm run spector-start`). If the spec does not map to `src`, verifying the generated output (step 7) is sufficient.
+
+### Inspect the TCGC output (SDK model)
+
+To debug how the emitter sees a spec, dump the TCGC SDK model (`SdkPackage`) it consumes — upstream of `code-model.yaml` — instead of adding emitter debug logging. Run TCGC as the emitter (already installed in the test module):
+
+```
+npx tsp compile <path-to-tsp> --emit @azure-tools/typespec-client-generator-core --option "@azure-tools/typespec-client-generator-core.emitter-output-dir=$PWD/tcgc-output"
+```
+
+This writes `tcgc-output/tcgc-output.yaml` (keys starting with `__` are omitted). It changes no code; the dump is verification-only, so do NOT commit it — delete it when done.
 
 ## Emitting static helper classes from resource templates
 


### PR DESCRIPTION
Adds a generic step to the http-client-java code-generator instructions describing how to inspect the **TCGC SDK model** for a spec.

The emitter is built on top of TCGC (`@azure-tools/typespec-client-generator-core`). When investigating how a type is named, whether a response has a body vs. only headers, how operations are nested under clients, etc., it is often more reliable to inspect what TCGC hands to the emitter than to add debug logging in the emitter.

The documented flow runs TCGC as the emitter to dump `tcgc-output.yaml` (the serialized `SdkPackage`):

```
npx tsp compile <path-to-tsp> --emit @azure-tools/typespec-client-generator-core --option "@azure-tools/typespec-client-generator-core.emitter-output-dir=$PWD/tcgc-output"
```

This is the SDK view upstream of `code-model.yaml`, requires no emitter/generator changes, and should not be committed (verification-only).

Docs-only change.
