### PR TITLE
fix(website): prevent playground page from overflowing the viewport

### DIFF
--- a/website/src/layouts/base-layout.astro
+++ b/website/src/layouts/base-layout.astro
@@ -73,6 +73,12 @@ const initJsIntegrity = computeSriHash("1ds-init.js");
 
     .main {
       flex: 1;
+      /* Lay out page content as a column so pages can opt into filling the
+         available height (e.g. the playground) via `flex: 1` on their content,
+         rather than hard-coding `100vh - var(--header-height)`, which does not
+         account for the real rendered header height. */
+      display: flex;
+      flex-direction: column;
       background-color: var(--colorNeutralBackground1);
     }
 

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -20,9 +20,25 @@ const latestVersion = versions[0];
   })}
 />
 <BaseLayout footer={false}>
-  <div style={{ height: "calc(100vh - var(--header-height))", width: "100%" }}>
+  <div class="playground-container">
     <AsyncPlayground client:only="react" latestVersion={latestVersion}>
       <LoadingSpinner slot="fallback" message="Loading playground..." />
     </AsyncPlayground>
   </div>
 </BaseLayout>
+
+<style>
+  /* Fill the remaining height provided by the base layout's `.main` flex column
+     instead of subtracting a fixed `--header-height`, which is smaller than the
+     real rendered header and caused the page to overflow with a vertical
+     scrollbar. `display: grid` gives the playground (which fills via
+     `height: 100%`) a definite track to resolve against — a flex-sized block on
+     its own is not treated as a definite height for percentage-height children,
+     which would otherwise collapse the playground. */
+  .playground-container {
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+    display: grid;
+  }
+</style>


### PR DESCRIPTION
## Problem

The `/playground` page overflows the viewport slightly, adding a vertical scrollbar.

The container hard-coded its height as `calc(100vh - var(--header-height))`. `--header-height` is `50px`, but the header actually renders at **54px**. Since #11292 changed the header from `position: fixed` (out of flow, overlaid) to `position: sticky` (in flow) and switched the navbar to `min-height` and the body to `min-height: 100vh`, that 4px difference now stacks: `54px + (100vh - 50px) = 100vh + 4px` → a small vertical scroll.

This is **not** related to header wrapping — the overflow is a constant 4px at every width.

## Fix

Stop hard-coding the header offset. Make `.main` a flex column in the base layout and let the playground fill the remaining space with `flex: 1`, so it always tracks the real rendered header height.

## Verification (Chromium / Playwright)

- Playground: container height = `846px` (= `900 - 54`), **0 vertical overflow** at 1440px and 800px viewports (previously 4px).
- Regression check on `/community`, `/videos`, `/blog`, `/can-i-use/http`, and `/`: rendered page height is **identical** with `.main` as a flex column vs. block (diff = 0), so the layout change is neutral for existing pages.

> `@typespec/website` is a private package (not published), so no changelog entry is required.