### PR TITLE
fix(http-client-java): avoid credential phrase in random mock map key

### DIFF
--- a/.chronus/changes/weidongxu-microsoft-fix-random-map-key-credential-2026-6-29-13-47-42.md
+++ b/.chronus/changes/weidongxu-microsoft-fix-random-map-key-credential-2026-6-29-13-47-42.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+Fixed an issue where a randomly generated JSON map key in the mock test could contain a credential phrase (e.g. key) and be unexpectedly redacted to fakeTokenPlaceholder by the test proxy.

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ModelTestCaseUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ModelTestCaseUtil.java
@@ -177,7 +177,9 @@ public class ModelTestCaseUtil {
                 for (int i = 0; i < count; ++i) {
                     Object element = jsonFromType(depth + 1, elementType);
                     if (element != null) {
-                        map.put(randomString(), element);
+                        // use randomKeyString to avoid the random key containing a possible credential phrase
+                        // (e.g. "key"), which would cause the value to be redacted by the test proxy
+                        map.put(randomKeyString(), element);
                     }
                 }
             } // else abort
@@ -193,12 +195,9 @@ public class ModelTestCaseUtil {
 
     public static String redactStringValue(List<String> serializedNames, String value) {
         for (String keyName : serializedNames) {
-            String keyNameLower = keyName.toLowerCase(Locale.ROOT);
-            for (String key : POSSIBLE_CREDENTIAL_KEY) {
-                if (keyNameLower.contains(key)) {
-                    value = "fakeTokenPlaceholder";
-                    break;
-                }
+            if (containsPossibleCredentialKey(keyName)) {
+                value = "fakeTokenPlaceholder";
+                break;
             }
         }
         return value;
@@ -269,13 +268,20 @@ public class ModelTestCaseUtil {
 
     private static void checkCredential(List<String> serializedNames) {
         for (String keyName : serializedNames) {
-            String keyNameLower = keyName.toLowerCase(Locale.ROOT);
-            for (String key : POSSIBLE_CREDENTIAL_KEY) {
-                if (keyNameLower.contains(key)) {
-                    throw new PossibleCredentialException(keyName);
-                }
+            if (containsPossibleCredentialKey(keyName)) {
+                throw new PossibleCredentialException(keyName);
             }
         }
+    }
+
+    private static boolean containsPossibleCredentialKey(String keyName) {
+        String keyNameLower = keyName.toLowerCase(Locale.ROOT);
+        for (String key : POSSIBLE_CREDENTIAL_KEY) {
+            if (keyNameLower.contains(key)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String randomString() {
@@ -287,6 +293,21 @@ public class ModelTestCaseUtil {
             .limit(targetStringLength)
             .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
             .toString();
+    }
+
+    /**
+     * Generate a random string to be used as a JSON key (e.g. a Map key), ensuring it does not contain a possible
+     * credential phrase (e.g. "key"). Otherwise the value under this key could be redacted by the test proxy, causing
+     * the test recording to mismatch.
+     *
+     * @return the random string that does not contain a possible credential phrase
+     */
+    private static String randomKeyString() {
+        String result = randomString();
+        while (containsPossibleCredentialKey(result)) {
+            result = randomString();
+        }
+        return result;
     }
 
     private static final OffsetDateTime TIME = OffsetDateTime.parse("2020-12-20T00:00:00.000Z");


### PR DESCRIPTION
## Problem

The mock/test JSON body is generated randomly. For a `Map` type, both keys and values are random. When a randomly generated **map key** happens to contain a credential phrase such as `key` (all map keys are random lowercase `a`-`z` strings, so this can occur by chance), the test proxy redacts the corresponding value to `fakeTokenPlaceholder`, causing the recording to mismatch on playback.

Reported via Azure/azure-sdk-for-java#49964.

## Root cause

`ModelTestCaseUtil` already had credential-phrase logic (`POSSIBLE_CREDENTIAL_KEY` + `checkCredential` / `redactStringValue`), but it only guarded **model property serialized names**, never the **randomly generated map keys** (`map.put(randomString(), element)`). So a random key containing `key` slipped through.

## Fix

Added `randomKeyString()`, which regenerates the random string until it no longer contains any `POSSIBLE_CREDENTIAL_KEY` phrase, and use it for map keys. Extracted the substring check into a shared `containsPossibleCredentialKey` helper reused by `checkCredential` and `redactStringValue`.