### PR TITLE
fix(http-client-java): exclude hidden maxpagesize param from generated sample

### DIFF
--- a/.chronus/changes/weidongxu-microsoft-fix-maxpagesize-sample-2026-6-29-14-26-5.md
+++ b/.chronus/changes/weidongxu-microsoft-fix-maxpagesize-sample-2026-6-29-14-26-5.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+Fixed an issue where the generated sample for a pageable method included the hidden maxpagesize parameter, producing code that did not match the client method signature.

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/example/ClientMethodExampleWriter.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/example/ClientMethodExampleWriter.java
@@ -14,6 +14,7 @@ import com.microsoft.typespec.http.client.generator.core.model.clientmodel.EnumT
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.GenericType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.IType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.IterableType;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.MethodPageDetails;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ParameterMapping;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ParameterTransformation;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ParameterTransformations;
@@ -50,6 +51,15 @@ public class ClientMethodExampleWriter {
     public ClientMethodExampleWriter(ClientMethod method, String clientVarName, ProxyMethodExample proxyMethodExample) {
 
         List<MethodParameter> methodParameters = MethodUtil.getParameters(method, true);
+        // Exclude parameters that are hidden from the client method signature (e.g. "maxpagesize", which is set via
+        // PagedIterable/PagedFlux instead). Otherwise the generated sample would pass an argument that the method
+        // signature does not accept, producing invalid code.
+        final MethodPageDetails pageDetails = method.getMethodPageDetails();
+        if (pageDetails != null) {
+            methodParameters = methodParameters.stream()
+                .filter(methodParameter -> !pageDetails.shouldHideParameter(methodParameter.getClientMethodParameter()))
+                .collect(Collectors.toList());
+        }
         List<ExampleNode> exampleNodes = methodParameters.stream()
             .map(methodParameter -> parseNodeFromParameter(method, proxyMethodExample, methodParameter))
             .collect(Collectors.toList());


### PR DESCRIPTION
## Problem

Generating a Java client for a pageable operation that has a hidden `maxpagesize` query parameter produced an **invalid sample**. The parameter is intentionally hidden from the convenience method signature (it is set via `PagedIterable` / `PagedFlux` instead), but the generated sample still passed a value for it.

Reported for the WebPubSubChat data-plane spec.

## Reproduction

For a paged operation `listStrings(@query maxpagesize?: int32)` (with `enable-page-size` on) and an example that sets `maxpagesize`, the generated sample was:

```java
PagedIterable<String> response = client.listStrings(10); // does not compile
```

while the actual convenience method is `listStrings()`.

## Root cause

The method signature (`ClientMethod.parametersDeclaration`) filters out page-hidden parameters via `MethodPageDetails.shouldHideParameter(...)`, but the sample writer (`ClientMethodExampleWriter`) built its argument list from `MethodUtil.getParameters(method, true)` (`getMethodInputParameters()`), which still includes the hidden `maxpagesize`.

## Fix

In `ClientMethodExampleWriter`, filter out parameters hidden by `MethodPageDetails` before building the example nodes, reusing the same `shouldHideParameter` logic used for the method signature. After the fix the sample is `client.listStrings();`.