### PR TITLE
Add workflow to fix pnpm lockfile on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-pnpm-install.yml
+++ b/.github/workflows/dependabot-pnpm-install.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "**/package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 permissions: {}
 

--- a/.github/workflows/dependabot-pnpm-install.yml
+++ b/.github/workflows/dependabot-pnpm-install.yml
@@ -1,0 +1,40 @@
+name: Dependabot pnpm install
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened]
+    paths:
+      - "**/package.json"
+      - "pnpm-lock.yaml"
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+          submodules: recursive
+
+      - uses: ./.github/actions/setup
+
+      - run: pnpm install --no-frozen-lockfile
+        name: Install dependencies
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update lockfile"
+            git push
+          fi


### PR DESCRIPTION
Adds a workflow that runs on dependabot PRs to ensure `pnpm install` works and commits any resulting lockfile diff back to the PR branch.

Adapted from Azure/typespec-azure's `dependabot-core-sync` workflow. Since this repo has no `core` submodule or `pnpm deps fix` step, it simply runs `pnpm install --no-frozen-lockfile` and commits any diff.

- Triggers on dependabot PRs to `main` touching any `package.json` or `pnpm-lock.yaml`
- Gated on `github.actor == 'dependabot[bot]'` with `contents: write`
- Commits and pushes the lockfile diff (or reports no changes)