### PR TITLE
fix(http-canonicalization): bump to 0.16.2 to fix duplicate Alloy load [skip chg]

### DIFF
--- a/packages/http-canonicalization/CHANGELOG.md
+++ b/packages/http-canonicalization/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - @typespec/http-canonicalization
 
+## 0.16.2
+
+### Bug Fixes
+
+- [#11456](https://github.com/microsoft/typespec/pull/11456) Re-release to realign the `@typespec/emitter-framework` dependency (Alloy `0.24`). The previous `0.16.1` still required `@typespec/emitter-framework@^0.17.0` (Alloy `0.22`), which caused `npm` installs of `@typespec/http-server-csharp` to load two incompatible `@alloy-js/core` versions ("Multiple versions of Alloy are loaded").
+
+
 ## 0.16.1
 
 ### Bump dependencies

--- a/packages/http-canonicalization/package.json
+++ b/packages/http-canonicalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-canonicalization",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "main": "dist/src/index.js",
   "repository": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/11443

## Problem

Compiling a project that uses `@typespec/http-server-csharp` with **npm** fails at load time with:

```
error js-error: ... Multiple versions of Alloy are loaded for this project.
```

Two incompatible `@alloy-js/core` copies get installed and both load: `0.24.1` (hoisted) and `0.22.0` (nested under `@typespec/http-canonicalization`).

## Root cause

- Published `@typespec/http-server-csharp@0.58.0-alpha.30` depends on `@typespec/emitter-framework@^0.19.0` (Alloy `0.24`) and `@typespec/http-canonicalization@^0.16.1`.
- `^0.16.1` resolves to the **stale stable** `@typespec/http-canonicalization@0.16.1`, whose published deps still require `@typespec/emitter-framework@^0.17.0` (Alloy `0.22`).
- npm 7+ auto-installs the unmet `^0.22.0` peer → a second nested `@alloy-js/core@0.22.0` → Alloy's runtime guard throws.

### Why the stable range went stale (a chronus bug)

`@typespec/emitter-framework` received **minor** bumps `0.17 → 0.18 → 0.19` (Alloy peer `^0.22 → ^0.24`). `@typespec/http-canonicalization` depends on it via `workspace:^`, but chronus **1.3.1** did not force `workspace:^` dependents to re-release on a **minor** bump of a `0.x` dependency (for `0.x`, `^0.n.x` locks the minor, so a minor bump is effectively breaking). As a result `http-canonicalization`'s stable `latest` stayed frozen at `0.16.1` with the old `^0.17.0` range.

This was fixed upstream in **chronus 1.4.0** ([timotheeguerin/chronus#590](https://github.com/timotheeguerin/chronus/pull/590)), which is already adopted here, so it won't recur.

## Fix

Manually bump `@typespec/http-canonicalization` to **0.16.2** and add the changelog entry (`[skip chg]`) to force a targeted patched re-release. On publish its `workspace:^` emitter-framework dependency is resolved to the current line (Alloy `0.24`), so a single Alloy version is required across the tree.

Patch (not minor) is deliberate: `http-server-csharp@0.58.0-alpha.30` requests `^0.16.1` (`>=0.16.1 <0.17.0`), so `0.16.2` is picked up automatically and retroactively fixes already-published consumers; `0.17.0` would not satisfy that range.
