### PR TITLE
fix(http-server-csharp): resolve ASP.NET Core MVC types in `Microsoft.*` namespaces

### DIFF
--- a/.chronus/changes/fix-controller-mvc-usings-2026-7-15-0-0-0.md
+++ b/.chronus/changes/fix-controller-mvc-usings-2026-7-15-0-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Fix generated controllers failing to compile when the service namespace starts with `Microsoft.` (as ARM resource providers do). `ControllerBase` and `IActionResult` are now emitted as `Microsoft.AspNetCore.Mvc` library references so they resolve in every namespace instead of being unresolved bare identifiers.

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
@@ -235,7 +235,7 @@ ${implCall}`;
       async
       virtual
       public
-      returns={code`Task<IActionResult>`}
+      returns={code`Task<${AspNetMvc.IActionResult}>`}
       parameters={parameters}
       attributes={attributes}
       doc={getDocComments($, props.operation.sourceType)}

--- a/packages/http-server-csharp/src/components/controllers/controllers.test.tsx
+++ b/packages/http-server-csharp/src/components/controllers/controllers.test.tsx
@@ -1,6 +1,6 @@
 import { Tester } from "#test/tester.js";
 import { type Children } from "@alloy-js/core";
-import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
+import { createCSharpNamePolicy, Namespace, SourceFile } from "@alloy-js/csharp";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { $ } from "@typespec/compiler/typekit";
 import { Output } from "@typespec/emitter-framework";
@@ -8,7 +8,7 @@ import {
   HttpCanonicalizer,
   type OperationHttpCanonicalization,
 } from "@typespec/http-canonicalization";
-import { beforeEach, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { BusinessLogicInterface } from "../interfaces/interfaces.jsx";
 import { Controller } from "./controllers.jsx";
 
@@ -18,11 +18,16 @@ beforeEach(async () => {
   runner = await Tester.createInstance();
 });
 
-function Wrapper(props: { children: Children }) {
+function Wrapper(props: { children: Children; namespace?: string }) {
   const policy = createCSharpNamePolicy();
+  const content = props.namespace ? (
+    <Namespace name={props.namespace}>{props.children}</Namespace>
+  ) : (
+    props.children
+  );
   return (
     <Output program={runner.program} namePolicy={policy}>
-      <SourceFile path="test.cs">{props.children}</SourceFile>
+      <SourceFile path="test.cs">{content}</SourceFile>
     </Output>
   );
 }
@@ -32,14 +37,17 @@ function canonicalizeOp(opType: any): OperationHttpCanonicalization {
   return canonicalizer.canonicalize(opType) as OperationHttpCanonicalization;
 }
 
-it("renders a controller class with an action method", async () => {
+async function compilePetStore() {
   const { PetStore, listPets } = await runner.compile(t.code`
     interface ${t.interface("PetStore")} {
       @route("/pets") @get ${t.op("listPets")}(): string[];
     }
   `);
+  return { PetStore, canonOp: canonicalizeOp(listPets) };
+}
 
-  const canonOp = canonicalizeOp(listPets);
+it("renders a controller class with an action method", async () => {
+  const { PetStore, canonOp } = await compilePetStore();
 
   expect(
     <Wrapper>
@@ -73,4 +81,94 @@ it("renders a controller class with an action method", async () => {
         }
     }
   `);
+});
+
+// Regression tests for https://github.com/microsoft/typespec/issues/11445.
+// `[ApiController]`, `ControllerBase` and `IActionResult` come from
+// `Microsoft.AspNetCore.Mvc`. They are emitted as library references so they
+// resolve in every service namespace, including namespaces that start with
+// `Microsoft.` (as every ARM resource provider does), where Alloy resolves them
+// relative to the shared `Microsoft` ancestor namespace instead of importing them.
+describe("ASP.NET Core MVC framework references resolve in any namespace (#11445)", () => {
+  it("imports Microsoft.AspNetCore.Mvc and uses short names for a plain namespace", async () => {
+    const { PetStore, canonOp } = await compilePetStore();
+
+    expect(
+      <Wrapper namespace="Contoso.Controllers">
+        <BusinessLogicInterface type={PetStore} />
+        {"\n"}
+        <Controller type={PetStore} operations={[canonOp]} />
+      </Wrapper>,
+    ).toRenderTo(`
+      using Microsoft.AspNetCore.Mvc;
+
+      namespace Contoso.Controllers
+      {
+          public interface IPetStore
+          {
+              Task<string[]> ListPetsAsync();
+          }
+          [ApiController]
+          public partial class PetStoreController : ControllerBase
+          {
+              internal virtual IPetStore PetStoreImpl { get; }
+              public PetStoreController(IPetStore operations)
+              {
+                  PetStoreImpl = operations;
+              }
+
+              [HttpGet]
+              [Route("/pets")]
+              [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string[]))]
+              public virtual async Task<IActionResult> ListPets()
+              {
+                  var result = await PetStoreImpl.ListPetsAsync();
+                  return Ok(result);
+              }
+          }
+      }
+    `);
+  });
+
+  it("qualifies the Mvc types via the ancestor namespace when the namespace starts with Microsoft.", async () => {
+    const { PetStore, canonOp } = await compilePetStore();
+
+    // No `using Microsoft.AspNetCore.Mvc;` is emitted here: the framework types
+    // are qualified relative to the enclosing `Microsoft` namespace, which
+    // resolves to `Microsoft.AspNetCore.Mvc.*` in C#. Before the fix these were
+    // bare, unresolved identifiers (`ControllerBase`, `IActionResult`).
+    expect(
+      <Wrapper namespace="Microsoft.Contoso.Controllers">
+        <BusinessLogicInterface type={PetStore} />
+        {"\n"}
+        <Controller type={PetStore} operations={[canonOp]} />
+      </Wrapper>,
+    ).toRenderTo(`
+      namespace Microsoft.Contoso.Controllers
+      {
+          public interface IPetStore
+          {
+              Task<string[]> ListPetsAsync();
+          }
+          [AspNetCore.Mvc.ApiControllerAttribute]
+          public partial class PetStoreController : AspNetCore.Mvc.ControllerBase
+          {
+              internal virtual IPetStore PetStoreImpl { get; }
+              public PetStoreController(IPetStore operations)
+              {
+                  PetStoreImpl = operations;
+              }
+
+              [AspNetCore.Mvc.HttpGetAttribute]
+              [AspNetCore.Mvc.RouteAttribute("/pets")]
+              [AspNetCore.Mvc.ProducesResponseTypeAttribute((int)HttpStatusCode.OK, Type = typeof(string[]))]
+              public virtual async Task<AspNetCore.Mvc.IActionResult> ListPets()
+              {
+                  var result = await PetStoreImpl.ListPetsAsync();
+                  return Ok(result);
+              }
+          }
+      }
+    `);
+  });
 });

--- a/packages/http-server-csharp/src/components/controllers/controllers.tsx
+++ b/packages/http-server-csharp/src/components/controllers/controllers.tsx
@@ -36,7 +36,7 @@ export function Controller(props: ControllerProps): Children {
       name={controllerName}
       public
       partial
-      baseType="ControllerBase"
+      baseType={AspNetMvc.ControllerBase}
       attributes={attributes}
     >
       <cs.Property name={implPropName} type={interfaceRef} internal virtual get />

--- a/packages/http-server-csharp/src/utils/csharp-libs.tsx
+++ b/packages/http-server-csharp/src/utils/csharp-libs.tsx
@@ -19,6 +19,8 @@ export const JsonSerialization = createLibrary("System.Text.Json.Serialization",
  */
 export const AspNetMvc = createLibrary("Microsoft.AspNetCore.Mvc", {
   ApiControllerAttribute: { kind: "class", members: {} },
+  ControllerBase: { kind: "class", members: {} },
+  IActionResult: { kind: "interface", members: {} },
   RouteAttribute: { kind: "class", members: {} },
   HttpGetAttribute: { kind: "class", members: {} },
   HttpPostAttribute: { kind: "class", members: {} },

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -1,3 +1,6 @@
+// NOTE: This file is LEGACY only. Do NOT add new tests here.
+// Add new tests to the co-located component `*.test.tsx` files (or another dedicated
+// test file) instead.
 import { resolveVirtualPath, TesterInstance, TestFileSystem } from "@typespec/compiler/testing";
 import assert, { deepStrictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";


### PR DESCRIPTION
## Fixes

Fixes https://github.com/microsoft/typespec/issues/11445

## Problem

Controllers generated by `@typespec/http-server-csharp` failed to compile when the service namespace begins with `Microsoft.` (as every ARM resource provider does). `ControllerBase` and `IActionResult` were emitted as raw string identifiers, so under a namespace like `Microsoft.Contoso.Controllers` they became **bare, unresolved identifiers** — there was no `using Microsoft.AspNetCore.Mvc;` and Alloy could not qualify them relative to the shared `Microsoft` ancestor namespace.

## Fix

Emit `ControllerBase` and `IActionResult` as `Microsoft.AspNetCore.Mvc` **library references** (like `[ApiController]` already was), so Alloy's name resolution handles them in every namespace:

- **Plain namespace** (e.g. `Contoso`): a single `using Microsoft.AspNetCore.Mvc;` is added and the short names `ControllerBase` / `IActionResult` / `[ApiController]` are used.
- **`Microsoft.*` namespace** (e.g. `Microsoft.Contoso`): the types are qualified relative to the enclosing `Microsoft` namespace — `AspNetCore.Mvc.ControllerBase`, `Task<AspNetCore.Mvc.IActionResult>`, `[AspNetCore.Mvc.ApiControllerAttribute]` — all of which resolve and compile.

Symbols dedupe through Alloy's `using` set, so no duplicate `using` directives are produced.

## Changes

- `src/utils/csharp-libs.tsx`: add `ControllerBase` and `IActionResult` to the `AspNetMvc` library.
- `src/components/controllers/controllers.tsx`: `baseType={AspNetMvc.ControllerBase}`.
- `src/components/controller-action/controller-action.tsx`: `returns={code\`Task<${AspNetMvc.IActionResult}>\`}`.

## Tests

Added `.toRenderTo` regression tests in `src/components/controllers/controllers.test.tsx` covering both a plain namespace and a `Microsoft.*` namespace. Full package suite passes (205 tests).