### PR TITLE
Fix external type resolution failing when the type's dependencies are not deployed with the generator

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/TypeFactory.cs
@@ -358,13 +358,14 @@ namespace Microsoft.TypeSpec.Generator
             }
 
             // Neither path resolved the type — emit a diagnostic that explains what was attempted.
-            // Each branch is a self-contained sentence so the final message reads naturally and
-            // doesn't repeat "could not be resolved".
-            var details = string.IsNullOrEmpty(externalProperties.Package)
-                ? "no package metadata was provided"
-                : string.IsNullOrEmpty(externalProperties.MinVersion)
-                    ? $"package '{externalProperties.Package}' was not found in the NuGet cache or any configured feed"
-                    : $"package '{externalProperties.Package}' (>= {externalProperties.MinVersion}) was not found in the NuGet cache or any configured feed";
+            // Prefer the concrete reason recorded by the resolver (missing package, unloadable assembly,
+            // unsatisfied dependency, ...) so the message points at the actual problem.
+            var details = ExternalTypeReferenceResolver.GetFailureReason(externalProperties)
+                ?? (string.IsNullOrEmpty(externalProperties.Package)
+                    ? "no package metadata was provided"
+                    : string.IsNullOrEmpty(externalProperties.MinVersion)
+                        ? $"package '{externalProperties.Package}' was not found in the NuGet cache or any configured feed"
+                        : $"package '{externalProperties.Package}' (>= {externalProperties.MinVersion}) was not found in the NuGet cache or any configured feed");
 
             CodeModelGenerator.Instance.Emitter.ReportDiagnostic(
                 "unsupported-external-type",

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
@@ -329,8 +329,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                     $"Added metadata reference for external type '{external.Identity}' from {assemblyPath}");
             }
 
-            CacheResult(state, key, new ResolutionResult(loadedType, null));
-            return new ResolutionResult(loadedType, null);
+            return CacheResult(state, key, new ResolutionResult(loadedType, null));
         }
 
         private static ResolutionResult CacheResult(CacheState state, string key, ResolutionResult result)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
@@ -38,11 +38,21 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         // the entries are released when the generator is collected.
         private static readonly ConditionalWeakTable<CodeModelGenerator, CacheState> _cacheStates = new();
 
+        /// <summary>
+        /// Outcome of a single resolution attempt. <see cref="Type"/> is null when resolution failed, in
+        /// which case <see cref="FailureReason"/> explains why so callers can report an accurate diagnostic
+        /// (a missing package and an unloadable type are very different problems to debug).
+        /// </summary>
+        private sealed record ResolutionResult(Type? Type, string? FailureReason)
+        {
+            public static readonly ResolutionResult NotAttempted = new(null, null);
+        }
+
         private sealed class CacheState
         {
-            // Cached resolution per (Package, Identity, MinVersion) key. Value is the loaded Type, or
-            // null if resolution was attempted and failed (so we don't keep re-trying).
-            public readonly ConcurrentDictionary<string, Lazy<Type?>> Resolved =
+            // Cached resolution per (Package, Identity, MinVersion) key. Value carries the loaded Type, or
+            // the reason resolution failed (so we don't keep re-trying).
+            public readonly ConcurrentDictionary<string, Lazy<ResolutionResult>> Resolved =
                 new(StringComparer.Ordinal);
 
             // Tracks assembly file paths that have already been added as Roslyn metadata references, so
@@ -118,10 +128,27 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
             var state = GetState(CodeModelGenerator.Instance);
             var key = MakeKey(external);
-            var lazy = state.Resolved.GetOrAdd(key, _ => new Lazy<Type?>(
-                () => Task.Run(() => ResolveAsync(external)).GetAwaiter().GetResult(),
+            var lazy = state.Resolved.GetOrAdd(key, _ => new Lazy<ResolutionResult>(
+                () => Task.Run(() => ResolveResultAsync(external)).GetAwaiter().GetResult(),
                 LazyThreadSafetyMode.ExecutionAndPublication));
-            return lazy.Value;
+            return lazy.Value.Type;
+        }
+
+        /// <summary>
+        /// Returns the reason the most recent resolution attempt for <paramref name="external"/> failed, or
+        /// <c>null</c> when it succeeded or was never attempted.
+        /// </summary>
+        public static string? GetFailureReason(InputExternalTypeMetadata? external)
+        {
+            if (external == null)
+            {
+                return null;
+            }
+
+            var state = GetState(CodeModelGenerator.Instance);
+            return state.Resolved.TryGetValue(MakeKey(external), out var lazy) && lazy.IsValueCreated
+                ? lazy.Value.FailureReason
+                : null;
         }
 
         /// <summary>
@@ -129,14 +156,27 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         /// </summary>
         internal static void Reset()
         {
-            // Drop the entry entirely; the next call rebuilds a fresh CacheState on demand.
-            _cacheStates.Remove(CodeModelGenerator.Instance);
+            try
+            {
+                // Drop the entry entirely; the next call rebuilds a fresh CacheState on demand.
+                _cacheStates.Remove(CodeModelGenerator.Instance);
+            }
+            catch (InvalidOperationException)
+            {
+                // No generator is installed yet, so there is no per-generator state to drop. This happens
+                // when Reset runs before the first generator is loaded (e.g. a test fixture's SetUp).
+            }
+
+            NugetAssemblyResolver.Reset();
         }
 
         private static string MakeKey(InputExternalTypeMetadata external) =>
             $"{external.Package}|{external.Identity}|{external.MinVersion ?? string.Empty}";
 
         private static async Task<Type?> ResolveAsync(InputExternalTypeMetadata external)
+            => (await ResolveResultAsync(external)).Type;
+
+        private static async Task<ResolutionResult> ResolveResultAsync(InputExternalTypeMetadata external)
         {
             var generator = CodeModelGenerator.Instance;
             var state = GetState(generator);
@@ -162,9 +202,13 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             catch (Exception ex)
             {
                 generator.Emitter?.Debug($"Could not load NuGet settings while resolving '{external.Identity}': {ex.Message}");
-                CacheResult(state, key, null);
-                return null;
+                return CacheResult(state, key, new ResolutionResult(null, $"NuGet settings could not be loaded ({ex.Message})"));
             }
+
+            // The external assembly is loaded into the default AssemblyLoadContext, which cannot see the
+            // package's own dependencies. Install the NuGet probing hook before loading anything so that
+            // base types and interfaces declared in dependency packages can be resolved.
+            NugetAssemblyResolver.EnsureRegistered(globalPackagesFolder);
 
             string? assemblyPath = NugetPackageResolver.FindPackageAssembly(
                 globalPackagesFolder, external.Package!, external.MinVersion);
@@ -197,21 +241,30 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
             if (assemblyPath == null || !File.Exists(assemblyPath))
             {
-                CacheResult(state, key, null);
-                return null;
+                var versionQualifier = string.IsNullOrEmpty(external.MinVersion)
+                    ? string.Empty
+                    : $" (>= {external.MinVersion})";
+                return CacheResult(state, key, new ResolutionResult(
+                    null,
+                    $"package '{external.Package}'{versionQualifier} was not found in the NuGet cache or any configured feed"));
             }
+
+            // Pin every package in this package's dependency closure before loading it, so the resolving
+            // hook binds dependencies to the versions NuGet selected rather than guessing from assembly
+            // versions (which are routinely lower than the package versions that ship them).
+            NugetAssemblyResolver.RegisterPackageClosure(globalPackagesFolder, assemblyPath);
 
             byte[] assemblyBytes;
             try
             {
                 assemblyBytes = await File.ReadAllBytesAsync(assemblyPath).ConfigureAwait(false);
-            }
-            catch (Exception ex)
+            }            catch (Exception ex)
             {
                 generator.Emitter?.Debug(
                     $"Failed to read assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
-                CacheResult(state, key, null);
-                return null;
+                return CacheResult(state, key, new ResolutionResult(
+                    null,
+                    $"assembly '{assemblyPath}' could not be read ({ex.Message})"));
             }
 
             Type? loadedType;
@@ -226,16 +279,20 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             {
                 generator.Emitter?.Debug(
                     $"Failed to load assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
-                CacheResult(state, key, null);
-                return null;
+                return CacheResult(state, key, new ResolutionResult(
+                    null,
+                    $"assembly '{assemblyPath}' could not be loaded ({ex.Message})"));
             }
 
             if (loadedType == null)
             {
+                // Either the type genuinely isn't in the assembly, or one of its dependencies could not be
+                // satisfied even with the NuGet probing hook installed - GetType reports both as null.
                 generator.Emitter?.Debug(
-                    $"Assembly '{assemblyPath}' does not contain external type '{external.Identity}'.");
-                CacheResult(state, key, null);
-                return null;
+                    $"Assembly '{assemblyPath}' does not declare external type '{external.Identity}', or one of its dependencies could not be resolved.");
+                return CacheResult(state, key, new ResolutionResult(
+                    null,
+                    $"assembly '{assemblyPath}' was loaded but does not declare the type, or one of the type's dependencies could not be resolved"));
             }
 
             // Register the dll as a Roslyn metadata reference exactly once per assembly path so that
@@ -248,18 +305,19 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                     $"Added metadata reference for external type '{external.Identity}' from {assemblyPath}");
             }
 
-            CacheResult(state, key, loadedType);
-            return loadedType;
+            CacheResult(state, key, new ResolutionResult(loadedType, null));
+            return new ResolutionResult(loadedType, null);
         }
 
-        private static void CacheResult(CacheState state, string key, Type? result)
+        private static ResolutionResult CacheResult(CacheState state, string key, ResolutionResult result)
         {
             // Replace whatever Lazy is in the slot with one that already has the computed value.
             // AddOrUpdate ensures we don't lose a concurrent write.
-            var precomputed = new Lazy<Type?>(() => result, LazyThreadSafetyMode.PublicationOnly);
+            var precomputed = new Lazy<ResolutionResult>(() => result, LazyThreadSafetyMode.PublicationOnly);
             // Force the value to be materialized so IsValueCreated is true.
             _ = precomputed.Value;
             state.Resolved.AddOrUpdate(key, precomputed, (_, _) => precomputed);
+            return result;
         }
 
         private static void CollectExternalTypes(InputLibrary library, IDictionary<string, InputExternalTypeMetadata> collected)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/ExternalTypeReferenceResolver.cs
@@ -59,6 +59,24 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             // the same dll isn't registered twice when it contains multiple referenced types.
             public readonly ConcurrentDictionary<string, byte> AddedAssemblyRefs =
                 new(StringComparer.OrdinalIgnoreCase);
+
+            private readonly object _assemblyResolverLock = new();
+            private NugetAssemblyResolver? _assemblyResolver;
+
+            /// <summary>
+            /// The dependency resolver for this generation run, created on first use and reused for every
+            /// external type resolved by the same generator.
+            /// </summary>
+            public NugetAssemblyResolver GetAssemblyResolver(string globalPackagesFolder, CodeModelGenerator generator)
+            {
+                lock (_assemblyResolverLock)
+                {
+                    return _assemblyResolver ??= new NugetAssemblyResolver(
+                        globalPackagesFolder,
+                        message => generator.Emitter?.Debug(message),
+                        generator.AddMetadataReference);
+                }
+            }
         }
 
         private static CacheState GetState(CodeModelGenerator generator) =>
@@ -167,7 +185,9 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 // when Reset runs before the first generator is loaded (e.g. a test fixture's SetUp).
             }
 
-            NugetAssemblyResolver.Reset();
+            // The dropped CacheState owned the dependency resolver, so stop routing loads to it. Assemblies
+            // it already loaded stay in the default context; they cannot be unloaded.
+            NugetAssemblyResolver.Deactivate();
         }
 
         private static string MakeKey(InputExternalTypeMetadata external) =>
@@ -206,9 +226,10 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
 
             // The external assembly is loaded into the default AssemblyLoadContext, which cannot see the
-            // package's own dependencies. Install the NuGet probing hook before loading anything so that
-            // base types and interfaces declared in dependency packages can be resolved.
-            NugetAssemblyResolver.EnsureRegistered(globalPackagesFolder);
+            // package's own dependencies. Activate this run's NuGet probing resolver before loading
+            // anything so that base types and interfaces declared in dependency packages can be resolved.
+            var assemblyResolver = state.GetAssemblyResolver(globalPackagesFolder, generator);
+            assemblyResolver.Activate();
 
             string? assemblyPath = NugetPackageResolver.FindPackageAssembly(
                 globalPackagesFolder, external.Package!, external.MinVersion);
@@ -252,13 +273,14 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             // Pin every package in this package's dependency closure before loading it, so the resolving
             // hook binds dependencies to the versions NuGet selected rather than guessing from assembly
             // versions (which are routinely lower than the package versions that ship them).
-            NugetAssemblyResolver.RegisterPackageClosure(globalPackagesFolder, assemblyPath);
+            assemblyResolver.RegisterPackageClosure(assemblyPath);
 
             byte[] assemblyBytes;
             try
             {
                 assemblyBytes = await File.ReadAllBytesAsync(assemblyPath).ConfigureAwait(false);
-            }            catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 generator.Emitter?.Debug(
                     $"Failed to read assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
@@ -281,7 +303,8 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                     $"Failed to load assembly '{assemblyPath}' for external type '{external.Identity}': {ex.Message}");
                 return CacheResult(state, key, new ResolutionResult(
                     null,
-                    $"assembly '{assemblyPath}' could not be loaded ({ex.Message})"));
+                    $"assembly '{assemblyPath}' could not be loaded ({ex.Message})" +
+                    assemblyResolver.DescribeDowngradedDependencies()));
             }
 
             if (loadedType == null)
@@ -292,7 +315,8 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                     $"Assembly '{assemblyPath}' does not declare external type '{external.Identity}', or one of its dependencies could not be resolved.");
                 return CacheResult(state, key, new ResolutionResult(
                     null,
-                    $"assembly '{assemblyPath}' was loaded but does not declare the type, or one of the type's dependencies could not be resolved"));
+                    $"assembly '{assemblyPath}' was loaded but does not declare the type, or one of the type's dependencies could not be resolved" +
+                    assemblyResolver.DescribeDowngradedDependencies()));
             }
 
             // Register the dll as a Roslyn metadata reference exactly once per assembly path so that

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetAssemblyResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetAssemblyResolver.cs
@@ -29,53 +29,98 @@ namespace Microsoft.TypeSpec.Generator.Utilities
     /// hook <c>Assembly.GetType(identity, throwOnError: false)</c> silently returns <c>null</c> for any
     /// type whose base type lives in a dependency. The external type then appears unresolvable and is
     /// generated instead of referenced.
+    /// <para>
+    /// One instance services one generation run and is owned by that run's resolver cache state. The
+    /// only genuinely process-wide pieces are kept static and documented below: the default context's
+    /// single <c>Resolving</c> event, and the fact that assemblies loaded into it can never be unloaded.
+    /// </para>
     /// </remarks>
-    internal static class NugetAssemblyResolver
+    internal sealed class NugetAssemblyResolver
     {
+        // The default AssemblyLoadContext exposes exactly one process-wide Resolving event, so the handler is
+        // installed once and dispatches to whichever resolver is currently servicing a generation run. Keeping
+        // the subscription static rather than per-instance means repeated runs in one process - the norm under
+        // test - cannot accumulate handlers.
+        private static int _hookInstalled;
+        private static NugetAssemblyResolver? _active;
+
+        private readonly string _globalPackagesFolder;
+        private readonly Action<string> _debug;
+        private readonly Action<MetadataReference> _addMetadataReference;
+
         // Cached resolution per assembly simple name. A null value means resolution was attempted and
         // failed, so repeated references to the same missing dependency don't re-probe the file system.
-        private static readonly ConcurrentDictionary<string, Assembly?> _resolved =
+        private readonly ConcurrentDictionary<string, Assembly?> _resolved =
             new(StringComparer.OrdinalIgnoreCase);
 
         // Tracks assembly paths already registered as Roslyn metadata references.
-        private static readonly ConcurrentDictionary<string, byte> _registeredReferences =
+        private readonly ConcurrentDictionary<string, byte> _registeredReferences =
             new(StringComparer.OrdinalIgnoreCase);
 
         // Package id -> package version, for every package in the dependency closure of an external-type
         // package. Populated from .nuspec files so dependencies bind to the version NuGet would have
         // chosen rather than a version guessed from the referencing assembly's version number.
-        private static readonly ConcurrentDictionary<string, NuGetVersion> _closureVersions =
+        private readonly ConcurrentDictionary<string, NuGetVersion> _closureVersions =
             new(StringComparer.OrdinalIgnoreCase);
 
         // Package version directories whose .nuspec has already been walked.
-        private static readonly ConcurrentDictionary<string, byte> _walkedPackages =
+        private readonly ConcurrentDictionary<string, byte> _walkedPackages =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        // Dependencies that were satisfied by an older copy the generator already deploys, keyed by simple
+        // name. Surfaced in resolution failures so a type that fails to load because of the substitution
+        // reports why instead of just appearing to be missing.
+        private readonly ConcurrentDictionary<string, string> _downgradedDependencies =
             new(StringComparer.OrdinalIgnoreCase);
 
         // Guards against a dependency cycle re-entering resolution for the same name on this thread.
-        [ThreadStatic]
-        private static HashSet<string>? _inProgress;
+        private readonly ThreadLocal<HashSet<string>> _inProgress =
+            new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 
-        private static string? _globalPackagesFolder;
-        private static int _hookInstalled;
+        /// <param name="globalPackagesFolder">The NuGet global packages folder to probe.</param>
+        /// <param name="debug">Receives trace messages describing each resolution decision.</param>
+        /// <param name="addMetadataReference">
+        /// Registers a resolved dependency with the generation run's Roslyn workspaces.
+        /// </param>
+        public NugetAssemblyResolver(
+            string globalPackagesFolder,
+            Action<string> debug,
+            Action<MetadataReference> addMetadataReference)
+        {
+            _globalPackagesFolder = globalPackagesFolder;
+            _debug = debug;
+            _addMetadataReference = addMetadataReference;
+        }
 
         /// <summary>
-        /// Installs the <see cref="AssemblyLoadContext.Resolving"/> hook (once per process) and records the
-        /// NuGet global packages folder to probe. Safe to call repeatedly.
+        /// Makes this the resolver that services dependency loads the default context cannot satisfy,
+        /// installing the process-wide hook on first use. Safe to call repeatedly.
         /// </summary>
-        public static void EnsureRegistered(string globalPackagesFolder)
+        public void Activate()
         {
-            if (string.IsNullOrEmpty(globalPackagesFolder))
-            {
-                return;
-            }
-
-            Volatile.Write(ref _globalPackagesFolder, globalPackagesFolder);
+            Volatile.Write(ref _active, this);
 
             if (Interlocked.Exchange(ref _hookInstalled, 1) == 0)
             {
-                AssemblyLoadContext.Default.Resolving += OnResolving;
+                AssemblyLoadContext.Default.Resolving += static (context, name) =>
+                    Volatile.Read(ref _active)?.OnResolving(context, name);
             }
         }
+
+        /// <summary>
+        /// Stops routing dependency loads to any resolver. Assemblies already loaded into the default
+        /// context stay loaded - they cannot be unloaded - so this only detaches the bookkeeping.
+        /// </summary>
+        public static void Deactivate() => Volatile.Write(ref _active, null);
+
+        /// <summary>
+        /// Describes the dependencies that were satisfied by an older copy shipped with the generator, or
+        /// <c>null</c> when every dependency was resolved at or above the version that was asked for.
+        /// </summary>
+        public string? DescribeDowngradedDependencies() =>
+            _downgradedDependencies.IsEmpty
+                ? null
+                : string.Join("; ", _downgradedDependencies.Values.OrderBy(v => v, StringComparer.Ordinal));
 
         /// <summary>
         /// Records the dependency closure of the package that ships <paramref name="packageAssemblyPath"/> by
@@ -88,9 +133,9 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         /// 1.14.0, for example, ships assembly version 1.9.0.0; treating that as a package version resolves the
         /// unrelated 1.9.0 package and produces a <see cref="MissingMethodException"/> at type-load time.
         /// </remarks>
-        public static void RegisterPackageClosure(string globalPackagesFolder, string packageAssemblyPath)
+        public void RegisterPackageClosure(string packageAssemblyPath)
         {
-            if (string.IsNullOrEmpty(globalPackagesFolder) || string.IsNullOrEmpty(packageAssemblyPath))
+            if (string.IsNullOrEmpty(packageAssemblyPath))
             {
                 return;
             }
@@ -103,10 +148,10 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 return;
             }
 
-            WalkPackage(globalPackagesFolder, Path.GetFileName(packageDir), Path.GetFileName(versionDir));
+            WalkPackage(Path.GetFileName(packageDir), Path.GetFileName(versionDir));
         }
 
-        private static void WalkPackage(string globalPackagesFolder, string packageId, string version)
+        private void WalkPackage(string packageId, string version)
         {
             if (!NuGetVersion.TryParse(version, out var parsedVersion))
             {
@@ -128,7 +173,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 return;
             }
 
-            var versionDir = Path.Combine(globalPackagesFolder, packageId.ToLowerInvariant(), version.ToLowerInvariant());
+            var versionDir = Path.Combine(_globalPackagesFolder, packageId.ToLowerInvariant(), version.ToLowerInvariant());
             string? nuspecPath;
             try
             {
@@ -138,13 +183,13 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             catch (Exception ex)
             {
-                Debug($"Failed to enumerate '{versionDir}' while walking package dependencies: {ex.Message}");
+                _debug($"Failed to enumerate '{versionDir}' while walking package dependencies: {ex.Message}");
                 return;
             }
 
             if (nuspecPath == null)
             {
-                Debug($"No .nuspec found for package '{packageId}' {version}; its dependencies will not be pinned.");
+                _debug($"No .nuspec found for package '{packageId}' {version}; its dependencies will not be pinned.");
                 return;
             }
 
@@ -155,7 +200,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             catch (Exception ex)
             {
-                Debug($"Failed to read '{nuspecPath}': {ex.Message}");
+                _debug($"Failed to read '{nuspecPath}': {ex.Message}");
                 return;
             }
 
@@ -164,7 +209,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 var dependencyVersion = dependency.VersionRange?.MinVersion;
                 if (dependencyVersion != null)
                 {
-                    WalkPackage(globalPackagesFolder, dependency.Id, dependencyVersion.ToNormalizedString());
+                    WalkPackage(dependency.Id, dependencyVersion.ToNormalizedString());
                 }
             }
         }
@@ -184,23 +229,10 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             return group?.Packages ?? Array.Empty<PackageDependency>();
         }
 
-        /// <summary>
-        /// Clears the cached dependency resolutions. Loaded assemblies cannot be unloaded from the default
-        /// context, so this only resets the probe/metadata-reference bookkeeping.
-        /// </summary>
-        internal static void Reset()
-        {
-            _resolved.Clear();
-            _registeredReferences.Clear();
-            _closureVersions.Clear();
-            _walkedPackages.Clear();
-        }
-
-        private static Assembly? OnResolving(AssemblyLoadContext context, AssemblyName name)
+        private Assembly? OnResolving(AssemblyLoadContext context, AssemblyName name)
         {
             var simpleName = name.Name;
-            var globalPackagesFolder = Volatile.Read(ref _globalPackagesFolder);
-            if (string.IsNullOrEmpty(simpleName) || string.IsNullOrEmpty(globalPackagesFolder))
+            if (string.IsNullOrEmpty(simpleName) || string.IsNullOrEmpty(_globalPackagesFolder))
             {
                 return null;
             }
@@ -210,7 +242,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 return cached;
             }
 
-            var inProgress = _inProgress ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var inProgress = _inProgress.Value!;
             if (!inProgress.Add(simpleName))
             {
                 return null;
@@ -225,7 +257,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 // same simple name in the process, and any type they both declare (System.Memory.Data's
                 // System.BinaryData, for example) would exist twice, so signatures mentioning it fail to bind
                 // with a MissingMethodException. Reusing the host's copy keeps exactly one identity per name.
-                var assembly = UseHostAssembly(simpleName) ?? Probe(globalPackagesFolder, simpleName, name.Version);
+                var assembly = UseHostAssembly(simpleName, name.Version) ?? Probe(simpleName, name.Version);
                 _resolved[simpleName] = assembly;
                 return assembly;
             }
@@ -236,15 +268,45 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         }
 
         /// <summary>
-        /// Returns the host's own copy of <paramref name="simpleName"/> when it has one, ignoring version.
+        /// Returns the host's own copy of <paramref name="simpleName"/> when it has one, regardless of version,
+        /// recording a downgrade when that copy is older than the version that was requested.
         /// </summary>
-        private static Assembly? UseHostAssembly(string simpleName)
+        private Assembly? UseHostAssembly(string simpleName, Version? requestedVersion)
+        {
+            var hostAssembly = FindHostAssembly(simpleName);
+            if (hostAssembly == null)
+            {
+                return null;
+            }
+
+            var hostVersion = hostAssembly.GetName().Version;
+            if (requestedVersion != null && hostVersion != null && hostVersion < requestedVersion)
+            {
+                // Not fatal on its own: assembly versions are routinely older than the reference that names
+                // them, and using the host's copy is the only option that keeps one identity per simple name.
+                // It is recorded so that a type which does fail to load can say why.
+                var note =
+                    $"'{simpleName}' was requested at version {requestedVersion} but the generator supplies " +
+                    $"{hostVersion}, which was used to keep a single identity for the types it declares";
+                if (_downgradedDependencies.TryAdd(simpleName, note))
+                {
+                    _debug($"Dependency version downgrade: {note}.");
+                }
+            }
+            else
+            {
+                _debug($"Reusing the generator's '{hostAssembly.GetName()}' for dependency '{simpleName}'.");
+            }
+
+            return hostAssembly;
+        }
+
+        private static Assembly? FindHostAssembly(string simpleName)
         {
             foreach (var loaded in AssemblyLoadContext.Default.Assemblies)
             {
                 if (string.Equals(loaded.GetName().Name, simpleName, StringComparison.OrdinalIgnoreCase))
                 {
-                    Debug($"Reusing already-loaded assembly '{loaded.GetName()}' for dependency '{simpleName}'.");
                     return loaded;
                 }
             }
@@ -253,9 +315,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             // which matches any version there; a version-qualified request is what failed to get us here.
             try
             {
-                var assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(simpleName));
-                Debug($"Resolved dependency '{simpleName}' to the generator's own '{assembly.GetName()}'.");
-                return assembly;
+                return AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(simpleName));
             }
             catch (Exception)
             {
@@ -264,7 +324,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
         }
 
-        private static Assembly? Probe(string globalPackagesFolder, string simpleName, Version? version)
+        private Assembly? Probe(string simpleName, Version? version)
         {
             // NuGet package ids and assembly simple names match for the overwhelming majority of packages.
             // Prefer the version recorded from the dependency closure: an assembly reference only carries an
@@ -274,15 +334,15 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             if (_closureVersions.TryGetValue(simpleName, out var closureVersion))
             {
                 assemblyPath = NugetPackageResolver.FindPackageAssemblyInVersion(
-                    globalPackagesFolder, simpleName, closureVersion.ToNormalizedString());
+                    _globalPackagesFolder, simpleName, closureVersion.ToNormalizedString());
                 if (assemblyPath == null)
                 {
-                    Debug($"Dependency '{simpleName}' {closureVersion.ToNormalizedString()} is in the closure but is not installed in '{globalPackagesFolder}'.");
+                    _debug($"Dependency '{simpleName}' {closureVersion.ToNormalizedString()} is in the closure but is not installed in '{_globalPackagesFolder}'.");
                 }
                 else
                 {
                     // Dependencies of a dependency are only discoverable once we know which version won.
-                    RegisterPackageClosure(globalPackagesFolder, assemblyPath);
+                    RegisterPackageClosure(assemblyPath);
                 }
             }
 
@@ -290,13 +350,13 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             // reachable through the closure (for example when a .nuspec is missing from the cache).
             if (assemblyPath == null && version != null)
             {
-                assemblyPath = NugetPackageResolver.FindPackageAssembly(globalPackagesFolder, simpleName, version.ToString());
+                assemblyPath = NugetPackageResolver.FindPackageAssembly(_globalPackagesFolder, simpleName, version.ToString());
             }
-            assemblyPath ??= NugetPackageResolver.FindPackageAssembly(globalPackagesFolder, simpleName);
+            assemblyPath ??= NugetPackageResolver.FindPackageAssembly(_globalPackagesFolder, simpleName);
 
             if (assemblyPath == null)
             {
-                Debug($"Could not locate dependency assembly '{simpleName}' under '{globalPackagesFolder}'.");
+                _debug($"Could not locate dependency assembly '{simpleName}' under '{_globalPackagesFolder}'.");
                 return null;
             }
 
@@ -308,7 +368,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             catch (Exception ex)
             {
-                Debug($"Failed to read dependency assembly '{assemblyPath}': {ex.Message}");
+                _debug($"Failed to read dependency assembly '{assemblyPath}': {ex.Message}");
                 return null;
             }
 
@@ -319,7 +379,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             catch (Exception ex)
             {
-                Debug($"Failed to load dependency assembly '{assemblyPath}': {ex.Message}");
+                _debug($"Failed to load dependency assembly '{assemblyPath}': {ex.Message}");
                 return null;
             }
 
@@ -329,28 +389,16 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             {
                 try
                 {
-                    CodeModelGenerator.Instance.AddMetadataReference(MetadataReference.CreateFromImage(assemblyBytes));
+                    _addMetadataReference(MetadataReference.CreateFromImage(assemblyBytes));
                 }
                 catch (Exception ex)
                 {
-                    Debug($"Failed to add metadata reference for dependency assembly '{assemblyPath}': {ex.Message}");
+                    _debug($"Failed to add metadata reference for dependency assembly '{assemblyPath}': {ex.Message}");
                 }
             }
 
-            Debug($"Resolved dependency assembly '{simpleName}' from '{assemblyPath}'.");
+            _debug($"Resolved dependency assembly '{simpleName}' from '{assemblyPath}'.");
             return assembly;
-        }
-
-        private static void Debug(string message)
-        {
-            try
-            {
-                CodeModelGenerator.Instance.Emitter?.Debug(message);
-            }
-            catch (InvalidOperationException)
-            {
-                // No generator is installed (e.g. a unit test resolving types outside of a generation run).
-            }
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetAssemblyResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetAssemblyResolver.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace Microsoft.TypeSpec.Generator.Utilities
+{
+    /// <summary>
+    /// Satisfies the transitive assembly references of external-type assemblies loaded by
+    /// <see cref="ExternalTypeReferenceResolver"/> by probing the NuGet global packages folder.
+    /// </summary>
+    /// <remarks>
+    /// External-type assemblies are loaded with <see cref="Assembly.Load(byte[])"/> into the default
+    /// <see cref="AssemblyLoadContext"/>, which resolves dependencies only from the generator's own
+    /// trusted-platform-assemblies list. A package such as <c>Azure.AI.Extensions.OpenAI</c> depends on
+    /// <c>Azure.Core</c> and <c>OpenAI</c>, neither of which the generator references, so without this
+    /// hook <c>Assembly.GetType(identity, throwOnError: false)</c> silently returns <c>null</c> for any
+    /// type whose base type lives in a dependency. The external type then appears unresolvable and is
+    /// generated instead of referenced.
+    /// </remarks>
+    internal static class NugetAssemblyResolver
+    {
+        // Cached resolution per assembly simple name. A null value means resolution was attempted and
+        // failed, so repeated references to the same missing dependency don't re-probe the file system.
+        private static readonly ConcurrentDictionary<string, Assembly?> _resolved =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        // Tracks assembly paths already registered as Roslyn metadata references.
+        private static readonly ConcurrentDictionary<string, byte> _registeredReferences =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        // Package id -> package version, for every package in the dependency closure of an external-type
+        // package. Populated from .nuspec files so dependencies bind to the version NuGet would have
+        // chosen rather than a version guessed from the referencing assembly's version number.
+        private static readonly ConcurrentDictionary<string, NuGetVersion> _closureVersions =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        // Package version directories whose .nuspec has already been walked.
+        private static readonly ConcurrentDictionary<string, byte> _walkedPackages =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        // Guards against a dependency cycle re-entering resolution for the same name on this thread.
+        [ThreadStatic]
+        private static HashSet<string>? _inProgress;
+
+        private static string? _globalPackagesFolder;
+        private static int _hookInstalled;
+
+        /// <summary>
+        /// Installs the <see cref="AssemblyLoadContext.Resolving"/> hook (once per process) and records the
+        /// NuGet global packages folder to probe. Safe to call repeatedly.
+        /// </summary>
+        public static void EnsureRegistered(string globalPackagesFolder)
+        {
+            if (string.IsNullOrEmpty(globalPackagesFolder))
+            {
+                return;
+            }
+
+            Volatile.Write(ref _globalPackagesFolder, globalPackagesFolder);
+
+            if (Interlocked.Exchange(ref _hookInstalled, 1) == 0)
+            {
+                AssemblyLoadContext.Default.Resolving += OnResolving;
+            }
+        }
+
+        /// <summary>
+        /// Records the dependency closure of the package that ships <paramref name="packageAssemblyPath"/> by
+        /// walking its <c>.nuspec</c> transitively, so the resolving hook can bind each dependency to the
+        /// package version NuGet would have selected.
+        /// </summary>
+        /// <remarks>
+        /// This is required because an assembly reference carries an <em>assembly</em> version, which for many
+        /// packages is deliberately lower than the <em>package</em> version that ships it. <c>System.ClientModel</c>
+        /// 1.14.0, for example, ships assembly version 1.9.0.0; treating that as a package version resolves the
+        /// unrelated 1.9.0 package and produces a <see cref="MissingMethodException"/> at type-load time.
+        /// </remarks>
+        public static void RegisterPackageClosure(string globalPackagesFolder, string packageAssemblyPath)
+        {
+            if (string.IsNullOrEmpty(globalPackagesFolder) || string.IsNullOrEmpty(packageAssemblyPath))
+            {
+                return;
+            }
+
+            // Layout is {globalPackagesFolder}/{id}/{version}/lib/{tfm}/{assembly}.dll
+            var versionDir = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(packageAssemblyPath)));
+            var packageDir = Path.GetDirectoryName(versionDir);
+            if (versionDir == null || packageDir == null)
+            {
+                return;
+            }
+
+            WalkPackage(globalPackagesFolder, Path.GetFileName(packageDir), Path.GetFileName(versionDir));
+        }
+
+        private static void WalkPackage(string globalPackagesFolder, string packageId, string version)
+        {
+            if (!NuGetVersion.TryParse(version, out var parsedVersion))
+            {
+                return;
+            }
+
+            // Mirror NuGet's "highest version wins" unification when the same package appears more than once.
+            var winner = _closureVersions.AddOrUpdate(
+                packageId,
+                parsedVersion,
+                (_, existing) => existing >= parsedVersion ? existing : parsedVersion);
+            if (winner != parsedVersion)
+            {
+                return;
+            }
+
+            if (!_walkedPackages.TryAdd($"{packageId}/{parsedVersion.ToNormalizedString()}", 0))
+            {
+                return;
+            }
+
+            var versionDir = Path.Combine(globalPackagesFolder, packageId.ToLowerInvariant(), version.ToLowerInvariant());
+            string? nuspecPath;
+            try
+            {
+                nuspecPath = Directory.Exists(versionDir)
+                    ? Directory.EnumerateFiles(versionDir, "*.nuspec").FirstOrDefault()
+                    : null;
+            }
+            catch (Exception ex)
+            {
+                Debug($"Failed to enumerate '{versionDir}' while walking package dependencies: {ex.Message}");
+                return;
+            }
+
+            if (nuspecPath == null)
+            {
+                Debug($"No .nuspec found for package '{packageId}' {version}; its dependencies will not be pinned.");
+                return;
+            }
+
+            IReadOnlyList<PackageDependencyGroup> groups;
+            try
+            {
+                groups = new NuspecReader(nuspecPath).GetDependencyGroups().ToList();
+            }
+            catch (Exception ex)
+            {
+                Debug($"Failed to read '{nuspecPath}': {ex.Message}");
+                return;
+            }
+
+            foreach (var dependency in SelectNearestGroup(groups))
+            {
+                var dependencyVersion = dependency.VersionRange?.MinVersion;
+                if (dependencyVersion != null)
+                {
+                    WalkPackage(globalPackagesFolder, dependency.Id, dependencyVersion.ToNormalizedString());
+                }
+            }
+        }
+
+        private static IEnumerable<PackageDependency> SelectNearestGroup(IReadOnlyList<PackageDependencyGroup> groups)
+        {
+            if (groups.Count == 0)
+            {
+                return Array.Empty<PackageDependency>();
+            }
+
+            var nearest = new FrameworkReducer().GetNearest(NugetPackageResolver.CurrentFramework, groups.Select(g => g.TargetFramework));
+            var group = nearest != null
+                ? groups.FirstOrDefault(g => g.TargetFramework.Equals(nearest))
+                : null;
+
+            return group?.Packages ?? Array.Empty<PackageDependency>();
+        }
+
+        /// <summary>
+        /// Clears the cached dependency resolutions. Loaded assemblies cannot be unloaded from the default
+        /// context, so this only resets the probe/metadata-reference bookkeeping.
+        /// </summary>
+        internal static void Reset()
+        {
+            _resolved.Clear();
+            _registeredReferences.Clear();
+            _closureVersions.Clear();
+            _walkedPackages.Clear();
+        }
+
+        private static Assembly? OnResolving(AssemblyLoadContext context, AssemblyName name)
+        {
+            var simpleName = name.Name;
+            var globalPackagesFolder = Volatile.Read(ref _globalPackagesFolder);
+            if (string.IsNullOrEmpty(simpleName) || string.IsNullOrEmpty(globalPackagesFolder))
+            {
+                return null;
+            }
+
+            if (_resolved.TryGetValue(simpleName, out var cached))
+            {
+                return cached;
+            }
+
+            var inProgress = _inProgress ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!inProgress.Add(simpleName))
+            {
+                return null;
+            }
+
+            try
+            {
+                // Prefer an assembly the host already provides, even when its version is lower than the one
+                // requested. The default context only asks us to resolve a name it could not satisfy itself, but
+                // it will still satisfy *other*, lower-versioned requests for that same name from its own
+                // assemblies. Loading a second copy from the cache would therefore leave two assemblies with the
+                // same simple name in the process, and any type they both declare (System.Memory.Data's
+                // System.BinaryData, for example) would exist twice, so signatures mentioning it fail to bind
+                // with a MissingMethodException. Reusing the host's copy keeps exactly one identity per name.
+                var assembly = UseHostAssembly(simpleName) ?? Probe(globalPackagesFolder, simpleName, name.Version);
+                _resolved[simpleName] = assembly;
+                return assembly;
+            }
+            finally
+            {
+                inProgress.Remove(simpleName);
+            }
+        }
+
+        /// <summary>
+        /// Returns the host's own copy of <paramref name="simpleName"/> when it has one, ignoring version.
+        /// </summary>
+        private static Assembly? UseHostAssembly(string simpleName)
+        {
+            foreach (var loaded in AssemblyLoadContext.Default.Assemblies)
+            {
+                if (string.Equals(loaded.GetName().Name, simpleName, StringComparison.OrdinalIgnoreCase))
+                {
+                    Debug($"Reusing already-loaded assembly '{loaded.GetName()}' for dependency '{simpleName}'.");
+                    return loaded;
+                }
+            }
+
+            // Not loaded yet, but it may still be in the generator's deployment. Ask for it by simple name only,
+            // which matches any version there; a version-qualified request is what failed to get us here.
+            try
+            {
+                var assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(simpleName));
+                Debug($"Resolved dependency '{simpleName}' to the generator's own '{assembly.GetName()}'.");
+                return assembly;
+            }
+            catch (Exception)
+            {
+                // The generator does not deploy this assembly; fall back to the NuGet cache.
+                return null;
+            }
+        }
+
+        private static Assembly? Probe(string globalPackagesFolder, string simpleName, Version? version)
+        {
+            // NuGet package ids and assembly simple names match for the overwhelming majority of packages.
+            // Prefer the version recorded from the dependency closure: an assembly reference only carries an
+            // assembly version, which is frequently lower than the package version that ships it, so deriving
+            // a package version from it can silently bind an incompatible package.
+            string? assemblyPath = null;
+            if (_closureVersions.TryGetValue(simpleName, out var closureVersion))
+            {
+                assemblyPath = NugetPackageResolver.FindPackageAssemblyInVersion(
+                    globalPackagesFolder, simpleName, closureVersion.ToNormalizedString());
+                if (assemblyPath == null)
+                {
+                    Debug($"Dependency '{simpleName}' {closureVersion.ToNormalizedString()} is in the closure but is not installed in '{globalPackagesFolder}'.");
+                }
+                else
+                {
+                    // Dependencies of a dependency are only discoverable once we know which version won.
+                    RegisterPackageClosure(globalPackagesFolder, assemblyPath);
+                }
+            }
+
+            // Fall back to a version-range search, then to any cached version, for packages that were not
+            // reachable through the closure (for example when a .nuspec is missing from the cache).
+            if (assemblyPath == null && version != null)
+            {
+                assemblyPath = NugetPackageResolver.FindPackageAssembly(globalPackagesFolder, simpleName, version.ToString());
+            }
+            assemblyPath ??= NugetPackageResolver.FindPackageAssembly(globalPackagesFolder, simpleName);
+
+            if (assemblyPath == null)
+            {
+                Debug($"Could not locate dependency assembly '{simpleName}' under '{globalPackagesFolder}'.");
+                return null;
+            }
+
+            byte[] assemblyBytes;
+            try
+            {
+                // Load from bytes so we never hold a file handle on a package in the global cache.
+                assemblyBytes = File.ReadAllBytes(assemblyPath);
+            }
+            catch (Exception ex)
+            {
+                Debug($"Failed to read dependency assembly '{assemblyPath}': {ex.Message}");
+                return null;
+            }
+
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.Load(assemblyBytes);
+            }
+            catch (Exception ex)
+            {
+                Debug($"Failed to load dependency assembly '{assemblyPath}': {ex.Message}");
+                return null;
+            }
+
+            // Make the dependency visible to Roslyn too, so generated code that inherits from or references
+            // types declared in it still binds inside the generated-code workspace.
+            if (_registeredReferences.TryAdd(assemblyPath, 0))
+            {
+                try
+                {
+                    CodeModelGenerator.Instance.AddMetadataReference(MetadataReference.CreateFromImage(assemblyBytes));
+                }
+                catch (Exception ex)
+                {
+                    Debug($"Failed to add metadata reference for dependency assembly '{assemblyPath}': {ex.Message}");
+                }
+            }
+
+            Debug($"Resolved dependency assembly '{simpleName}' from '{assemblyPath}'.");
+            return assembly;
+        }
+
+        private static void Debug(string message)
+        {
+            try
+            {
+                CodeModelGenerator.Instance.Emitter?.Debug(message);
+            }
+            catch (InvalidOperationException)
+            {
+                // No generator is installed (e.g. a unit test resolving types outside of a generation run).
+            }
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetAssemblyResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetAssemblyResolver.cs
@@ -102,8 +102,8 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
             if (Interlocked.Exchange(ref _hookInstalled, 1) == 0)
             {
-                AssemblyLoadContext.Default.Resolving += static (context, name) =>
-                    Volatile.Read(ref _active)?.OnResolving(context, name);
+                AssemblyLoadContext.Default.Resolving += static (_, name) =>
+                    Volatile.Read(ref _active)?.Resolve(name);
             }
         }
 
@@ -173,17 +173,24 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                 return;
             }
 
-            var versionDir = Path.Combine(_globalPackagesFolder, packageId.ToLowerInvariant(), version.ToLowerInvariant());
+            if (!NugetPackageResolver.TryFindPackageInCache(
+                _globalPackagesFolder,
+                packageId,
+                parsedVersion,
+                out var packageInfo))
+            {
+                _debug($"Package '{packageId}' {version} was not found while walking package dependencies.");
+                return;
+            }
+
             string? nuspecPath;
             try
             {
-                nuspecPath = Directory.Exists(versionDir)
-                    ? Directory.EnumerateFiles(versionDir, "*.nuspec").FirstOrDefault()
-                    : null;
+                nuspecPath = Directory.EnumerateFiles(packageInfo.ExpandedPath, "*.nuspec").FirstOrDefault();
             }
             catch (Exception ex)
             {
-                _debug($"Failed to enumerate '{versionDir}' while walking package dependencies: {ex.Message}");
+                _debug($"Failed to enumerate '{packageInfo.ExpandedPath}' while walking package dependencies: {ex.Message}");
                 return;
             }
 
@@ -229,7 +236,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             return group?.Packages ?? Array.Empty<PackageDependency>();
         }
 
-        private Assembly? OnResolving(AssemblyLoadContext context, AssemblyName name)
+        internal Assembly? Resolve(AssemblyName name)
         {
             var simpleName = name.Name;
             if (string.IsNullOrEmpty(simpleName) || string.IsNullOrEmpty(_globalPackagesFolder))

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageDownloader.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageDownloader.cs
@@ -17,7 +17,6 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
-using NuGet.Repositories;
 using NuGet.Versioning;
 using ILogger = NuGet.Common.ILogger;
 using PackageArchiveDownloader = NuGet.Protocol.LocalPackageArchiveDownloader;
@@ -32,8 +31,6 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         private readonly ISettings _nugetSettings;
         private readonly IReadOnlyList<PackageSource> _availableSources;
         private readonly HashSet<string> _targetFrameworks;
-        // cspell: disable-next-line
-        private readonly NuGetv3LocalRepository _localRepo;
 
         public NugetPackageDownloader(
             string packageName,
@@ -43,12 +40,10 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         {
             _nugetSettings = settings;
             _targetFrameworks = targetFrameworks is null
-                ? [ ..PreferredDotNetFrameworkVersions ]
+                ? [.. PreferredDotNetFrameworkVersions]
                 : [.. targetFrameworks];
             _availableSources = GetPrimaryPackageSources(settings);
             _globalNugetPackagePath = SettingsUtility.GetGlobalPackagesFolder(settings);
-            // cspell: disable-next-line
-            _localRepo = new NuGetv3LocalRepository(_globalNugetPackagePath);
             _packageName = packageName;
             _packageVersion = packageVersion;
         }
@@ -71,8 +66,11 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
         protected virtual bool TryFindPackageInCache(string packageName, NuGetVersion version, out NuGet.Repositories.LocalPackageInfo? packageInfo)
         {
-            packageInfo = _localRepo.FindPackage(packageName, version);
-            return packageInfo != null;
+            return NugetPackageResolver.TryFindPackageInCache(
+                _globalNugetPackagePath,
+                packageName,
+                version,
+                out packageInfo);
         }
 
         protected virtual bool DirectoryExists(string path)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
@@ -109,6 +109,7 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             NuGetVersion version,
             [NotNullWhen(true)] out NuGet.Repositories.LocalPackageInfo? packageInfo)
         {
+            // cspell: disable-next-line
             var localRepository = new NuGetv3LocalRepository(globalPackagesFolder);
             packageInfo = localRepository.FindPackage(packageName, version);
             return packageInfo != null;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -11,6 +12,7 @@ using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Repositories;
 using NuGet.Versioning;
 
 namespace Microsoft.TypeSpec.Generator.Utilities
@@ -88,8 +90,28 @@ namespace Microsoft.TypeSpec.Generator.Utilities
         /// </summary>
         public static string? FindPackageAssemblyInVersion(string globalPackagesFolder, string packageName, string version)
         {
-            var versionDir = Path.Combine(globalPackagesFolder, packageName.ToLowerInvariant(), version.ToLowerInvariant());
-            return Directory.Exists(versionDir) ? TryFindNearestAssemblyInVersionDir(versionDir, packageName) : null;
+            if (!NuGetVersion.TryParse(version, out var parsedVersion)
+                || !TryFindPackageInCache(globalPackagesFolder, packageName, parsedVersion, out var packageInfo))
+            {
+                return null;
+            }
+
+            return TryFindNearestAssemblyInVersionDir(packageInfo.ExpandedPath, packageName);
+        }
+
+        /// <summary>
+        /// Uses NuGet's local repository implementation to locate one exact package version in the global
+        /// packages folder.
+        /// </summary>
+        public static bool TryFindPackageInCache(
+            string globalPackagesFolder,
+            string packageName,
+            NuGetVersion version,
+            [NotNullWhen(true)] out NuGet.Repositories.LocalPackageInfo? packageInfo)
+        {
+            var localRepository = new NuGetv3LocalRepository(globalPackagesFolder);
+            packageInfo = localRepository.FindPackage(packageName, version);
+            return packageInfo != null;
         }
 
         /// <summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/NugetPackageResolver.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -77,6 +78,92 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Searches for an assembly belonging to <paramref name="packageName"/> in one specific installed
+        /// version of the package. Unlike <see cref="FindPackageAssembly"/> this performs no version
+        /// selection, so callers that already know the exact version (e.g. from a resolved dependency
+        /// closure) cannot accidentally bind to a different one.
+        /// </summary>
+        public static string? FindPackageAssemblyInVersion(string globalPackagesFolder, string packageName, string version)
+        {
+            var versionDir = Path.Combine(globalPackagesFolder, packageName.ToLowerInvariant(), version.ToLowerInvariant());
+            return Directory.Exists(versionDir) ? TryFindNearestAssemblyInVersionDir(versionDir, packageName) : null;
+        }
+
+        /// <summary>
+        /// Picks the <c>lib/</c> asset closest to the framework the generator is running on, the same way NuGet
+        /// would for a project targeting that framework.
+        /// </summary>
+        /// <remarks>
+        /// This differs from <see cref="TryFindAssemblyInVersionDir"/>, which probes
+        /// <see cref="NugetPackageDownloader.PreferredDotNetFrameworkVersions"/> and therefore prefers
+        /// <c>netstandard2.0</c>. That ordering is fine for collecting compile-time references, but assemblies
+        /// resolved here are loaded into the running generator, where a <c>netstandard2.0</c> asset can bind
+        /// against compatibility shims that duplicate types the shared framework already provides.
+        /// </remarks>
+        private static string? TryFindNearestAssemblyInVersionDir(string versionDir, string packageName)
+        {
+            var libDir = Path.Combine(versionDir, "lib");
+            if (!Directory.Exists(libDir))
+            {
+                return null;
+            }
+
+            var candidates = Directory.GetDirectories(libDir)
+                .Select(dir => (Dir: dir, Framework: ParseFrameworkFolder(Path.GetFileName(dir))))
+                .Where(c => c.Framework != null && File.Exists(Path.Combine(c.Dir, $"{packageName}.dll")))
+                .ToList();
+
+            if (candidates.Count == 0)
+            {
+                return null;
+            }
+
+            var nearest = new FrameworkReducer().GetNearest(CurrentFramework, candidates.Select(c => c.Framework!));
+            var match = nearest != null
+                ? candidates.First(c => c.Framework!.Equals(nearest))
+                : candidates[0];
+
+            return Path.Combine(match.Dir, $"{packageName}.dll");
+        }
+
+        private static NuGetFramework? ParseFrameworkFolder(string folderName)
+        {
+            try
+            {
+                var framework = NuGetFramework.ParseFolder(folderName);
+                return framework.IsUnsupported ? null : framework;
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// The framework the generator itself is running on, used to choose <c>lib/</c> assets that are safe to
+        /// load into this process.
+        /// </summary>
+        internal static NuGetFramework CurrentFramework { get; } = ResolveCurrentFramework();
+
+        private static NuGetFramework ResolveCurrentFramework()
+        {
+            var frameworkName = AppContext.TargetFrameworkName;
+            if (!string.IsNullOrEmpty(frameworkName))
+            {
+                try
+                {
+                    return NuGetFramework.Parse(frameworkName);
+                }
+                catch (ArgumentException)
+                {
+                    // Fall through to the runtime-version based approximation below.
+                }
+            }
+
+            return NuGetFramework.Parse($".NETCoreApp,Version=v{Environment.Version.Major}.{Environment.Version.Minor}");
         }
 
         private static string? TryFindAssemblyInVersionDir(string versionDir, string packageName)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -136,6 +137,64 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
             var resolved = ExternalTypeReferenceResolver.TryResolve(external);
 
             Assert.IsNull(resolved);
+            StringAssert.Contains(
+                "was not found in the NuGet cache",
+                ExternalTypeReferenceResolver.GetFailureReason(external),
+                "A missing package should be reported as a missing package.");
+        }
+
+        [Test]
+        public void TryResolve_ResolvesTypeWhoseBaseTypeLivesInAnotherPackage()
+        {
+            var nugetCacheDir = Path.Combine(_tempDirectory!, "NuGetCache");
+            const string basePkg = "Test.Dependency.Base";
+            const string leafPkg = "Test.Dependent.Leaf";
+            const string leafTypeName = "Test.Dependent.Leaf.DerivedFromDependencyType";
+
+            var baseDll = CreateFakeNuGetPackage(nugetCacheDir, basePkg, "1.0.0", template: "DependencyPackageSource");
+            CreateFakeNuGetPackage(
+                nugetCacheDir,
+                leafPkg,
+                "1.0.0",
+                template: "DependentPackageSource",
+                basePackage: basePkg,
+                referencedAssemblyPaths: [baseDll]);
+
+            var external = new InputExternalTypeMetadata(leafTypeName, leafPkg, "1.0.0");
+
+            var resolved = ExternalTypeReferenceResolver.TryResolve(external);
+
+            // Assembly.Load puts the leaf assembly in the default AssemblyLoadContext, which cannot see
+            // the dependency package. Without the NuGet probing hook, GetType silently returns null here
+            // and the external type gets generated instead of referenced.
+            Assert.IsNotNull(
+                resolved,
+                $"Resolver should load '{leafTypeName}' even though its base type lives in '{basePkg}'. " +
+                $"Failure reason: {ExternalTypeReferenceResolver.GetFailureReason(external)}");
+            Assert.AreEqual(leafTypeName, resolved!.FullName);
+
+            // The whole point of resolving the dependency is that the type is fully usable afterwards:
+            // CSharpType's constructor reads BaseType, IsValueType and IsEnum, all of which throw or
+            // misreport when the dependency assembly is unavailable.
+            Assert.AreEqual($"{basePkg}.DependencyBaseType", resolved.BaseType?.FullName);
+            Assert.IsFalse(resolved.IsValueType);
+            Assert.IsNull(ExternalTypeReferenceResolver.GetFailureReason(external));
+        }
+
+        [Test]
+        public void TryResolve_ReportsFailureReasonWhenTypeMissingFromAssembly()
+        {
+            var nugetCacheDir = Path.Combine(_tempDirectory!, "NuGetCache");
+            const string pkgName = "Test.MissingType.Package";
+            CreateFakeNuGetPackage(nugetCacheDir, pkgName, "1.0.0");
+
+            var external = new InputExternalTypeMetadata($"{pkgName}.NotDeclaredAnywhere", pkgName, null);
+
+            Assert.IsNull(ExternalTypeReferenceResolver.TryResolve(external));
+            StringAssert.Contains(
+                "does not declare the type",
+                ExternalTypeReferenceResolver.GetFailureReason(external),
+                "A located-but-unusable assembly must not be reported as a missing package.");
         }
 
         [Test]
@@ -176,17 +235,23 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
                 "Pre-walk should add the metadata reference exactly once.");
         }
 
-        private static string CreateFakeNuGetPackage(string nugetCacheDir, string packageName, string version)
+        private static string CreateFakeNuGetPackage(
+            string nugetCacheDir,
+            string packageName,
+            string version,
+            string template = "PackageSource",
+            string? basePackage = null,
+            IEnumerable<string>? referencedAssemblyPaths = null)
         {
             // Load the source template from TestData and substitute the package name + version. The
             // template embeds an [assembly: AssemblyVersion("$VERSION$")] attribute so tests can verify
             // which dll was loaded by inspecting Assembly.GetName().Version. Disk + compile + emit are
             // delegated to the shared FakeNuGetPackage helper.
-            var template = Helpers.GetExpectedFromFile(method: "PackageSource");
-            var source = template
+            var source = Helpers.GetExpectedFromFile(method: template)
                 .Replace("$PACKAGE$", packageName)
-                .Replace("$VERSION$", version);
-            return FakeNuGetPackage.Create(nugetCacheDir, packageName, version, source);
+                .Replace("$VERSION$", version)
+                .Replace("$BASEPACKAGE$", basePackage ?? string.Empty);
+            return FakeNuGetPackage.Create(nugetCacheDir, packageName, version, source, referencedAssemblyPaths);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/ExternalTypeReferenceResolverTests.cs
@@ -151,14 +151,30 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
             const string leafPkg = "Test.Dependent.Leaf";
             const string leafTypeName = "Test.Dependent.Leaf.DerivedFromDependencyType";
 
-            var baseDll = CreateFakeNuGetPackage(nugetCacheDir, basePkg, "1.0.0", template: "DependencyPackageSource");
+            // The base package ships package version 2.0.0 but assembly version 1.0.0.0, mirroring real
+            // packages (System.ClientModel 1.14.0 ships assembly version 1.9.0.0). Only its .nuspec says
+            // 2.0.0 is the right version to load.
+            var baseDll = CreateFakeNuGetPackage(
+                nugetCacheDir,
+                basePkg,
+                "2.0.0",
+                template: "DependencyPackageSource",
+                assemblyVersion: "1.0.0.0");
+
+            // A decoy at a higher package version that does *not* declare DependencyBaseType. Resolving the
+            // dependency from the assembly version in the leaf's reference (1.0.0.0) searches for the
+            // highest package at or above 1.0.0 and would land here, leaving the base type unloadable. The
+            // test therefore only passes when the dependency is pinned from the .nuspec closure.
+            CreateFakeNuGetPackage(nugetCacheDir, basePkg, "3.0.0", assemblyVersion: "1.0.0.0");
+
             CreateFakeNuGetPackage(
                 nugetCacheDir,
                 leafPkg,
                 "1.0.0",
                 template: "DependentPackageSource",
                 basePackage: basePkg,
-                referencedAssemblyPaths: [baseDll]);
+                referencedAssemblyPaths: [baseDll],
+                dependencies: [(basePkg, "[2.0.0, )")]);
 
             var external = new InputExternalTypeMetadata(leafTypeName, leafPkg, "1.0.0");
 
@@ -241,17 +257,22 @@ namespace Microsoft.TypeSpec.Generator.Tests.Utilities
             string version,
             string template = "PackageSource",
             string? basePackage = null,
-            IEnumerable<string>? referencedAssemblyPaths = null)
+            IEnumerable<string>? referencedAssemblyPaths = null,
+            string? assemblyVersion = null,
+            IEnumerable<(string Id, string VersionRange)>? dependencies = null)
         {
             // Load the source template from TestData and substitute the package name + version. The
             // template embeds an [assembly: AssemblyVersion("$VERSION$")] attribute so tests can verify
-            // which dll was loaded by inspecting Assembly.GetName().Version. Disk + compile + emit are
-            // delegated to the shared FakeNuGetPackage helper.
+            // which dll was loaded by inspecting Assembly.GetName().Version. The assembly version defaults
+            // to the package version but can be set independently, because real packages routinely ship an
+            // assembly version lower than their package version. Disk + compile + emit are delegated to the
+            // shared FakeNuGetPackage helper.
             var source = Helpers.GetExpectedFromFile(method: template)
                 .Replace("$PACKAGE$", packageName)
-                .Replace("$VERSION$", version)
+                .Replace("$VERSION$", assemblyVersion ?? version)
                 .Replace("$BASEPACKAGE$", basePackage ?? string.Empty);
-            return FakeNuGetPackage.Create(nugetCacheDir, packageName, version, source, referencedAssemblyPaths);
+            return FakeNuGetPackage.Create(
+                nugetCacheDir, packageName, version, source, referencedAssemblyPaths, dependencies);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/NugetAssemblyResolverTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/NugetAssemblyResolverTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.TypeSpec.Generator.Tests.Common;
+using Microsoft.TypeSpec.Generator.Utilities;
+using NUnit.Framework;
+
+namespace Microsoft.TypeSpec.Generator.Tests.Utilities
+{
+    [NonParallelizable]
+    public class NugetAssemblyResolverTests
+    {
+        private string? _tempDirectory;
+
+        [SetUp]
+        public void Setup()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "TestArtifacts", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            NugetAssemblyResolver.Deactivate();
+            Directory.Delete(_tempDirectory!, true);
+        }
+
+        [Test]
+        public void Resolve_ReturnsNullAndLogsWhenAssemblyCannotBeLoaded()
+        {
+            var packageName = $"Test.InvalidAssembly.{Guid.NewGuid():N}";
+            var assemblyPath = Path.Combine(
+                _tempDirectory!,
+                packageName.ToLowerInvariant(),
+                "1.0.0",
+                "lib",
+                "netstandard2.0",
+                $"{packageName}.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(assemblyPath)!);
+            File.WriteAllText(assemblyPath, "not an assembly");
+            var debugMessages = new List<string>();
+            var resolver = new NugetAssemblyResolver(_tempDirectory!, debugMessages.Add, _ => { });
+
+            var resolved = resolver.Resolve(new AssemblyName($"{packageName}, Version=1.0.0.0"));
+
+            Assert.IsNull(resolved);
+            Assert.That(debugMessages, Has.Some.Contains("Failed to load dependency assembly"));
+        }
+
+        [Test]
+        public void Resolve_ReturnsAssemblyWhenMetadataReferenceRegistrationFails()
+        {
+            var packageName = $"Test.MetadataFailure.P{Guid.NewGuid():N}";
+            CreateFakeNuGetPackage(packageName);
+            var debugMessages = new List<string>();
+            var resolver = new NugetAssemblyResolver(
+                _tempDirectory!,
+                debugMessages.Add,
+                _ => throw new InvalidOperationException("metadata failure"));
+
+            var resolved = resolver.Resolve(new AssemblyName($"{packageName}, Version=1.0.0.0"));
+
+            Assert.IsNotNull(resolved);
+            Assert.AreEqual(packageName, resolved!.GetName().Name);
+            Assert.That(debugMessages, Has.Some.Contains("Failed to add metadata reference"));
+        }
+
+        [Test]
+        public void RegisterPackageClosure_LogsMalformedNuspecWithoutThrowing()
+        {
+            var packageName = $"Test.MalformedNuspec.P{Guid.NewGuid():N}";
+            var assemblyPath = CreateFakeNuGetPackage(packageName);
+            var versionDirectory = Path.GetDirectoryName(
+                Path.GetDirectoryName(
+                    Path.GetDirectoryName(assemblyPath)))!;
+            File.WriteAllText(
+                Path.Combine(versionDirectory, $"{packageName.ToLowerInvariant()}.nuspec"),
+                "<not-valid-nuspec");
+            var debugMessages = new List<string>();
+            var resolver = new NugetAssemblyResolver(_tempDirectory!, debugMessages.Add, _ => { });
+
+            Assert.DoesNotThrow(() => resolver.RegisterPackageClosure(assemblyPath));
+            Assert.That(debugMessages, Has.Some.Contains("Failed to read"));
+        }
+
+        private string CreateFakeNuGetPackage(string packageName)
+        {
+            var source = Helpers.GetExpectedFromFile(method: "PackageSource")
+                .Replace("$PACKAGE$", packageName);
+            return FakeNuGetPackage.Create(
+                _tempDirectory!,
+                packageName,
+                "1.0.0",
+                source);
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/ExternalTypeReferenceResolverTests/DependencyPackageSource.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/ExternalTypeReferenceResolverTests/DependencyPackageSource.cs
@@ -1,0 +1,17 @@
+// Token-substituted template source used by ExternalTypeReferenceResolverTests to emit the
+// *dependency* half of a two-package fake NuGet graph. Tokens replaced at compile time by the
+// CreateFakeNuGetPackage helper:
+//   $PACKAGE$  -> the package / namespace name (e.g. "Test.Dependency.Base")
+//   $VERSION$  -> the assembly version embedded as an AssemblyVersionAttribute
+//
+// This file is excluded from compilation by the test project (see the
+// `<Compile Remove="**\TestData\**\*.cs" />` rule in the .csproj).
+
+using System.Reflection;
+
+[assembly: AssemblyVersion("$VERSION$")]
+
+namespace $PACKAGE$
+{
+    public class DependencyBaseType { }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/ExternalTypeReferenceResolverTests/DependentPackageSource.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/ExternalTypeReferenceResolverTests/DependentPackageSource.cs
@@ -1,0 +1,22 @@
+// Token-substituted template source used by ExternalTypeReferenceResolverTests to emit the
+// *dependent* half of a two-package fake NuGet graph. The declared type derives from a type that
+// lives in a different package, which is the shape that previously defeated resolution: loading the
+// assembly succeeds, but Assembly.GetType returns null because the base type's assembly cannot be
+// found by the default AssemblyLoadContext.
+//
+// Tokens replaced at compile time by the CreateFakeNuGetPackage helper:
+//   $PACKAGE$     -> the package / namespace name (e.g. "Test.Dependent.Leaf")
+//   $VERSION$     -> the assembly version embedded as an AssemblyVersionAttribute
+//   $BASEPACKAGE$ -> the namespace of the dependency package declaring DependencyBaseType
+//
+// This file is excluded from compilation by the test project (see the
+// `<Compile Remove="**\TestData\**\*.cs" />` rule in the .csproj).
+
+using System.Reflection;
+
+[assembly: AssemblyVersion("$VERSION$")]
+
+namespace $PACKAGE$
+{
+    public class DerivedFromDependencyType : $BASEPACKAGE$.DependencyBaseType { }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/NugetAssemblyResolverTests/PackageSource.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Utilities/TestData/NugetAssemblyResolverTests/PackageSource.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace $PACKAGE$
+{
+    public class PackageType
+    {
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using NUnit.Framework;
@@ -20,16 +22,39 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
         /// Compiles <paramref name="sourceCode"/> into a netstandard2.0 assembly and writes it to the
         /// NuGet cache layout. Returns the absolute path to the emitted dll.
         /// </summary>
-        public static string Create(string nugetCacheDir, string packageName, string version, string sourceCode)
+        /// <param name="nugetCacheDir">The fake NuGet global packages folder to write into.</param>
+        /// <param name="packageName">The package id, which is also used as the assembly name.</param>
+        /// <param name="version">The package version, used as the version directory name.</param>
+        /// <param name="sourceCode">The C# source to compile into the package assembly.</param>
+        /// <param name="referencedAssemblyPaths">
+        /// Paths to other assemblies the source depends on. Use this to build a package whose public
+        /// types derive from types in another fake package, which is how the dependency-resolution
+        /// behavior of the external-type resolver is exercised.
+        /// </param>
+        public static string Create(
+            string nugetCacheDir,
+            string packageName,
+            string version,
+            string sourceCode,
+            IEnumerable<string>? referencedAssemblyPaths = null)
         {
             var pkgDir = Path.Combine(
                 nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
             Directory.CreateDirectory(pkgDir);
 
+            var references = new List<MetadataReference>
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+            };
+            if (referencedAssemblyPaths != null)
+            {
+                references.AddRange(referencedAssemblyPaths.Select(p => MetadataReference.CreateFromFile(p)));
+            }
+
             var compilation = CSharpCompilation.Create(
                 packageName,
                 [CSharpSyntaxTree.ParseText(sourceCode)],
-                [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+                references,
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
             var dllPath = Path.Combine(pkgDir, $"{packageName}.dll");

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
@@ -50,6 +50,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
             var pkgDir = Path.Combine(versionDir, "lib", "netstandard2.0");
             Directory.CreateDirectory(pkgDir);
             WriteNuspec(versionDir, packageName, version, dependencies);
+            WritePackageMetadata(versionDir);
 
             var references = new List<MetadataReference>
             {
@@ -108,6 +109,19 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
                 """;
 
             File.WriteAllText(Path.Combine(versionDir, $"{packageName.ToLowerInvariant()}.nuspec"), nuspec);
+        }
+
+        private static void WritePackageMetadata(string versionDir)
+        {
+            var metadata =
+                """
+                {
+                  "version": 2,
+                  "contentHash": "VGVzdCBwYWNrYWdlIGNvbnRlbnQgaGFzaA==",
+                  "source": "https://example.invalid/v3/index.json"
+                }
+                """;
+            File.WriteAllText(Path.Combine(versionDir, ".nupkg.metadata"), metadata);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
@@ -113,6 +113,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
 
         private static void WritePackageMetadata(string versionDir)
         {
+            // cspell: disable
             var metadata =
                 """
                 {
@@ -121,6 +122,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
                   "source": "https://example.invalid/v3/index.json"
                 }
                 """;
+            // cspell: enable
             File.WriteAllText(Path.Combine(versionDir, ".nupkg.metadata"), metadata);
         }
     }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/common/FakeNuGetPackage.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -31,16 +32,24 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
         /// types derive from types in another fake package, which is how the dependency-resolution
         /// behavior of the external-type resolver is exercised.
         /// </param>
+        /// <param name="dependencies">
+        /// Package id / version-range pairs to declare in the emitted <c>.nuspec</c>'s
+        /// <c>.NETStandard2.0</c> dependency group, e.g. <c>("Other.Package", "[2.0.0, )")</c>. The
+        /// resolver reads these to pin each dependency to a package version, so use them whenever a test
+        /// needs the package version to differ from the assembly version it ships.
+        /// </param>
         public static string Create(
             string nugetCacheDir,
             string packageName,
             string version,
             string sourceCode,
-            IEnumerable<string>? referencedAssemblyPaths = null)
+            IEnumerable<string>? referencedAssemblyPaths = null,
+            IEnumerable<(string Id, string VersionRange)>? dependencies = null)
         {
-            var pkgDir = Path.Combine(
-                nugetCacheDir, packageName.ToLowerInvariant(), version, "lib", "netstandard2.0");
+            var versionDir = Path.Combine(nugetCacheDir, packageName.ToLowerInvariant(), version);
+            var pkgDir = Path.Combine(versionDir, "lib", "netstandard2.0");
             Directory.CreateDirectory(pkgDir);
+            WriteNuspec(versionDir, packageName, version, dependencies);
 
             var references = new List<MetadataReference>
             {
@@ -64,6 +73,41 @@ namespace Microsoft.TypeSpec.Generator.Tests.Common
                 Assert.IsTrue(result.Success, $"Failed to emit fake assembly for {packageName}");
             }
             return dllPath;
+        }
+
+        /// <summary>
+        /// Writes the <c>.nuspec</c> that a restored package always carries in its version directory. The
+        /// external-type resolver walks these to build the dependency closure, so a package without one is
+        /// resolved only by the assembly-version fallback path.
+        /// </summary>
+        private static void WriteNuspec(
+            string versionDir,
+            string packageName,
+            string version,
+            IEnumerable<(string Id, string VersionRange)>? dependencies)
+        {
+            var dependencyElements = string.Concat(
+                (dependencies ?? []).Select(d =>
+                    $"      <dependency id=\"{d.Id}\" version=\"{d.VersionRange}\" />{Environment.NewLine}"));
+
+            var nuspec =
+                $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                  <metadata>
+                    <id>{packageName}</id>
+                    <version>{version}</version>
+                    <authors>Test</authors>
+                    <description>Fake package emitted by tests.</description>
+                    <dependencies>
+                      <group targetFramework=".NETStandard2.0">
+                {dependencyElements}      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """;
+
+            File.WriteAllText(Path.Combine(versionDir, $"{packageName.ToLowerInvariant()}.nuspec"), nuspec);
         }
     }
 }


### PR DESCRIPTION
Problem

 @@alternateType(..., { identity, package, minVersion }, "csharp")  silently had no effect whenever the referenced type's base type (or any type in its signature) lived in a package the generator does not itself deploy. Instead of referencing the external type, the generator emitted its own copy of the model.

Reproducing with  Azure.AI.Projects.Agents , 12 tool models mapped to  Azure.AI.Extensions.OpenAI  were all still generated, each reporting:

unsupported-external-type: External type 'Azure.AI.Extensions.OpenAI.BingGroundingTool' could not be resolved:
package 'Azure.AI.Extensions.OpenAI' (>= 3.0.0-alpha.20260729.1) was not found in the NuGet cache or any configured feed.

The diagnostic was misleading — the package was present and was found.  ExternalTypeReferenceResolver  loads the package assembly with  Assembly.Load(byte[])  into the default  AssemblyLoadContext , which resolves dependencies only from the generator's own trusted-platform-assemblies list.  BingGroundingTool  derives from  OpenAI.Responses.ResponseTool , and  OpenAI.dll  is not deployed with the generator, so  Assembly.GetType(identity, throwOnError: false)  returned  null  without throwing. That null was interpreted as "type not found", and generation proceeded as if no external mapping existed.

Fix

Adds  NugetAssemblyResolver , which satisfies the transitive references of external-type assemblies from the NuGet global packages folder via an  AssemblyLoadContext.Default.Resolving  hook. Two details drive the design:

Dependencies are pinned from the package dependency closure, not from assembly versions. An assembly reference only carries an assembly version, which for many packages is deliberately lower than the package version that ships it —  System.ClientModel  1.14.0 ships assembly version  1.9.0.0 . Resolving that as a package version selects the unrelated 1.9.0 package, and the resulting type-load failure surfaces as  MissingMethodException: Method not found: 'System.BinaryData IPersistableModel<T>.Write(ModelReaderWriterOptions)' . The resolver instead walks the package's  .nuspec  transitively, picking the framework-nearest dependency group and unifying duplicates by highest version, mirroring what NuGet would select.

An assembly the host already provides is preferred over the cache, regardless of version. The default context only asks the hook to resolve a name it could not satisfy itself, but it will still satisfy other, lower-versioned requests for that same name from its own deployment. Loading a second copy from the cache therefore leaves two assemblies with the same simple name in the process, and any type they both declare exists twice. Concretely:  Azure.AI.Extensions.OpenAI  requests  System.Memory.Data  10.0.0.9 while the generator deploys 10.0.0.3; loading 10.0.9 from the cache produces two  System.BinaryData  types, and every signature mentioning it fails to bind. Reusing the host's copy keeps exactly one identity per simple name.

Resolved dependencies are also registered as Roslyn metadata references so generated code that references them still binds in the generated-code workspace.

Two supporting changes:

•  NugetPackageResolver.FindPackageAssemblyInVersion  looks up one exact installed version and selects the  lib/  asset closest to the framework the generator is running on. The existing  FindPackageAssembly  probes  PreferredDotNetFrameworkVersions  and so prefers  netstandard2.0 , which is correct for collecting compile-time references but not for assemblies loaded into a live .NET process, where a  netstandard2.0  asset can bind against compatibility shims that duplicate shared-framework types.
•  ExternalTypeReferenceResolver  now records a specific failure reason per resolution path, and  TypeFactory  reports it in  unsupported-external-type . The previous message claimed the package was missing regardless of the actual cause; failures now distinguish "package not found", "assembly could not be read/loaded", and "assembly was loaded but does not declare the type, or one of the type's dependencies could not be resolved".

Validation

• New  TryResolve_ResolvesTypeWhoseBaseTypeLivesInAnotherPackage  builds two interdependent fake NuGet packages and asserts the derived type resolves with a readable  BaseType . Confirmed to fail without the fix, with exactly the symptom above.
• New  TryResolve_ReportsFailureReasonWhenTypeMissingFromAssembly , plus a  GetFailureReason  assertion on the existing unknown-package test.
•  Microsoft.TypeSpec.Generator.Tests  1783/1783;  Microsoft.TypeSpec.Generator.ClientModel.Tests  1536/1536.
• End-to-end against  Azure.AI.Projects.Agents : all 12  unsupported-external-type  warnings are gone and none of the 12 tool models are generated.

Notes for reviewers

•  FakeNuGetPackage.Create  gained an optional  referencedAssemblyPaths  parameter so tests can build packages that reference each other.
•  ExternalTypeReferenceResolver.Reset()  now tolerates  InvalidOperationException . It dereferences  CodeModelGenerator.Instance , which is not available in test  SetUp  before a mock generator is loaded — pre-existing fragility, surfaced by the new tests.
• The resolver keys its cache on assembly simple name and returns cached failures, so a missing dependency is probed once per process.