### PR TITLE
fix(http-server-csharp): don't emit auth scheme models and fix enum member rendering

### DIFF
--- a/.chronus/changes/fix-server-csharp-auth-models-2026-7-29-16-40-0.md
+++ b/.chronus/changes/fix-server-csharp-auth-models-2026-7-29-16-40-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Do not generate C# model classes for authentication scheme models (e.g. models referenced by `@useAuth`), aligning with the OpenAPI3 emitter which treats them as security metadata. Also fix a property typed as an enum member (e.g. `kind: Color.red`) rendering as an unresolved symbol; it now uses the parent enum type.

--- a/packages/http-server-csharp/src/components/models/models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/models.test.tsx
@@ -132,16 +132,13 @@ it("renders a model with nullable union property", async () => {
 
 it("does not emit a model class for an @useAuth scheme model", async () => {
   await runner.compile(`
-    @service(#{ title: "Contoso" })
+    @service
     @useAuth(MyKeyAuth)
-    namespace Contoso {
-      model MyKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "x-api-key">;
-      model Widget {
-        id: string;
-      }
-      @route("/widgets") interface Widgets {
-        @get list(): Widget[];
-      }
+    namespace Contoso;
+
+    model MyKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "x-api-key">;
+    model Widget {
+      id: string;
     }
   `);
   const tk = $(runner.program);

--- a/packages/http-server-csharp/src/components/models/models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/models.test.tsx
@@ -135,7 +135,7 @@ it("does not emit a model class for an @useAuth scheme model", async () => {
     @service(#{ title: "Contoso" })
     @useAuth(MyKeyAuth)
     namespace Contoso {
-      model MyKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
+      model MyKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "x-api-key">;
       model Widget {
         id: string;
       }

--- a/packages/http-server-csharp/src/components/models/models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/models.test.tsx
@@ -2,9 +2,12 @@ import { Tester } from "#test/tester.js";
 import { type Children } from "@alloy-js/core";
 import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
+import { $ } from "@typespec/compiler/typekit";
 import { Output } from "@typespec/emitter-framework";
 import { ClassDeclaration } from "@typespec/emitter-framework/csharp";
+import { HttpCanonicalizer } from "@typespec/http-canonicalization";
 import { beforeEach, expect, it } from "vitest";
+import { resolveServiceTypes } from "../../service-resolution.js";
 
 let runner: TesterInstance;
 
@@ -123,6 +126,40 @@ it("renders a model with nullable union property", async () => {
     {
         [JsonPropertyName("name")]
         public required string? Name { get; set; }
+    }
+  `);
+});
+
+it("does not emit a model class for an @useAuth scheme model", async () => {
+  await runner.compile(`
+    @service(#{ title: "Contoso" })
+    @useAuth(MyKeyAuth)
+    namespace Contoso {
+      model MyKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
+      model Widget {
+        id: string;
+      }
+      @route("/widgets") interface Widgets {
+        @get list(): Widget[];
+      }
+    }
+  `);
+  const tk = $(runner.program);
+  const resolution = resolveServiceTypes(runner.program, tk, new HttpCanonicalizer(tk));
+
+  // Auth scheme models are security metadata and must be excluded from the
+  // emitted payload models (only the regular `Widget` model remains).
+  expect(resolution.models.map((m) => m.name)).toEqual(["Widget"]);
+  expect(
+    <Wrapper>
+      {resolution.models.map((m) => (
+        <ClassDeclaration type={m} />
+      ))}
+    </Wrapper>,
+  ).toRenderTo(`
+    class Widget
+    {
+        public required string Id { get; set; }
     }
   `);
 });

--- a/packages/http-server-csharp/src/components/type-expression/type-expression.test.tsx
+++ b/packages/http-server-csharp/src/components/type-expression/type-expression.test.tsx
@@ -1,12 +1,13 @@
 import { Tester } from "#test/tester.js";
 import { type Children } from "@alloy-js/core";
+import * as cs from "@alloy-js/csharp";
 import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
-import type { ModelProperty } from "@typespec/compiler";
+import type { EnumMember, ModelProperty } from "@typespec/compiler";
 import { type TesterInstance } from "@typespec/compiler/testing";
 import { $ } from "@typespec/compiler/typekit";
 import { Experimental_ComponentOverrides, Output } from "@typespec/emitter-framework";
 import { beforeEach, describe, expect, it } from "vitest";
-import { createServerScalarOverrides, TypeExpression } from "./type-expression.jsx";
+import { createServerScalarOverrides, efRefkey, TypeExpression } from "./type-expression.jsx";
 
 let runner: TesterInstance;
 
@@ -188,5 +189,48 @@ describe("literal types", () => {
         <TypeExpression type={type} />
       </Wrapper>,
     ).toRenderTo("bool");
+  });
+});
+
+describe("enum member types", () => {
+  it("renders a property typed as an enum member using the parent enum type", async () => {
+    const { test } = await runner.compile(`
+      enum Color {
+        red,
+        green,
+      }
+      model Test {
+        @test test: Color.red;
+      }
+    `);
+    const member = (test as ModelProperty).type as EnumMember;
+    // The enum declaration must exist in the render tree for the reference to
+    // resolve; here it stands in for the emitted `Color` enum file.
+    expect(
+      <Wrapper>
+        <cs.EnumDeclaration name="Color" refkey={efRefkey(member.enum)}>
+          Red
+        </cs.EnumDeclaration>
+        <hbr />
+        <TypeExpression type={member} />
+      </Wrapper>,
+    ).toRenderTo(`
+      enum Color
+      {
+          Red
+      }
+      Color
+    `);
+  });
+
+  it("falls back to the primitive value type for non-emitted std-lib enum members", async () => {
+    // `AuthType` lives in the TypeSpec.Http std library and is never emitted,
+    // so a member reference must not become an unresolved enum reference.
+    const type = await compileType("TypeSpec.Http.AuthType.apiKey");
+    expect(
+      <Wrapper>
+        <TypeExpression type={type} />
+      </Wrapper>,
+    ).toRenderTo("string");
   });
 });

--- a/packages/http-server-csharp/src/components/type-expression/type-expression.test.tsx
+++ b/packages/http-server-csharp/src/components/type-expression/type-expression.test.tsx
@@ -2,8 +2,8 @@ import { Tester } from "#test/tester.js";
 import { type Children } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
 import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
-import type { EnumMember, ModelProperty } from "@typespec/compiler";
-import { type TesterInstance } from "@typespec/compiler/testing";
+import type { ModelProperty } from "@typespec/compiler";
+import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { $ } from "@typespec/compiler/typekit";
 import { Experimental_ComponentOverrides, Output } from "@typespec/emitter-framework";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -194,21 +194,21 @@ describe("literal types", () => {
 
 describe("enum member types", () => {
   it("renders a property typed as an enum member using the parent enum type", async () => {
-    const { test } = await runner.compile(`
-      enum Color {
+    const { Color } = await runner.compile(t.code`
+      enum ${t.enum("Color")} {
         red,
         green,
       }
       model Test {
-        @test test: Color.red;
+        test: Color.red;
       }
     `);
-    const member = (test as ModelProperty).type as EnumMember;
+    const member = Color.members.get("red")!;
     // The enum declaration must exist in the render tree for the reference to
     // resolve; here it stands in for the emitted `Color` enum file.
     expect(
       <Wrapper>
-        <cs.EnumDeclaration name="Color" refkey={efRefkey(member.enum)}>
+        <cs.EnumDeclaration name="Color" refkey={efRefkey(Color)}>
           Red
         </cs.EnumDeclaration>
         <hbr />

--- a/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
+++ b/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
@@ -1,5 +1,5 @@
 import { code, type Children } from "@alloy-js/core";
-import type { Scalar, Type } from "@typespec/compiler";
+import { isStdNamespace, type Namespace, type Scalar, type Type } from "@typespec/compiler";
 import type { Typekit } from "@typespec/compiler/typekit";
 import { Experimental_ComponentOverridesConfig, useTsp } from "@typespec/emitter-framework";
 import {
@@ -43,6 +43,18 @@ export function TypeExpression(props: TypeExpressionProps): Children {
       } catch {
         return code`${type.name ?? "object"}`;
       }
+    case "EnumMember": {
+      // A property typed as a specific enum member (e.g. `kind: Color.red`) uses
+      // the parent enum type in C#. Std-lib enums (e.g. auth `AuthType`) are not
+      // emitted, so fall back to the member's underlying primitive value type.
+      if (isInStdLibNamespace(type.enum.namespace)) {
+        if (typeof type.value === "number") {
+          return Number.isInteger(type.value) ? code`int` : code`double`;
+        }
+        return code`string`;
+      }
+      return code`${efRefkey(type.enum)}`;
+    }
     case "Tuple":
       // Tuple of values — use the type of the first element as array
       if (type.values.length > 0) {
@@ -156,6 +168,21 @@ export function TypeExpression(props: TypeExpressionProps): Children {
         return code`object`;
       }
   }
+}
+
+/**
+ * Returns true when the namespace (or any of its ancestors) is a TypeSpec
+ * standard-library namespace. Enums declared under the std library (e.g.
+ * `TypeSpec.Http.AuthType`) are never emitted, so references to their members
+ * must fall back to a primitive type instead of an (unresolved) enum reference.
+ */
+function isInStdLibNamespace(namespace: Namespace | undefined): boolean {
+  let current = namespace;
+  while (current) {
+    if (isStdNamespace(current)) return true;
+    current = current.namespace;
+  }
+  return false;
 }
 
 function resolveUnionType($: Typekit, union: import("@typespec/compiler").Union): Children {

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -11,6 +11,7 @@ import {
   type Union,
 } from "@typespec/compiler";
 import type { Typekit } from "@typespec/compiler/typekit";
+import { getAllHttpServices, resolveAuthentication } from "@typespec/http";
 import type {
   HttpCanonicalizer,
   OperationHttpCanonicalization,
@@ -78,7 +79,11 @@ export function resolveServiceTypes(
   collectEnumsFromNamespaces(globalNs, enums, unionEnums);
 
   // Phase 5: Model discovery (namespace models + operation-referenced models)
-  const models = getServiceModels($, globalNs);
+  // Auth scheme models (e.g. those referenced by `@useAuth`) are protocol metadata,
+  // not payload data, so they must not be emitted as C# model classes (aligns with
+  // the OpenAPI3 emitter, which emits them under `components.securitySchemes`).
+  const authModels = getAuthSchemeModels(program);
+  const models = getServiceModels($, globalNs, authModels);
 
   // Phase 6: Canonicalize all HTTP operations
   const canonicalOpsMap = canonicalizeAllInterfaces(canonicalizer, interfaces);
@@ -154,14 +159,18 @@ function canonicalizeAllInterfaces(
 /**
  * Retrieves all models from the program that should be emitted.
  * Includes namespace-level models AND models referenced by operations.
+ *
+ * @param authModels Models that back authentication schemes; these are excluded
+ * from emission because they represent protocol metadata rather than payloads.
  */
-function getServiceModels($: Typekit, globalNs: TspNamespace): Model[] {
+function getServiceModels($: Typekit, globalNs: TspNamespace, authModels: Set<Model>): Model[] {
   const models: Model[] = [];
   const seen = new Set<Model>();
 
   function addModel(model: Model) {
     if (seen.has(model)) return;
     seen.add(model);
+    if (authModels.has(model)) return;
     if (shouldEmitModel($, model)) {
       models.push(model);
     }
@@ -173,7 +182,7 @@ function getServiceModels($: Typekit, globalNs: TspNamespace): Model[] {
   }
   for (const ns of globalNs.namespaces.values()) {
     if (isStdNamespace(ns)) continue;
-    collectModelsFromNamespace($, ns, models, seen);
+    collectModelsFromNamespace($, ns, models, seen, authModels);
   }
 
   // Walk operations to discover referenced models (template instantiations, etc.)
@@ -267,16 +276,35 @@ function collectModelsFromNamespace(
   ns: TspNamespace,
   models: Model[],
   seen: Set<Model>,
+  authModels: Set<Model>,
 ): void {
   for (const model of ns.models?.values() ?? []) {
-    if (!seen.has(model) && shouldEmitModel($, model)) {
+    if (!seen.has(model) && !authModels.has(model) && shouldEmitModel($, model)) {
       seen.add(model);
       models.push(model);
     }
   }
   for (const childNs of ns.namespaces?.values() ?? []) {
-    collectModelsFromNamespace($, childNs, models, seen);
+    collectModelsFromNamespace($, childNs, models, seen, authModels);
   }
+}
+
+/**
+ * Collects the models that back authentication schemes for every HTTP service.
+ * These correspond to `@useAuth` scheme models (e.g. `ApiKeyAuth`, `BearerAuth`)
+ * and are emitted as security metadata, not as payload model classes.
+ */
+function getAuthSchemeModels(program: Program): Set<Model> {
+  const authModels = new Set<Model>();
+  const [services] = getAllHttpServices(program);
+  for (const service of services) {
+    for (const scheme of resolveAuthentication(service).schemes) {
+      if (scheme.model) {
+        authModels.add(scheme.model);
+      }
+    }
+  }
+  return authModels;
 }
 
 function shouldEmitModel($: Typekit, model: Model): boolean {


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/11449

## Problem

When a spec applies `@useAuth(...)` with a named auth scheme model (e.g. `model AzureApiKeyAuthentication is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">`), `@typespec/http-server-csharp` generated a C# model class for the auth scheme. That class:

1. **Should not be generated at all** — auth scheme models are protocol/security metadata, not payloads. The OpenAPI3 emitter emits them under `components.securitySchemes`, never as `schemas`.
2. **Failed to compile** — its enum-member-typed properties (`type: AuthType.apiKey`, `in: Location`) rendered as `<Unresolved Symbol: refkey[...]>`, producing C# errors like `The name 'refkey' does not exist in the current context`.

These are two independent bugs.

## Root causes

- **Auth models emitted:** `getServiceModels` (`service-resolution.ts`) collected every named model in the service namespace, including `@useAuth` scheme models.
- **Unresolved symbol:** the server `TypeExpression` had no `EnumMember` case, so it fell through to the emitter-framework component which emits `efRefkey(enumMember)`. Regular `Enum` members never register a member refkey (only union-enums do), so the reference was unresolved.

## Fix

- **`service-resolution.ts`** — collect auth scheme models via `getAllHttpServices` + `resolveAuthentication` (the same source the OpenAPI3 emitter uses) and exclude them from model discovery.
- **`type-expression.tsx`** — add an `EnumMember` case that renders the **parent enum type** (`kind: Color.red` → `Color`), with a primitive-type fallback for std-lib enums (e.g. `TypeSpec.Http.AuthType`) that are never emitted.

## Tests

Added `toRenderTo` component tests (no additions to `generation.test.ts`):
- `models.test.tsx` — an `@useAuth` scheme model is excluded from `resolveServiceTypes(...).models` and not rendered.
- `type-expression.test.tsx` — an enum-member property renders as its parent enum; a std-lib enum member falls back to `string`.

Full package suite passes (206 tests). Changeset included.