### PR TITLE
fix(compiler): enter template scope before resolving operation param defaults

### DIFF
--- a/.chronus/changes/compiler-fix-template-param-decorator-2026-7-30.md
+++ b/.chronus/changes/compiler-fix-template-param-decorator-2026-7-30.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix decorators running with unresolved template parameters when a decorated template is used as a template parameter default of an operation (e.g. `op foo<Resource, Properties = Decorated<Resource>>(...)`, the ARM `TagsUpdateModel<Resource>` pattern). Operations now enter the template declaration scope before resolving template parameter defaults, so decorators on those defaults are no longer executed with the still-unresolved template parameter. This matches the existing behavior for models and interfaces.

--- a/.chronus/changes/http-server-csharp-fix-friendly-name-file-2026-7-29.md
+++ b/.chronus/changes/http-server-csharp-fix-friendly-name-file-2026-7-29.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Fix model file name for `@friendlyName` ARM-style template patterns (e.g. `@friendlyName("{name}TagsUpdate", Resource)` on `TagsUpdate<Resource>`). The instantiation now correctly receives the substituted name (e.g. `FooResourceTagsUpdate.cs`) from the compiler.

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -2629,6 +2629,16 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
         node.parent,
       );
     }
+    // Enter the template declaration scope before checking the template declaration itself.
+    // `checkTemplateDeclaration` resolves template parameter defaults (e.g.
+    // `Properties extends {} = TagsUpdateModel<Resource>`), which can instantiate types and run
+    // their decorators. Those instantiations still reference the enclosing template parameters, so
+    // they must be treated as being in a template declaration (skipDecorators) to avoid running
+    // decorators with unresolved template parameters. This mirrors what `checkModelStatement` does.
+    if (ctx.mapper === undefined && node.templateParameters.length > 0) {
+      ctx = ctx.withFlags(CheckFlags.InTemplateDeclaration);
+    }
+
     checkTemplateDeclaration(ctx, node);
 
     // If we are instantating operation inside of interface
@@ -2636,7 +2646,7 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
       ctx = ctx.withMapper({ ...ctx.mapper, partial: true });
     }
 
-    if ((ctx.mapper === undefined || ctx.mapper.partial) && node.templateParameters.length > 0) {
+    if (ctx.mapper?.partial && node.templateParameters.length > 0) {
       ctx = ctx.withFlags(CheckFlags.InTemplateDeclaration);
     }
 

--- a/packages/compiler/test/decorators/decorators.test.ts
+++ b/packages/compiler/test/decorators/decorators.test.ts
@@ -19,6 +19,7 @@ import {
   setMediaTypeHint,
 } from "../../src/lib/decorators.js";
 import { expectDiagnosticEmpty, expectDiagnostics, t } from "../../src/testing/index.js";
+import { createTestHost } from "../../src/testing/test-host.js";
 import { Tester } from "../tester.js";
 
 describe("dev comment /** */", () => {
@@ -367,6 +368,60 @@ describe("@friendlyName", () => {
       `);
     strictEqual(getFriendlyName(program, A), "MyNameIsA");
     strictEqual(getFriendlyName(program, B), "BModel");
+  });
+
+  it("does not run decorators with unresolved template parameter arguments when a decorated template is used as a template parameter default", async () => {
+    // Regression test for https://github.com/microsoft/typespec/issues/11454
+    // When an operation uses a decorated template as a template parameter default
+    // (e.g. `Properties extends {} = TagsUpdateModel<Resource>`, the ARM tags-update pattern),
+    // checking that default must happen within the template declaration scope so the
+    // decorators on the default type are NOT executed with the still-unresolved template parameter.
+    const host = await createTestHost();
+    const trackArgKinds: string[] = [];
+    host.addJsFile("track.js", {
+      namespace: "Test",
+      $track(_ctx: any, _target: any, arg: any) {
+        trackArgKinds.push(arg?.kind);
+      },
+    });
+    host.addTypeSpecFile(
+      "main.tsp",
+      `
+      import "./track.js";
+
+      namespace Test {
+        extern dec track(target: unknown, arg: unknown);
+      }
+
+      using Test;
+
+      @track(Resource)
+      model TagsUpdateModel<Resource extends {}> {
+        tags?: string;
+      }
+
+      op armTagsPatch<
+        Resource extends {},
+        Properties extends {} = TagsUpdateModel<Resource>
+      >(body: Properties): void;
+
+      model FooResource { id: string; }
+
+      op patch is armTagsPatch<FooResource>;
+      `,
+    );
+    await host.compile("main.tsp");
+
+    // The decorator must only run on the concrete instantiation (FooResource), never with the
+    // unresolved `Resource` template parameter of the operation.
+    ok(
+      !trackArgKinds.includes("TemplateParameter"),
+      `@track should never run with a TemplateParameter argument, but ran with: [${trackArgKinds.join(", ")}]`,
+    );
+    ok(
+      trackArgKinds.includes("Model"),
+      "expected @track to run on the concrete TagsUpdateModel<FooResource> instantiation",
+    );
   });
 
   it(" @friendlyName doesn't carry over to derived models", async () => {

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -3448,3 +3448,36 @@ it("emits class for model extending another model with no additional properties"
     ],
   );
 });
+
+it("emits correct file name for @friendlyName template used as a template parameter default (ARM pattern)", async () => {
+  // Regression test for https://github.com/microsoft/typespec/issues/11454
+  // A model decorated with @friendlyName("{name}...", Resource) is used as an operation template
+  // parameter default (the ARM `TagsUpdateModel<Resource>` pattern). The concrete instantiation must
+  // get the substituted friendly name as its file/class name, and no file with an unresolved
+  // `{name}` placeholder should be emitted.
+  const [result] = await compileAndDiagnose(
+    tester,
+    `
+      @service(#{title: "Test"})
+      namespace Test {
+        @friendlyName("{name}TagsUpdate", Resource)
+        model TagsUpdateModel<Resource extends {}> {
+          tags?: string;
+        }
+
+        op armTagsPatch<
+          Resource extends {},
+          Properties extends {} = TagsUpdateModel<Resource>
+        >(...Properties): void;
+
+        model FooResource { id: string; }
+
+        @route("/tags") @patch op patch is armTagsPatch<FooResource>;
+      }
+      `,
+  );
+  const files = [...result.fs.fs.keys()];
+  // No emitted file should contain an unresolved template placeholder.
+  const unresolved = files.filter((f) => f.includes("{") || f.includes("}"));
+  deepStrictEqual(unresolved, [], `Unexpected files with unresolved placeholders: ${unresolved}`);
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/11454

## Problem

`checkOperation` resolves template parameter **defaults** (via `checkTemplateDeclaration`) *before* entering the `InTemplateDeclaration` scope — unlike `checkModelStatement` and interface/union checks, which set the flag first.

As a result, when a decorated template is used as an operation template parameter default (the ARM tags-update pattern, e.g. `op foo<Resource, Properties extends {} = TagsUpdateModel<Resource>>(...)`), the default is instantiated with `Resource` still an unresolved `TemplateParameter`, and `skipDecorators` is `false`. The decorators on the default type (`@friendlyName`, `@doc`, …) therefore run with an unresolved template parameter argument and store unresolved `{name}` strings. In `@typespec/http-server-csharp` this surfaced as a model file named `{name}TagsUpdate.cs` instead of `FooResourceTagsUpdate.cs`.

A decorator should never run with a `TemplateParameter` argument — the real bug is the ordering, not the emitter.

## Fix

In `checkOperation`, set `CheckFlags.InTemplateDeclaration` **before** calling `checkTemplateDeclaration`, mirroring `checkModelStatement`. Operations now enter the template declaration scope before resolving parameter defaults, so decorators on those defaults are no longer executed with the still-unresolved template parameter.

## Tests

- **compiler**: regression test using a custom `@track` decorator that records the kind of its argument. It asserts `@track` never runs with a `TemplateParameter` (only the concrete `Model`). Verified: fails before the fix, passes after.
- **http-server-csharp**: integration test using the real operation default-arg pattern, asserting no emitted file name contains an unresolved `{`/`}` placeholder.

## Background

This supersedes and replaces https://github.com/microsoft/typespec/pull/11459, which had diverged from its original purpose and accumulated several earlier band-aid attempts. This PR contains only the root-cause compiler fix plus tests.
