### PR TITLE
Enable verbatimModuleSyntax on easy-tier packages

### DIFF
--- a/.chronus/changes/enable-verbatim-module-syntax-easy-tier-2026-7-30-10-30-0.md
+++ b/.chronus/changes/enable-verbatim-module-syntax-easy-tier-2026-7-30-10-30-0.md
@@ -1,0 +1,11 @@
+---
+changeKind: internal
+packages:
+  - tmlanguage-generator
+  - "@typespec/streams"
+  - "@typespec/spec-coverage-sdk"
+  - "@typespec/library-linter"
+  - "@typespec/bundler"
+---
+
+Enable `verbatimModuleSyntax` in TypeScript configuration and convert type-only imports and re-exports to `import type` / `export type` accordingly.

--- a/packages/best-practices/test/rules/casing.rule.test.ts
+++ b/packages/best-practices/test/rules/casing.rule.test.ts
@@ -1,7 +1,7 @@
 import {
-  LinterRuleTester,
   createLinterRuleTester,
   createTestRunner,
+  type LinterRuleTester,
 } from "@typespec/compiler/testing";
 import { beforeEach, describe, it } from "vitest";
 import { casingRule } from "../../src/rules/casing.rule.js";

--- a/packages/best-practices/tsconfig.json
+++ b/packages/best-practices/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{ "path": "../compiler/tsconfig.json" }],
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "rootDir": ".",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"

--- a/packages/bundle-uploader/src/upload-browser-package.ts
+++ b/packages/bundle-uploader/src/upload-browser-package.ts
@@ -1,11 +1,11 @@
-import { TokenCredential } from "@azure/identity";
+import type { TokenCredential } from "@azure/identity";
 import {
   AnonymousCredential,
   BlobServiceClient,
   ContainerClient,
   StorageSharedKeyCredential,
 } from "@azure/storage-blob";
-import { BundleManifest, TypeSpecBundle, TypeSpecBundleFile } from "@typespec/bundler";
+import type { BundleManifest, TypeSpecBundle, TypeSpecBundleFile } from "@typespec/bundler";
 import { join } from "path/posix";
 import { pkgsContainer, storageAccountName } from "./constants.js";
 

--- a/packages/bundle-uploader/src/upload-browser-package.ts
+++ b/packages/bundle-uploader/src/upload-browser-package.ts
@@ -1,10 +1,10 @@
 import type { TokenCredential } from "@azure/identity";
-import {
+import type {
   AnonymousCredential,
-  BlobServiceClient,
   ContainerClient,
   StorageSharedKeyCredential,
 } from "@azure/storage-blob";
+import { BlobServiceClient } from "@azure/storage-blob";
 import type { BundleManifest, TypeSpecBundle, TypeSpecBundleFile } from "@typespec/bundler";
 import { join } from "path/posix";
 import { pkgsContainer, storageAccountName } from "./constants.js";

--- a/packages/bundle-uploader/tsconfig.json
+++ b/packages/bundle-uploader/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "rootDir": ".",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -1,5 +1,5 @@
 import { compile, joinPaths, NodeHost, normalizePath, resolvePath } from "@typespec/compiler";
-import { BuildOptions, BuildResult, context, Plugin } from "esbuild";
+import { context, type BuildOptions, type BuildResult, type Plugin } from "esbuild";
 import { access, mkdir, readFile, realpath, writeFile } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
 import { promisify } from "util";

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -1,8 +1,8 @@
 export {
-  BundleManifest,
-  CreateTypeSpecBundleOptions,
-  TypeSpecBundle,
-  TypeSpecBundleDefinition,
-  TypeSpecBundleFile,
   createTypeSpecBundle,
+  type BundleManifest,
+  type CreateTypeSpecBundleOptions,
+  type TypeSpecBundle,
+  type TypeSpecBundleDefinition,
+  type TypeSpecBundleFile,
 } from "./bundler.js";

--- a/packages/bundler/src/vite/index.ts
+++ b/packages/bundler/src/vite/index.ts
@@ -1,1 +1,1 @@
-export { TypeSpecBundlePluginOptions, typespecBundlePlugin } from "./vite-plugin.js";
+export { typespecBundlePlugin, type TypeSpecBundlePluginOptions } from "./vite-plugin.js";

--- a/packages/bundler/src/vite/vite-plugin.ts
+++ b/packages/bundler/src/vite/vite-plugin.ts
@@ -2,11 +2,11 @@ import { resolvePath } from "@typespec/compiler";
 import { resolve } from "path";
 import type { IndexHtmlTransformContext, Plugin, ResolvedConfig } from "vite";
 import {
-  CreateTypeSpecBundleOptions,
-  TypeSpecBundle,
-  TypeSpecBundleDefinition,
   createTypeSpecBundle,
   watchTypeSpecBundle,
+  type CreateTypeSpecBundleOptions,
+  type TypeSpecBundle,
+  type TypeSpecBundleDefinition,
 } from "../bundler.js";
 
 export interface TypeSpecBundlePluginOptions {

--- a/packages/bundler/tsconfig.json
+++ b/packages/bundler/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{ "path": "../compiler/tsconfig.json" }, { "path": "../rest/tsconfig.json" }],
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "rootDir": ".",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",

--- a/packages/internal-build-utils/src/common.ts
+++ b/packages/internal-build-utils/src/common.ts
@@ -1,4 +1,5 @@
-import { ChildProcess, type SpawnOptions } from "child_process";
+import type { ChildProcess } from "child_process";
+import { type SpawnOptions } from "child_process";
 import { spawn } from "cross-spawn";
 
 export class CommandFailedError extends Error {

--- a/packages/internal-build-utils/src/common.ts
+++ b/packages/internal-build-utils/src/common.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, SpawnOptions } from "child_process";
+import { ChildProcess, type SpawnOptions } from "child_process";
 import { spawn } from "cross-spawn";
 
 export class CommandFailedError extends Error {

--- a/packages/internal-build-utils/src/dotnet.ts
+++ b/packages/internal-build-utils/src/dotnet.ts
@@ -1,4 +1,4 @@
-import { execAsync, run, RunOptions } from "./common.js";
+import { execAsync, run, type RunOptions } from "./common.js";
 import { MinimumDotnetVersion } from "./constants.js";
 
 export async function runDotnet(

--- a/packages/internal-build-utils/tsconfig.json
+++ b/packages/internal-build-utils/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "rootDir": ".",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"

--- a/packages/library-linter/src/linter.ts
+++ b/packages/library-linter/src/linter.ts
@@ -1,4 +1,4 @@
-import { Namespace, Program, Type } from "@typespec/compiler";
+import type { Namespace, Program, Type } from "@typespec/compiler";
 import { SyntaxKind } from "@typespec/compiler/ast";
 import { reportDiagnostic } from "./lib.js";
 

--- a/packages/library-linter/src/testing/index.ts
+++ b/packages/library-linter/src/testing/index.ts
@@ -1,7 +1,7 @@
 import {
   createTestLibrary,
   findTestPackageRoot,
-  TypeSpecTestLibrary,
+  type TypeSpecTestLibrary,
 } from "@typespec/compiler/testing";
 
 /** @deprecated Use `createTester` from `@typespec/compiler/testing` instead */

--- a/packages/library-linter/tsconfig.json
+++ b/packages/library-linter/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "../openapi/tsconfig.json" }
   ],
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "rootDir": ".",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"

--- a/packages/spec-coverage-sdk/src/client.ts
+++ b/packages/spec-coverage-sdk/src/client.ts
@@ -1,11 +1,11 @@
 import type { TokenCredential } from "@azure/identity";
-import {
+import type {
   AnonymousCredential,
-  BlobServiceClient,
   BlockBlobClient,
   ContainerClient,
   StorageSharedKeyCredential,
 } from "@azure/storage-blob";
+import { BlobServiceClient } from "@azure/storage-blob";
 import { eq as semverEq, gt as semverGt, valid as semverValid } from "semver";
 import type {
   CoverageReport,

--- a/packages/spec-coverage-sdk/src/client.ts
+++ b/packages/spec-coverage-sdk/src/client.ts
@@ -1,4 +1,4 @@
-import { TokenCredential } from "@azure/identity";
+import type { TokenCredential } from "@azure/identity";
 import {
   AnonymousCredential,
   BlobServiceClient,
@@ -7,7 +7,7 @@ import {
   StorageSharedKeyCredential,
 } from "@azure/storage-blob";
 import { eq as semverEq, gt as semverGt, valid as semverValid } from "semver";
-import {
+import type {
   CoverageReport,
   GeneratorMetadata,
   ResolvedCoverageReport,

--- a/packages/spec-coverage-sdk/src/index.ts
+++ b/packages/spec-coverage-sdk/src/index.ts
@@ -1,5 +1,5 @@
 export { SpecCoverageClient, SpecCoverageOperations, SpecManifestOperations } from "./client.js";
-export {
+export type {
   CoverageReport,
   GeneratorMetadata,
   LineAndCharacter,

--- a/packages/spec-coverage-sdk/tsconfig.json
+++ b/packages/spec-coverage-sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "tsBuildInfoFile": "temp/.tsbuildinfo"
   },

--- a/packages/streams/tsconfig.json
+++ b/packages/streams/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{ "path": "../compiler/tsconfig.json" }],
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "rootDir": ".",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"

--- a/packages/tmlanguage-generator/tsconfig.json
+++ b/packages/tmlanguage-generator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": true,
     "outDir": "dist",
     "rootDir": "src",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"


### PR DESCRIPTION
## Summary

Incrementally rolls out TypeScript's `verbatimModuleSyntax` to the packages that are cheapest to migrate (the "easy tier"), converting type-only imports/re-exports to `import type` / `export type`.

This is part of a broader effort to enable `verbatimModuleSyntax` across the workspace. This first pass targets the 8 lowest-effort packages to prove out the workflow with minimal churn.

## Packages migrated

| Package | Change |
| --- | --- |
| `tmlanguage-generator` | flag only, no code changes |
| `@typespec/streams` | flag only, no code changes |
| `@typespec/best-practices` | 1 import (test) |
| `@typespec/bundle-uploader` | 2 imports to `import type` |
| `@typespec/spec-coverage-sdk` | imports + a re-export block to `export type` |
| `@typespec/internal-build-utils` | 2 mixed imports, inline `type` |
| `@typespec/library-linter` | `import type` + inline `type` |
| `@typespec/bundler` | imports + `index.ts` re-exports (inline `type`) |

## Conventions followed

- Fully type-only imports/exports use `import type` / `export type`.
- Mixed value + type imports use the inline `type` modifier (matching existing usage in already-migrated packages).

## Out of scope

- `tsconfig.base.json` is intentionally untouched (that would force all packages at once).
- Standalone runtime emitters (`http-client-csharp`, `http-client-java`, `http-client-python`).
- Larger packages (e.g. `http`, `openapi3`, `compiler`) are deferred to later passes.

## Validation

- `tsc -b` emit build for all 8 packages
- `prettier --check` on all changed files
- `oxlint` on all 8 packages
- `chronus verify`
