### PR TITLE
[http-client-csharp] Serialize enum options-bag properties when protocol flattens them to string

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -916,7 +916,21 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     if (ScmCodeModelGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(convenienceParam.Type, out var typeProvider) &&
                         typeProvider is ModelProvider paramModel)
                     {
-                        AddArgument(protocolParam, paramModel.GetPropertyExpression(convenienceParam, propertySegments));
+                        var propertyExpression = paramModel.GetPropertyExpression(convenienceParam, propertySegments, out var leafProperty);
+
+                        // When the options property is an enum but the protocol method flattens it to its
+                        // serialized (string/number) form, serialize it before forwarding, mirroring the
+                        // conversion applied to non-grouped enum convenience parameters below.
+                        if (leafProperty.Type.IsEnum && !protocolParam.Type.IsEnum)
+                        {
+                            if (leafProperty.Type.IsNullable)
+                            {
+                                propertyExpression = propertyExpression.NullConditional();
+                            }
+                            propertyExpression = leafProperty.Type.ToSerial(propertyExpression);
+                        }
+
+                        AddArgument(protocolParam, propertyExpression);
                     }
                 }
                 else

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1736,8 +1736,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         {
             // Options-bag override where a grouped query property is an (extensible) enum, while the
             // protocol method flattens that parameter to string. The convenience body must serialize
-            // the enum (options.Resampling.ToString()) before passing it to the protocol method;
-            // otherwise the generated code passes the enum where a string is expected and won't compile.
+            // the enum (options.Resampling?.ToString(), null-conditional because the property is optional)
+            // before passing it to the protocol method; otherwise the generated code passes the enum
+            // where a string is expected and won't compile.
             var resamplingEnum = InputFactory.StringEnum(
                 "Resampling",
                 [("Nearest", "nearest"), ("Bilinear", "bilinear")],

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -1732,6 +1732,69 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         }
 
         [Test]
+        public async Task MethodParameterSegments_EnumGroupedQueryParam_SerializesToProtocol()
+        {
+            // Options-bag override where a grouped query property is an (extensible) enum, while the
+            // protocol method flattens that parameter to string. The convenience body must serialize
+            // the enum (options.Resampling.ToString()) before passing it to the protocol method;
+            // otherwise the generated code passes the enum where a string is expected and won't compile.
+            var resamplingEnum = InputFactory.StringEnum(
+                "Resampling",
+                [("Nearest", "nearest"), ("Bilinear", "bilinear")],
+                isExtensible: true);
+
+            var optionsModel = InputFactory.Model(
+                "GetPointOptions",
+                properties:
+                [
+                    InputFactory.Property(
+                        "resampling",
+                        resamplingEnum,
+                        isRequired: false,
+                        isHttpMetadata: true,
+                        wireName: "resampling"),
+                ]);
+
+            var collectionIdParam = InputFactory.PathParameter("collectionId", InputPrimitiveType.String, isRequired: true);
+            // Protocol flattens the enum query parameter to string.
+            var resamplingParam = InputFactory.QueryParameter("resampling", InputPrimitiveType.String, isRequired: false, serializedName: "resampling");
+            resamplingParam.Update(methodParameterSegments:
+            [
+                InputFactory.MethodParameter("options", optionsModel, isRequired: true, location: InputRequestLocation.Query),
+                InputFactory.MethodParameter("resampling", resamplingEnum, isRequired: false),
+            ]);
+
+            var serviceMethod = InputFactory.BasicServiceMethod(
+                "GetPoint",
+                InputFactory.Operation(
+                    "GetPoint",
+                    parameters: [collectionIdParam, resamplingParam],
+                    responses: [InputFactory.OperationResponse([200])]),
+                parameters:
+                [
+                    InputFactory.MethodParameter("collectionId", InputPrimitiveType.String, isRequired: true, location: InputRequestLocation.Path),
+                    InputFactory.MethodParameter("options", optionsModel, isRequired: true, location: InputRequestLocation.Query),
+                ]);
+
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+            await MockHelpers.LoadMockGeneratorAsync(clients: () => [inputClient], inputModels: () => [optionsModel]);
+
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+            Assert.IsNotNull(methodCollection);
+
+            var convenienceMethod = methodCollection.FirstOrDefault(m =>
+                m.Signature.Name == "GetPoint" &&
+                m.Signature.Parameters.Any(p => p.Type.Name == "CancellationToken"));
+            Assert.IsNotNull(convenienceMethod);
+
+            var methodBody = convenienceMethod!.BodyStatements!.ToDisplayString();
+            Assert.AreEqual(Helpers.GetExpectedFromFile(), methodBody);
+        }
+
+        [Test]
         public async Task MethodParameterSegments_BodyParameterSerialization()
         {
             // Test scenario: Body parameter with MethodParameterSegments should be serialized

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/MethodParameterSegments_EnumGroupedQueryParam_SerializesToProtocol.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ScmMethodProviderCollectionTests/MethodParameterSegments_EnumGroupedQueryParam_SerializesToProtocol.cs
@@ -1,0 +1,4 @@
+global::Sample.Argument.AssertNotNullOrEmpty(collectionId, nameof(collectionId));
+global::Sample.Argument.AssertNotNull(options, nameof(options));
+
+return this.GetPoint(collectionId, options.Resampling?.ToString(), cancellationToken.ToRequestOptions());

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Snippets/ModelProviderSnippets.cs
@@ -13,22 +13,32 @@ namespace Microsoft.TypeSpec.Generator.Snippets
     {
         public static ValueExpression GetPropertyExpression(this ModelProvider model, ValueExpression modelVariable, IReadOnlyList<string> propertySegments)
         {
-            return model.BuildPropertyAccessExpression(modelVariable, propertySegments);
+            return model.BuildPropertyAccessExpression(modelVariable, propertySegments, out _);
+        }
+
+        /// <summary>
+        /// Builds a property-access expression for the given segment path and also returns the leaf
+        /// <see cref="PropertyProvider"/> so callers can inspect its type (e.g. to apply enum serialization).
+        /// </summary>
+        public static ValueExpression GetPropertyExpression(this ModelProvider model, ValueExpression modelVariable, IReadOnlyList<string> propertySegments, out PropertyProvider leafProperty)
+        {
+            return model.BuildPropertyAccessExpression(modelVariable, propertySegments, out leafProperty);
         }
 
         public static AssignmentExpression SetPropertyExpression(this ModelProvider model, ValueExpression modelVariable, ValueExpression value, IReadOnlyList<string> propertySegments)
         {
-            return model.BuildPropertyAccessExpression(modelVariable, propertySegments).Assign(value);
+            return model.BuildPropertyAccessExpression(modelVariable, propertySegments, out _).Assign(value);
         }
 
-        private static ValueExpression BuildPropertyAccessExpression(this ModelProvider model, ValueExpression modelVariable, IReadOnlyList<string> propertySegments)
+        private static ValueExpression BuildPropertyAccessExpression(this ModelProvider model, ValueExpression modelVariable, IReadOnlyList<string> propertySegments, out PropertyProvider leafProperty)
         {
             ModelProvider currentModel = model;
             ValueExpression propertyAccessExpression = modelVariable;
+            PropertyProvider? property = null;
 
             for (int i = 0; i < propertySegments.Count; i++)
             {
-                var property = FindPropertyInModelHierarchy(currentModel, propertySegments[i]);
+                property = FindPropertyInModelHierarchy(currentModel, propertySegments[i]);
 
                 propertyAccessExpression = propertyAccessExpression.Property(property.Name);
 
@@ -43,6 +53,8 @@ namespace Microsoft.TypeSpec.Generator.Snippets
                 }
             }
 
+            leafProperty = property
+                ?? throw new System.InvalidOperationException("Cannot build a property-access expression from an empty segment path.");
             return propertyAccessExpression;
         }
 


### PR DESCRIPTION
## Problem

When an `@@override` groups operation parameters into an options-bag model, the generated convenience method delegates to the protocol method by reading each argument off the options model (`options.Foo`). If an options property is an **enum/union** but the protocol method flattens that parameter to its serialized form (e.g. `string`), the delegation passed the enum value directly where a `string` is expected — so the generated code does not compile.

The non-grouped convenience path already handles this: for an enum convenience parameter it emits `convenienceParam.Type.ToSerial(...)` (e.g. `foo?.ToString()`). The grouped path — which resolves arguments through `MethodParameterSegments` (introduced in #11238) — built a raw property-access expression and skipped that conversion.

### Before

```csharp
// options.Resampling is an (extensible) enum; the protocol method takes a string
return this.GetPoint(collectionId, options.Resampling, cancellationToken.ToRequestOptions());
```

### After

```csharp
return this.GetPoint(collectionId, options.Resampling?.ToString(), cancellationToken.ToRequestOptions());
```

## Fix

- `ModelProviderSnippets.GetPropertyExpression` gains an overload that also returns the leaf `PropertyProvider`, so callers can inspect the resolved property's type.
- `ScmMethodProviderCollection.GetProtocolMethodArguments` serializes the leaf in the grouped path when it is an enum and the protocol parameter is not — applying a null-conditional first when the property is nullable — mirroring the non-grouped path's `ToSerial` behavior. Non-enum properties are unchanged.

## Tests

- New `MethodParameterSegments_EnumGroupedQueryParam_SerializesToProtocol` (validated against a `TestData` expected file) — reproduces the missing conversion without the fix, passes with it.
- Full `Microsoft.TypeSpec.Generator.ClientModel` (1539) and `Microsoft.TypeSpec.Generator` (1781) suites pass.
