### PR TITLE
[http-client-csharp] Rename current compilation type lookup

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
@@ -522,7 +522,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         internal static CSharpType? TryGetStructUnderlyingType(CSharpType type)
         {
             var typeProvider = CodeModelGenerator.Instance.SourceInputModel
-                .FindForTypeInCustomization(type.Namespace, type.Name);
+                .FindForTypeInCurrentCompilation(type.Namespace, type.Name);
 
             if (typeProvider == null)
             {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ModelReaderWriterContextDefinition.cs
@@ -183,7 +183,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 }
                 else
                 {
-                    resolvedProvider = ScmCodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(
+                    resolvedProvider = ScmCodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
                         targetType.Namespace,
                         targetType.ClrMetadataName,
                         null,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Utilities/ModelReaderWriterHelpers.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Utilities/ModelReaderWriterHelpers.cs
@@ -107,7 +107,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Utilities
         private static TypeProvider? GetReferencedType(CSharpType type)
             => string.IsNullOrEmpty(type.Namespace)
                 ? null
-                : CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(
+                : CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
                     type.Namespace,
                     type.Name,
                     declaringTypeName: type.DeclaringType?.Name,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ConfigurationSchemaGeneratorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ConfigurationSchemaGeneratorTests.cs
@@ -988,7 +988,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var typeProvider = CodeModelGenerator.Instance.SourceInputModel
-                .FindForTypeInCustomization("SampleNamespace", "CustomAudience");
+                .FindForTypeInCurrentCompilation("SampleNamespace", "CustomAudience");
             Assert.IsNotNull(typeProvider, "CustomAudience should be found in custom code");
 
             var schema = ConfigurationSchemaGenerator.GetJsonSchemaForType(typeProvider!.Type);
@@ -1003,7 +1003,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var typeProvider = CodeModelGenerator.Instance.SourceInputModel
-                .FindForTypeInCustomization("SampleNamespace", "CustomPriority");
+                .FindForTypeInCurrentCompilation("SampleNamespace", "CustomPriority");
             Assert.IsNotNull(typeProvider, "CustomPriority should be found in custom code");
 
             var schema = ConfigurationSchemaGenerator.GetJsonSchemaForType(typeProvider!.Type);
@@ -1018,7 +1018,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var typeProvider = CodeModelGenerator.Instance.SourceInputModel
-                .FindForTypeInCustomization("SampleNamespace", "CustomComplex");
+                .FindForTypeInCurrentCompilation("SampleNamespace", "CustomComplex");
             Assert.IsNotNull(typeProvider, "CustomComplex should be found in custom code");
 
             var schema = ConfigurationSchemaGenerator.GetJsonSchemaForType(typeProvider!.Type);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientSettingsProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientSettingsProviderTests.cs
@@ -924,7 +924,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var typeProvider = CodeModelGenerator.Instance.SourceInputModel
-                .FindForTypeInCustomization("SampleNamespace", "CustomAudience");
+                .FindForTypeInCurrentCompilation("SampleNamespace", "CustomAudience");
             Assert.IsNotNull(typeProvider, "CustomAudience should be found in custom code");
 
             var body = new List<MethodBodyStatement>();
@@ -954,7 +954,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var typeProvider = CodeModelGenerator.Instance.SourceInputModel
-                .FindForTypeInCustomization("SampleNamespace", "CustomPriority");
+                .FindForTypeInCurrentCompilation("SampleNamespace", "CustomPriority");
             Assert.IsNotNull(typeProvider, "CustomPriority should be found in custom code");
 
             var body = new List<MethodBodyStatement>();
@@ -985,7 +985,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var typeProvider = CodeModelGenerator.Instance.SourceInputModel
-                .FindForTypeInCustomization("SampleNamespace", "CustomComplex");
+                .FindForTypeInCurrentCompilation("SampleNamespace", "CustomComplex");
             Assert.IsNotNull(typeProvider, "CustomComplex should be found in custom code");
 
             var body = new List<MethodBodyStatement>();

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelFactoryProvider.cs
@@ -262,7 +262,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             var declaringTypeName = type.DeclaringType?.Name;
-            if (CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(
+            if (CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
                 type.Namespace,
                 type.Name,
                 declaringTypeName,
@@ -298,7 +298,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 return true;
             }
 
-            return CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(
+            return CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
                 ns,
                 name,
                 declaringTypeName,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -153,7 +153,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // Try to find the type in the customization compilation. Referenced assemblies are
                 // included so custom bases from framework or external packages are represented by
                 // normal symbol-backed providers.
-                var baseTypeProvider = CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(
+                var baseTypeProvider = CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
                     baseType.Namespace,
                     baseType.Name,
                     baseType.DeclaringType?.Name,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/SystemObjectModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/SystemObjectModelProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 return [.. frameworkType.GetInterfaces().Select(type => CreateInterfaceType(type, typeArguments))];
             }
 
-            return [.. CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(
+            return [.. CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
                     SystemType.Namespace,
                     SystemType.Name,
                     declaringTypeName: SystemType.DeclaringType?.Name,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         }
 
         private protected virtual TypeProvider? BuildCustomCodeView(string? generatedTypeName = null, string? generatedTypeNamespace = null)
-            => CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCustomization(
+            => CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
                 generatedTypeNamespace ?? BuildNamespace(),
                 generatedTypeName ?? BuildName(),
                 _declaringTypeName.Value);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
@@ -67,12 +67,6 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
             return FindTypeInCompilation(Customization, ns, name, includeReferencedAssemblies, declaringTypeName);
         }
 
-        [Obsolete($"Use {nameof(FindForTypeInCurrentCompilation)} instead.")]
-        public TypeProvider? FindForTypeInCustomization(string ns, string name, string? declaringTypeName = null, bool includeReferencedAssemblies = false)
-        {
-            return FindForTypeInCurrentCompilation(ns, name, declaringTypeName, includeReferencedAssemblies);
-        }
-
         public TypeProvider? FindForTypeInLastContract(string ns, string name, string? declaringTypeName = null)
         {
             return FindTypeInCompilation(LastContract, ns, name, true, declaringTypeName, includeInternal: false);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/SourceInput/SourceInputModel.cs
@@ -62,9 +62,15 @@ namespace Microsoft.TypeSpec.Generator.SourceInput
             return nameMap;
         }
 
-        public TypeProvider? FindForTypeInCustomization(string ns, string name, string? declaringTypeName = null, bool includeReferencedAssemblies = false)
+        public TypeProvider? FindForTypeInCurrentCompilation(string ns, string name, string? declaringTypeName = null, bool includeReferencedAssemblies = false)
         {
             return FindTypeInCompilation(Customization, ns, name, includeReferencedAssemblies, declaringTypeName);
+        }
+
+        [Obsolete($"Use {nameof(FindForTypeInCurrentCompilation)} instead.")]
+        public TypeProvider? FindForTypeInCustomization(string ns, string name, string? declaringTypeName = null, bool includeReferencedAssemblies = false)
+        {
+            return FindForTypeInCurrentCompilation(ns, name, declaringTypeName, includeReferencedAssemblies);
         }
 
         public TypeProvider? FindForTypeInLastContract(string ns, string name, string? declaringTypeName = null)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/NamedTypeSymbolProviderTests.cs
@@ -443,7 +443,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
             var compilation = await Helpers.GetCompilationFromDirectoryAsync();
             var sourceInputModel = new SourceInputModel(compilation, lastContract: null);
 
-            var nestedType = sourceInputModel.FindForTypeInCustomization("Sample", "Target", "Outer+Middle");
+            var nestedType = sourceInputModel.FindForTypeInCurrentCompilation("Sample", "Target", "Outer+Middle");
 
             Assert.IsNotNull(nestedType);
             Assert.AreEqual("Sample.Outer+Middle+Target", ((NamedTypeSymbolProvider)nestedType!).MetadataName);


### PR DESCRIPTION
## Summary

- rename `SourceInputModel.FindForTypeInCustomization` to `FindForTypeInCurrentCompilation` to describe the actual lookup scope
- update generator, ClientModel, and test call sites to use the renamed API

## Testing

- `Microsoft.TypeSpec.Generator.Tests` (1,781 passed)
- affected ClientModel suites: `ConfigurationSchemaGeneratorTests`, `ClientSettingsProviderTests`, and `ModelReaderWriterContextDefinitionTests` (127 passed)

Fixes #11487