### PR TITLE
fix(http-client-python): boot pyodide lazily in the browser

### DIFF
--- a/.chronus/changes/lazy-browser-pyodide-2026-7-31-9-30-0.md
+++ b/.chronus/changes/lazy-browser-pyodide-2026-7-31-9-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Only boot the Pyodide runtime in the browser on the first emit instead of when the emitter module is imported. Hosts such as the TypeSpec playground import every available emitter up front, so the eager bootstrap downloaded a full CPython WebAssembly runtime and its wheels on every page load, which prevented the page from loading on mobile browsers.

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -223,7 +223,7 @@ async function onEmitMain(context: EmitContext<PythonEmitterOptions>) {
 
   if (typeof window !== "undefined") {
     // Running in browser with Pyodide - fileURLToPath and other filesystem operations are browser-incompatible
-    const pyodide = await browserPyodidePromise;
+    const pyodide = await getBrowserPyodide();
 
     if (!pyodide) {
       reportDiagnostic(program, {
@@ -253,8 +253,29 @@ async function onEmitMain(context: EmitContext<PythonEmitterOptions>) {
   }
 }
 
-const browserPyodidePromise: Promise<PyodideInterface> | null =
-  typeof window !== "undefined" ? setupPyodideCallBrowser() : null;
+let browserPyodidePromise: Promise<PyodideInterface> | undefined;
+
+/**
+ * Boot the Pyodide runtime lazily, on the first browser emit.
+ *
+ * This must not happen when the module is imported: hosts like the TypeSpec playground import every
+ * available emitter up front, and booting Pyodide downloads a full CPython WebAssembly runtime plus
+ * its wheels (~10MB, ~290MB of resident memory). Doing that eagerly pushed the playground past the
+ * per-tab memory budget on mobile browsers, which made the page fail to load.
+ */
+function getBrowserPyodide(): Promise<PyodideInterface> | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  if (browserPyodidePromise === undefined) {
+    browserPyodidePromise = setupPyodideCallBrowser().catch((error) => {
+      // Clear the cached promise so a later emit can retry after a transient failure.
+      browserPyodidePromise = undefined;
+      throw error;
+    });
+  }
+  return browserPyodidePromise;
+}
 
 function clearMemfsDirectory(pyodide: PyodideInterface, dir: string): void {
   const entries: string[] = pyodide.FS.readdir(dir).filter(

--- a/packages/http-client-python/emitter/test/browser-pyodide.test.ts
+++ b/packages/http-client-python/emitter/test/browser-pyodide.test.ts
@@ -1,0 +1,25 @@
+import { strictEqual } from "assert";
+import { afterEach, describe, it, vi } from "vitest";
+
+const loadPyodide = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/pyodide-loader.js", () => ({ loadPyodide }));
+
+describe("typespec-python: browser pyodide bootstrap", () => {
+  afterEach(() => {
+    delete (globalThis as any).window;
+    loadPyodide.mockReset();
+    vi.resetModules();
+  });
+
+  // Hosts like the TypeSpec playground import every available emitter up front. Booting Pyodide at
+  // module scope downloaded a full CPython WebAssembly runtime on every page load, which pushed the
+  // page past the per-tab memory budget on mobile browsers and prevented it from loading.
+  it("does not boot pyodide when the emitter is imported in a browser", async () => {
+    (globalThis as any).window = globalThis;
+
+    await import("../src/emitter.js");
+
+    strictEqual(loadPyodide.mock.calls.length, 0);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/typespec/issues/11506

## Problem

The browser Pyodide bootstrap ran as a **module-level side effect**:

```ts
const browserPyodidePromise: Promise<PyodideInterface> | null =
  typeof window !== "undefined" ? setupPyodideCallBrowser() : null;
```

So merely `import`ing `@typespec/http-client-python` downloaded a full CPython WebAssembly runtime (`pyodide.asm.wasm`, `python_stdlib.zip`) and micropip-installed `jinja2`, `black`, `setuptools`, … live from PyPI.

The playground imports **every** library in its import map up front (`loadLibraries` in `packages/playground/src/browser-host.ts`), so this happened on every single page load, whether or not the user ever selected the Python emitter.

## Impact

Measured against the live `typespec.io/playground` with Playwright WebKit under iPhone 15 emulation:

| Scenario | Peak WebContent RSS |
|---|---|
| typespec.io homepage | 195 MB |
| Playground, python/csharp emitters blocked | 463 MB |
| **Playground as shipped** | **752 MB** |

Total page weight was 22.9 MB across 197 requests, of which ~8 MB was Pyodide + PyPI wheels.

~750 MB is past what iOS Safari allows a single tab, so the WebContent process gets killed and reloaded — which is exactly the "loads infinitely" symptom in the issue.

## Fix

Boot Pyodide on the first browser emit instead of at import time. The cached promise is dropped if the bootstrap rejects, so a later emit can retry after a transient failure (matching the existing behaviour in `pyodide-loader.browser.ts`).

No behaviour change for the Node path, and no change for users who actually select the Python emitter beyond moving the download to the point where it's needed.

## Testing

Added `emitter/test/browser-pyodide.test.ts`, which stubs `window` and asserts that importing the emitter does not call `loadPyodide`. Verified it fails against the previous implementation and passes with this change.

```
✓ emitter/test/browser-pyodide.test.ts (1 test)
✓ emitter/test/external-process.test.ts (2 tests)
✓ emitter/test/utils.test.ts (3 tests)
```

## Follow-ups (not in this PR)

- Monaco's web workers fail to be created on typespec.io (`Could not create web worker(s). Falling back to loading web worker code in main thread`) on desktop and mobile alike, so compilation runs on the main thread. Painful on a phone CPU.
- The playground eagerly imports every emitter module; deferring emitter loading until selection would make it resilient to this class of regression.
