### PR TITLE
fix(vscode): terminate both debug sessions together when debugging the extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -122,6 +122,9 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/typespec-vscode"],
       "outFiles": ["${workspaceFolder}/packages/typespec-vscode/dist/**/*.cjs"],
+      // Closing the Extension Development Host window ends this session without a manual stop,
+      // which compound `stopAll` does not cover, so cascade the termination explicitly.
+      "cascadeTerminateToConfigurations": ["Attach to Language Server"],
       "env": {
         // Log elapsed time for each call to server.
         //"TYPESPEC_SERVER_LOG_TIMING": "true",
@@ -187,6 +190,9 @@
     {
       "name": "VS Code Extension",
       "configurations": ["VS Code Extension (Client)", "Attach to Language Server"],
+      // Stopping either the extension host or the language server session terminates both,
+      // instead of leaving an orphan session behind in the Call Stack view.
+      "stopAll": true,
       "presentation": {
         "order": 1
       }


### PR DESCRIPTION
Debugging the VS Code extension leaves orphaned debug sessions behind.

The `VS Code Extension` compound launches two sessions: the extension host client and an attach to the language server. Ending the debug session the usual way — closing the Extension Development Host window — terminates the client without going through a manual stop, so the language server session keeps running and lingers in the Call Stack view. You then have to stop it by hand before the next `F5`, and stale servers accumulate across iterations.

Two small config additions fix it:

- `cascadeTerminateToConfigurations` on **VS Code Extension (Client)** tears down the attach session when the extension host window closes. The compound's `stopAll` alone does not cover this case, because closing the window is not a stop request.
- `stopAll: true` on the **VS Code Extension** compound makes stopping either session terminate both, so neither can be orphaned.

Now `F5` → close the dev host window returns you to a clean Call Stack every time.
