### PR TITLE
Enable verbatimModuleSyntax for @typespec/http

### DIFF
--- a/.chronus/changes/type-import-pass-7-2026-7-31.md
+++ b/.chronus/changes/type-import-pass-7-2026-7-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http"
+---
+
+Enable `verbatimModuleSyntax` and convert type-only imports/exports to `import type` / `export type`

--- a/packages/http/src/auth.ts
+++ b/packages/http/src/auth.ts
@@ -1,7 +1,7 @@
-import { Operation, Program } from "@typespec/compiler";
+import type { Operation, Program } from "@typespec/compiler";
 import { deepEquals } from "@typespec/compiler/utils";
 import { getAuthentication } from "./decorators.js";
-import {
+import type {
   Authentication,
   AuthenticationOptionReference,
   AuthenticationReference,

--- a/packages/http/src/content-types.ts
+++ b/packages/http/src/content-types.ts
@@ -1,4 +1,5 @@
-import { createDiagnosticCollector, Diagnostic, ModelProperty } from "@typespec/compiler";
+import type { Diagnostic, ModelProperty } from "@typespec/compiler";
+import { createDiagnosticCollector } from "@typespec/compiler";
 import { createDiagnostic } from "./lib.js";
 
 /**

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DecoratorContext,
   Diagnostic,
   DiagnosticTarget,
@@ -11,6 +11,8 @@ import {
   Tuple,
   Type,
   Union,
+} from "@typespec/compiler";
+import {
   createDiagnosticCollector,
   getDoc,
   ignoreDiagnostics,
@@ -19,7 +21,7 @@ import {
 } from "@typespec/compiler";
 import { SyntaxKind } from "@typespec/compiler/ast";
 import { useStateMap } from "@typespec/compiler/utils";
-import {
+import type {
   BodyDecorator,
   BodyIgnoreDecorator,
   BodyRootDecorator,
@@ -43,7 +45,7 @@ import {
 } from "../generated-defs/TypeSpec.Http.js";
 import { HttpStateKeys, createDiagnostic, reportDiagnostic } from "./lib.js";
 import { getStatusCodesFromType } from "./status-codes.js";
-import {
+import type {
   Authentication,
   AuthenticationOption,
   CookieParameterOptions,

--- a/packages/http/src/decorators/route.ts
+++ b/packages/http/src/decorators/route.ts
@@ -6,7 +6,7 @@ import {
   type Operation,
 } from "@typespec/compiler";
 import { useStateMap } from "@typespec/compiler/utils";
-import { RouteDecorator } from "../../generated-defs/TypeSpec.Http.js";
+import type { RouteDecorator } from "../../generated-defs/TypeSpec.Http.js";
 import { HttpStateKeys, reportDiagnostic } from "../lib.js";
 import type { RoutePath } from "../types.js";
 import { setSharedRoute } from "./shared-route.js";

--- a/packages/http/src/decorators/shared-route.ts
+++ b/packages/http/src/decorators/shared-route.ts
@@ -1,6 +1,6 @@
 import type { DecoratorContext, Operation, Program } from "@typespec/compiler";
 import { useStateMap } from "@typespec/compiler/utils";
-import { SharedRouteDecorator } from "../../generated-defs/TypeSpec.Http.js";
+import type { SharedRouteDecorator } from "../../generated-defs/TypeSpec.Http.js";
 import { HttpStateKeys } from "../lib.js";
 
 const [getSharedRoute, setSharedRouteFor] = useStateMap(HttpStateKeys.sharedRoutes);

--- a/packages/http/src/experimental/index.ts
+++ b/packages/http/src/experimental/index.ts
@@ -10,4 +10,5 @@ export {
   type RouteProducerResult as unsafe_RouteProducerResult,
   type RouteResolutionOptions as unsafe_RouteResolutionOptions,
 } from "../types.js";
-export { StreamMetadata, getStreamMetadata } from "./streams.js";
+export { getStreamMetadata } from "./streams.js";
+export type { StreamMetadata } from "./streams.js";

--- a/packages/http/src/experimental/merge-patch/helpers.ts
+++ b/packages/http/src/experimental/merge-patch/helpers.ts
@@ -1,4 +1,5 @@
-import { isArrayModelType, Model, ModelProperty, Program, Type, Value } from "@typespec/compiler";
+import type { Model, ModelProperty, Program, Type, Value } from "@typespec/compiler";
+import { isArrayModelType } from "@typespec/compiler";
 import { useStateMap } from "@typespec/compiler/utils";
 import { HttpStateKeys } from "../../lib.js";
 

--- a/packages/http/src/experimental/merge-patch/index.ts
+++ b/packages/http/src/experimental/merge-patch/index.ts
@@ -1,6 +1,4 @@
 export {
-  MergePatchProperties,
-  MergePatchPropertyOverrides,
   getMergePatchProperties,
   getMergePatchPropertyOverrides,
   getMergePatchPropertySource,
@@ -10,3 +8,4 @@ export {
   setMergePatchPropertySource,
   setMergePatchSource,
 } from "./helpers.js";
+export type { MergePatchProperties, MergePatchPropertyOverrides } from "./helpers.js";

--- a/packages/http/src/experimental/merge-patch/internal.ts
+++ b/packages/http/src/experimental/merge-patch/internal.ts
@@ -1,4 +1,4 @@
-import { Program, Type } from "@typespec/compiler";
+import type { Program, Type } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import { getMergePatchPropertySource, isMergePatch } from "./helpers.js";
 

--- a/packages/http/src/experimental/streams.ts
+++ b/packages/http/src/experimental/streams.ts
@@ -1,5 +1,5 @@
-import { Model, ModelProperty, Program, Type } from "@typespec/compiler";
-import { HttpOperationParameters, HttpOperationResponseContent } from "../types.js";
+import type { Model, ModelProperty, Program, Type } from "@typespec/compiler";
+import type { HttpOperationParameters, HttpOperationResponseContent } from "../types.js";
 let getStreamOf: typeof import("@typespec/streams").getStreamOf;
 try {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/http/src/experimental/typekit/kits/http-operation.ts
+++ b/packages/http/src/experimental/typekit/kits/http-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, StringLiteral, Type, VoidType } from "@typespec/compiler";
+import type { Operation, StringLiteral, Type, VoidType } from "@typespec/compiler";
 import {
   createDiagnosable,
   defineKit,
@@ -6,7 +6,7 @@ import {
   type Typekit,
 } from "@typespec/compiler/typekit";
 import { getHttpOperation } from "../../../operations.js";
-import {
+import type {
   HttpOperation,
   HttpOperationResponseContent,
   HttpStatusCodesEntry,

--- a/packages/http/src/experimental/typekit/kits/http-part.ts
+++ b/packages/http/src/experimental/typekit/kits/http-part.ts
@@ -1,6 +1,7 @@
 import type { Type } from "@typespec/compiler";
 import { defineKit } from "@typespec/compiler/typekit";
-import { getHttpPart, HttpPart } from "../../../private.decorators.js";
+import type { HttpPart } from "../../../private.decorators.js";
+import { getHttpPart } from "../../../private.decorators.js";
 
 /**
  * Utilities for working with HTTP Parts.

--- a/packages/http/src/experimental/typekit/kits/http-request.ts
+++ b/packages/http/src/experimental/typekit/kits/http-request.ts
@@ -1,6 +1,6 @@
-import { Model, ModelProperty } from "@typespec/compiler";
+import type { Model, ModelProperty } from "@typespec/compiler";
 import { defineKit } from "@typespec/compiler/typekit";
-import { HttpOperation } from "../../../types.js";
+import type { HttpOperation } from "../../../types.js";
 
 export type HttpRequestParameterKind = "query" | "header" | "path" | "contentType" | "body";
 

--- a/packages/http/src/experimental/typekit/kits/http-response.ts
+++ b/packages/http/src/experimental/typekit/kits/http-response.ts
@@ -1,7 +1,7 @@
 import { isErrorModel } from "@typespec/compiler";
 import { defineKit } from "@typespec/compiler/typekit";
-import { HttpStatusCodeRange, HttpStatusCodesEntry } from "../../../types.js";
-import { FlatHttpResponse } from "./http-operation.js";
+import type { HttpStatusCodeRange, HttpStatusCodesEntry } from "../../../types.js";
+import type { FlatHttpResponse } from "./http-operation.js";
 
 /**
  * Utilities for working with HTTP responses.

--- a/packages/http/src/experimental/typekit/kits/model-property.ts
+++ b/packages/http/src/experimental/typekit/kits/model-property.ts
@@ -1,4 +1,4 @@
-import { ModelProperty } from "@typespec/compiler";
+import type { ModelProperty } from "@typespec/compiler";
 import { defineKit } from "@typespec/compiler/typekit";
 import {
   getHeaderFieldOptions,
@@ -9,7 +9,11 @@ import {
   isPathParam,
   isQueryParam,
 } from "../../../decorators.js";
-import { HeaderFieldOptions, PathParameterOptions, QueryParameterOptions } from "../../../types.js";
+import type {
+  HeaderFieldOptions,
+  PathParameterOptions,
+  QueryParameterOptions,
+} from "../../../types.js";
 
 /**
  * Utilities for working with model properties in the context of Http.

--- a/packages/http/src/http-property.ts
+++ b/packages/http/src/http-property.ts
@@ -1,15 +1,13 @@
+import type { DiagnosticResult, Model, Type } from "@typespec/compiler";
 import {
   compilerAssert,
   createDiagnosticCollector,
-  DiagnosticResult,
-  Model,
-  Type,
   walkPropertiesInherited,
   type Diagnostic,
   type ModelProperty,
   type Program,
 } from "@typespec/compiler";
-import { PathOptions, QueryOptions } from "../generated-defs/TypeSpec.Http.js";
+import type { PathOptions, QueryOptions } from "../generated-defs/TypeSpec.Http.js";
 import {
   getCookieParamOptions,
   getHeaderFieldOptions,
@@ -24,9 +22,10 @@ import {
   resolveQueryOptionsWithDefaults,
 } from "./decorators.js";
 import { createDiagnostic } from "./lib.js";
-import { isVisible, Visibility } from "./metadata.js";
+import type { Visibility } from "./metadata.js";
+import { isVisible } from "./metadata.js";
 import { HttpPayloadDisposition } from "./payload.js";
-import {
+import type {
   CookieParameterOptions,
   HeaderFieldOptions,
   PathParameterOptions,

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -75,12 +75,12 @@ export {
 } from "./operations.js";
 export { getOperationParameters } from "./parameters.js";
 export {
-  HttpPart,
   getHttpFileModel,
   getHttpPart,
   isHttpFile,
   isOrExtendsHttpFile,
 } from "./private.decorators.js";
+export type { HttpPart } from "./private.decorators.js";
 export { getResponsesForOperation } from "./responses.js";
 export {
   addQueryParamsToUriTemplate,

--- a/packages/http/src/merge-patch.ts
+++ b/packages/http/src/merge-patch.ts
@@ -1,48 +1,52 @@
-import {
-  $invisible,
-  $removeVisibility,
-  $visibility,
-  compilerAssert,
+import type {
   DecoratorApplication,
   DecoratorContext,
   EnumValue,
   FunctionContext,
-  getDiscriminatedUnion,
-  getDiscriminator,
-  getLifecycleVisibilityEnum,
-  isVisible,
   Model,
   ModelProperty,
-  navigateType,
   Program,
-  resetVisibilityModifiersForClass,
-  setMediaTypeHint,
   Tuple,
   Type,
   Union,
   UnionVariant,
   VisibilityFilter,
 } from "@typespec/compiler";
-
 import {
+  $invisible,
+  $removeVisibility,
+  $visibility,
+  compilerAssert,
+  getDiscriminatedUnion,
+  getDiscriminator,
+  getLifecycleVisibilityEnum,
+  isVisible,
+  navigateType,
+  resetVisibilityModifiersForClass,
+  setMediaTypeHint,
+} from "@typespec/compiler";
+
+import type {
   unsafe_MutableType as MutableType,
-  unsafe_mutateSubgraph as mutateSubgraph,
   unsafe_Mutator as Mutator,
-  unsafe_MutatorFlow as MutatorFlow,
   unsafe_Realm as Realm,
+} from "@typespec/compiler/experimental";
+import {
+  unsafe_mutateSubgraph as mutateSubgraph,
+  unsafe_MutatorFlow as MutatorFlow,
 } from "@typespec/compiler/experimental";
 import { $ } from "@typespec/compiler/typekit";
 
-import {
+import type {
   ApplyMergePatchDecorator,
   ApplyMergePatchOptions,
   MergePatchModelDecorator,
   MergePatchPropertyDecorator,
 } from "../generated-defs/TypeSpec.Http.Private.js";
 import { isCookieParam, isHeader, isPathParam, isQueryParam, isStatusCode } from "./decorators.js";
+import type { MergePatchPropertyOverrides } from "./experimental/merge-patch/index.js";
 import {
   getMergePatchPropertyOverrides,
-  MergePatchPropertyOverrides,
   setMergePatchPropertyOverrides,
   setMergePatchPropertySource,
   setMergePatchSource,

--- a/packages/http/src/metadata.ts
+++ b/packages/http/src/metadata.ts
@@ -1,18 +1,20 @@
-import {
-  compilerAssert,
+import type {
   EnumMember,
-  getEffectiveModelType,
-  getLifecycleVisibilityEnum,
-  getParameterVisibilityFilter,
-  isVisible as isVisibleCore,
   Model,
   ModelProperty,
   Operation,
   Program,
   Type,
   Union,
-  type VisibilityFilter,
   VisibilityProvider,
+} from "@typespec/compiler";
+import {
+  compilerAssert,
+  getEffectiveModelType,
+  getLifecycleVisibilityEnum,
+  getParameterVisibilityFilter,
+  isVisible as isVisibleCore,
+  type VisibilityFilter,
 } from "@typespec/compiler";
 import { TwoLevelMap } from "@typespec/compiler/utils";
 import {
@@ -28,7 +30,7 @@ import {
   isQueryParam,
   isStatusCode,
 } from "./decorators.js";
-import { HttpVerb, OperationParameterOptions } from "./types.js";
+import type { HttpVerb, OperationParameterOptions } from "./types.js";
 
 // Used in @link JsDoc tag.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/http/src/operations.ts
+++ b/packages/http/src/operations.ts
@@ -1,16 +1,18 @@
-import {
-  createDiagnosticCollector,
+import type {
   Diagnostic,
   DiagnosticCollector,
+  Namespace,
+  Operation,
+  Program,
+} from "@typespec/compiler";
+import {
+  createDiagnosticCollector,
   getLocationContext,
   getOverloadedOperation,
   getOverloads,
   listOperationsIn,
   listServices,
-  Namespace,
   navigateProgram,
-  Operation,
-  Program,
 } from "@typespec/compiler";
 import { unsafe_useCache as useCache } from "@typespec/compiler/experimental";
 import { getAuthenticationForOperation } from "./auth.js";
@@ -19,7 +21,7 @@ import { isSharedRoute } from "./decorators/shared-route.js";
 import { createDiagnostic, reportDiagnostic } from "./lib.js";
 import { getResponsesForOperation } from "./responses.js";
 import { resolvePathAndParameters } from "./route.js";
-import {
+import type {
   HttpOperation,
   HttpService,
   HttpVerb,

--- a/packages/http/src/parameters.ts
+++ b/packages/http/src/parameters.ts
@@ -1,14 +1,9 @@
-import {
-  createDiagnosticCollector,
-  Diagnostic,
-  ModelProperty,
-  Operation,
-  Program,
-} from "@typespec/compiler";
+import type { Diagnostic, ModelProperty, Operation, Program } from "@typespec/compiler";
+import { createDiagnosticCollector } from "@typespec/compiler";
 import { getOperationVerb, getPathOptions, getQueryOptions } from "./decorators.js";
 import { resolveRequestVisibility } from "./metadata.js";
 import { HttpPayloadDisposition, resolveHttpPayload } from "./payload.js";
-import {
+import type {
   HttpOperation,
   HttpOperationParameter,
   HttpOperationParameters,

--- a/packages/http/src/payload.ts
+++ b/packages/http/src/payload.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DiagnosticResult,
   LiteralType,
   Model,
@@ -9,6 +9,8 @@ import {
   Tuple,
   Type,
   Union,
+} from "@typespec/compiler";
+import {
   createDiagnosticCollector,
   filterModelProperties,
   getDiscriminator,
@@ -22,16 +24,13 @@ import { DuplicateTracker } from "@typespec/compiler/utils";
 import { getContentTypes } from "./content-types.js";
 import { isCookieParam, isHeader, isPathParam, isQueryParam, isStatusCode } from "./decorators.js";
 import { isMergePatchBody } from "./experimental/merge-patch/internal.js";
-import {
-  GetHttpPropertyOptions,
-  HeaderProperty,
-  HttpProperty,
-  resolvePayloadProperties,
-} from "./http-property.js";
+import type { GetHttpPropertyOptions, HeaderProperty, HttpProperty } from "./http-property.js";
+import { resolvePayloadProperties } from "./http-property.js";
 import { createDiagnostic, reportDiagnostic } from "./lib.js";
-import { Visibility } from "./metadata.js";
-import { HttpFileModel, getHttpFileModel, getHttpPart } from "./private.decorators.js";
-import {
+import type { Visibility } from "./metadata.js";
+import type { HttpFileModel } from "./private.decorators.js";
+import { getHttpFileModel, getHttpPart } from "./private.decorators.js";
+import type {
   HttpOperationFileBody,
   HttpOperationModelPart,
   HttpOperationMultipartBody,

--- a/packages/http/src/private.decorators.ts
+++ b/packages/http/src/private.decorators.ts
@@ -1,20 +1,18 @@
-import {
+import type {
   DecoratorContext,
   DiagnosticTarget,
   IndeterminateEntity,
   Model,
   ModelProperty,
   Namespace,
-  NoTarget,
   Program,
   Type,
   Value,
-  getProperty,
-  getTypeName,
-  walkPropertiesInherited,
 } from "@typespec/compiler";
-import { Node, SyntaxKind, TemplateableNode } from "@typespec/compiler/ast";
-import {
+import { NoTarget, getProperty, getTypeName, walkPropertiesInherited } from "@typespec/compiler";
+import type { Node, TemplateableNode } from "@typespec/compiler/ast";
+import { SyntaxKind } from "@typespec/compiler/ast";
+import type {
   HttpFileDecorator,
   HttpPartDecorator,
   HttpPartOptions,
@@ -31,7 +29,7 @@ import {
   isStatusCode,
 } from "./decorators.js";
 import { HttpStateKeys, reportDiagnostic } from "./lib.js";
-import { HttpOperationFileBody } from "./types.js";
+import type { HttpOperationFileBody } from "./types.js";
 
 export const $plainData: PlainDataDecorator = (context: DecoratorContext, entity: Model) => {
   const { program } = context;

--- a/packages/http/src/responses.ts
+++ b/packages/http/src/responses.ts
@@ -1,18 +1,20 @@
-import {
-  createDiagnosticCollector,
+import type {
   Diagnostic,
   DiagnosticCollector,
+  Model,
+  ModelProperty,
+  Operation,
+  Program,
+  Type,
+} from "@typespec/compiler";
+import {
+  createDiagnosticCollector,
   getDoc,
   getErrorsDoc,
   getReturnsDoc,
   isErrorModel,
   isNullType,
   isVoidType,
-  Model,
-  ModelProperty,
-  Operation,
-  Program,
-  Type,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import {
@@ -20,11 +22,11 @@ import {
   getStatusCodeDescription,
   getStatusCodesWithDiagnostics,
 } from "./decorators.js";
-import { HttpProperty } from "./http-property.js";
+import type { HttpProperty } from "./http-property.js";
 import { HttpStateKeys, reportDiagnostic } from "./lib.js";
 import { Visibility } from "./metadata.js";
 import { HttpPayloadDisposition, resolveHttpPayload } from "./payload.js";
-import { HttpOperationResponse, HttpStatusCodes, HttpStatusCodesEntry } from "./types.js";
+import type { HttpOperationResponse, HttpStatusCodes, HttpStatusCodesEntry } from "./types.js";
 
 /**
  * Get the responses for a given operation.

--- a/packages/http/src/route.ts
+++ b/packages/http/src/route.ts
@@ -1,5 +1,4 @@
-import {
-  createDiagnosticCollector,
+import type {
   Diagnostic,
   DiagnosticResult,
   Interface,
@@ -7,10 +6,11 @@ import {
   Operation,
   Program,
 } from "@typespec/compiler";
+import { createDiagnosticCollector } from "@typespec/compiler";
 import { isSharedRoute } from "./decorators/shared-route.js";
 import { createDiagnostic, HttpStateKeys } from "./lib.js";
 import { getOperationParameters } from "./parameters.js";
-import {
+import type {
   HttpOperation,
   HttpOperationParameter,
   HttpOperationParameters,
@@ -23,7 +23,8 @@ import {
   RouteProducerResult,
   RouteResolutionOptions,
 } from "./types.js";
-import { parseUriTemplate, UriTemplate } from "./uri-template.js";
+import type { UriTemplate } from "./uri-template.js";
+import { parseUriTemplate } from "./uri-template.js";
 
 // The set of allowed segment separator characters
 const AllowedSegmentSeparators = ["/", ":", "?"];

--- a/packages/http/src/rules/op-reference-container-route.ts
+++ b/packages/http/src/rules/op-reference-container-route.ts
@@ -1,6 +1,7 @@
-import { Operation, createRule, fileRef, paramMessage } from "@typespec/compiler";
+import type { Operation } from "@typespec/compiler";
+import { createRule, fileRef, paramMessage } from "@typespec/compiler";
 import { getRoutePath } from "../route.js";
-import { OperationContainer } from "../types.js";
+import type { OperationContainer } from "../types.js";
 
 export const opReferenceContainerRouteRule = createRule({
   name: "op-reference-container-route",

--- a/packages/http/src/status-codes.ts
+++ b/packages/http/src/status-codes.ts
@@ -1,14 +1,12 @@
-import {
+import type {
   Diagnostic,
   DiagnosticTarget,
   ModelProperty,
   Program,
   Scalar,
   Type,
-  createDiagnosticCollector,
-  getMaxValue,
-  getMinValue,
 } from "@typespec/compiler";
+import { createDiagnosticCollector, getMaxValue, getMinValue } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import { createDiagnostic } from "./lib.js";
 import type { HttpStatusCodeRange, HttpStatusCodes } from "./types.js";

--- a/packages/http/src/testing/index.ts
+++ b/packages/http/src/testing/index.ts
@@ -1,8 +1,5 @@
-import {
-  createTestLibrary,
-  findTestPackageRoot,
-  TypeSpecTestLibrary,
-} from "@typespec/compiler/testing";
+import type { TypeSpecTestLibrary } from "@typespec/compiler/testing";
+import { createTestLibrary, findTestPackageRoot } from "@typespec/compiler/testing";
 
 /** @deprecated Use `createTester` from `@typespec/compiler/testing` instead */
 /* eslint-disable @typescript-eslint/no-deprecated */

--- a/packages/http/src/tsp-index.ts
+++ b/packages/http/src/tsp-index.ts
@@ -1,5 +1,5 @@
-import { TypeSpecHttpDecorators } from "../generated-defs/TypeSpec.Http.js";
-import {
+import type { TypeSpecHttpDecorators } from "../generated-defs/TypeSpec.Http.js";
+import type {
   TypeSpecHttpPrivateDecorators,
   TypeSpecHttpPrivateFunctions,
 } from "../generated-defs/TypeSpec.Http.Private.js";

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DiagnosticResult,
   Interface,
   ListOperationOptions,
@@ -11,8 +11,8 @@ import {
   Tuple,
   Type,
 } from "@typespec/compiler";
-import { CookieOptions, PathOptions, QueryOptions } from "../generated-defs/TypeSpec.Http.js";
-import { HeaderProperty, HttpProperty } from "./http-property.js";
+import type { CookieOptions, PathOptions, QueryOptions } from "../generated-defs/TypeSpec.Http.js";
+import type { HeaderProperty, HttpProperty } from "./http-property.js";
 
 export type HttpVerb = "get" | "put" | "post" | "patch" | "delete" | "head";
 

--- a/packages/http/src/validate.ts
+++ b/packages/http/src/validate.ts
@@ -2,7 +2,7 @@ import type { Program } from "@typespec/compiler";
 import { isSharedRoute } from "./decorators/shared-route.js";
 import { reportDiagnostic } from "./lib.js";
 import { getAllHttpServices } from "./operations.js";
-import { HttpOperation, HttpService } from "./types.js";
+import type { HttpOperation, HttpService } from "./types.js";
 
 export function $onValidate(program: Program) {
   // Pass along any diagnostics that might be returned from the HTTP library

--- a/packages/http/test/http-decorators.test.ts
+++ b/packages/http/test/http-decorators.test.ts
@@ -1,4 +1,4 @@
-import { ModelProperty } from "@typespec/compiler";
+import type { ModelProperty } from "@typespec/compiler";
 import { expectDiagnosticEmpty, expectDiagnostics, t } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";

--- a/packages/http/test/merge-patch.test.ts
+++ b/packages/http/test/merge-patch.test.ts
@@ -1,21 +1,11 @@
-import {
-  Diagnostic,
-  getMediaTypeHint,
-  Model,
-  ModelProperty,
-  Program,
-  Type,
-  TypeKind,
-} from "@typespec/compiler";
+import type { Diagnostic, Model, ModelProperty, Program, Type, TypeKind } from "@typespec/compiler";
+import { getMediaTypeHint } from "@typespec/compiler";
 import {
   type unsafe_MutatorWithNamespace as MutatorWithNamespace,
   unsafe_mutateSubgraphWithNamespace,
 } from "@typespec/compiler/experimental";
-import {
-  expectDiagnosticEmpty,
-  expectDiagnostics,
-  TesterInstance,
-} from "@typespec/compiler/testing";
+import type { TesterInstance } from "@typespec/compiler/testing";
+import { expectDiagnosticEmpty, expectDiagnostics } from "@typespec/compiler/testing";
 import { $ } from "@typespec/compiler/typekit";
 import { deepStrictEqual, ok } from "assert";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -27,7 +17,7 @@ import {
 } from "../src/experimental/merge-patch/helpers.js";
 import { isMergePatchBody } from "../src/experimental/merge-patch/internal.js";
 import { getAllHttpServices, getHttpService } from "../src/operations.js";
-import { HttpOperation, RouteResolutionOptions } from "../src/types.js";
+import type { HttpOperation, RouteResolutionOptions } from "../src/types.js";
 import { diagnoseOperations, getOperationsWithServiceNamespace, Tester } from "./test-host.js";
 
 let runner: TesterInstance;

--- a/packages/http/test/multipart.test.ts
+++ b/packages/http/test/multipart.test.ts
@@ -1,7 +1,7 @@
 import { expectDiagnosticEmpty, expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, it } from "vitest";
-import { HttpOperationMultipartBody } from "../src/types.js";
+import type { HttpOperationMultipartBody } from "../src/types.js";
 import { getOperationsWithServiceNamespace } from "./test-host.js";
 
 it("emit diagnostic when using invalid content type for multipart ", async () => {

--- a/packages/http/test/routes.test.ts
+++ b/packages/http/test/routes.test.ts
@@ -1,13 +1,9 @@
 import { expectDiagnosticEmpty, expectDiagnostics, t } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
-import { PathOptions } from "../generated-defs/TypeSpec.Http.js";
-import {
-  getRoutePath,
-  HttpOperation,
-  HttpOperationParameter,
-  joinPathSegments,
-} from "../src/index.js";
+import type { PathOptions } from "../generated-defs/TypeSpec.Http.js";
+import type { HttpOperation, HttpOperationParameter } from "../src/index.js";
+import { getRoutePath, joinPathSegments } from "../src/index.js";
 import {
   compileOperations,
   diagnoseOperations,

--- a/packages/http/test/rules/op-reference-container-route.test.ts
+++ b/packages/http/test/rules/op-reference-container-route.test.ts
@@ -1,4 +1,5 @@
-import { createLinterRuleTester, LinterRuleTester } from "@typespec/compiler/testing";
+import type { LinterRuleTester } from "@typespec/compiler/testing";
+import { createLinterRuleTester } from "@typespec/compiler/testing";
 import { beforeEach, it } from "vitest";
 import { opReferenceContainerRouteRule } from "../../src/rules/op-reference-container-route.js";
 import { Tester } from "../test-host.js";

--- a/packages/http/test/test-host.ts
+++ b/packages/http/test/test-host.ts
@@ -1,12 +1,9 @@
-import { createDiagnosticCollector, Diagnostic, Program, resolvePath } from "@typespec/compiler";
+import type { Diagnostic, Program } from "@typespec/compiler";
+import { createDiagnosticCollector, resolvePath } from "@typespec/compiler";
 import { createTester, expectDiagnosticEmpty } from "@typespec/compiler/testing";
-import {
-  getAllHttpServices,
-  HttpOperation,
-  HttpOperationParameter,
-  HttpVerb,
-} from "../src/index.js";
-import { RouteResolutionOptions } from "../src/types.js";
+import type { HttpOperation, HttpOperationParameter, HttpVerb } from "../src/index.js";
+import { getAllHttpServices } from "../src/index.js";
+import type { RouteResolutionOptions } from "../src/types.js";
 
 export const Tester = createTester(resolvePath(import.meta.dirname, ".."), {
   libraries: ["@typespec/http"],

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "verbatimModuleSyntax": true,
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
   }
 }


### PR DESCRIPTION
Part of the incremental rollout of TypeScript's `verbatimModuleSyntax` across the workspace (batch 7).

Enables `verbatimModuleSyntax: true` for `@typespec/http` — the first of the three large core packages.

### Changes
- Added `"verbatimModuleSyntax": true` to `packages/http/tsconfig.json` (inherited by `tsconfig.build.json`).
- Converted type-only imports/exports to `import type` / `export type` (via oxlint type-aware autofix).
- Kept the experimental typekit barrels (`experimental/typekit/index.ts`, `experimental/typekit/kits/index.ts`) as value `export *`. Those `kits/*` modules run `defineKit(...)` registration side effects at import time; converting the star re-exports to `export type *` would erase the modules and skip registration, breaking downstream typekit consumers.

### Validation
- `tsc` — 0 verbatim (TS1484/TS1205/TS1485) errors.
- Build: `tsc -p tsconfig.build.json` passes; emitted `dist` typekit barrels remain runtime `export *`.
- oxlint `--type-aware --deny-warnings` clean.
- Tests: 406 passed.

Standalone runtime emitters (`http-client-csharp`, `http-client-java`, `http-client-python`) remain out of scope, and `tsconfig.base.json` is intentionally untouched. Remaining after this: `openapi3` and `compiler`, each in its own PR.
