### PR TITLE
Enable verbatimModuleSyntax for @typespec/openapi3

### DIFF
--- a/.chronus/changes/type-import-pass-8-2026-7-31.md
+++ b/.chronus/changes/type-import-pass-8-2026-7-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/openapi3"
+---
+
+Enable `verbatimModuleSyntax` and convert type-only imports/exports to `import type` / `export type`

--- a/packages/openapi3/src/attach-extensions.ts
+++ b/packages/openapi3/src/attach-extensions.ts
@@ -1,4 +1,4 @@
-import { Program, Type } from "@typespec/compiler";
+import type { Program, Type } from "@typespec/compiler";
 import { getExtensions } from "@typespec/openapi";
 
 export function attachExtensions(program: Program, type: Type, emitObject: any) {

--- a/packages/openapi3/src/cli/actions/convert/convert-file.ts
+++ b/packages/openapi3/src/cli/actions/convert/convert-file.ts
@@ -1,12 +1,12 @@
 import { bundle } from "@scalar/json-magic/bundle";
 import { fetchUrls, parseJson, parseYaml } from "@scalar/json-magic/bundle/plugins/browser";
 import { readFiles } from "@scalar/json-magic/bundle/plugins/node";
-import { OpenAPI } from "@scalar/openapi-types";
+import type { OpenAPI } from "@scalar/openapi-types";
 import { formatTypeSpec, resolvePath } from "@typespec/compiler";
-import { OpenAPI3Document } from "../../../types.js";
-import { CliHost } from "../../types.js";
+import type { OpenAPI3Document } from "../../../types.js";
+import type { CliHost } from "../../types.js";
 import { handleInternalCompilerError } from "../../utils.js";
-import { ConvertCliArgs } from "./args.js";
+import type { ConvertCliArgs } from "./args.js";
 import { generateMain } from "./generators/generate-main.js";
 import { transform } from "./transforms/transforms.js";
 import { createContext } from "./utils/context.js";

--- a/packages/openapi3/src/cli/actions/convert/convert.ts
+++ b/packages/openapi3/src/cli/actions/convert/convert.ts
@@ -1,6 +1,7 @@
-import { AnyObject, dereference } from "@scalar/openapi-parser";
+import type { AnyObject } from "@scalar/openapi-parser";
+import { dereference } from "@scalar/openapi-parser";
 import { formatTypeSpec } from "@typespec/compiler";
-import { SupportedOpenAPIDocuments } from "../../../types.js";
+import type { SupportedOpenAPIDocuments } from "../../../types.js";
 import { generateMain } from "./generators/generate-main.js";
 import { transform } from "./transforms/transforms.js";
 import { createContext } from "./utils/context.js";

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-decorators.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-decorators.ts
@@ -1,4 +1,4 @@
-import { TSValue, TypeSpecDecorator, TypeSpecDirective } from "../interfaces.js";
+import type { TSValue, TypeSpecDecorator, TypeSpecDirective } from "../interfaces.js";
 import { stringLiteral } from "./common.js";
 
 function generateDirective({ name, message }: TypeSpecDirective): string {

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-main.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-main.ts
@@ -1,5 +1,5 @@
-import { TypeSpecProgram } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { TypeSpecProgram } from "../interfaces.js";
+import type { Context } from "../utils/context.js";
 import { generateHelpers } from "../utils/generate-helpers.js";
 import { generateDataType } from "./generate-model.js";
 import { generateNamespace } from "./generate-namespace.js";

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-model.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-model.ts
@@ -1,6 +1,6 @@
 import { printIdentifier } from "@typespec/compiler";
-import { OpenAPI3Encoding, Refable, SupportedOpenAPISchema } from "../../../../types.js";
-import {
+import type { OpenAPI3Encoding, Refable, SupportedOpenAPISchema } from "../../../../types.js";
+import type {
   TypeSpecAlias,
   TypeSpecDataTypes,
   TypeSpecEnum,
@@ -9,7 +9,7 @@ import {
   TypeSpecScalar,
   TypeSpecUnion,
 } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { Context } from "../utils/context.js";
 import { getDecoratorsForSchema } from "../utils/decorators.js";
 import { generateDocs } from "../utils/docs.js";
 import { generateDecorators, generateDirectives } from "./generate-decorators.js";

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-namespace.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-namespace.ts
@@ -1,5 +1,5 @@
-import { TypeSpecNamespace } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { TypeSpecNamespace } from "../interfaces.js";
+import type { Context } from "../utils/context.js";
 import { generateDataType } from "./generate-model.js";
 import { generateOperation } from "./generate-operation.js";
 

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-operation.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-operation.ts
@@ -1,10 +1,10 @@
-import { Refable } from "../../../../types.js";
-import {
+import type { Refable } from "../../../../types.js";
+import type {
   TypeSpecOperation,
   TypeSpecOperationParameter,
   TypeSpecRequestBody,
 } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { Context } from "../utils/context.js";
 import { generateDocs } from "../utils/docs.js";
 import { generateDecorators, generateDirectives } from "./generate-decorators.js";
 import { generateOperationReturnType } from "./generate-response-expressions.js";

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-response-expressions.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-response-expressions.ts
@@ -1,12 +1,12 @@
-import {
+import type {
   OpenAPI3Header,
   OpenAPI3MediaType,
   OpenAPI3Response,
   OpenAPI3Schema,
   Refable,
 } from "../../../../types.js";
-import { TypeSpecDecorator, TypeSpecModelProperty, TypeSpecOperation } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { TypeSpecDecorator, TypeSpecModelProperty, TypeSpecOperation } from "../interfaces.js";
+import type { Context } from "../utils/context.js";
 import { convertHeaderName } from "../utils/convert-header-name.js";
 import { getDecoratorsForSchema } from "../utils/decorators.js";
 import { generateModelExpression } from "./generate-model.js";

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-servers.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-servers.ts
@@ -1,4 +1,4 @@
-import { TypeSpecServer, TypeSpecServerVariable } from "../interfaces.js";
+import type { TypeSpecServer, TypeSpecServerVariable } from "../interfaces.js";
 import { generateDocs } from "../utils/docs.js";
 import { stringLiteral } from "./common.js";
 

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-service-info.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-service-info.ts
@@ -1,4 +1,4 @@
-import { TypeSpecServer, TypeSpecServiceInfo, TypeSpecTagMetadata } from "../interfaces.js";
+import type { TypeSpecServer, TypeSpecServiceInfo, TypeSpecTagMetadata } from "../interfaces.js";
 import { generateDocs } from "../utils/docs.js";
 import { generateNamespaceName } from "../utils/generate-namespace-name.js";
 import { toTspValues } from "../utils/tsp-values.js";

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-tags.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-tags.ts
@@ -1,4 +1,4 @@
-import { TypeSpecExternalDocs, TypeSpecTagMetadata } from "../interfaces.js";
+import type { TypeSpecExternalDocs, TypeSpecTagMetadata } from "../interfaces.js";
 
 function generateExternalDocs(externalDocs?: TypeSpecExternalDocs): string {
   if (!externalDocs) {

--- a/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
+++ b/packages/openapi3/src/cli/actions/convert/generators/generate-types.ts
@@ -1,11 +1,11 @@
 import { printIdentifier } from "@typespec/compiler";
-import {
+import type {
   OpenAPI3Encoding,
   OpenAPISchema3_2,
   Refable,
   SupportedOpenAPISchema,
 } from "../../../../types.js";
-import { Context } from "../utils/context.js";
+import type { Context } from "../utils/context.js";
 import {
   getDecoratorsForSchema,
   normalizeObjectValueToTSValueExpression,

--- a/packages/openapi3/src/cli/actions/convert/interfaces.ts
+++ b/packages/openapi3/src/cli/actions/convert/interfaces.ts
@@ -1,5 +1,5 @@
-import { Contact, License } from "@typespec/openapi";
-import {
+import type { Contact, License } from "@typespec/openapi";
+import type {
   OpenAPI3Encoding,
   OpenAPI3Responses,
   Refable,

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-component-parameters.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-component-parameters.ts
@@ -1,7 +1,7 @@
 import { printIdentifier } from "@typespec/compiler";
-import { OpenAPI3Parameter, OpenAPIParameter3_2 } from "../../../../types.js";
-import { TypeSpecDataTypes, TypeSpecModelProperty } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { OpenAPI3Parameter, OpenAPIParameter3_2 } from "../../../../types.js";
+import type { TypeSpecDataTypes, TypeSpecModelProperty } from "../interfaces.js";
+import type { Context } from "../utils/context.js";
 import { getParameterDecorators } from "../utils/decorators.js";
 import { getScopeAndName } from "../utils/get-scope-and-name.js";
 

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-component-schemas.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-component-schemas.ts
@@ -1,13 +1,13 @@
 import { printIdentifier } from "@typespec/compiler";
-import { Refable, SupportedOpenAPISchema } from "../../../../types.js";
-import {
+import type { Refable, SupportedOpenAPISchema } from "../../../../types.js";
+import type {
   TypeSpecDataTypes,
   TypeSpecDecorator,
   TypeSpecEnum,
   TypeSpecModelProperty,
   TypeSpecUnion,
 } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { Context } from "../utils/context.js";
 import { getDecoratorsForSchema, getDirectivesForSchema } from "../utils/decorators.js";
 import { getScopeAndName } from "../utils/get-scope-and-name.js";
 

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-namespaces.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-namespaces.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   TypeSpecDataTypes,
   TypeSpecNamespace,
   TypeSpecOperation,

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-paths.ts
@@ -1,5 +1,5 @@
 import { printIdentifier } from "@typespec/compiler";
-import {
+import type {
   OpenAPI3Parameter,
   OpenAPI3PathItem,
   OpenAPI3RequestBody,
@@ -8,13 +8,13 @@ import {
   OpenAPIRequestBody3_2,
   Refable,
 } from "../../../../types.js";
-import {
+import type {
   TypeSpecDirective,
   TypeSpecOperation,
   TypeSpecOperationParameter,
   TypeSpecRequestBody,
 } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { Context } from "../utils/context.js";
 import {
   getDirectivesForSchema,
   getExtensions,

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-servers.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-servers.ts
@@ -1,5 +1,5 @@
-import { OpenAPI3Server, OpenAPI3ServerVariable } from "../../../../types.js";
-import { TypeSpecServer, TypeSpecServerVariable } from "../interfaces.js";
+import type { OpenAPI3Server, OpenAPI3ServerVariable } from "../../../../types.js";
+import type { TypeSpecServer, TypeSpecServerVariable } from "../interfaces.js";
 
 function transformServerVariables(
   variables?: Record<string, OpenAPI3ServerVariable>,

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-service-info.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-service-info.ts
@@ -1,6 +1,6 @@
 import type { License } from "@typespec/openapi";
-import { OpenAPI3Info } from "../../../../types.js";
-import { TypeSpecServiceInfo } from "../interfaces.js";
+import type { OpenAPI3Info } from "../../../../types.js";
+import type { TypeSpecServiceInfo } from "../interfaces.js";
 
 export function transformServiceInfo(info: OpenAPI3Info): TypeSpecServiceInfo {
   let license = info.license;

--- a/packages/openapi3/src/cli/actions/convert/transforms/transform-tags.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transform-tags.ts
@@ -1,5 +1,5 @@
-import { OpenAPI3Tag, OpenAPITag3_2 } from "../../../../types.js";
-import { TypeSpecTagMetadata } from "../interfaces.js";
+import type { OpenAPI3Tag, OpenAPITag3_2 } from "../../../../types.js";
+import type { TypeSpecTagMetadata } from "../interfaces.js";
 
 export function transformTags(tags: OpenAPI3Tag[]): TypeSpecTagMetadata[] {
   return tags.map((tag) => {

--- a/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
+++ b/packages/openapi3/src/cli/actions/convert/transforms/transforms.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   OpenAPI3PathItem,
   OpenAPI3RequestBody,
   OpenAPI3Responses,
@@ -8,8 +8,8 @@ import {
   Refable,
   SupportedOpenAPIDocuments,
 } from "../../../../types.js";
-import { TypeSpecModel, TypeSpecProgram } from "../interfaces.js";
-import { Context } from "../utils/context.js";
+import type { TypeSpecModel, TypeSpecProgram } from "../interfaces.js";
+import type { Context } from "../utils/context.js";
 import { transformComponentParameters } from "./transform-component-parameters.js";
 import { transformComponentSchemas } from "./transform-component-schemas.js";
 import { transformNamespaces } from "./transform-namespaces.js";

--- a/packages/openapi3/src/cli/actions/convert/utils/context.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/context.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   OpenAPI3Encoding,
   OpenAPIDocument3_1,
   Refable,
   SupportedOpenAPIDocuments,
   SupportedOpenAPISchema,
 } from "../../../../types.js";
-import { Logger } from "../../../types.js";
+import type { Logger } from "../../../types.js";
 import { SchemaToExpressionGenerator } from "../generators/generate-types.js";
 import { generateNamespaceName } from "./generate-namespace-name.js";
 

--- a/packages/openapi3/src/cli/actions/convert/utils/decorators.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/decorators.ts
@@ -1,6 +1,6 @@
 import { printIdentifier } from "@typespec/compiler";
-import { ExtensionKey } from "@typespec/openapi";
-import {
+import type { ExtensionKey } from "@typespec/openapi";
+import type {
   Extensions,
   OpenAPI3Parameter,
   OpenAPI3Schema,
@@ -10,7 +10,7 @@ import {
   Refable,
 } from "../../../../types.js";
 import { stringLiteral } from "../generators/common.js";
-import { TSValue, TypeSpecDecorator, TypeSpecDirective } from "../interfaces.js";
+import type { TSValue, TypeSpecDecorator, TypeSpecDirective } from "../interfaces.js";
 import type { Context } from "./context.js";
 
 const validLocations = ["header", "query", "path", "cookie"];

--- a/packages/openapi3/src/cli/actions/convert/utils/generate-helpers.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/generate-helpers.ts
@@ -1,4 +1,4 @@
-import { Context } from "./context.js";
+import type { Context } from "./context.js";
 import { supportedHttpMethods } from "./supported-http-methods.js";
 
 export function generateHelpers(context: Context): string {

--- a/packages/openapi3/src/cli/actions/convert/utils/supported-http-methods.ts
+++ b/packages/openapi3/src/cli/actions/convert/utils/supported-http-methods.ts
@@ -1,4 +1,4 @@
-import { HttpVerb } from "@typespec/http";
+import type { HttpVerb } from "@typespec/http";
 
 export const supportedHttpMethods = new Set<HttpVerb>([
   "delete",

--- a/packages/openapi3/src/cli/cli.ts
+++ b/packages/openapi3/src/cli/cli.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "util";
-import { ConvertCliArgs } from "./actions/convert/args.js";
+import type { ConvertCliArgs } from "./actions/convert/args.js";
 import { convertAction } from "./actions/convert/convert-file.js";
 import { createCliHost } from "./utils.js";
 

--- a/packages/openapi3/src/cli/types.ts
+++ b/packages/openapi3/src/cli/types.ts
@@ -1,4 +1,4 @@
-import { SourceFile } from "@typespec/compiler";
+import type { SourceFile } from "@typespec/compiler";
 
 export interface CliHost {
   logger: Logger;

--- a/packages/openapi3/src/cli/utils.ts
+++ b/packages/openapi3/src/cli/utils.ts
@@ -1,5 +1,5 @@
 import { NodeHost } from "@typespec/compiler";
-import { CliHost, CliHostArgs, Logger } from "./types.js";
+import type { CliHost, CliHostArgs, Logger } from "./types.js";
 
 export function withCliHost<T extends CliHostArgs>(
   fn: (host: CliHost, args: T) => void | Promise<void>,

--- a/packages/openapi3/src/decorators.ts
+++ b/packages/openapi3/src/decorators.ts
@@ -1,5 +1,12 @@
-import { DecoratorContext, Model, ModelProperty, Program, Type, Union } from "@typespec/compiler";
-import { OneOfDecorator, UseRefDecorator } from "../generated-defs/TypeSpec.OpenAPI.js";
+import type {
+  DecoratorContext,
+  Model,
+  ModelProperty,
+  Program,
+  Type,
+  Union,
+} from "@typespec/compiler";
+import type { OneOfDecorator, UseRefDecorator } from "../generated-defs/TypeSpec.OpenAPI.js";
 import { createStateSymbol, reportDiagnostic } from "./lib.js";
 
 const refTargetsKey = createStateSymbol("refs");

--- a/packages/openapi3/src/encoding.ts
+++ b/packages/openapi3/src/encoding.ts
@@ -1,5 +1,6 @@
 import { ObjectBuilder } from "@typespec/asset-emitter";
-import { type ModelProperty, Program, type Scalar, getEncode } from "@typespec/compiler";
+import type { Program } from "@typespec/compiler";
+import { type ModelProperty, type Scalar, getEncode } from "@typespec/compiler";
 import { isHeader, isQueryParam } from "@typespec/http";
 import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { getSchemaForStdScalars } from "./std-scalar-schemas.js";

--- a/packages/openapi3/src/examples.ts
+++ b/packages/openapi3/src/examples.ts
@@ -1,18 +1,20 @@
-import {
+import type {
   BooleanValue,
   EncodeData,
   Example,
-  getEncode,
-  getOpExamples,
-  ignoreDiagnostics,
   ModelProperty,
   NumericValue,
   OpExample,
   Program,
-  serializeValueAsJson,
   StringValue,
   Type,
   Value,
+} from "@typespec/compiler";
+import {
+  getEncode,
+  getOpExamples,
+  ignoreDiagnostics,
+  serializeValueAsJson,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import {
@@ -23,16 +25,12 @@ import {
   type HttpProperty,
   type HttpStatusCodeRange,
 } from "@typespec/http";
-import { ExperimentalParameterExamplesStrategy } from "./lib.js";
+import type { ExperimentalParameterExamplesStrategy } from "./lib.js";
 import { getParameterStyle } from "./parameters.js";
 import { getOpenAPI3StatusCodes } from "./status-codes.js";
-import { OpenAPI3Example, OpenAPI3MediaType } from "./types.js";
-import {
-  HttpParameterProperties,
-  isHttpParameterProperty,
-  isSharedHttpOperation,
-  SharedHttpOperation,
-} from "./util.js";
+import type { OpenAPI3Example, OpenAPI3MediaType } from "./types.js";
+import type { HttpParameterProperties, SharedHttpOperation } from "./util.js";
+import { isHttpParameterProperty, isSharedHttpOperation } from "./util.js";
 
 export interface OperationExamples {
   requestBody: Record<string, [Example, Type][]>;

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -1,4 +1,5 @@
-import { createTypeSpecLibrary, fileRef, JSONSchemaType, paramMessage } from "@typespec/compiler";
+import type { JSONSchemaType } from "@typespec/compiler";
+import { createTypeSpecLibrary, fileRef, paramMessage } from "@typespec/compiler";
 
 export type FileType = "yaml" | "json";
 export type OpenAPIVersion = "3.0.0" | "3.1.0" | "3.2.0";

--- a/packages/openapi3/src/openapi-helpers-3-0.ts
+++ b/packages/openapi3/src/openapi-helpers-3-0.ts
@@ -1,6 +1,6 @@
 import { applyEncoding as baseApplyEncoding } from "./encoding.js";
-import { OpenApiSpecSpecificProps } from "./openapi-spec-mappings.js";
-import { OpenAPI3Schema } from "./types.js";
+import type { OpenApiSpecSpecificProps } from "./openapi-spec-mappings.js";
+import type { OpenAPI3Schema } from "./types.js";
 
 function getEncodingFieldName() {
   // In Open API 3.0, format is always used for encoding.

--- a/packages/openapi3/src/openapi-helpers-3-1.ts
+++ b/packages/openapi3/src/openapi-helpers-3-1.ts
@@ -1,7 +1,7 @@
-import { ModelProperty, Scalar } from "@typespec/compiler";
+import type { ModelProperty, Scalar } from "@typespec/compiler";
 import { applyEncoding as baseApplyEncoding } from "./encoding.js";
-import { OpenApiSpecSpecificProps } from "./openapi-spec-mappings.js";
-import { OpenAPISchema3_1 } from "./types.js";
+import type { OpenApiSpecSpecificProps } from "./openapi-spec-mappings.js";
+import type { OpenAPISchema3_1 } from "./types.js";
 import { isScalarExtendsBytes } from "./util.js";
 
 function getEncodingFieldName(typespecType: Scalar | ModelProperty) {

--- a/packages/openapi3/src/openapi-spec-mappings.ts
+++ b/packages/openapi3/src/openapi-spec-mappings.ts
@@ -1,9 +1,9 @@
-import { AssetEmitter } from "@typespec/asset-emitter";
-import { EmitContext, ModelProperty, Namespace, Program, Scalar } from "@typespec/compiler";
-import { MetadataInfo } from "@typespec/http";
+import type { AssetEmitter } from "@typespec/asset-emitter";
+import type { EmitContext, ModelProperty, Namespace, Program, Scalar } from "@typespec/compiler";
+import type { MetadataInfo } from "@typespec/http";
 import { getExternalDocs, resolveInfo } from "@typespec/openapi";
-import { JsonSchemaModule } from "./json-schema.js";
-import { OpenAPI3EmitterOptions, OpenAPIVersion } from "./lib.js";
+import type { JsonSchemaModule } from "./json-schema.js";
+import type { OpenAPI3EmitterOptions, OpenAPIVersion } from "./lib.js";
 import {
   applyEncoding as applyEncoding3_0,
   getRawBinarySchema as getRawBinarySchema3_0,
@@ -14,14 +14,14 @@ import {
   getRawBinarySchema as getRawBinarySchema3_1,
   isRawBinarySchema as isRawBinarySchema3_1,
 } from "./openapi-helpers-3-1.js";
-import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
+import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { createSchemaEmitter3_0 } from "./schema-emitter-3-0.js";
 import { createSchemaEmitter3_1 } from "./schema-emitter-3-1.js";
 import { createSchemaEmitter3_2 } from "./schema-emitter-3-2.js";
-import { SSEModule } from "./sse-module.js";
-import { OpenAPI3Schema, OpenAPISchema3_1, SupportedOpenAPIDocuments } from "./types.js";
-import { VisibilityUsageTracker } from "./visibility-usage.js";
-import { XmlModule } from "./xml-module.js";
+import type { SSEModule } from "./sse-module.js";
+import type { OpenAPI3Schema, OpenAPISchema3_1, SupportedOpenAPIDocuments } from "./types.js";
+import type { VisibilityUsageTracker } from "./visibility-usage.js";
+import type { XmlModule } from "./xml-module.js";
 
 export type CreateSchemaEmitter = (props: {
   program: Program;

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1,12 +1,21 @@
-import { AssetEmitter, EmitEntity } from "@typespec/asset-emitter";
-import {
-  compilerAssert,
-  createDiagnosticCollector,
+import type { AssetEmitter, EmitEntity } from "@typespec/asset-emitter";
+import type {
   Diagnostic,
   DiagnosticCollector,
   EmitContext,
-  emitFile,
   Example,
+  ModelProperty,
+  Namespace,
+  NewLine,
+  Program,
+  Service,
+  Type,
+  TypeNameOptions,
+} from "@typespec/compiler";
+import {
+  compilerAssert,
+  createDiagnosticCollector,
+  emitFile,
   getAllTags,
   getAnyExtensionFromPath,
   getDoc,
@@ -29,30 +38,17 @@ import {
   isSecret,
   isVoidType,
   listServices,
-  ModelProperty,
-  Namespace,
   navigateTypesInNamespace,
-  NewLine,
   NoTarget,
-  Program,
   resolvePath,
-  Service,
-  Type,
-  TypeNameOptions,
 } from "@typespec/compiler";
-import {
-  unsafe_mutateSubgraphWithNamespace,
-  unsafe_MutatorWithNamespace,
-} from "@typespec/compiler/experimental";
+import type { unsafe_MutatorWithNamespace } from "@typespec/compiler/experimental";
+import { unsafe_mutateSubgraphWithNamespace } from "@typespec/compiler/experimental";
 import { $ } from "@typespec/compiler/typekit";
 import { createPerfReporter, perf } from "@typespec/compiler/utils";
-import {
+import type {
   AuthenticationOptionReference,
   AuthenticationReference,
-  createMetadataInfo,
-  getHttpService,
-  getServers,
-  getStatusCodeDescription,
   HttpAuth,
   HttpOperation,
   HttpOperationMultipartBody,
@@ -63,9 +59,15 @@ import {
   HttpProperty,
   HttpServer,
   HttpServiceAuthentication,
+  MetadataInfo,
+} from "@typespec/http";
+import {
+  createMetadataInfo,
+  getHttpService,
+  getServers,
+  getStatusCodeDescription,
   isOrExtendsHttpFile,
   isOverloadSameEndpoint,
-  MetadataInfo,
   reportIfNoRoutes,
   resolveAuthentication,
   resolveRequestVisibility,
@@ -83,24 +85,26 @@ import {
 } from "@typespec/openapi";
 import { stringify } from "yaml";
 import { getRef } from "./decorators.js";
-import { getExampleOrExamples, OperationExamples, resolveOperationExamples } from "./examples.js";
-import { JsonSchemaModule, resolveJsonSchemaModule } from "./json-schema.js";
-import {
-  createDiagnostic,
+import type { OperationExamples } from "./examples.js";
+import { getExampleOrExamples, resolveOperationExamples } from "./examples.js";
+import type { JsonSchemaModule } from "./json-schema.js";
+import { resolveJsonSchemaModule } from "./json-schema.js";
+import type {
   EnumStrategy,
   FileType,
   OpenAPI3EmitterOptions,
   OpenAPIVersion,
   OperationIdStrategy,
-  reportDiagnostic,
 } from "./lib.js";
+import { createDiagnostic, reportDiagnostic } from "./lib.js";
 import { getOpenApiSpecProps } from "./openapi-spec-mappings.js";
 import { OperationIdResolver } from "./operation-id-resolver/operation-id-resolver.js";
 import { getParameterStyle } from "./parameters.js";
 import { getMaxValueAsJson, getMinValueAsJson } from "./range.js";
-import { resolveSSEModule, SSEModule } from "./sse-module.js";
+import type { SSEModule } from "./sse-module.js";
+import { resolveSSEModule } from "./sse-module.js";
 import { getOpenAPI3StatusCodes } from "./status-codes.js";
-import {
+import type {
   OpenAPI3Encoding,
   OpenAPI3Header,
   OpenAPI3MediaType,
@@ -123,18 +127,19 @@ import {
   Refable,
   SupportedOpenAPIDocuments,
 } from "./types.js";
+import type { HttpParameterProperties, SharedHttpOperation } from "./util.js";
 import {
   deepEquals,
   ensureValidComponentFixedFieldKey,
   getDefaultValue,
-  HttpParameterProperties,
   isBytesKeptRaw,
   isSharedHttpOperation,
-  SharedHttpOperation,
 } from "./util.js";
 import { resolveVersioningModule } from "./versioning-module.js";
-import { resolveVisibilityUsage, VisibilityUsageTracker } from "./visibility-usage.js";
-import { resolveXmlModule, XmlModule } from "./xml-module.js";
+import type { VisibilityUsageTracker } from "./visibility-usage.js";
+import { resolveVisibilityUsage } from "./visibility-usage.js";
+import type { XmlModule } from "./xml-module.js";
+import { resolveXmlModule } from "./xml-module.js";
 
 const defaultFileType: FileType = "yaml";
 const defaultOptions = {

--- a/packages/openapi3/src/operation-id-resolver/operation-id-resolver.test.ts
+++ b/packages/openapi3/src/operation-id-resolver/operation-id-resolver.test.ts
@@ -2,7 +2,7 @@ import { ApiTester } from "#test/test-host.js";
 import { t } from "@typespec/compiler/testing";
 import { ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
-import { OperationIdStrategy } from "../lib.js";
+import type { OperationIdStrategy } from "../lib.js";
 import { OperationIdResolver } from "./operation-id-resolver.js";
 
 async function testResolveOperationId(code: string, strategy: OperationIdStrategy) {

--- a/packages/openapi3/src/operation-id-resolver/operation-id-resolver.ts
+++ b/packages/openapi3/src/operation-id-resolver/operation-id-resolver.ts
@@ -1,6 +1,6 @@
 import { isGlobalNamespace, isService, type Operation, type Program } from "@typespec/compiler";
 import { getOperationId } from "@typespec/openapi";
-import { OperationIdStrategy } from "../lib.js";
+import type { OperationIdStrategy } from "../lib.js";
 
 export interface OperationIdResolverOptions {
   strategy: OperationIdStrategy;

--- a/packages/openapi3/src/parameters.ts
+++ b/packages/openapi3/src/parameters.ts
@@ -1,4 +1,5 @@
-import { getEncode, ModelProperty, Program } from "@typespec/compiler";
+import type { ModelProperty, Program } from "@typespec/compiler";
+import { getEncode } from "@typespec/compiler";
 
 export function getParameterStyle(
   program: Program,

--- a/packages/openapi3/src/schema-emitter-3-0.ts
+++ b/packages/openapi3/src/schema-emitter-3-0.ts
@@ -1,42 +1,43 @@
+import type { AssetEmitter, EmitterOutput, TypeEmitter } from "@typespec/asset-emitter";
 import {
-  AssetEmitter,
   createAssetEmitter,
-  EmitterOutput,
   ObjectBuilder,
   Placeholder,
   setProperty,
-  TypeEmitter,
 } from "@typespec/asset-emitter";
-import {
-  compilerAssert,
+import type {
   Enum,
-  getDiscriminatedUnion,
-  getExamples,
-  getMaxValueExclusive,
-  getMinValueExclusive,
   IntrinsicType,
-  isNullType,
   Model,
   ModelProperty,
   Scalar,
   Type,
   Union,
 } from "@typespec/compiler";
+import {
+  compilerAssert,
+  getDiscriminatedUnion,
+  getExamples,
+  getMaxValueExclusive,
+  getMinValueExclusive,
+  isNullType,
+} from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
-import { MetadataInfo } from "@typespec/http";
+import type { MetadataInfo } from "@typespec/http";
 import { shouldInline } from "@typespec/openapi";
 import { getOneOf } from "./decorators.js";
 import { serializeExample } from "./examples.js";
-import { JsonSchemaModule } from "./json-schema.js";
-import { OpenAPI3EmitterOptions, reportDiagnostic } from "./lib.js";
+import type { JsonSchemaModule } from "./json-schema.js";
+import type { OpenAPI3EmitterOptions } from "./lib.js";
+import { reportDiagnostic } from "./lib.js";
 import { applyEncoding, getRawBinarySchema } from "./openapi-helpers-3-0.js";
-import { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
-import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
+import type { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
+import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { Builders, OpenAPI3SchemaEmitterBase } from "./schema-emitter.js";
-import { JsonType, OpenAPI3Schema } from "./types.js";
+import type { JsonType, OpenAPI3Schema } from "./types.js";
 import { isBytesKeptRaw, isLiteralType, literalType } from "./util.js";
-import { VisibilityUsageTracker } from "./visibility-usage.js";
-import { XmlModule } from "./xml-module.js";
+import type { VisibilityUsageTracker } from "./visibility-usage.js";
+import type { XmlModule } from "./xml-module.js";
 
 function createWrappedSchemaEmitterClass(
   metadataInfo: MetadataInfo,

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -1,22 +1,17 @@
-import {
-  ArrayBuilder,
+import type {
   AssetEmitter,
-  createAssetEmitter,
   EmitterOutput,
-  ObjectBuilder,
   Placeholder,
-  setProperty,
   TypeEmitter,
 } from "@typespec/asset-emitter";
 import {
-  compilerAssert,
+  ArrayBuilder,
+  createAssetEmitter,
+  ObjectBuilder,
+  setProperty,
+} from "@typespec/asset-emitter";
+import type {
   Enum,
-  getDiscriminatedUnion,
-  getDoc,
-  getExamples,
-  getMaxValueExclusive,
-  getMinValueExclusive,
-  getSummary,
   IntrinsicScalarName,
   IntrinsicType,
   Model,
@@ -28,19 +23,29 @@ import {
   Union,
   UnionVariant,
 } from "@typespec/compiler";
-import { MetadataInfo } from "@typespec/http";
+import {
+  compilerAssert,
+  getDiscriminatedUnion,
+  getDoc,
+  getExamples,
+  getMaxValueExclusive,
+  getMinValueExclusive,
+  getSummary,
+} from "@typespec/compiler";
+import type { MetadataInfo } from "@typespec/http";
 import { getOneOf } from "./decorators.js";
 import { serializeExample } from "./examples.js";
-import { JsonSchemaModule } from "./json-schema.js";
-import { OpenAPI3EmitterOptions, reportDiagnostic } from "./lib.js";
+import type { JsonSchemaModule } from "./json-schema.js";
+import type { OpenAPI3EmitterOptions } from "./lib.js";
+import { reportDiagnostic } from "./lib.js";
 import { applyEncoding, getRawBinarySchema } from "./openapi-helpers-3-1.js";
-import { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
-import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
+import type { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
+import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { OpenAPI3SchemaEmitterBase } from "./schema-emitter.js";
-import { JsonType, OpenAPISchema3_1 } from "./types.js";
+import type { JsonType, OpenAPISchema3_1 } from "./types.js";
 import { isBytesKeptRaw, isLiteralType, literalType } from "./util.js";
-import { VisibilityUsageTracker } from "./visibility-usage.js";
-import { XmlModule } from "./xml-module.js";
+import type { VisibilityUsageTracker } from "./visibility-usage.js";
+import type { XmlModule } from "./xml-module.js";
 
 function createWrappedSchemaEmitterClass(
   metadataInfo: MetadataInfo,

--- a/packages/openapi3/src/schema-emitter-3-2.ts
+++ b/packages/openapi3/src/schema-emitter-3-2.ts
@@ -1,21 +1,16 @@
-import {
-  ArrayBuilder,
-  AssetEmitter,
-  createAssetEmitter,
-  ObjectBuilder,
-  Placeholder,
-  TypeEmitter,
-} from "@typespec/asset-emitter";
-import { compilerAssert, DiscriminatedUnion, Type } from "@typespec/compiler";
-import { MetadataInfo } from "@typespec/http";
-import { JsonSchemaModule } from "./json-schema.js";
-import { OpenAPI3EmitterOptions } from "./lib.js";
-import { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
-import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
+import type { AssetEmitter, ObjectBuilder, TypeEmitter } from "@typespec/asset-emitter";
+import { ArrayBuilder, createAssetEmitter, Placeholder } from "@typespec/asset-emitter";
+import type { DiscriminatedUnion, Type } from "@typespec/compiler";
+import { compilerAssert } from "@typespec/compiler";
+import type { MetadataInfo } from "@typespec/http";
+import type { JsonSchemaModule } from "./json-schema.js";
+import type { OpenAPI3EmitterOptions } from "./lib.js";
+import type { CreateSchemaEmitter } from "./openapi-spec-mappings.js";
+import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { OpenAPI31SchemaEmitter } from "./schema-emitter-3-1.js";
-import { OpenAPIDiscriminator3_2, OpenAPISchema3_2 } from "./types.js";
-import { VisibilityUsageTracker } from "./visibility-usage.js";
-import { XmlModule } from "./xml-module.js";
+import type { OpenAPIDiscriminator3_2, OpenAPISchema3_2 } from "./types.js";
+import type { VisibilityUsageTracker } from "./visibility-usage.js";
+import type { XmlModule } from "./xml-module.js";
 
 function createWrappedSchemaEmitterClass(
   metadataInfo: MetadataInfo,

--- a/packages/openapi3/src/schema-emitter.ts
+++ b/packages/openapi3/src/schema-emitter.ts
@@ -1,19 +1,21 @@
-import {
-  ArrayBuilder,
+import type {
   AssetEmitter,
   Context,
   Declaration,
   EmitEntity,
   EmitterOutput,
-  ObjectBuilder,
-  Placeholder,
   ReferenceCycle,
   Scope,
   SourceFileScope,
+} from "@typespec/asset-emitter";
+import {
+  ArrayBuilder,
+  ObjectBuilder,
+  Placeholder,
   TypeEmitter,
   setProperty,
 } from "@typespec/asset-emitter";
-import {
+import type {
   BooleanLiteral,
   DiscriminatedUnion,
   Enum,
@@ -31,6 +33,8 @@ import {
   TypeNameOptions,
   Union,
   UnionVariant,
+} from "@typespec/compiler";
+import {
   compilerAssert,
   explainStringTemplateNotSerializable,
   getDeprecated,
@@ -54,7 +58,8 @@ import {
 } from "@typespec/compiler";
 import { capitalize } from "@typespec/compiler/casing";
 import { $ } from "@typespec/compiler/typekit";
-import { MetadataInfo, Visibility, getVisibilitySuffix } from "@typespec/http";
+import type { MetadataInfo } from "@typespec/http";
+import { Visibility, getVisibilitySuffix } from "@typespec/http";
 import {
   checkDuplicateTypeName,
   getExtensions,
@@ -65,21 +70,22 @@ import {
 } from "@typespec/openapi";
 import { attachExtensions } from "./attach-extensions.js";
 import { getOneOf, getRef } from "./decorators.js";
-import { JsonSchemaModule } from "./json-schema.js";
-import { OpenAPI3EmitterOptions, reportDiagnostic } from "./lib.js";
-import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
+import type { JsonSchemaModule } from "./json-schema.js";
+import type { OpenAPI3EmitterOptions } from "./lib.js";
+import { reportDiagnostic } from "./lib.js";
+import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
 import { getMaxValueAsJson, getMinValueAsJson } from "./range.js";
-import { SSEModule } from "./sse-module.js";
+import type { SSEModule } from "./sse-module.js";
 import { getSchemaForStdScalars } from "./std-scalar-schemas.js";
-import { CommonOpenAPI3Schema, OpenAPI3Schema, OpenAPISchema3_1, Refable } from "./types.js";
+import type { CommonOpenAPI3Schema, OpenAPI3Schema, OpenAPISchema3_1, Refable } from "./types.js";
 import {
   ensureValidComponentFixedFieldKey,
   getDefaultValue,
   includeDerivedModel,
   isStdType,
 } from "./util.js";
-import { VisibilityUsageTracker } from "./visibility-usage.js";
-import { XmlModule } from "./xml-module.js";
+import type { VisibilityUsageTracker } from "./visibility-usage.js";
+import type { XmlModule } from "./xml-module.js";
 
 /**
  * Base OpenAPI3 schema emitter. Deals with emitting content of `components/schemas` section.

--- a/packages/openapi3/src/sse-module.ts
+++ b/packages/openapi3/src/sse-module.ts
@@ -1,7 +1,7 @@
-import { Program, Type } from "@typespec/compiler";
+import type { Program, Type } from "@typespec/compiler";
 import { attachExtensions } from "./attach-extensions.js";
-import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
-import { OpenAPIMediaType3_2, OpenAPISchema3_2, Refable } from "./types.js";
+import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
+import type { OpenAPIMediaType3_2, OpenAPISchema3_2, Refable } from "./types.js";
 
 export interface SSEModule {
   isSSEStream(program: Program, type: Type): boolean;

--- a/packages/openapi3/src/status-codes.ts
+++ b/packages/openapi3/src/status-codes.ts
@@ -1,8 +1,8 @@
-import { Diagnostic, DiagnosticTarget, Program, Type } from "@typespec/compiler";
-import { HttpStatusCodeRange, HttpStatusCodesEntry } from "@typespec/http";
+import type { Diagnostic, DiagnosticTarget, Program, Type } from "@typespec/compiler";
+import type { HttpStatusCodeRange, HttpStatusCodesEntry } from "@typespec/http";
 import { isDefaultResponse } from "@typespec/openapi";
 import { createDiagnostic } from "./lib.js";
-import { OpenAPI3StatusCode } from "./types.js";
+import type { OpenAPI3StatusCode } from "./types.js";
 
 export function getOpenAPI3StatusCodes(
   program: Program,

--- a/packages/openapi3/src/testing/index.ts
+++ b/packages/openapi3/src/testing/index.ts
@@ -1,8 +1,5 @@
-import {
-  TypeSpecTestLibrary,
-  createTestLibrary,
-  findTestPackageRoot,
-} from "@typespec/compiler/testing";
+import type { TypeSpecTestLibrary } from "@typespec/compiler/testing";
+import { createTestLibrary, findTestPackageRoot } from "@typespec/compiler/testing";
 
 /** @deprecated use new Tester */
 /* eslint-disable @typescript-eslint/no-deprecated */

--- a/packages/openapi3/src/tsp-index.ts
+++ b/packages/openapi3/src/tsp-index.ts
@@ -1,4 +1,4 @@
-import { TypeSpecOpenAPIDecorators } from "../generated-defs/TypeSpec.OpenAPI.js";
+import type { TypeSpecOpenAPIDecorators } from "../generated-defs/TypeSpec.OpenAPI.js";
 import { $oneOf, $useRef } from "./decorators.js";
 
 export { $lib } from "./lib.js";

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -1,5 +1,5 @@
-import { Diagnostic, Service } from "@typespec/compiler";
-import { Contact, ExtensionKey, License } from "@typespec/openapi";
+import type { Diagnostic, Service } from "@typespec/compiler";
+import type { Contact, ExtensionKey, License } from "@typespec/openapi";
 
 export type CommonOpenAPI3Schema = OpenAPI3Schema & OpenAPISchema3_1 & OpenAPISchema3_2;
 

--- a/packages/openapi3/src/util.ts
+++ b/packages/openapi3/src/util.ts
@@ -1,20 +1,22 @@
-import {
+import type {
   BooleanLiteral,
-  getEncode,
   IntrinsicScalarName,
-  isTemplateDeclaration,
   Model,
   ModelProperty,
   NumericLiteral,
   Program,
   Scalar,
-  serializeValueAsJson,
   StringLiteral,
   Type,
-  UnserializableValueError,
   Value,
 } from "@typespec/compiler";
-import { HttpOperation, HttpProperty } from "@typespec/http";
+import {
+  getEncode,
+  isTemplateDeclaration,
+  serializeValueAsJson,
+  UnserializableValueError,
+} from "@typespec/compiler";
+import type { HttpOperation, HttpProperty } from "@typespec/http";
 import { createDiagnostic, reportDiagnostic } from "./lib.js";
 
 /**

--- a/packages/openapi3/src/visibility-usage.ts
+++ b/packages/openapi3/src/visibility-usage.ts
@@ -1,19 +1,8 @@
-import {
-  Interface,
-  Namespace,
-  Operation,
-  Program,
-  Type,
-  ignoreDiagnostics,
-  navigateTypesInNamespace,
-} from "@typespec/compiler";
+import type { Interface, Namespace, Operation, Program, Type } from "@typespec/compiler";
+import { ignoreDiagnostics, navigateTypesInNamespace } from "@typespec/compiler";
 import { TwoLevelMap } from "@typespec/compiler/utils";
-import {
-  MetadataInfo,
-  Visibility,
-  getHttpOperation,
-  resolveRequestVisibility,
-} from "@typespec/http";
+import type { MetadataInfo } from "@typespec/http";
+import { Visibility, getHttpOperation, resolveRequestVisibility } from "@typespec/http";
 
 export interface VisibilityUsageTracker {
   getUsage(type: Type): Set<Visibility> | undefined;

--- a/packages/openapi3/src/xml-module.ts
+++ b/packages/openapi3/src/xml-module.ts
@@ -1,18 +1,17 @@
 import { ArrayBuilder, ObjectBuilder, Placeholder } from "@typespec/asset-emitter";
-import {
+import type {
   ArrayModelType,
   Enum,
   Model,
   ModelProperty,
   Program,
   Scalar,
-  isArrayModelType,
-  resolveEncodedName,
 } from "@typespec/compiler";
+import { isArrayModelType, resolveEncodedName } from "@typespec/compiler";
 import { shouldInline } from "@typespec/openapi";
 import { reportDiagnostic } from "./lib.js";
-import { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
-import { OpenAPI3Schema, OpenAPI3XmlSchema, OpenAPISchema3_1 } from "./types.js";
+import type { ResolvedOpenAPI3EmitterOptions } from "./openapi.js";
+import type { OpenAPI3Schema, OpenAPI3XmlSchema, OpenAPISchema3_1 } from "./types.js";
 
 export interface XmlModule {
   attachXmlObjectForScalarOrModel(

--- a/packages/openapi3/test/additional-properties.test.ts
+++ b/packages/openapi3/test/additional-properties.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok } from "assert";
 import { describe, it } from "vitest";
-import { OpenAPI3EmitterOptions } from "../src/lib.js";
+import type { OpenAPI3EmitterOptions } from "../src/lib.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
 worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {

--- a/packages/openapi3/test/component.test.ts
+++ b/packages/openapi3/test/component.test.ts
@@ -1,6 +1,6 @@
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { describe, expect, it } from "vitest";
-import { OpenAPI3Document } from "../src/types.js";
+import type { OpenAPI3Document } from "../src/types.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
 interface DiagnosticCheck {

--- a/packages/openapi3/test/examples.test.ts
+++ b/packages/openapi3/test/examples.test.ts
@@ -1,6 +1,6 @@
 import { ok } from "assert/strict";
 import { describe, expect, it } from "vitest";
-import { OpenAPI3Document, OpenAPI3Parameter, OpenAPI3RequestBody } from "../src/types.js";
+import type { OpenAPI3Document, OpenAPI3Parameter, OpenAPI3RequestBody } from "../src/types.js";
 import { openApiFor } from "./test-host.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 

--- a/packages/openapi3/test/merge-patch.test.ts
+++ b/packages/openapi3/test/merge-patch.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok } from "assert";
 import { expect, it } from "vitest";
-import { OpenAPI3EmitterOptions } from "../src/lib.js";
+import type { OpenAPI3EmitterOptions } from "../src/lib.js";
 import { openApiFor } from "./test-host.js";
 
 export async function oapiForPatchRequest(

--- a/packages/openapi3/test/models.test.ts
+++ b/packages/openapi3/test/models.test.ts
@@ -1,4 +1,4 @@
-import { DiagnosticTarget } from "@typespec/compiler";
+import type { DiagnosticTarget } from "@typespec/compiler";
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";

--- a/packages/openapi3/test/multipart.test.ts
+++ b/packages/openapi3/test/multipart.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual } from "assert";
 import { describe, expect, it } from "vitest";
-import { OpenAPI3Encoding, OpenAPI3Schema, OpenAPISchema3_1 } from "../src/types.js";
+import type { OpenAPI3Encoding, OpenAPI3Schema, OpenAPISchema3_1 } from "../src/types.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
 worksFor(supportedVersions, ({ openApiFor }) => {

--- a/packages/openapi3/test/nullable-properties.test.ts
+++ b/packages/openapi3/test/nullable-properties.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok } from "assert";
 import { describe, expect, it } from "vitest";
-import { OpenAPI3Schema, OpenAPISchema3_1, Refable } from "../src/types.js";
+import type { OpenAPI3Schema, OpenAPISchema3_1, Refable } from "../src/types.js";
 import { worksFor } from "./works-for.js";
 
 worksFor(["3.0.0"], ({ oapiForModel, openApiFor }) => {

--- a/packages/openapi3/test/operation-id.test.ts
+++ b/packages/openapi3/test/operation-id.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { OpenAPI3Document } from "../src/types.js";
+import type { OpenAPI3Document } from "../src/types.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
 interface Case {

--- a/packages/openapi3/test/output-file.test.ts
+++ b/packages/openapi3/test/output-file.test.ts
@@ -1,12 +1,9 @@
 import { resolvePath } from "@typespec/compiler";
-import {
-  expectDiagnosticEmpty,
-  resolveVirtualPath,
-  TesterInstance,
-} from "@typespec/compiler/testing";
+import type { TesterInstance } from "@typespec/compiler/testing";
+import { expectDiagnosticEmpty, resolveVirtualPath } from "@typespec/compiler/testing";
 import { ok, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
-import { OpenAPI3EmitterOptions } from "../src/lib.js";
+import type { OpenAPI3EmitterOptions } from "../src/lib.js";
 import { ApiTester } from "./test-host.js";
 
 describe("openapi3: output file", () => {

--- a/packages/openapi3/test/output-spec-versions.test.ts
+++ b/packages/openapi3/test/output-spec-versions.test.ts
@@ -1,12 +1,9 @@
 import { resolvePath } from "@typespec/compiler";
-import {
-  expectDiagnosticEmpty,
-  resolveVirtualPath,
-  TesterInstance,
-} from "@typespec/compiler/testing";
+import type { TesterInstance } from "@typespec/compiler/testing";
+import { expectDiagnosticEmpty, resolveVirtualPath } from "@typespec/compiler/testing";
 import { ok } from "assert";
 import { beforeEach, expect, it } from "vitest";
-import { OpenAPI3EmitterOptions } from "../src/lib.js";
+import type { OpenAPI3EmitterOptions } from "../src/lib.js";
 import { ApiTester } from "./test-host.js";
 
 const outputDir = resolveVirtualPath("test-output");

--- a/packages/openapi3/test/overloads.test.ts
+++ b/packages/openapi3/test/overloads.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
-import { OpenAPI3Document, OpenAPI3RequestBody } from "../src/types.js";
+import type { OpenAPI3Document, OpenAPI3RequestBody } from "../src/types.js";
 import { openApiForVersions } from "./test-host.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -1,7 +1,7 @@
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
-import { OpenAPI3PathParameter, OpenAPI3QueryParameter } from "../src/types.js";
+import type { OpenAPI3PathParameter, OpenAPI3QueryParameter } from "../src/types.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
 worksFor(supportedVersions, ({ diagnoseOpenApiFor, openApiFor, version }) => {

--- a/packages/openapi3/test/primitive-types.test.ts
+++ b/packages/openapi3/test/primitive-types.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, it } from "vitest";
-import { OpenAPI3Schema } from "../src/types.js";
+import type { OpenAPI3Schema } from "../src/types.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
 worksFor(supportedVersions, ({ oapiForModel, openApiFor }) => {

--- a/packages/openapi3/test/sse.test.ts
+++ b/packages/openapi3/test/sse.test.ts
@@ -1,7 +1,7 @@
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok } from "assert";
 import { describe, it } from "vitest";
-import { OpenAPIDocument3_2 } from "../src/types.js";
+import type { OpenAPIDocument3_2 } from "../src/types.js";
 import { ApiTester } from "./test-host.js";
 
 // Use ApiTester with SSE-specific imports

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -1,4 +1,5 @@
-import { Diagnostic, interpolatePath, resolvePath } from "@typespec/compiler";
+import type { Diagnostic } from "@typespec/compiler";
+import { interpolatePath, resolvePath } from "@typespec/compiler";
 import {
   createTester,
   expectDiagnosticEmpty,
@@ -6,8 +7,8 @@ import {
 } from "@typespec/compiler/testing";
 import { ok } from "assert";
 import { parse } from "yaml";
-import { OpenAPI3EmitterOptions } from "../src/lib.js";
-import { OpenAPI3Document } from "../src/types.js";
+import type { OpenAPI3EmitterOptions } from "../src/lib.js";
+import type { OpenAPI3Document } from "../src/types.js";
 
 export const ApiTester = createTester(resolvePath(import.meta.dirname, ".."), {
   libraries: [

--- a/packages/openapi3/test/tsp-openapi3/anyof-ref-and-object.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/anyof-ref-and-object.test.ts
@@ -1,11 +1,11 @@
 import { dereference } from "@scalar/openapi-parser";
-import { OpenAPI } from "@scalar/openapi-types";
+import type { OpenAPI } from "@scalar/openapi-types";
 import { beforeAll, describe, expect, it } from "vitest";
 import { generateDataType } from "../../src/cli/actions/convert/generators/generate-model.js";
-import { TypeSpecDataTypes, TypeSpecUnion } from "../../src/cli/actions/convert/interfaces.js";
+import type { TypeSpecDataTypes, TypeSpecUnion } from "../../src/cli/actions/convert/interfaces.js";
 import { transformComponentSchemas } from "../../src/cli/actions/convert/transforms/transform-component-schemas.js";
 import { createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { OpenAPI3Document } from "../../src/types.js";
+import type { OpenAPI3Document } from "../../src/types.js";
 
 describe("tsp-openapi: anyOf with $ref and inline object should produce union", () => {
   let doc: OpenAPI.Document<{}>;

--- a/packages/openapi3/test/tsp-openapi3/context.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/context.test.ts
@@ -1,8 +1,8 @@
 import { dereference } from "@scalar/openapi-parser";
-import { OpenAPI } from "@scalar/openapi-types";
+import type { OpenAPI } from "@scalar/openapi-types";
 import { beforeAll, describe, expect, it } from "vitest";
 import { createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { OpenAPI3Document } from "../../src/types.js";
+import type { OpenAPI3Document } from "../../src/types.js";
 
 describe("tsp-openapi: Context methods", () => {
   let doc: OpenAPI.Document<{}>;

--- a/packages/openapi3/test/tsp-openapi3/convert-openapi3-doc.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/convert-openapi3-doc.test.ts
@@ -1,7 +1,8 @@
 import { formatTypeSpec } from "@typespec/compiler";
 import { strictEqual } from "node:assert";
 import { describe, it } from "vitest";
-import { OpenAPITag3_2, convertOpenAPI3Document } from "../../src/index.js";
+import type { OpenAPITag3_2 } from "../../src/index.js";
+import { convertOpenAPI3Document } from "../../src/index.js";
 
 const versions = ["3.0.0", "3.1.0", "3.2.0"] as const;
 

--- a/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/generate-type.test.ts
@@ -2,8 +2,14 @@ import { dereference } from "@scalar/openapi-parser";
 import { formatTypeSpec } from "@typespec/compiler";
 import { strictEqual } from "node:assert";
 import { beforeAll, describe, it } from "vitest";
-import { Context, createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { OpenAPI3Document, OpenAPI3Schema, OpenAPISchema3_1, Refable } from "../../src/types.js";
+import type { Context } from "../../src/cli/actions/convert/utils/context.js";
+import { createContext } from "../../src/cli/actions/convert/utils/context.js";
+import type {
+  OpenAPI3Document,
+  OpenAPI3Schema,
+  OpenAPISchema3_1,
+  Refable,
+} from "../../src/types.js";
 
 interface TestScenario {
   schema: Refable<OpenAPI3Schema | OpenAPISchema3_1>;

--- a/packages/openapi3/test/tsp-openapi3/http-part-methods.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/http-part-methods.test.ts
@@ -2,8 +2,9 @@ import { dereference } from "@scalar/openapi-parser";
 import { formatTypeSpec } from "@typespec/compiler";
 import { strictEqual } from "node:assert";
 import { beforeAll, describe, it } from "vitest";
-import { Context, createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { OpenAPI3Document, OpenAPI3Schema } from "../../src/types.js";
+import type { Context } from "../../src/cli/actions/convert/utils/context.js";
+import { createContext } from "../../src/cli/actions/convert/utils/context.js";
+import type { OpenAPI3Document, OpenAPI3Schema } from "../../src/types.js";
 
 /**
  * Unit tests for the new HTTP part generation methods in SchemaToExpressionGenerator:

--- a/packages/openapi3/test/tsp-openapi3/missing-operation-id.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/missing-operation-id.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { transformPaths } from "../../src/cli/actions/convert/transforms/transform-paths.js";
 import { createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { convertOpenAPI3Document, JsonSchemaType } from "../../src/index.js";
+import type { JsonSchemaType } from "../../src/index.js";
+import { convertOpenAPI3Document } from "../../src/index.js";
 
 describe("Convert OpenAPI3 with missing operationId", () => {
   // Mock logger to capture warnings

--- a/packages/openapi3/test/tsp-openapi3/namespace-option.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/namespace-option.test.ts
@@ -2,7 +2,7 @@ import { formatTypeSpec } from "@typespec/compiler";
 import { strictEqual } from "node:assert";
 import { describe, it } from "vitest";
 import { convertOpenAPI3Document } from "../../src/index.js";
-import { OpenAPI3Document } from "../../src/types.js";
+import type { OpenAPI3Document } from "../../src/types.js";
 
 describe("namespace option", () => {
   const testDocument: OpenAPI3Document = {

--- a/packages/openapi3/test/tsp-openapi3/page-items.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/page-items.test.ts
@@ -1,4 +1,4 @@
-import { Model } from "@typespec/compiler";
+import type { Model } from "@typespec/compiler";
 import { describe, expect, it } from "vitest";
 import { expectDecorators } from "./utils/expect.js";
 import { compileForOpenAPI3, renderTypeSpecForOpenAPI3 } from "./utils/tsp-for-openapi3.js";

--- a/packages/openapi3/test/tsp-openapi3/paths.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { OpenAPI3Response } from "../../src/types.js";
+import type { OpenAPI3Response } from "../../src/types.js";
 import { renderTypeSpecForOpenAPI3, validateTsp } from "./utils/tsp-for-openapi3.js";
 
 const response: OpenAPI3Response = {

--- a/packages/openapi3/test/tsp-openapi3/single-anyof-oneof.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/single-anyof-oneof.test.ts
@@ -1,11 +1,11 @@
 import { dereference } from "@scalar/openapi-parser";
-import { OpenAPI } from "@scalar/openapi-types";
+import type { OpenAPI } from "@scalar/openapi-types";
 import { beforeAll, describe, expect, it } from "vitest";
 import { generateDataType } from "../../src/cli/actions/convert/generators/generate-model.js";
-import { TypeSpecDataTypes, TypeSpecModel } from "../../src/cli/actions/convert/interfaces.js";
+import type { TypeSpecDataTypes, TypeSpecModel } from "../../src/cli/actions/convert/interfaces.js";
 import { transformComponentSchemas } from "../../src/cli/actions/convert/transforms/transform-component-schemas.js";
 import { createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { OpenAPI3Document } from "../../src/types.js";
+import type { OpenAPI3Document } from "../../src/types.js";
 
 describe("tsp-openapi: single anyOf/oneOf inline schema should produce model", () => {
   let doc: OpenAPI.Document<{}>;

--- a/packages/openapi3/test/tsp-openapi3/transform-component-schemas.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/transform-component-schemas.test.ts
@@ -1,10 +1,10 @@
 import { dereference } from "@scalar/openapi-parser";
-import { OpenAPI } from "@scalar/openapi-types";
+import type { OpenAPI } from "@scalar/openapi-types";
 import { beforeAll, describe, expect, it } from "vitest";
-import { TypeSpecModel } from "../../src/cli/actions/convert/interfaces.js";
+import type { TypeSpecModel } from "../../src/cli/actions/convert/interfaces.js";
 import { transformComponentSchemas } from "../../src/cli/actions/convert/transforms/transform-component-schemas.js";
 import { createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { OpenAPI3Document } from "../../src/types.js";
+import type { OpenAPI3Document } from "../../src/types.js";
 
 describe("tsp-openapi: transform component schemas", () => {
   let doc: OpenAPI.Document<{}>;

--- a/packages/openapi3/test/tsp-openapi3/union-anyof-with-null.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/union-anyof-with-null.test.ts
@@ -1,11 +1,11 @@
 import { dereference } from "@scalar/openapi-parser";
-import { OpenAPI } from "@scalar/openapi-types";
+import type { OpenAPI } from "@scalar/openapi-types";
 import { beforeAll, describe, expect, it } from "vitest";
 import { generateDataType } from "../../src/cli/actions/convert/generators/generate-model.js";
-import { TypeSpecUnion } from "../../src/cli/actions/convert/interfaces.js";
+import type { TypeSpecUnion } from "../../src/cli/actions/convert/interfaces.js";
 import { transformComponentSchemas } from "../../src/cli/actions/convert/transforms/transform-component-schemas.js";
 import { createContext } from "../../src/cli/actions/convert/utils/context.js";
-import { OpenAPI3Document } from "../../src/types.js";
+import type { OpenAPI3Document } from "../../src/types.js";
 
 describe("tsp-openapi: union anyOf with null", () => {
   let doc: OpenAPI.Document<{}>;

--- a/packages/openapi3/test/tsp-openapi3/utils/expect.ts
+++ b/packages/openapi3/test/tsp-openapi3/utils/expect.ts
@@ -1,4 +1,5 @@
-import { DecoratorApplication, isType, Numeric, typespecTypeToJson } from "@typespec/compiler";
+import type { DecoratorApplication } from "@typespec/compiler";
+import { isType, Numeric, typespecTypeToJson } from "@typespec/compiler";
 import { assert, expect } from "vitest";
 
 export interface DecoratorMatch {

--- a/packages/openapi3/test/tsp-openapi3/utils/spec-snapshot-testing.ts
+++ b/packages/openapi3/test/tsp-openapi3/utils/spec-snapshot-testing.ts
@@ -1,5 +1,5 @@
+import type { CompilerHost } from "@typespec/compiler";
 import {
-  CompilerHost,
   NodeHost,
   getDirectoryPath,
   getRelativePathFromDirectory,
@@ -9,7 +9,8 @@ import {
 import { fail, ok, strictEqual } from "assert";
 import { readdirSync } from "fs";
 import { mkdir, readFile, readdir, rm, writeFile } from "fs/promises";
-import { RunnerTestFile, RunnerTestSuite, afterAll, beforeAll, it } from "vitest";
+import type { RunnerTestFile, RunnerTestSuite } from "vitest";
+import { afterAll, beforeAll, it } from "vitest";
 import { convertAction } from "../../../src/cli/actions/convert/convert-file.js";
 
 const shouldUpdateSnapshots = process.env.RECORD === "true";

--- a/packages/openapi3/test/tsp-openapi3/utils/tsp-for-openapi3.ts
+++ b/packages/openapi3/test/tsp-openapi3/utils/tsp-for-openapi3.ts
@@ -1,9 +1,9 @@
 import { ApiTester } from "#test/test-host.js";
-import { Diagnostic, Namespace, Program } from "@typespec/compiler";
+import type { Diagnostic, Namespace, Program } from "@typespec/compiler";
 import { expectDiagnosticEmpty } from "@typespec/compiler/testing";
 import assert from "node:assert";
 import { convertOpenAPI3Document } from "../../../src/index.js";
-import {
+import type {
   OpenAPI3Document,
   OpenAPI3Header,
   OpenAPI3Parameter,

--- a/packages/openapi3/test/tsp-openapi3/x-ms-list.test.ts
+++ b/packages/openapi3/test/tsp-openapi3/x-ms-list.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { OpenAPI3Response } from "../../src/types.js";
+import type { OpenAPI3Response } from "../../src/types.js";
 import { renderTypeSpecForOpenAPI3, validateTsp } from "./utils/tsp-for-openapi3.js";
 
 const response: OpenAPI3Response = {

--- a/packages/openapi3/test/works-for.ts
+++ b/packages/openapi3/test/works-for.ts
@@ -1,5 +1,5 @@
 import { describe } from "vitest";
-import { OpenAPIVersion } from "../src/lib.js";
+import type { OpenAPIVersion } from "../src/lib.js";
 import {
   diagnoseOpenApiFor,
   emitOpenApiWithDiagnostics,

--- a/packages/openapi3/tsconfig.json
+++ b/packages/openapi3/tsconfig.json
@@ -8,6 +8,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "verbatimModuleSyntax": true,
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
   }
 }


### PR DESCRIPTION
Part of the incremental rollout of TypeScript's `verbatimModuleSyntax` across the workspace (batch 8).

Enables `verbatimModuleSyntax: true` for `@typespec/openapi3` — the second of the three large core packages.

### Changes
- Added `"verbatimModuleSyntax": true` to `packages/openapi3/tsconfig.json` (inherited by `tsconfig.build.json`).
- Converted type-only imports/exports to `import type` / `export type` across ~83 source files (via oxlint type-aware autofix). The library entry (`tsp-index.ts`) keeps `$lib` / `$decorators` and the decorator implementations as value exports; only the decorator type interfaces became `import type`.

### Validation
- `tsc` — 0 verbatim (TS1484/TS1205/TS1485) errors.
- Build: `tsc -p tsconfig.build.json` passes.
- oxlint `--type-aware --deny-warnings` clean.
- Tests: 2576 passed (2 skipped).

Standalone runtime emitters (`http-client-csharp`, `http-client-java`, `http-client-python`) remain out of scope, and `tsconfig.base.json` is intentionally untouched. Only `@typespec/compiler` remains after this, in its own PR.
