### PR TITLE
Enable verbatimModuleSyntax in http-client-java emitter

### DIFF
--- a/.chronus/changes/type-import-emitter-java-2026-7-31.md
+++ b/.chronus/changes/type-import-emitter-java-2026-7-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-java"
+---
+
+Enable `verbatimModuleSyntax` in the emitter's TypeScript config and convert type-only imports/exports to `import type`/`export type`.

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -1,3 +1,4 @@
+import type { Schema, SecurityScheme } from "@autorest/codemodel";
 import {
   AnySchema,
   ApiVersion,
@@ -29,11 +30,9 @@ import {
   Property,
   Relations,
   Response,
-  Schema,
   SchemaResponse,
   SchemaType,
   Security,
-  SecurityScheme,
   SerializationStyle,
   StringSchema,
   TimeSchema,
@@ -43,10 +42,9 @@ import {
   VirtualParameter,
 } from "@autorest/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
-import {
+import type {
   CreateSdkContextOptions,
   DecoratedType,
-  InitializedByFlags,
   SdkArrayType,
   SdkBodyParameter,
   SdkBuiltInType,
@@ -71,6 +69,9 @@ import {
   SdkServiceMethod,
   SdkType,
   SdkUnionType,
+} from "@azure-tools/typespec-client-generator-core";
+import {
+  InitializedByFlags,
   UsageFlags,
   createSdkContext,
   getAllModels,
@@ -81,16 +82,18 @@ import {
   isSdkBuiltInKind,
   isSdkIntKind,
 } from "@azure-tools/typespec-client-generator-core";
-import {
+import type {
   EmitContext,
   Interface,
   Namespace,
-  NoTarget,
   Operation,
   Program,
   Type,
   TypeNameOptions,
   Union,
+} from "@typespec/compiler";
+import {
+  NoTarget,
   getDoc,
   getNamespaceFullName,
   getOverloadedOperation,
@@ -99,23 +102,13 @@ import {
   isRecordModelType,
   listServices,
 } from "@typespec/compiler";
-import {
-  Authentication,
-  HttpStatusCodeRange,
-  HttpStatusCodesEntry,
-  Visibility,
-  getAuthentication,
-} from "@typespec/http";
+import type { Authentication, HttpStatusCodeRange, HttpStatusCodesEntry } from "@typespec/http";
+import { Visibility, getAuthentication } from "@typespec/http";
 import { getSegment } from "@typespec/rest";
 import { getAddedOnVersions } from "@typespec/versioning";
 import { fail } from "assert";
-import {
-  Client as CodeModelClient,
-  EncodedProperty,
-  EncodedSchema,
-  PageableContinuationToken,
-  Serializable,
-} from "./common/client.js";
+import type { EncodedProperty, EncodedSchema, Serializable } from "./common/client.js";
+import { Client as CodeModelClient, PageableContinuationToken } from "./common/client.js";
 import { CodeModel } from "./common/code-model.js";
 import { LongRunningMetadata } from "./common/long-running-metadata.js";
 import { Operation as CodeModelOperation, ConvenienceApi, Request } from "./common/operation.js";
@@ -123,7 +116,8 @@ import { ChoiceSchema, SealedChoiceSchema } from "./common/schemas/choice.js";
 import { ConstantSchema, ConstantValue } from "./common/schemas/constant.js";
 import { OrSchema } from "./common/schemas/relationship.js";
 import { DurationSchema } from "./common/schemas/time.js";
-import { SchemaContext, SchemaUsage } from "./common/schemas/usage.js";
+import type { SchemaUsage } from "./common/schemas/usage.js";
+import { SchemaContext } from "./common/schemas/usage.js";
 import { createPollOperationDetailsSchema, getFileDetailsSchema } from "./external-schemas.js";
 import { createDiagnostic, reportDiagnostic } from "./lib.js";
 import { ClientContext } from "./models.js";
@@ -140,7 +134,8 @@ import {
   operationIsMultipart,
   operationIsMultipleContentTypes,
 } from "./operation-utils.js";
-import { DevOptions, EmitterOptions, LIB_NAME } from "./options.js";
+import type { DevOptions, EmitterOptions } from "./options.js";
+import { LIB_NAME } from "./options.js";
 import {
   BYTES_KNOWN_ENCODING,
   DATETIME_KNOWN_ENCODING,

--- a/packages/http-client-java/emitter/src/common/client.ts
+++ b/packages/http-client-java/emitter/src/common/client.ts
@@ -1,16 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-import {
-  Aspect,
-  HttpHeader,
-  Metadata,
-  OperationGroup,
-  Parameter,
-  Property,
-  Security,
-} from "@autorest/codemodel";
-import { DeepPartial } from "@azure-tools/codegen";
-import { ArrayKnownEncoding } from "@azure-tools/typespec-client-generator-core";
-import { XmlSerializationFormat } from "./formats/xml.js";
+import type { HttpHeader, OperationGroup, Parameter, Property } from "@autorest/codemodel";
+import { Aspect, Metadata, Security } from "@autorest/codemodel";
+import type { DeepPartial } from "@azure-tools/codegen";
+import type { ArrayKnownEncoding } from "@azure-tools/typespec-client-generator-core";
+import type { XmlSerializationFormat } from "./formats/xml.js";
 
 export interface Client extends Aspect {
   /** All operations  */

--- a/packages/http-client-java/emitter/src/common/code-model.ts
+++ b/packages/http-client-java/emitter/src/common/code-model.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-import { Info, Metadata, OperationGroup, Parameter, Schemas, Security } from "@autorest/codemodel";
-import { DeepPartial, enableSourceTracking } from "@azure-tools/codegen";
-import { Client } from "./client.js";
+import type { Parameter } from "@autorest/codemodel";
+import { Info, Metadata, OperationGroup, Schemas, Security } from "@autorest/codemodel";
+import type { DeepPartial } from "@azure-tools/codegen";
+import { enableSourceTracking } from "@azure-tools/codegen";
+import type { Client } from "./client.js";
 
 /** the model that contains all the information required to generate a service api */
 export interface CodeModel extends Metadata {

--- a/packages/http-client-java/emitter/src/common/formats/xml.ts
+++ b/packages/http-client-java/emitter/src/common/formats/xml.ts
@@ -1,4 +1,4 @@
-import { SerializationFormat } from "@autorest/codemodel";
+import type { SerializationFormat } from "@autorest/codemodel";
 
 export interface XmlSerializationFormat extends SerializationFormat {
   name?: string;

--- a/packages/http-client-java/emitter/src/common/long-running-metadata.ts
+++ b/packages/http-client-java/emitter/src/common/long-running-metadata.ts
@@ -1,4 +1,4 @@
-import { Metadata, Schema } from "@autorest/codemodel";
+import type { Metadata, Schema } from "@autorest/codemodel";
 
 export class LongRunningMetadata {
   longRunning: boolean = false;

--- a/packages/http-client-java/emitter/src/common/operation.ts
+++ b/packages/http-client-java/emitter/src/common/operation.ts
@@ -1,15 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-import {
-  ApiVersion,
-  Aspect,
-  ImplementationLocation,
-  Metadata,
-  Parameter,
-  Response,
-  SchemaType,
-} from "@autorest/codemodel";
-import { DeepPartial } from "@azure-tools/codegen";
-import { LongRunningMetadata } from "./long-running-metadata.js";
+import type { ApiVersion, Parameter, Response } from "@autorest/codemodel";
+import { Aspect, ImplementationLocation, Metadata, SchemaType } from "@autorest/codemodel";
+import type { DeepPartial } from "@azure-tools/codegen";
+import type { LongRunningMetadata } from "./long-running-metadata.js";
 
 /** represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)  */
 export interface Operation extends Aspect {

--- a/packages/http-client-java/emitter/src/common/schemas/choice.ts
+++ b/packages/http-client-java/emitter/src/common/schemas/choice.ts
@@ -1,14 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-import {
-  ChoiceValue,
-  PrimitiveSchema,
-  Schema,
-  SchemaType,
-  StringSchema,
-  ValueSchema,
-} from "@autorest/codemodel";
-import { DeepPartial } from "@azure-tools/codegen";
-import { SchemaUsage } from "./usage.js";
+import type { ChoiceValue, PrimitiveSchema, StringSchema, ValueSchema } from "@autorest/codemodel";
+import { Schema, SchemaType } from "@autorest/codemodel";
+import type { DeepPartial } from "@azure-tools/codegen";
+import type { SchemaUsage } from "./usage.js";
 
 /** a schema that represents a choice of several values (ie, an 'enum') */
 export interface ChoiceSchema<ChoiceType extends PrimitiveSchema = StringSchema>

--- a/packages/http-client-java/emitter/src/common/schemas/constant.ts
+++ b/packages/http-client-java/emitter/src/common/schemas/constant.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-import { Extensions, Languages, Schema, SchemaType } from "@autorest/codemodel";
-import { DeepPartial, Initializer } from "@azure-tools/codegen";
-import { SchemaUsage } from "./usage.js";
+import type { Extensions, Languages } from "@autorest/codemodel";
+import { Schema, SchemaType } from "@autorest/codemodel";
+import type { DeepPartial } from "@azure-tools/codegen";
+import { Initializer } from "@azure-tools/codegen";
+import type { SchemaUsage } from "./usage.js";
 
 /** a container for the actual constant value */
 export interface ConstantValue extends Extensions {

--- a/packages/http-client-java/emitter/src/common/schemas/relationship.ts
+++ b/packages/http-client-java/emitter/src/common/schemas/relationship.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-import { ComplexSchema, ObjectSchema, Schema, SchemaType } from "@autorest/codemodel";
-import { DeepPartial } from "@azure-tools/codegen";
-import { SchemaUsage } from "./usage.js";
+import type { ComplexSchema, ObjectSchema } from "@autorest/codemodel";
+import { Schema, SchemaType } from "@autorest/codemodel";
+import type { DeepPartial } from "@azure-tools/codegen";
+import type { SchemaUsage } from "./usage.js";
 
 /** an OR relationship between several schemas
  *

--- a/packages/http-client-java/emitter/src/common/schemas/time.ts
+++ b/packages/http-client-java/emitter/src/common/schemas/time.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 import { PrimitiveSchema, SchemaType } from "@autorest/codemodel";
-import { DeepPartial } from "@azure-tools/codegen";
+import type { DeepPartial } from "@azure-tools/codegen";
 
 /** a schema that represents a Duration value */
 export interface DurationSchema extends PrimitiveSchema {

--- a/packages/http-client-java/emitter/src/common/schemas/usage.ts
+++ b/packages/http-client-java/emitter/src/common/schemas/usage.ts
@@ -1,4 +1,4 @@
-import { KnownMediaType } from "@azure-tools/codegen";
+import type { KnownMediaType } from "@azure-tools/codegen";
 
 export enum SchemaContext {
   /** Schema is used as an input to an operation. */

--- a/packages/http-client-java/emitter/src/emitter.ts
+++ b/packages/http-client-java/emitter/src/emitter.ts
@@ -1,18 +1,14 @@
-import {
-  EmitContext,
-  getNormalizedAbsolutePath,
-  NoTarget,
-  Program,
-  resolvePath,
-} from "@typespec/compiler";
+import type { EmitContext, Program } from "@typespec/compiler";
+import { getNormalizedAbsolutePath, NoTarget, resolvePath } from "@typespec/compiler";
 import { promises } from "fs";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { stringify } from "yaml";
-import { CodeModelBuilder, EmitterOptionsDev } from "./code-model-builder.js";
-import { CodeModel } from "./common/code-model.js";
+import type { EmitterOptionsDev } from "./code-model-builder.js";
+import { CodeModelBuilder } from "./code-model-builder.js";
+import type { CodeModel } from "./common/code-model.js";
 import { LibName, reportDiagnostic } from "./lib.js";
-import { EmitterOptions } from "./options.js";
+import type { EmitterOptions } from "./options.js";
 import { DiagnosticError, spawnAsync, SpawnError, trace } from "./utils.js";
 import { validateDependencies } from "./validate.js";
 

--- a/packages/http-client-java/emitter/src/external-schemas.ts
+++ b/packages/http-client-java/emitter/src/external-schemas.ts
@@ -1,14 +1,7 @@
-import {
-  ArraySchema,
-  BinarySchema,
-  ObjectSchema,
-  Property,
-  Schema,
-  Schemas,
-  StringSchema,
-} from "@autorest/codemodel";
+import type { BinarySchema, Schema, Schemas, StringSchema } from "@autorest/codemodel";
+import { ArraySchema, ObjectSchema, Property } from "@autorest/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
-import {
+import type {
   SdkModelPropertyType,
   SdkModelType,
   SdkType,

--- a/packages/http-client-java/emitter/src/index.ts
+++ b/packages/http-client-java/emitter/src/index.ts
@@ -2,4 +2,4 @@
 export { $onEmit } from "./emitter.js";
 // emit options interface is required to be exported
 export { $lib } from "./lib.js";
-export { DevOptions, EmitterOptions } from "./options.js";
+export type { DevOptions, EmitterOptions } from "./options.js";

--- a/packages/http-client-java/emitter/src/models.ts
+++ b/packages/http-client-java/emitter/src/models.ts
@@ -1,6 +1,7 @@
-import { ApiVersions, Parameter } from "@autorest/codemodel";
-import { ModelProperty, Namespace, Operation, Program } from "@typespec/compiler";
-import { findVersionedNamespace, getVersions, Version } from "@typespec/versioning";
+import type { ApiVersions, Parameter } from "@autorest/codemodel";
+import type { ModelProperty, Namespace, Operation, Program } from "@typespec/compiler";
+import type { Version } from "@typespec/versioning";
+import { findVersionedNamespace, getVersions } from "@typespec/versioning";
 import {
   getFilteredApiVersions,
   InconsistentVersions,

--- a/packages/http-client-java/emitter/src/operation-utils.ts
+++ b/packages/http-client-java/emitter/src/operation-utils.ts
@@ -1,5 +1,6 @@
-import { ObjectSchema, Parameter, Property, SchemaResponse } from "@autorest/codemodel";
-import {
+import type { Property } from "@autorest/codemodel";
+import { ObjectSchema, Parameter, SchemaResponse } from "@autorest/codemodel";
+import type {
   SdkCookieParameter,
   SdkHeaderParameter,
   SdkHttpOperation,
@@ -9,11 +10,12 @@ import {
   SdkQueryParameter,
   SdkServiceResponseHeader,
 } from "@azure-tools/typespec-client-generator-core";
-import { Operation, Program, Type, Union } from "@typespec/compiler";
-import { HttpOperation } from "@typespec/http";
-import { Client as CodeModelClient, ServiceVersion } from "./common/client.js";
-import { CodeModel } from "./common/code-model.js";
-import { Operation as CodeModelOperation } from "./common/operation.js";
+import type { Operation, Program, Type, Union } from "@typespec/compiler";
+import type { HttpOperation } from "@typespec/http";
+import type { Client as CodeModelClient } from "./common/client.js";
+import { ServiceVersion } from "./common/client.js";
+import type { CodeModel } from "./common/code-model.js";
+import type { Operation as CodeModelOperation } from "./common/operation.js";
 import { getPropertySerializedName, modelIs, unionReferredByType } from "./type-utils.js";
 import { getNamespace, pascalCase } from "./utils.js";
 

--- a/packages/http-client-java/emitter/src/options.ts
+++ b/packages/http-client-java/emitter/src/options.ts
@@ -1,5 +1,5 @@
 import { UnbrandedSdkEmitterOptions } from "@azure-tools/typespec-client-generator-core";
-import { JSONSchemaType } from "@typespec/compiler";
+import type { JSONSchemaType } from "@typespec/compiler";
 
 // typespec-java has another "options.ts" file, with same "export".
 // If add/remove "export" here, please also check typespec-java in autorest.java repository.

--- a/packages/http-client-java/emitter/src/type-utils.ts
+++ b/packages/http-client-java/emitter/src/type-utils.ts
@@ -1,14 +1,13 @@
 import { getUnionAsEnum } from "@azure-tools/typespec-azure-core";
-import {
+import type {
   SdkDurationType,
   SdkEnumType,
   SdkModelPropertyType,
   SdkModelType,
   SdkType,
-  isSdkFloatKind,
-  isSdkIntKind,
 } from "@azure-tools/typespec-client-generator-core";
-import {
+import { isSdkFloatKind, isSdkIntKind } from "@azure-tools/typespec-client-generator-core";
+import type {
   DecoratedType,
   DecoratorApplication,
   EnumMember,
@@ -23,14 +22,16 @@ import {
   TypeNameOptions,
   Union,
   Value,
+} from "@typespec/compiler";
+import {
   getTypeName,
   isNullType,
   isTemplateDeclaration,
   isTemplateInstance,
   isTypeSpecValueTypeOf,
 } from "@typespec/compiler";
-import { XmlSerializationFormat } from "./common/formats/xml.js";
-import { DurationSchema } from "./common/schemas/time.js";
+import type { XmlSerializationFormat } from "./common/formats/xml.js";
+import type { DurationSchema } from "./common/schemas/time.js";
 import { SchemaContext } from "./common/schemas/usage.js";
 import { getNamespace } from "./utils.js";
 

--- a/packages/http-client-java/emitter/src/utils.ts
+++ b/packages/http-client-java/emitter/src/utils.ts
@@ -1,5 +1,6 @@
-import { Diagnostic, Program, Type } from "@typespec/compiler";
-import { spawn, SpawnOptions } from "child_process";
+import type { Diagnostic, Program, Type } from "@typespec/compiler";
+import type { SpawnOptions } from "child_process";
+import { spawn } from "child_process";
 
 export function trace(program: Program, msg: string) {
   program.trace("http-client-java", msg);

--- a/packages/http-client-java/emitter/src/validate.ts
+++ b/packages/http-client-java/emitter/src/validate.ts
@@ -1,4 +1,5 @@
-import { NoTarget, Program } from "@typespec/compiler";
+import type { Program } from "@typespec/compiler";
+import { NoTarget } from "@typespec/compiler";
 import { reportDiagnostic } from "./lib.js";
 import { spawnAsync, trace } from "./utils.js";
 

--- a/packages/http-client-java/emitter/src/versioning-utils.ts
+++ b/packages/http-client-java/emitter/src/versioning-utils.ts
@@ -1,7 +1,8 @@
 import { isPreviewVersion } from "@azure-tools/typespec-azure-core";
-import { SdkClientType, SdkHttpOperation } from "@azure-tools/typespec-client-generator-core";
-import { Namespace, Program } from "@typespec/compiler";
-import { findVersionedNamespace, getVersions, Version } from "@typespec/versioning";
+import type { SdkClientType, SdkHttpOperation } from "@azure-tools/typespec-client-generator-core";
+import type { Namespace, Program } from "@typespec/compiler";
+import type { Version } from "@typespec/versioning";
+import { findVersionedNamespace, getVersions } from "@typespec/versioning";
 
 /**
  * Sentinel values that describe a client that not have consistent api-versions.

--- a/packages/http-client-java/emitter/tsconfig.json
+++ b/packages/http-client-java/emitter/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*"],
   "sourceMap": true


### PR DESCRIPTION
Extends the ongoing `verbatimModuleSyntax` rollout to the standalone Java client emitter (`@typespec/http-client-java`).

`verbatimModuleSyntax` makes TypeScript emit imports/exports exactly as written, keeping type-only imports out of the runtime module graph. This is the same flag already enabled across most workspace packages; this PR turns it on for the Java emitter's TypeScript layer.

What changed:
- Add `"verbatimModuleSyntax": true` to `emitter/tsconfig.json`.
- Convert type-only imports/exports to `import type` / `export type` (oxlint autofix, plus a `export type` fix for the options re-export in `emitter/src/index.ts`).

No runtime behavior change — a dev-only TypeScript configuration/import-style change.
