### PR TITLE
Enable verbatimModuleSyntax in http-client-python emitter

### DIFF
--- a/.chronus/changes/type-import-emitter-python-2026-7-31.md
+++ b/.chronus/changes/type-import-emitter-python-2026-7-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-python"
+---
+
+Enable `verbatimModuleSyntax` in the emitter's TypeScript config and convert type-only imports/exports to `import type`/`export type`.

--- a/packages/http-client-python/emitter/src/code-model.ts
+++ b/packages/http-client-python/emitter/src/code-model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SdkBasicServiceMethod,
   SdkClientType,
   SdkCredentialParameter,
@@ -12,6 +12,8 @@ import {
   SdkServiceMethod,
   SdkServiceOperation,
   SdkUnionType,
+} from "@azure-tools/typespec-client-generator-core";
+import {
   UsageFlags,
   getCrossLanguagePackageId,
   isAzureCoreModel,
@@ -24,7 +26,7 @@ import {
   emitLroPagingHttpMethod,
   emitPagingHttpMethod,
 } from "./http.js";
-import { PythonSdkContext } from "./lib.js";
+import type { PythonSdkContext } from "./lib.js";
 import { KnownTypes, emitEndpointType, getType } from "./types.js";
 import { emitParamBase, getClientNamespace, getImplementation, getRootNamespace } from "./utils.js";
 

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -1,5 +1,6 @@
 import { createSdkContext } from "@azure-tools/typespec-client-generator-core";
-import { EmitContext, emitFile, joinPaths, NoTarget } from "@typespec/compiler";
+import type { EmitContext } from "@typespec/compiler";
+import { emitFile, joinPaths, NoTarget } from "@typespec/compiler";
 import pkgJson from "../../package.json" with { type: "json" };
 import { emitCodeModel } from "./code-model.js";
 import {
@@ -9,9 +10,11 @@ import {
   PYODIDE_VERSION,
 } from "./constants.js";
 import { dumpCodeModelToYaml } from "./external-process.js";
-import { PythonEmitterOptions, PythonSdkContext, reportDiagnostic } from "./lib.js";
+import type { PythonEmitterOptions, PythonSdkContext } from "./lib.js";
+import { reportDiagnostic } from "./lib.js";
 import { runNodeEmit } from "./node-runner.js";
-import { loadPyodide, PyodideInterface } from "./pyodide-loader.js";
+import type { PyodideInterface } from "./pyodide-loader.js";
+import { loadPyodide } from "./pyodide-loader.js";
 import { getRootNamespace, md2Rst } from "./utils.js";
 
 function getBrowserPygenWheelUrl(): string {

--- a/packages/http-client-python/emitter/src/external-process.ts
+++ b/packages/http-client-python/emitter/src/external-process.ts
@@ -1,5 +1,6 @@
 import { joinPaths } from "@typespec/compiler";
-import { ChildProcess, spawn, SpawnOptions } from "child_process";
+import type { ChildProcess, SpawnOptions } from "child_process";
+import { spawn } from "child_process";
 import { randomUUID } from "crypto";
 import { mkdir, writeFile } from "fs/promises";
 import jsyaml from "js-yaml";

--- a/packages/http-client-python/emitter/src/http.ts
+++ b/packages/http-client-python/emitter/src/http.ts
@@ -1,7 +1,6 @@
 import { getNamespaceFullName, NoTarget } from "@typespec/compiler";
 
-import {
-  getHttpOperationParameter,
+import type {
   SdkBasicServiceMethod,
   SdkBodyParameter,
   SdkClientType,
@@ -20,10 +19,11 @@ import {
   SdkServiceMethod,
   SdkServiceResponseHeader,
   SdkType,
-  UsageFlags,
 } from "@azure-tools/typespec-client-generator-core";
-import { HttpStatusCodeRange } from "@typespec/http";
-import { PythonSdkContext, reportDiagnostic } from "./lib.js";
+import { getHttpOperationParameter, UsageFlags } from "@azure-tools/typespec-client-generator-core";
+import type { HttpStatusCodeRange } from "@typespec/http";
+import type { PythonSdkContext } from "./lib.js";
+import { reportDiagnostic } from "./lib.js";
 import { getType, KnownTypes } from "./types.js";
 import {
   emitParamBase,

--- a/packages/http-client-python/emitter/src/index.ts
+++ b/packages/http-client-python/emitter/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./emitter.js";
-export { $lib, PythonEmitterOptions, PythonEmitterOptionsSchema } from "./lib.js";
+export { $lib, PythonEmitterOptionsSchema } from "./lib.js";
+export type { PythonEmitterOptions } from "./lib.js";

--- a/packages/http-client-python/emitter/src/lib.ts
+++ b/packages/http-client-python/emitter/src/lib.ts
@@ -1,9 +1,7 @@
-import {
-  SdkContext,
-  SdkType,
-  UnbrandedSdkEmitterOptions,
-} from "@azure-tools/typespec-client-generator-core";
-import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
+import type { SdkContext, SdkType } from "@azure-tools/typespec-client-generator-core";
+import { UnbrandedSdkEmitterOptions } from "@azure-tools/typespec-client-generator-core";
+import type { JSONSchemaType } from "@typespec/compiler";
+import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
 
 export interface PythonEmitterOptions {
   "api-version"?: string;

--- a/packages/http-client-python/emitter/src/node-runner.browser.ts
+++ b/packages/http-client-python/emitter/src/node-runner.browser.ts
@@ -6,7 +6,8 @@
 import type { EmitContext } from "@typespec/compiler";
 import { NoTarget } from "@typespec/compiler";
 import type { PyodideInterface } from "pyodide";
-import { PythonEmitterOptions, reportDiagnostic } from "./lib.js";
+import type { PythonEmitterOptions } from "./lib.js";
+import { reportDiagnostic } from "./lib.js";
 
 export interface RunNodeEmitArgs {
   context: EmitContext<PythonEmitterOptions>;

--- a/packages/http-client-python/emitter/src/node-runner.ts
+++ b/packages/http-client-python/emitter/src/node-runner.ts
@@ -5,16 +5,19 @@
 // `node-runner.browser.ts` stub is swapped in via the `"browser"` field in
 // `package.json` when bundling with `platform: "browser"`.
 
-import { EmitContext, NoTarget } from "@typespec/compiler";
+import type { EmitContext } from "@typespec/compiler";
+import { NoTarget } from "@typespec/compiler";
 import { execSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path, { dirname } from "path";
-import { loadPyodide, PyodideInterface } from "pyodide";
+import type { PyodideInterface } from "pyodide";
+import { loadPyodide } from "pyodide";
 import { fileURLToPath } from "url";
 import { blackExcludeDirs, PYGEN_WHEEL_FILENAME } from "./constants.js";
 import { saveCodeModelAsYaml } from "./external-process.js";
-import { PythonEmitterOptions, reportDiagnostic } from "./lib.js";
+import type { PythonEmitterOptions } from "./lib.js";
+import { reportDiagnostic } from "./lib.js";
 import { runPython3 } from "./run-python3.js";
 import { quoteShellArg } from "./utils.js";
 

--- a/packages/http-client-python/emitter/src/system-requirements.ts
+++ b/packages/http-client-python/emitter/src/system-requirements.ts
@@ -1,4 +1,5 @@
-import { ChildProcess, spawn, SpawnOptions } from "child_process";
+import type { ChildProcess, SpawnOptions } from "child_process";
+import { spawn } from "child_process";
 import { coerce, satisfies } from "semver";
 
 /*

--- a/packages/http-client-python/emitter/src/types.ts
+++ b/packages/http-client-python/emitter/src/types.ts
@@ -1,5 +1,4 @@
-import {
-  isHttpMetadata,
+import type {
   SdkArrayType,
   SdkBuiltInType,
   SdkConstantType,
@@ -14,12 +13,14 @@ import {
   SdkModelType,
   SdkType,
   SdkUnionType,
-  UsageFlags,
 } from "@azure-tools/typespec-client-generator-core";
-import { getEncode, Type } from "@typespec/compiler";
-import { HttpAuth, Visibility } from "@typespec/http";
+import { isHttpMetadata, UsageFlags } from "@azure-tools/typespec-client-generator-core";
+import type { Type } from "@typespec/compiler";
+import { getEncode } from "@typespec/compiler";
+import type { HttpAuth } from "@typespec/http";
+import { Visibility } from "@typespec/http";
 import { dump } from "js-yaml";
-import { PythonSdkContext } from "./lib.js";
+import type { PythonSdkContext } from "./lib.js";
 import {
   camelToSnakeCase,
   emitParamBase,

--- a/packages/http-client-python/emitter/src/utils.ts
+++ b/packages/http-client-python/emitter/src/utils.ts
@@ -1,5 +1,4 @@
-import {
-  InitializedByFlags,
+import type {
   SdkCredentialParameter,
   SdkEndpointParameter,
   SdkHeaderParameter,
@@ -13,9 +12,11 @@ import {
   SdkServiceResponseHeader,
   SdkType,
 } from "@azure-tools/typespec-client-generator-core";
+import { InitializedByFlags } from "@azure-tools/typespec-client-generator-core";
 import { getNamespaceFullName } from "@typespec/compiler";
-import { marked, Token } from "marked";
-import { PythonSdkContext } from "./lib.js";
+import type { Token } from "marked";
+import { marked } from "marked";
+import type { PythonSdkContext } from "./lib.js";
 import { getSimpleTypeResult, getType } from "./types.js";
 
 function IsFullyUpperCase(identifier: string, maxUppercasePreserve: number) {

--- a/packages/http-client-python/emitter/tsconfig.json
+++ b/packages/http-client-python/emitter/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Extends the ongoing `verbatimModuleSyntax` rollout to the standalone Python client emitter (`@typespec/http-client-python`).

`verbatimModuleSyntax` makes TypeScript emit imports/exports exactly as written, keeping type-only imports out of the runtime module graph. This is the same flag already enabled across most workspace packages; this PR turns it on for the Python emitter's TypeScript layer.

What changed:
- Add `"verbatimModuleSyntax": true` to `emitter/tsconfig.json`.
- Convert type-only imports/exports to `import type` / `export type` (oxlint autofix, plus a `export type` split for the options re-export in `emitter/src/index.ts`).

No runtime behavior change — a dev-only TypeScript configuration/import-style change.
