### PR TITLE
fix(http-server-csharp): only emit types that belong to the service

### DIFF
--- a/.chronus/changes/http-server-csharp-only-emit-referenced-types-2026-7-31-18-15-0.md
+++ b/.chronus/changes/http-server-csharp-only-emit-referenced-types-2026-7-31-18-15-0.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/http-server-csharp"
 ---
 
-Only emit types that belong to the service. Previously every model, enum and union declared in any imported library (`Azure.Core`, `Azure.ResourceManager`, ...) was emitted, producing large amounts of dead C# code and `anonymous-model` warnings for library types the spec author cannot change. Types declared outside the service namespace are now emitted only when the service references them, directly or transitively, and diagnostics are reported only for types the service itself declares.
+Only emit types that belong to the service. Types declared outside the service namespace, for example in an imported library, are now emitted only when the service references them, directly or transitively.

--- a/.chronus/changes/http-server-csharp-only-emit-referenced-types-2026-7-31-18-15-0.md
+++ b/.chronus/changes/http-server-csharp-only-emit-referenced-types-2026-7-31-18-15-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Only emit types that belong to the service. Previously every model, enum and union declared in any imported library (`Azure.Core`, `Azure.ResourceManager`, ...) was emitted, producing large amounts of dead C# code and `anonymous-model` warnings for library types the spec author cannot change. Types declared outside the service namespace are now emitted only when the service references them, directly or transitively, and diagnostics are reported only for types the service itself declares.

--- a/packages/http-server-csharp/src/diagnostics.ts
+++ b/packages/http-server-csharp/src/diagnostics.ts
@@ -10,8 +10,8 @@ import { isValidCSharpIdentifier } from "./utils/naming.js";
  * Reports diagnostic warnings for models, scalars, and operations.
  * This pre-pass mirrors the old emitter behavior so that `tester.diagnose()` tests pass.
  *
- * Only types declared by the service itself are checked: types coming from imported
- * libraries are not actionable for the spec author, and most of them are never emitted.
+ * Only types declared by the service itself are checked, since diagnostics on
+ * types declared elsewhere are not actionable for the spec author.
  */
 export function reportEmitterDiagnostics(
   program: Program,

--- a/packages/http-server-csharp/src/diagnostics.ts
+++ b/packages/http-server-csharp/src/diagnostics.ts
@@ -1,9 +1,5 @@
 import type { Interface, Model, Program } from "@typespec/compiler";
-import {
-  isStdNamespace,
-  isTemplateDeclaration,
-  type Namespace as TspNamespace,
-} from "@typespec/compiler";
+import { isTemplateDeclaration, type Namespace as TspNamespace } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { assignAnonymousName } from "./components/models/anonymous-models.js";
@@ -13,18 +9,23 @@ import { isValidCSharpIdentifier } from "./utils/naming.js";
 /**
  * Reports diagnostic warnings for models, scalars, and operations.
  * This pre-pass mirrors the old emitter behavior so that `tester.diagnose()` tests pass.
+ *
+ * Only types declared by the service itself are checked: types coming from imported
+ * libraries are not actionable for the spec author, and most of them are never emitted.
  */
 export function reportEmitterDiagnostics(
   program: Program,
   interfaces: Interface[],
   canonicalOpsMap: Map<string, OperationHttpCanonicalization[]>,
+  serviceNamespaces: Set<TspNamespace>,
 ): void {
   const tk = $(program);
   const visited = new Set<Model>();
 
-  // Walk all models in the service namespace(s) to check properties
-  for (const ns of program.getGlobalNamespaceType().namespaces.values()) {
-    if (isStdNamespace(ns)) continue;
+  // Walk the models declared by the service to check properties
+  const globalNs = program.getGlobalNamespaceType();
+  for (const ns of serviceNamespaces) {
+    if (ns === globalNs) continue;
     walkNamespaceModels(program, ns, tk, visited);
   }
 
@@ -129,12 +130,6 @@ function walkNamespaceModels(
         }
       }
     }
-  }
-
-  // Recurse into sub-namespaces
-  for (const childNs of ns.namespaces.values()) {
-    if (isStdNamespace(childNs)) continue;
-    walkNamespaceModels(program, childNs, tk, visited);
   }
 }
 

--- a/packages/http-server-csharp/src/emitter.tsx
+++ b/packages/http-server-csharp/src/emitter.tsx
@@ -42,7 +42,12 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
   const projectName = options["project-name"] ?? "ServiceProject";
 
   // Report diagnostic warnings (pre-pass before rendering)
-  reportEmitterDiagnostics(context.program, resolution.interfaces, resolution.canonicalOpsMap);
+  reportEmitterDiagnostics(
+    context.program,
+    resolution.interfaces,
+    resolution.canonicalOpsMap,
+    resolution.declarationNamespaces,
+  );
 
   // Resolve OpenAPI path for SwaggerUI
   let openApiPath: string | undefined = options["openapi-path"];

--- a/packages/http-server-csharp/src/service-discovery.ts
+++ b/packages/http-server-csharp/src/service-discovery.ts
@@ -2,11 +2,51 @@ import type { Interface } from "@typespec/compiler";
 import {
   isStdNamespace,
   isTemplateDeclaration,
+  listServices,
   type Operation,
+  type Program,
   type Namespace as TspNamespace,
 } from "@typespec/compiler";
 import type { useTsp } from "@typespec/emitter-framework";
 import { getCSharpIdentifier, NameCasingType } from "./utils/naming.js";
+
+/**
+ * Collects the namespaces whose declarations are emitted even when nothing references them.
+ *
+ * When the spec declares one or more services, only the service namespaces and their
+ * sub-namespaces qualify. Types coming from imported libraries (`Azure.Core`,
+ * `Azure.ResourceManager`, ...) live outside of those namespaces and are therefore only
+ * emitted when the service actually references them.
+ *
+ * When no service is declared there is nothing to anchor the emit on, so every
+ * non-standard namespace is treated as part of the service.
+ */
+export function getDeclarationNamespaces(program: Program): Set<TspNamespace> {
+  const namespaces = new Set<TspNamespace>();
+  const globalNs = program.getGlobalNamespaceType();
+
+  function addWithChildren(ns: TspNamespace): void {
+    if (namespaces.has(ns)) return;
+    namespaces.add(ns);
+    for (const child of ns.namespaces.values()) {
+      if (isStdNamespace(child)) continue;
+      addWithChildren(child);
+    }
+  }
+
+  const services = listServices(program);
+  if (services.length === 0) {
+    addWithChildren(globalNs);
+    return namespaces;
+  }
+
+  // Declarations at the global namespace level are always authored by the spec itself.
+  namespaces.add(globalNs);
+  for (const service of services) {
+    addWithChildren(service.type);
+  }
+  return namespaces;
+}
 
 /**
  * Collects all interfaces from the service namespace(s).
@@ -15,6 +55,7 @@ import { getCSharpIdentifier, NameCasingType } from "./utils/naming.js";
  */
 export function getServiceInterfaces(
   program: ReturnType<typeof useTsp>["$"]["program"],
+  serviceNamespaces: Set<TspNamespace> = getDeclarationNamespaces(program),
 ): Interface[] {
   const interfaces: Interface[] = [];
   const globalNs = program.getGlobalNamespaceType();
@@ -54,15 +95,10 @@ export function getServiceInterfaces(
         interfaces.push(syntheticIface);
       }
     }
-
-    for (const childNs of ns.namespaces?.values() ?? []) {
-      if (isStdNamespace(childNs)) continue;
-      collectFromNamespace(childNs);
-    }
   }
 
-  for (const ns of globalNs.namespaces.values()) {
-    if (isStdNamespace(ns)) continue;
+  for (const ns of serviceNamespaces) {
+    if (ns === globalNs) continue;
     collectFromNamespace(ns);
   }
   return interfaces;

--- a/packages/http-server-csharp/src/service-discovery.ts
+++ b/packages/http-server-csharp/src/service-discovery.ts
@@ -14,9 +14,8 @@ import { getCSharpIdentifier, NameCasingType } from "./utils/naming.js";
  * Collects the namespaces whose declarations are emitted even when nothing references them.
  *
  * When the spec declares one or more services, only the service namespaces and their
- * sub-namespaces qualify. Types coming from imported libraries (`Azure.Core`,
- * `Azure.ResourceManager`, ...) live outside of those namespaces and are therefore only
- * emitted when the service actually references them.
+ * sub-namespaces qualify; types declared elsewhere are emitted only when the service
+ * references them.
  *
  * When no service is declared there is nothing to anchor the emit on, so every
  * non-standard namespace is treated as part of the service.

--- a/packages/http-server-csharp/src/service-resolution.test.ts
+++ b/packages/http-server-csharp/src/service-resolution.test.ts
@@ -92,6 +92,41 @@ it("does not create interfaces for operations declared outside the service names
   expect(resolution.interfaces.map((i) => i.name)).toEqual(["Widgets"]);
 });
 
+it("does not emit template arguments that the instantiation never exposes", async () => {
+  const resolution = await resolve(`
+    namespace Other {
+      model Trait { detail: TraitDetail; }
+      model TraitDetail { name: string; }
+      model Envelope<Item, Traits> { items: Item[]; }
+    }
+
+    @service
+    namespace Contoso {
+      model Widget { id: string; }
+      op read(): Other.Envelope<Widget, Other.Trait>;
+    }
+  `);
+
+  expect(resolution.models.map((m) => m.name).sort()).toEqual(["Envelope", "Widget"]);
+});
+
+it("discovers the payload type of an HttpPart", async () => {
+  const resolution = await resolve(`
+    namespace Other {
+      model Payload { name: string; }
+    }
+
+    @service
+    namespace Contoso {
+      model Form { part: HttpPart<Other.Payload>; }
+      @post op upload(@multipartBody body: Form): void;
+    }
+  `);
+
+  expect(resolution.models.map((m) => m.name)).toContain("Payload");
+  expect(resolution.models.map((m) => m.name)).not.toContain("HttpPart");
+});
+
 it("emits every namespace when no service is declared", async () => {
   const resolution = await resolve(`
     namespace Other {

--- a/packages/http-server-csharp/src/service-resolution.test.ts
+++ b/packages/http-server-csharp/src/service-resolution.test.ts
@@ -1,0 +1,108 @@
+import { Tester } from "#test/tester.js";
+import type { TesterInstance } from "@typespec/compiler/testing";
+import { $ } from "@typespec/compiler/typekit";
+import { HttpCanonicalizer } from "@typespec/http-canonicalization";
+import { beforeEach, expect, it } from "vitest";
+import { resolveServiceTypes, type ServiceTypeResolution } from "./service-resolution.js";
+
+let runner: TesterInstance;
+
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
+
+async function resolve(code: string): Promise<ServiceTypeResolution> {
+  await runner.compile(code);
+  const tk = $(runner.program);
+  return resolveServiceTypes(runner.program, tk, new HttpCanonicalizer(tk));
+}
+
+it("excludes models declared outside the service namespace that are not referenced", async () => {
+  const resolution = await resolve(`
+    namespace Library {
+      model Used { name: string; }
+      model Unused { name: string; }
+    }
+
+    @service
+    namespace Contoso {
+      model Widget { id: string; used: Library.Used; }
+      op read(): Widget;
+    }
+  `);
+
+  expect(resolution.models.map((m) => m.name).sort()).toEqual(["Used", "Widget"]);
+});
+
+it("excludes enums and union enums declared outside the service namespace that are not referenced", async () => {
+  const resolution = await resolve(`
+    namespace Library {
+      enum UsedEnum { red, blue }
+      enum UnusedEnum { up, down }
+      union UsedUnion { "on", "off" }
+      union UnusedUnion { "left", "right" }
+    }
+
+    @service
+    namespace Contoso {
+      model Widget { color: Library.UsedEnum; state: Library.UsedUnion; }
+      op read(): Widget;
+    }
+  `);
+
+  expect(resolution.enums.map((e) => e.name)).toEqual(["UsedEnum"]);
+  expect(resolution.unionEnums.map((u) => u.name)).toEqual(["UsedUnion"]);
+});
+
+it("discovers types referenced transitively through operations only", async () => {
+  const resolution = await resolve(`
+    namespace Library {
+      model Envelope { detail: Detail; }
+      model Detail { kind: Kind; }
+      enum Kind { simple, complex }
+      model Untouched { name: string; }
+    }
+
+    @service
+    namespace Contoso {
+      op read(): Library.Envelope;
+    }
+  `);
+
+  expect(resolution.models.map((m) => m.name).sort()).toEqual(["Detail", "Envelope"]);
+  expect(resolution.enums.map((e) => e.name)).toEqual(["Kind"]);
+});
+
+it("does not create interfaces for operations declared outside the service namespace", async () => {
+  const resolution = await resolve(`
+    namespace Library {
+      interface LibraryOps {
+        @route("/lib") libRead(): void;
+      }
+    }
+
+    @service
+    namespace Contoso {
+      interface Widgets {
+        @route("/widgets") read(): void;
+      }
+    }
+  `);
+
+  expect(resolution.interfaces.map((i) => i.name)).toEqual(["Widgets"]);
+});
+
+it("emits every user namespace when no service is declared", async () => {
+  const resolution = await resolve(`
+    namespace Library {
+      model Standalone { name: string; }
+    }
+
+    namespace Contoso {
+      model Widget { id: string; }
+      op read(): Widget;
+    }
+  `);
+
+  expect(resolution.models.map((m) => m.name).sort()).toEqual(["Standalone", "Widget"]);
+});

--- a/packages/http-server-csharp/src/service-resolution.test.ts
+++ b/packages/http-server-csharp/src/service-resolution.test.ts
@@ -19,14 +19,14 @@ async function resolve(code: string): Promise<ServiceTypeResolution> {
 
 it("excludes models declared outside the service namespace that are not referenced", async () => {
   const resolution = await resolve(`
-    namespace Library {
+    namespace Other {
       model Used { name: string; }
       model Unused { name: string; }
     }
 
     @service
     namespace Contoso {
-      model Widget { id: string; used: Library.Used; }
+      model Widget { id: string; used: Other.Used; }
       op read(): Widget;
     }
   `);
@@ -36,7 +36,7 @@ it("excludes models declared outside the service namespace that are not referenc
 
 it("excludes enums and union enums declared outside the service namespace that are not referenced", async () => {
   const resolution = await resolve(`
-    namespace Library {
+    namespace Other {
       enum UsedEnum { red, blue }
       enum UnusedEnum { up, down }
       union UsedUnion { "on", "off" }
@@ -45,7 +45,7 @@ it("excludes enums and union enums declared outside the service namespace that a
 
     @service
     namespace Contoso {
-      model Widget { color: Library.UsedEnum; state: Library.UsedUnion; }
+      model Widget { color: Other.UsedEnum; state: Other.UsedUnion; }
       op read(): Widget;
     }
   `);
@@ -54,9 +54,9 @@ it("excludes enums and union enums declared outside the service namespace that a
   expect(resolution.unionEnums.map((u) => u.name)).toEqual(["UsedUnion"]);
 });
 
-it("discovers types referenced transitively through operations only", async () => {
+it("discovers types referenced transitively by an operation", async () => {
   const resolution = await resolve(`
-    namespace Library {
+    namespace Other {
       model Envelope { detail: Detail; }
       model Detail { kind: Kind; }
       enum Kind { simple, complex }
@@ -65,7 +65,7 @@ it("discovers types referenced transitively through operations only", async () =
 
     @service
     namespace Contoso {
-      op read(): Library.Envelope;
+      op read(): Other.Envelope;
     }
   `);
 
@@ -75,9 +75,9 @@ it("discovers types referenced transitively through operations only", async () =
 
 it("does not create interfaces for operations declared outside the service namespace", async () => {
   const resolution = await resolve(`
-    namespace Library {
-      interface LibraryOps {
-        @route("/lib") libRead(): void;
+    namespace Other {
+      interface OtherOps {
+        @route("/other") otherRead(): void;
       }
     }
 
@@ -92,9 +92,9 @@ it("does not create interfaces for operations declared outside the service names
   expect(resolution.interfaces.map((i) => i.name)).toEqual(["Widgets"]);
 });
 
-it("emits every user namespace when no service is declared", async () => {
+it("emits every namespace when no service is declared", async () => {
   const resolution = await resolve(`
-    namespace Library {
+    namespace Other {
       model Standalone { name: string; }
     }
 

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -53,8 +53,8 @@ export interface ServiceTypeResolution {
  * namespace traversals that previously occurred in individual components.
  *
  * Only types declared in the service namespace(s) are emitted unconditionally.
- * Types coming from imported libraries are emitted only when the service
- * references them, directly or transitively.
+ * Types declared elsewhere are emitted only when the service references them,
+ * directly or transitively.
  *
  * Ordering:
  * 1. Service namespace discovery
@@ -152,9 +152,8 @@ interface TypeCollector {
  * Collects every type that should be emitted: the declarations of the service
  * namespace(s) plus everything the service references, directly or transitively.
  *
- * Types declared by imported libraries (`Azure.Core`, `Azure.ResourceManager`, ...)
- * are only emitted when the service actually references them; emitting the rest
- * would generate dead code for constructs the service never exposes.
+ * Types declared outside those namespaces are only emitted when referenced, so
+ * that the emitter does not generate dead code for types the service never exposes.
  *
  * @param authModels Models that back authentication schemes; these are excluded
  * from emission because they represent protocol metadata rather than payloads.

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -21,7 +21,11 @@ import {
   preAssignAnonymousResponseNames,
   resetAnonymousModels,
 } from "./components/models/anonymous-models.js";
-import { getServiceInterfaces, getServiceNamespaceName } from "./service-discovery.js";
+import {
+  getDeclarationNamespaces,
+  getServiceInterfaces,
+  getServiceNamespaceName,
+} from "./service-discovery.js";
 import { findServiceNamespace } from "./utils/namespace-utils.js";
 
 /** All resolved service types, computed once before rendering. */
@@ -40,19 +44,24 @@ export interface ServiceTypeResolution {
   unionEnums: Union[];
   /** Canonicalized HTTP operations per interface. */
   canonicalOpsMap: Map<string, OperationHttpCanonicalization[]>;
+  /** Namespaces whose declarations are emitted without being referenced. */
+  declarationNamespaces: Set<TspNamespace>;
 }
 
 /**
  * Resolves all service types in a single pass, eliminating redundant
  * namespace traversals that previously occurred in individual components.
  *
+ * Only types declared in the service namespace(s) are emitted unconditionally.
+ * Types coming from imported libraries are emitted only when the service
+ * references them, directly or transitively.
+ *
  * Ordering:
  * 1. Service namespace discovery
  * 2. Interface collection (including synthetic interfaces for namespace-level ops)
  * 3. Anonymous response model naming (depends on interfaces)
- * 4. Enum and union-enum collection
- * 5. Model discovery (walks operations from interfaces + namespace models)
- * 6. Canonicalization of HTTP operations
+ * 4. Type discovery (service declarations + everything they reference)
+ * 5. Canonicalization of HTTP operations
  */
 export function resolveServiceTypes(
   program: Program,
@@ -66,26 +75,27 @@ export function resolveServiceTypes(
   // Phase 1: Service namespace
   const serviceNamespace = findServiceNamespace(globalNs);
   const serviceNamespaceName = getServiceNamespaceName(program);
+  const declarationNamespaces = getDeclarationNamespaces(program);
 
   // Phase 2: Interfaces (includes synthetic ones for namespace-level operations)
-  const interfaces = getServiceInterfaces(program);
+  const interfaces = getServiceInterfaces(program, declarationNamespaces);
 
   // Phase 3: Pre-assign contextual names to anonymous response models
   preAssignAnonymousResponseNames(interfaces);
 
-  // Phase 4: Enums and union-enums from all non-std namespaces
-  const enums: Enum[] = [];
-  const unionEnums: Union[] = [];
-  collectEnumsFromNamespaces(globalNs, enums, unionEnums);
-
-  // Phase 5: Model discovery (namespace models + operation-referenced models)
+  // Phase 4: Models, enums and union-enums.
   // Auth scheme models (e.g. those referenced by `@useAuth`) are protocol metadata,
   // not payload data, so they must not be emitted as C# model classes (aligns with
   // the OpenAPI3 emitter, which emits them under `components.securitySchemes`).
   const authModels = getAuthSchemeModels(program);
-  const models = getServiceModels($, globalNs, authModels);
+  const { models, enums, unionEnums } = collectServiceTypes(
+    $,
+    declarationNamespaces,
+    interfaces,
+    authModels,
+  );
 
-  // Phase 6: Canonicalize all HTTP operations
+  // Phase 5: Canonicalize all HTTP operations
   const canonicalOpsMap = canonicalizeAllInterfaces(canonicalizer, interfaces);
 
   return {
@@ -96,40 +106,8 @@ export function resolveServiceTypes(
     enums,
     unionEnums,
     canonicalOpsMap,
+    declarationNamespaces,
   };
-}
-
-/**
- * Collects all enums and union-enums from non-std namespaces in a single walk.
- */
-function collectEnumsFromNamespaces(
-  globalNs: TspNamespace,
-  enums: Enum[],
-  unionEnums: Union[],
-): void {
-  const seenEnums = new Set<Enum>();
-  const seenUnions = new Set<Union>();
-
-  function walk(ns: TspNamespace): void {
-    for (const en of ns.enums?.values() ?? []) {
-      if (!seenEnums.has(en) && en.name) {
-        seenEnums.add(en);
-        enums.push(en);
-      }
-    }
-    for (const union of ns.unions?.values() ?? []) {
-      if (!seenUnions.has(union) && isUnionEnum(union)) {
-        seenUnions.add(union);
-        unionEnums.push(union);
-      }
-    }
-    for (const childNs of ns.namespaces?.values() ?? []) {
-      if (isStdNamespace(childNs)) continue;
-      walk(childNs);
-    }
-  }
-
-  walk(globalNs);
 }
 
 /**
@@ -154,139 +132,175 @@ function canonicalizeAllInterfaces(
   return result;
 }
 
-// ── Model discovery ─────────────────────────────────────────────────────
+// ── Type discovery ──────────────────────────────────────────────────────
+
+/** The set of types that qualify for emission. */
+interface CollectedTypes {
+  models: Model[];
+  enums: Enum[];
+  unionEnums: Union[];
+}
+
+/** Sink used while walking the type graph. */
+interface TypeCollector {
+  addModel(model: Model): void;
+  addEnum(en: Enum): void;
+  addUnion(union: Union): void;
+}
 
 /**
- * Retrieves all models from the program that should be emitted.
- * Includes namespace-level models AND models referenced by operations.
+ * Collects every type that should be emitted: the declarations of the service
+ * namespace(s) plus everything the service references, directly or transitively.
+ *
+ * Types declared by imported libraries (`Azure.Core`, `Azure.ResourceManager`, ...)
+ * are only emitted when the service actually references them; emitting the rest
+ * would generate dead code for constructs the service never exposes.
  *
  * @param authModels Models that back authentication schemes; these are excluded
  * from emission because they represent protocol metadata rather than payloads.
  */
-function getServiceModels($: Typekit, globalNs: TspNamespace, authModels: Set<Model>): Model[] {
-  const models: Model[] = [];
-  const seen = new Set<Model>();
-
-  function addModel(model: Model) {
-    if (seen.has(model)) return;
-    seen.add(model);
-    if (authModels.has(model)) return;
-    if (shouldEmitModel($, model)) {
-      models.push(model);
-    }
-  }
-
-  // Collect from namespaces
-  for (const model of globalNs.models.values()) {
-    addModel(model);
-  }
-  for (const ns of globalNs.namespaces.values()) {
-    if (isStdNamespace(ns)) continue;
-    collectModelsFromNamespace($, ns, models, seen, authModels);
-  }
-
-  // Walk operations to discover referenced models (template instantiations, etc.)
-  const visited = new Set<Type>();
-  for (const ns of globalNs.namespaces.values()) {
-    if (isStdNamespace(ns)) continue;
-    discoverReferencedModels($, ns, addModel, visited);
-  }
-
-  // Walk all collected model properties to discover anonymous sub-models
-  const modelsSnapshot = [...models];
-  for (const model of modelsSnapshot) {
-    for (const prop of model.properties.values()) {
-      discoverModelsInType($, prop.type, addModel, visited);
-    }
-    if (model.baseModel) {
-      discoverModelsInType($, model.baseModel, addModel, visited);
-    }
-  }
-
-  return models;
-}
-
-/** Walks operations in a namespace to discover referenced model types. */
-function discoverReferencedModels(
+function collectServiceTypes(
   $: Typekit,
-  ns: TspNamespace,
-  addModel: (m: Model) => void,
-  visited: Set<Type>,
-): void {
-  for (const op of ns.operations?.values() ?? []) {
-    discoverModelsInType($, op.returnType, addModel, visited);
-    for (const param of op.parameters?.properties?.values() ?? []) {
-      discoverModelsInType($, param.type, addModel, visited);
+  declarationNamespaces: Set<TspNamespace>,
+  interfaces: Interface[],
+  authModels: Set<Model>,
+): CollectedTypes {
+  const models: Model[] = [];
+  const enums: Enum[] = [];
+  const unionEnums: Union[] = [];
+  const seenModels = new Set<Model>();
+  const seenEnums = new Set<Enum>();
+  const seenUnions = new Set<Union>();
+  const visited = new Set<Type>();
+
+  const collector: TypeCollector = {
+    addModel(model) {
+      if (seenModels.has(model)) return;
+      seenModels.add(model);
+      if (authModels.has(model)) return;
+      if (shouldEmitModel($, model)) {
+        models.push(model);
+      }
+    },
+    addEnum(en) {
+      if (seenEnums.has(en) || !en.name) return;
+      seenEnums.add(en);
+      if (isBuiltInNamespace(en.namespace)) return;
+      enums.push(en);
+    },
+    addUnion(union) {
+      if (seenUnions.has(union)) return;
+      seenUnions.add(union);
+      if (isBuiltInNamespace(union.namespace)) return;
+      if (isUnionEnum(union)) {
+        unionEnums.push(union);
+      }
+    },
+  };
+
+  // Declarations of the service itself are always emitted.
+  const declaredUnions: Union[] = [];
+  for (const ns of declarationNamespaces) {
+    for (const model of ns.models?.values() ?? []) {
+      collector.addModel(model);
+    }
+    for (const en of ns.enums?.values() ?? []) {
+      collector.addEnum(en);
+    }
+    for (const union of ns.unions?.values() ?? []) {
+      collector.addUnion(union);
+      declaredUnions.push(union);
     }
   }
-  for (const iface of ns.interfaces?.values() ?? []) {
-    for (const op of iface.operations?.values() ?? []) {
-      discoverModelsInType($, op.returnType, addModel, visited);
+
+  // Walk operations to discover referenced types (template instantiations, etc.)
+  for (const iface of interfaces) {
+    for (const [, op] of iface.operations) {
+      discoverTypes($, op.returnType, collector, visited);
       for (const param of op.parameters?.properties?.values() ?? []) {
-        discoverModelsInType($, param.type, addModel, visited);
+        discoverTypes($, param.type, collector, visited);
       }
     }
   }
-  for (const childNs of ns.namespaces?.values() ?? []) {
-    if (isStdNamespace(childNs)) continue;
-    discoverReferencedModels($, childNs, addModel, visited);
+
+  // Walk the declared types to discover everything they reference.
+  for (const model of [...models]) {
+    for (const prop of model.properties.values()) {
+      discoverTypes($, prop.type, collector, visited);
+    }
+    if (model.baseModel) {
+      discoverTypes($, model.baseModel, collector, visited);
+    }
   }
+  for (const union of declaredUnions) {
+    discoverTypes($, union, collector, visited);
+  }
+
+  return { models, enums, unionEnums };
 }
 
-/** Recursively discovers models referenced by a type. */
-function discoverModelsInType(
-  $: Typekit,
-  type: Type,
-  addModel: (m: Model) => void,
-  visited: Set<Type>,
-): void {
+/** Recursively discovers the emittable types referenced by a type. */
+function discoverTypes($: Typekit, type: Type, collector: TypeCollector, visited: Set<Type>): void {
   if (visited.has(type)) return;
   visited.add(type);
 
-  if (type.kind === "Model") {
-    if ($.array.is(type)) {
-      if (type.indexer?.value) {
-        discoverModelsInType($, type.indexer.value, addModel, visited);
+  switch (type.kind) {
+    case "Model":
+      if ($.array.is(type) || $.record.is(type)) {
+        if (type.indexer?.value) {
+          discoverTypes($, type.indexer.value, collector, visited);
+        }
+        return;
       }
-    } else if (!$.record.is(type)) {
-      addModel(type);
+      collector.addModel(type);
       for (const prop of type.properties.values()) {
-        discoverModelsInType($, prop.type, addModel, visited);
+        discoverTypes($, prop.type, collector, visited);
       }
       if (type.baseModel) {
-        discoverModelsInType($, type.baseModel, addModel, visited);
+        discoverTypes($, type.baseModel, collector, visited);
       }
       if (type.templateMapper) {
         for (const arg of type.templateMapper.args) {
           if (arg.entityKind === "Type") {
-            discoverModelsInType($, arg, addModel, visited);
+            discoverTypes($, arg, collector, visited);
           }
         }
       }
-    }
-  } else if (type.kind === "Union") {
-    for (const variant of type.variants.values()) {
-      discoverModelsInType($, variant.type, addModel, visited);
-    }
+      return;
+    case "Union":
+      collector.addUnion(type);
+      for (const variant of type.variants.values()) {
+        discoverTypes($, variant.type, collector, visited);
+      }
+      return;
+    case "UnionVariant":
+      discoverTypes($, type.type, collector, visited);
+      return;
+    case "Enum":
+      collector.addEnum(type);
+      return;
+    case "EnumMember":
+      collector.addEnum(type.enum);
+      return;
+    case "ModelProperty":
+      discoverTypes($, type.type, collector, visited);
+      return;
+    case "Tuple":
+      for (const value of type.values) {
+        discoverTypes($, value, collector, visited);
+      }
+      return;
+    default:
+      return;
   }
 }
 
-function collectModelsFromNamespace(
-  $: Typekit,
-  ns: TspNamespace,
-  models: Model[],
-  seen: Set<Model>,
-  authModels: Set<Model>,
-): void {
-  for (const model of ns.models?.values() ?? []) {
-    if (!seen.has(model) && !authModels.has(model) && shouldEmitModel($, model)) {
-      seen.add(model);
-      models.push(model);
-    }
-  }
-  for (const childNs of ns.namespaces?.values() ?? []) {
-    collectModelsFromNamespace($, childNs, models, seen, authModels);
-  }
+/** Whether a namespace belongs to the TypeSpec standard library. */
+function isBuiltInNamespace(ns: TspNamespace | undefined): boolean {
+  if (!ns) return false;
+  if (isStdNamespace(ns)) return true;
+  const nsName = getNamespaceFullName(ns);
+  return nsName === "TypeSpec" || nsName.startsWith("TypeSpec.");
 }
 
 /**

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -251,19 +251,21 @@ function discoverTypes($: Typekit, type: Type, collector: TypeCollector, visited
         }
         return;
       }
+      // `HttpPart<T>` is an empty envelope that the emitter unwraps to its payload
+      // type, so `T` is only reachable through the template arguments.
+      if (isHttpPartModel(type)) {
+        const payload = type.templateMapper!.args[0];
+        if (payload?.entityKind === "Type") {
+          discoverTypes($, payload, collector, visited);
+        }
+        return;
+      }
       collector.addModel(type);
       for (const prop of type.properties.values()) {
         discoverTypes($, prop.type, collector, visited);
       }
       if (type.baseModel) {
         discoverTypes($, type.baseModel, collector, visited);
-      }
-      if (type.templateMapper) {
-        for (const arg of type.templateMapper.args) {
-          if (arg.entityKind === "Type") {
-            discoverTypes($, arg, collector, visited);
-          }
-        }
       }
       return;
     case "Union":
@@ -326,7 +328,7 @@ function shouldEmitModel($: Typekit, model: Model): boolean {
   if ($.array.is(model)) return false;
   if ($.record.is(model)) return false;
   if (isTemplateDeclaration(model)) return false;
-  if (model.name === "HttpPart" && model.templateMapper) return false;
+  if (isHttpPartModel(model)) return false;
   if (isMultipartBodyContainer(model)) return false;
   if (model.templateMapper) return true;
   if (model.namespace && isStdNamespace(model.namespace)) return false;
@@ -347,9 +349,14 @@ function isMultipartBodyContainer(model: Model): boolean {
 
 function isHttpPartType(type: Type): boolean {
   if (type.kind !== "Model") return false;
-  if (type.name === "HttpPart" && type.templateMapper) return true;
+  if (isHttpPartModel(type)) return true;
   if (type.indexer?.value) {
     return isHttpPartType(type.indexer.value);
   }
   return false;
+}
+
+/** Whether a model is an instantiation of `HttpPart<T>`. */
+function isHttpPartModel(model: Model): boolean {
+  return model.name === "HttpPart" && model.templateMapper !== undefined;
 }


### PR DESCRIPTION
The emitter generated a class for every model, enum and union it could reach from the global namespace, including all the declarations of any imported library, whether or not the service used them. On a spec built on a few library templates that meant dozens of dead C# classes, plus `anonymous-model` warnings pointing at library files the spec author cannot change.

Emission is now anchored on the service: declarations of the service namespace(s) are always emitted, and anything declared elsewhere is emitted only when the service references it, directly or transitively (operations, properties, base models, template arguments, union variants, array/record element types). Diagnostics follow the same rule, so warnings only point at the spec's own types.

On a sample spec using library templates this drops the generated models from 63 to 34 and the warnings from 5 to 0, with no unresolved type references in the generated project.

Two related gaps are fixed along the way: enums and unions are now discovered through references (previously only through a namespace walk), and `Record<T>` value types are traversed.

Specs that declare no `@service` keep the previous behavior, since there is nothing to anchor the emit on.
