### PR TITLE
Refactor Java API metadata

### DIFF
--- a/.chronus/changes/refactor-api-metadata-2026-08-04-13-50-00.md
+++ b/.chronus/changes/refactor-api-metadata-2026-08-04-13-50-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-client-java"
+---
+
+Centralize generated API metadata in a dedicated model.

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMapper.java
@@ -24,6 +24,7 @@ import com.microsoft.typespec.http.client.generator.core.extension.model.codemod
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.SealedChoiceSchema;
 import com.microsoft.typespec.http.client.generator.core.extension.model.extensionmodel.XmsExtensions;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ApiMetadata;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.AsyncSyncClient;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.Client;
@@ -342,7 +343,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
                         String clientBuilderName = clientName + builderSuffix;
                         ClientBuilder clientBuilder = new ClientBuilder(builderPackage, clientBuilderName,
                             serviceClient, (syncClient == null) ? List.of() : List.of(syncClient), List.of(asyncClient),
-                            serviceClient.getCrossLanguageDefinitionId());
+                            serviceClient.getApiMetadata());
 
                         addBuilderTraits(clientBuilder, serviceClient);
                         clientBuilders.add(clientBuilder);
@@ -356,7 +357,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
                 } else {
                     // service client builder
                     ClientBuilder clientBuilder = new ClientBuilder(builderPackage, builderName, serviceClient,
-                        syncClientsLocal, asyncClientsLocal, serviceClient.getCrossLanguageDefinitionId());
+                        syncClientsLocal, asyncClientsLocal, serviceClient.getApiMetadata());
                     addBuilderTraits(clientBuilder, serviceClient);
                     clientBuilders.add(clientBuilder);
 
@@ -370,7 +371,8 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
             asyncClients.addAll(asyncClientsLocal);
         }
         builder.clientBuilders(clientBuilders);
-        builder.crossLanguageDefinitionId(codeModel.getLanguage().getJava().getName());
+        builder.apiMetadata(
+            new ApiMetadata.Builder().crossLanguageDefinitionId(codeModel.getLanguage().getJava().getName()).build());
 
         // example/test
         if (settings.isDataPlaneClient() && (settings.isGenerateSamples() || settings.isGenerateTests())) {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
@@ -287,9 +287,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
         if (operation.getLanguage().getJava() != null
             && !CoreUtils.isNullOrEmpty(operation.getLanguage().getJava().getComment())) {
-            // API comment.
-            builder.implementationDetails(
-                new ImplementationDetails.Builder().comment(operation.getLanguage().getJava().getComment()).build());
+            builder.devMessage(operation.getLanguage().getJava().getComment());
         }
 
         if (operation.getExternalDocs() != null) {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
@@ -9,6 +9,7 @@ import com.microsoft.typespec.http.client.generator.core.extension.model.codemod
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings.SyncMethodsGeneration;
 import com.microsoft.typespec.http.client.generator.core.implementation.OperationInstrumentationInfo;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ApiMetadata;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethod;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethodParameter;
@@ -131,7 +132,11 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .clientReference((operation.getOperationGroup() == null
                 || operation.getOperationGroup().getLanguage().getJava().getName().isEmpty()) ? "this" : "this.client")
             .operationInstrumentationInfo(new OperationInstrumentationInfo(operation))
-            .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(operation));
+            .apiMetadata(new ApiMetadata.Builder()
+                .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(operation))
+                .devMessage(
+                    operation.getLanguage().getJava() == null ? null : operation.getLanguage().getJava().getComment())
+                .build());
 
         setJavaDoc(builder, operation);
 
@@ -283,11 +288,6 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             builder.description(String.format("The %s operation.", operation.getLanguage().getJava().getName()));
         } else {
             builder.description(SchemaUtil.mergeSummaryWithDescription(summary, description));
-        }
-
-        if (operation.getLanguage().getJava() != null
-            && !CoreUtils.isNullOrEmpty(operation.getLanguage().getJava().getComment())) {
-            builder.devMessage(operation.getLanguage().getJava().getComment());
         }
 
         if (operation.getExternalDocs() != null) {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ClientMethodMapper.java
@@ -131,7 +131,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .clientReference((operation.getOperationGroup() == null
                 || operation.getOperationGroup().getLanguage().getJava().getName().isEmpty()) ? "this" : "this.client")
             .operationInstrumentationInfo(new OperationInstrumentationInfo(operation))
-            .setCrossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(operation));
+            .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(operation));
 
         setJavaDoc(builder, operation);
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/MapperUtils.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/MapperUtils.java
@@ -10,6 +10,7 @@ import com.microsoft.typespec.http.client.generator.core.extension.model.codemod
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Schema;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.SchemaContext;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ApiMetadata;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientEnumValue;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.EnumType;
@@ -91,7 +92,9 @@ public final class MapperUtils {
                 .implementationDetails(
                     new ImplementationDetails.Builder().usages(SchemaUtil.mapSchemaContext(enumType.getUsage()))
                         .build())
-                .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(enumType))
+                .apiMetadata(new ApiMetadata.Builder()
+                    .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(enumType))
+                    .build())
                 .fromMethodName(deserializationMethodName)
                 .toMethodName(serializationMethodName)
                 .build();

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/MethodGroupMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/MethodGroupMapper.java
@@ -7,6 +7,7 @@ import com.microsoft.typespec.http.client.generator.core.extension.model.codemod
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Operation;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.OperationGroup;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ApiMetadata;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethod;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModels;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.IType;
@@ -166,7 +167,9 @@ public class MethodGroupMapper implements IMapper<OperationGroup, MethodGroupCli
                 .collect(Collectors.toList()));
         }
 
-        builder.crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(methodGroup));
+        builder.apiMetadata(
+            new ApiMetadata.Builder().crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(methodGroup))
+                .build());
 
         return builder.build();
     }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ModelMapper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/mapper/ModelMapper.java
@@ -12,6 +12,7 @@ import com.microsoft.typespec.http.client.generator.core.extension.model.codemod
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Schema;
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.XmlSerializationFormat;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ApiMetadata;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModel;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientModelProperty;
@@ -347,7 +348,9 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel>, NeedsPla
 
             builder.properties(properties);
             builder.propertyReferences(propertyReferences);
-            builder.crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(compositeType));
+            builder.apiMetadata(new ApiMetadata.Builder()
+                .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(compositeType))
+                .build());
 
             result = builder.build();
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadata.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadata.java
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.typespec.http.client.generator.core.model.clientmodel;
+
+/**
+ * Metadata associated with a generated API.
+ */
+public final class ApiMetadata {
+    private final String crossLanguageDefinitionId;
+    private final String devMessage;
+
+    private ApiMetadata(String crossLanguageDefinitionId, String devMessage) {
+        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.devMessage = devMessage;
+    }
+
+    /**
+     * Gets the cross-language definition ID.
+     *
+     * @return the cross-language definition ID.
+     */
+    public String getCrossLanguageDefinitionId() {
+        return crossLanguageDefinitionId;
+    }
+
+    /**
+     * Gets the message for SDK developers.
+     *
+     * @return the message for SDK developers.
+     */
+    public String getDevMessage() {
+        return devMessage;
+    }
+
+    /**
+     * Creates a builder initialized with this metadata.
+     *
+     * @return the initialized builder.
+     */
+    public Builder newBuilder() {
+        return new Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).devMessage(devMessage);
+    }
+
+    /**
+     * Builder for {@link ApiMetadata}.
+     */
+    public static final class Builder {
+        private String crossLanguageDefinitionId;
+        private String devMessage;
+
+        /**
+         * Sets the cross-language definition ID.
+         *
+         * @param crossLanguageDefinitionId the cross-language definition ID.
+         * @return this builder.
+         */
+        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
+            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+            return this;
+        }
+
+        /**
+         * Sets the message for SDK developers.
+         *
+         * @param devMessage the message for SDK developers.
+         * @return this builder.
+         */
+        public Builder devMessage(String devMessage) {
+            this.devMessage = devMessage;
+            return this;
+        }
+
+        /**
+         * Builds the API metadata.
+         *
+         * @return the API metadata.
+         */
+        public ApiMetadata build() {
+            return new ApiMetadata(crossLanguageDefinitionId, devMessage);
+        }
+    }
+}

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/AsyncSyncClient.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/AsyncSyncClient.java
@@ -19,7 +19,7 @@ public class AsyncSyncClient {
     private final ServiceClient serviceClient;
 
     private final List<ConvenienceMethod> convenienceMethods;
-    private final String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
 
     // There is also reference from Client to ClientBuilder via "@ServiceClient(builder = ClientBuilder.class)"
     // clientBuilder can be null, if builder is disabled via "disable-client-builder"
@@ -32,11 +32,15 @@ public class AsyncSyncClient {
         this.methodGroupClient = methodGroupClient;
         this.serviceClient = serviceClient;
         this.convenienceMethods = convenienceMethods;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
     }
 
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/AsyncSyncClient.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/AsyncSyncClient.java
@@ -26,17 +26,13 @@ public class AsyncSyncClient {
     private ClientBuilder clientBuilder;
 
     private AsyncSyncClient(String packageName, String className, MethodGroupClient methodGroupClient,
-        ServiceClient serviceClient, List<ConvenienceMethod> convenienceMethods, String crossLanguageDefinitionId) {
+        ServiceClient serviceClient, List<ConvenienceMethod> convenienceMethods, ApiMetadata apiMetadata) {
         this.packageName = packageName;
         this.className = className;
         this.methodGroupClient = methodGroupClient;
         this.serviceClient = serviceClient;
         this.convenienceMethods = convenienceMethods;
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
-    }
-
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
+        this.apiMetadata = apiMetadata;
     }
 
     public ApiMetadata getApiMetadata() {
@@ -129,7 +125,7 @@ public class AsyncSyncClient {
         private ServiceClient serviceClient;
 
         private List<ConvenienceMethod> convenienceMethods = List.of();
-        private String crossLanguageDefinitionId;
+        private ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
 
         /**
          * Sets the class name.
@@ -186,8 +182,8 @@ public class AsyncSyncClient {
             return this;
         }
 
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
@@ -198,7 +194,7 @@ public class AsyncSyncClient {
          */
         public AsyncSyncClient build() {
             return new AsyncSyncClient(packageName, className, methodGroupClient, serviceClient, convenienceMethods,
-                crossLanguageDefinitionId);
+                apiMetadata);
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/Client.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/Client.java
@@ -91,7 +91,7 @@ public class Client {
         List<ServiceClient> serviceClients, ModuleInfo moduleInfo, List<AsyncSyncClient> syncClients,
         List<AsyncSyncClient> asyncClients, List<ClientBuilder> clientBuilders, List<ProtocolExample> protocolExamples,
         List<LiveTests> liveTests, List<UnionModel> unionModels, List<ClientMethodExample> clientMethodExamples,
-        String crossLanguageDefinitionId, GraalVmConfig graalVmConfig) {
+        ApiMetadata apiMetadata, GraalVmConfig graalVmConfig) {
         this.clientName = clientName;
         this.clientDescription = clientDescription;
         this.enums = enums;
@@ -111,12 +111,8 @@ public class Client {
         this.liveTests = liveTests;
         this.unionModels = unionModels;
         this.clientMethodExamples = clientMethodExamples;
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+        this.apiMetadata = apiMetadata;
         this.graalVmConfig = graalVmConfig;
-    }
-
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
     }
 
     public ApiMetadata getApiMetadata() {
@@ -231,10 +227,10 @@ public class Client {
         private List<UnionModel> unionModels = List.of();
         private List<ClientMethodExample> clientMethodExamples = List.of();
         private GraalVmConfig graalVmConfig;
-        private String crossLanguageDefinitionId;
+        private ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
 
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
@@ -447,8 +443,8 @@ public class Client {
             }
             return new Client(clientName, clientDescription, enums, exceptions, xmlSequenceWrappers, responseModels,
                 models, packageInfos, manager, serviceClient, serviceClients, moduleInfo, syncClients, asyncClients,
-                clientBuilders, protocolExamples, liveTests, unionModels, clientMethodExamples,
-                crossLanguageDefinitionId, graalVmConfig);
+                clientBuilders, protocolExamples, liveTests, unionModels, clientMethodExamples, apiMetadata,
+                graalVmConfig);
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/Client.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/Client.java
@@ -9,7 +9,7 @@ import java.util.List;
  * A container for the types associated for accessing a specific service.
  */
 public class Client {
-    private final String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
 
     /**
      * The name of this service client.
@@ -111,12 +111,16 @@ public class Client {
         this.liveTests = liveTests;
         this.unionModels = unionModels;
         this.clientMethodExamples = clientMethodExamples;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
         this.graalVmConfig = graalVmConfig;
     }
 
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     public final String getClientName() {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientBuilder.java
@@ -22,7 +22,7 @@ public class ClientBuilder {
     private final List<AsyncSyncClient> syncClients;
     private final List<AsyncSyncClient> asyncClients;
     private final List<ClientBuilderTrait> builderTraits = new ArrayList<>();
-    private String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
 
     public ClientBuilder(String packageName, String className, ServiceClient serviceClient,
         List<AsyncSyncClient> syncClients, List<AsyncSyncClient> asyncClients, String crossLanguageDefinitionId) {
@@ -31,7 +31,7 @@ public class ClientBuilder {
         this.serviceClient = Objects.requireNonNull(serviceClient);
         this.syncClients = Objects.requireNonNull(syncClients);
         this.asyncClients = Objects.requireNonNull(asyncClients);
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
     }
 
     public String getPackageName() {
@@ -81,6 +81,10 @@ public class ClientBuilder {
     }
 
     public String getCrossLanguageDefinitionId() {
-        return this.crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientBuilder.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientBuilder.java
@@ -25,13 +25,13 @@ public class ClientBuilder {
     private final ApiMetadata apiMetadata;
 
     public ClientBuilder(String packageName, String className, ServiceClient serviceClient,
-        List<AsyncSyncClient> syncClients, List<AsyncSyncClient> asyncClients, String crossLanguageDefinitionId) {
+        List<AsyncSyncClient> syncClients, List<AsyncSyncClient> asyncClients, ApiMetadata apiMetadata) {
         this.packageName = Objects.requireNonNull(packageName);
         this.className = Objects.requireNonNull(className);
         this.serviceClient = Objects.requireNonNull(serviceClient);
         this.syncClients = Objects.requireNonNull(syncClients);
         this.asyncClients = Objects.requireNonNull(asyncClients);
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+        this.apiMetadata = apiMetadata;
     }
 
     public String getPackageName() {
@@ -78,10 +78,6 @@ public class ClientBuilder {
 
     public List<ClientBuilderTrait> getBuilderTraits() {
         return this.builderTraits;
-    }
-
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
     }
 
     public ApiMetadata getApiMetadata() {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
@@ -29,7 +29,7 @@ public class ClientMethod {
         "StatusCheckPollingStrategy", "SyncDefaultPollingStrategy", "SyncChainedPollingStrategy",
         "SyncOperationResourcePollingStrategy", "SyncLocationPollingStrategy", "SyncStatusCheckPollingStrategy");
 
-    private final String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
     /**
      * The description of this ClientMethod.
      */
@@ -138,7 +138,7 @@ public class ClientMethod {
             .methodPollingDetails(methodPollingDetails)
             .methodDocumentation(externalDocumentation)
             .operationInstrumentationInfo(instrumentationInfo)
-            .setCrossLanguageDefinitionId(crossLanguageDefinitionId)
+            .apiMetadata(apiMetadata)
             .hasWithContextOverload(hasWithContextOverload)
             .overloadedClientMethod(overloadedClientMethod);
     }
@@ -172,9 +172,9 @@ public class ClientMethod {
         String groupedParameterTypeName, MethodPageDetails methodPageDetails,
         ParameterTransformations parameterTransformations, JavaVisibility methodVisibility,
         JavaVisibility methodVisibilityInWrapperClient, ImplementationDetails implementationDetails,
-        MethodPollingDetails methodPollingDetails, ExternalDocumentation externalDocumentation,
-        String crossLanguageDefinitionId, boolean hasWithContextOverload,
-        OperationInstrumentationInfo instrumentationInfo, ClientMethod overloadedClientMethod) {
+        MethodPollingDetails methodPollingDetails, ExternalDocumentation externalDocumentation, ApiMetadata apiMetadata,
+        boolean hasWithContextOverload, OperationInstrumentationInfo instrumentationInfo,
+        ClientMethod overloadedClientMethod) {
         this.description = description;
         this.returnValue = returnValue;
         this.name = name;
@@ -204,7 +204,7 @@ public class ClientMethod {
         this.methodPollingDetails = methodPollingDetails;
         this.externalDocumentation = externalDocumentation;
         this.methodVisibilityInWrapperClient = methodVisibilityInWrapperClient;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = apiMetadata;
         this.hasWithContextOverload = hasWithContextOverload;
         if (isPageStreamingType() && methodPageDetails != null) {
             this.parametersDeclaration = getMethodInputParameters().stream()
@@ -249,7 +249,11 @@ public class ClientMethod {
     }
 
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     public final String getDescription() {
@@ -636,14 +640,24 @@ public class ClientMethod {
         protected ImplementationDetails implementationDetails;
         protected MethodPollingDetails methodPollingDetails;
         protected ExternalDocumentation externalDocumentation;
-        protected String crossLanguageDefinitionId;
+        protected ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
         protected boolean hasWithContextOverload;
         protected boolean hidePageableParams;
         protected OperationInstrumentationInfo instrumentationInfo;
         protected ClientMethod overloadedClientMethod;
 
         public Builder setCrossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+            this.apiMetadata = apiMetadata.newBuilder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+            return this;
+        }
+
+        public Builder devMessage(String devMessage) {
+            this.apiMetadata = apiMetadata.newBuilder().devMessage(devMessage).build();
+            return this;
+        }
+
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
@@ -910,7 +924,7 @@ public class ClientMethod {
                 clientReference, CollectionUtil.toImmutableList(requiredNullableParameterExpressions),
                 isGroupedParameterRequired, groupedParameterTypeName, methodPageDetails, parameterTransformations,
                 methodVisibility, methodVisibilityInWrapperClient, implementationDetails, methodPollingDetails,
-                externalDocumentation, crossLanguageDefinitionId, hasWithContextOverload, instrumentationInfo,
+                externalDocumentation, apiMetadata, hasWithContextOverload, instrumentationInfo,
                 overloadedClientMethod);
         }
     }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
@@ -138,7 +138,8 @@ public class ClientMethod {
             .methodPollingDetails(methodPollingDetails)
             .methodDocumentation(externalDocumentation)
             .operationInstrumentationInfo(instrumentationInfo)
-            .apiMetadata(apiMetadata)
+            .crossLanguageDefinitionId(apiMetadata.getCrossLanguageDefinitionId())
+            .devMessage(apiMetadata.getDevMessage())
             .hasWithContextOverload(hasWithContextOverload)
             .overloadedClientMethod(overloadedClientMethod);
     }
@@ -653,11 +654,6 @@ public class ClientMethod {
 
         public Builder devMessage(String devMessage) {
             this.apiMetadata = apiMetadata.newBuilder().devMessage(devMessage).build();
-            return this;
-        }
-
-        public Builder apiMetadata(ApiMetadata apiMetadata) {
-            this.apiMetadata = apiMetadata;
             return this;
         }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
@@ -646,7 +646,7 @@ public class ClientMethod {
         protected OperationInstrumentationInfo instrumentationInfo;
         protected ClientMethod overloadedClientMethod;
 
-        public Builder setCrossLanguageDefinitionId(String crossLanguageDefinitionId) {
+        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
             this.apiMetadata = apiMetadata.newBuilder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
             return this;
         }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientMethod.java
@@ -138,8 +138,7 @@ public class ClientMethod {
             .methodPollingDetails(methodPollingDetails)
             .methodDocumentation(externalDocumentation)
             .operationInstrumentationInfo(instrumentationInfo)
-            .crossLanguageDefinitionId(apiMetadata.getCrossLanguageDefinitionId())
-            .devMessage(apiMetadata.getDevMessage())
+            .apiMetadata(apiMetadata)
             .hasWithContextOverload(hasWithContextOverload)
             .overloadedClientMethod(overloadedClientMethod);
     }
@@ -247,10 +246,6 @@ public class ClientMethod {
         return Objects.hash(returnValue.getType(), name, getParametersDeclaration(), onlyRequiredParameters, type,
             requiredNullableParameterExpressions, isGroupedParameterRequired, groupedParameterTypeName,
             parameterTransformations, methodVisibility);
-    }
-
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
     }
 
     public ApiMetadata getApiMetadata() {
@@ -647,13 +642,8 @@ public class ClientMethod {
         protected OperationInstrumentationInfo instrumentationInfo;
         protected ClientMethod overloadedClientMethod;
 
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.apiMetadata = apiMetadata.newBuilder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
-            return this;
-        }
-
-        public Builder devMessage(String devMessage) {
-            this.apiMetadata = apiMetadata.newBuilder().devMessage(devMessage).build();
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientModel.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientModel.java
@@ -170,7 +170,7 @@ public class ClientModel {
      * @param stronglyTypedHeader Whether this model is a strongly-typed HTTP headers class.
      * @param implementationDetails The implementation details for the model.
      * @param usedInXml Whether the model is used in XML serialization.
-     * @param crossLanguageDefinitionId The cross language definition id for the model.
+     * @param apiMetadata The API metadata for the model.
      */
     protected ClientModel(String packageKeyword, String name, List<String> imports, String description,
         boolean isPolymorphic, ClientModelProperty polymorphicDiscriminator, String polymorphicDiscriminatorName,
@@ -178,7 +178,7 @@ public class ClientModel {
         String xmlName, String xmlNamespace, List<ClientModelProperty> properties,
         List<ClientModelPropertyReference> propertyReferences, IType modelType, boolean stronglyTypedHeader,
         ImplementationDetails implementationDetails, boolean usedInXml, Set<String> serializationFormats,
-        String crossLanguageDefinitionId) {
+        ApiMetadata apiMetadata) {
         this.packageName = packageKeyword;
         this.name = name;
         this.fullName = packageName + "." + name;
@@ -201,7 +201,7 @@ public class ClientModel {
         this.stronglyTypedHeader = stronglyTypedHeader;
         this.implementationDetails = implementationDetails;
         this.usedInXml = usedInXml;
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+        this.apiMetadata = apiMetadata;
         this.serializationFormats = serializationFormats;
     }
 
@@ -210,10 +210,6 @@ public class ClientModel {
      *
      * @return the cross language definition id for the model.
      */
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
-    }
-
     public ApiMetadata getApiMetadata() {
         return apiMetadata;
     }
@@ -646,7 +642,7 @@ public class ClientModel {
         private boolean stronglyTypedHeader;
         private ImplementationDetails implementationDetails;
         private boolean usedInXml;
-        private String crossLanguageDefinitionId;
+        private ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
         private Set<String> serializationFormats = Set.of();
 
         /**
@@ -853,13 +849,13 @@ public class ClientModel {
         }
 
         /**
-         * Sets the cross language definition id for the model.
+         * Sets the API metadata for the model.
          *
-         * @param crossLanguageDefinitionId the cross language definition id for the model.
+         * @param apiMetadata the API metadata for the model.
          * @return the Builder itself
          */
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
@@ -883,7 +879,7 @@ public class ClientModel {
             return new ClientModel(packageName, name, imports, description, isPolymorphic, polymorphicDiscriminator,
                 polymorphicDiscriminatorName, serializedName, needsFlatten, parentModelName, derivedModels, xmlName,
                 xmlNamespace, properties, propertyReferences, modelType, stronglyTypedHeader, implementationDetails,
-                usedInXml, serializationFormats, crossLanguageDefinitionId);
+                usedInXml, serializationFormats, apiMetadata);
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientModel.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientModel.java
@@ -125,7 +125,7 @@ public class ClientModel {
     /**
      * The cross language definition id for the model.
      */
-    private final String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
 
     // Set of non-final properties that are set on access.
     // This pattern is used as when the ClientModel is initialized the ModelMapper may not have mapped all models
@@ -201,7 +201,7 @@ public class ClientModel {
         this.stronglyTypedHeader = stronglyTypedHeader;
         this.implementationDetails = implementationDetails;
         this.usedInXml = usedInXml;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
         this.serializationFormats = serializationFormats;
     }
 
@@ -211,7 +211,11 @@ public class ClientModel {
      * @return the cross language definition id for the model.
      */
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientResponse.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientResponse.java
@@ -15,13 +15,13 @@ public final class ClientResponse {
     private final ApiMetadata apiMetadata;
 
     private ClientResponse(String name, String packageKeyword, String description, IType headersType, IType bodyType,
-        String crossLanguageDefinitionId) {
+        ApiMetadata apiMetadata) {
         this.name = name;
         packageName = packageKeyword;
         this.description = description;
         this.headersType = headersType;
         this.bodyType = bodyType;
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+        this.apiMetadata = apiMetadata;
     }
 
     public String getName() {
@@ -44,10 +44,6 @@ public final class ClientResponse {
         return bodyType;
     }
 
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
-    }
-
     public ApiMetadata getApiMetadata() {
         return apiMetadata;
     }
@@ -59,7 +55,7 @@ public final class ClientResponse {
         private IType headersType;
         private IType bodyType;
 
-        private String crossLanguageDefinitionId;
+        private ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
 
         public Builder name(String name) {
             this.name = name;
@@ -86,13 +82,13 @@ public final class ClientResponse {
             return this;
         }
 
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
         public ClientResponse build() {
-            return new ClientResponse(name, packageName, description, headersType, bodyType, crossLanguageDefinitionId);
+            return new ClientResponse(name, packageName, description, headersType, bodyType, apiMetadata);
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientResponse.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ClientResponse.java
@@ -12,7 +12,7 @@ public final class ClientResponse {
     private String description;
     private IType headersType;
     private IType bodyType;
-    private String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
 
     private ClientResponse(String name, String packageKeyword, String description, IType headersType, IType bodyType,
         String crossLanguageDefinitionId) {
@@ -21,7 +21,7 @@ public final class ClientResponse {
         this.description = description;
         this.headersType = headersType;
         this.bodyType = bodyType;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
     }
 
     public String getName() {
@@ -45,7 +45,11 @@ public final class ClientResponse {
     }
 
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     public static class Builder {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/EnumType.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/EnumType.java
@@ -34,7 +34,7 @@ public class EnumType implements IType, ConvertToJsonTypeTrait, ConvertFromJsonT
 
     private final ImplementationDetails implementationDetails;
 
-    private String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
     private final String fromMethodName;
     private final String toMethodName;
 
@@ -58,13 +58,17 @@ public class EnumType implements IType, ConvertToJsonTypeTrait, ConvertFromJsonT
         this.values = values;
         this.elementType = elementType;
         this.implementationDetails = implementationDetails;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
         this.fromMethodName = fromMethodName;
         this.toMethodName = toMethodName;
     }
 
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     public final String getName() {

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/EnumType.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/EnumType.java
@@ -50,7 +50,7 @@ public class EnumType implements IType, ConvertToJsonTypeTrait, ConvertFromJsonT
      */
     private EnumType(String packageKeyword, String name, String description, boolean expandable,
         List<ClientEnumValue> values, IType elementType, ImplementationDetails implementationDetails,
-        String crossLanguageDefinitionId, String fromMethodName, String toMethodName) {
+        ApiMetadata apiMetadata, String fromMethodName, String toMethodName) {
         this.name = name;
         this.packageName = packageKeyword;
         this.description = description;
@@ -58,13 +58,9 @@ public class EnumType implements IType, ConvertToJsonTypeTrait, ConvertFromJsonT
         this.values = values;
         this.elementType = elementType;
         this.implementationDetails = implementationDetails;
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+        this.apiMetadata = apiMetadata;
         this.fromMethodName = fromMethodName;
         this.toMethodName = toMethodName;
-    }
-
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
     }
 
     public ApiMetadata getApiMetadata() {
@@ -252,7 +248,7 @@ public class EnumType implements IType, ConvertToJsonTypeTrait, ConvertFromJsonT
 
         private ImplementationDetails implementationDetails;
 
-        private String crossLanguageDefinitionId;
+        private ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
         private String fromMethodName;
         private String toMethodName;
 
@@ -335,8 +331,8 @@ public class EnumType implements IType, ConvertToJsonTypeTrait, ConvertFromJsonT
             return this;
         }
 
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
@@ -355,7 +351,7 @@ public class EnumType implements IType, ConvertToJsonTypeTrait, ConvertFromJsonT
          */
         public EnumType build() {
             return new EnumType(packageName, name, description, expandable, values, elementType, implementationDetails,
-                crossLanguageDefinitionId, fromMethodName, toMethodName);
+                apiMetadata, fromMethodName, toMethodName);
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ImplementationDetails.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ImplementationDetails.java
@@ -164,8 +164,6 @@ public class ImplementationDetails {
 
     private final Set<Usage> usages;
 
-    private final String comment;
-
     /**
      * Usually on a method, that it is only required in implementation class (FooClientImpl), but not in public class
      * (FooClient).
@@ -231,29 +229,18 @@ public class ImplementationDetails {
     }
 
     /**
-     * Get the API comment.
-     *
-     * @return API comment.
-     */
-    public String getComment() {
-        return comment;
-    }
-
-    /**
      * Creates an instance of ImplementationDetails class.
      *
      * @param implementationOnly whether only required in implementation class.
      * @param usages usage of the model or method.
-     * @param comment API comment.
      */
-    protected ImplementationDetails(boolean implementationOnly, Set<Usage> usages, String comment) {
+    protected ImplementationDetails(boolean implementationOnly, Set<Usage> usages) {
         this.implementationOnly = implementationOnly;
         this.usages = usages;
-        this.comment = comment;
     }
 
     public Builder newBuilder() {
-        return new Builder().implementationOnly(implementationOnly).usages(usages).comment(comment);
+        return new Builder().implementationOnly(implementationOnly).usages(usages);
     }
 
     /**
@@ -262,7 +249,6 @@ public class ImplementationDetails {
     public static final class Builder {
         private boolean implementationOnly = false;
         private Set<Usage> usages = new LinkedHashSet<>();
-        private String comment;
 
         /**
          * Creates an instance of Builder class.
@@ -293,23 +279,12 @@ public class ImplementationDetails {
         }
 
         /**
-         * Sets API comment.
-         *
-         * @param comment API comment.
-         * @return the Builder itself.
-         */
-        public Builder comment(String comment) {
-            this.comment = comment;
-            return this;
-        }
-
-        /**
          * Builds an instance of ImplementationDetails class.
          *
          * @return the ImplementationDetails instance.
          */
         public ImplementationDetails build() {
-            return new ImplementationDetails(implementationOnly, CollectionUtil.toImmutableSet(usages), comment);
+            return new ImplementationDetails(implementationOnly, CollectionUtil.toImmutableSet(usages));
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/MethodGroupClient.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/MethodGroupClient.java
@@ -58,7 +58,7 @@ public class MethodGroupClient {
 
     private final List<ServiceClientProperty> properties;
 
-    private final String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
 
     /**
      * Create a new MethodGroupClient with the provided properties.
@@ -91,7 +91,7 @@ public class MethodGroupClient {
             ? classBaseName
             : (className.endsWith("Impl") ? className.substring(0, className.length() - 4) : className);
         this.properties = properties;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
     }
 
     public final String getPackage() {
@@ -143,7 +143,11 @@ public class MethodGroupClient {
     }
 
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/MethodGroupClient.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/MethodGroupClient.java
@@ -76,7 +76,7 @@ public class MethodGroupClient {
     protected MethodGroupClient(String packageKeyword, String className, String interfaceName,
         List<String> implementedInterfaces, Proxy proxy, String serviceClientName, String variableType,
         String variableName, List<ClientMethod> clientMethods, List<IType> supportedInterfaces, String classBaseName,
-        List<ServiceClientProperty> properties, String crossLanguageDefinitionId) {
+        List<ServiceClientProperty> properties, ApiMetadata apiMetadata) {
         packageName = packageKeyword;
         this.className = className;
         this.interfaceName = interfaceName;
@@ -91,7 +91,7 @@ public class MethodGroupClient {
             ? classBaseName
             : (className.endsWith("Impl") ? className.substring(0, className.length() - 4) : className);
         this.properties = properties;
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+        this.apiMetadata = apiMetadata;
     }
 
     public final String getPackage() {
@@ -140,10 +140,6 @@ public class MethodGroupClient {
 
     public List<ServiceClientProperty> getProperties() {
         return properties;
-    }
-
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
     }
 
     public ApiMetadata getApiMetadata() {
@@ -205,7 +201,7 @@ public class MethodGroupClient {
         protected List<IType> supportedInterfaces;
         protected String classBaseName;
         private List<ServiceClientProperty> properties;
-        private String crossLanguageDefinitionId;
+        private ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
 
         /**
          * Sets the name of the package.
@@ -339,21 +335,15 @@ public class MethodGroupClient {
             return this;
         }
 
-        /**
-         * Sets crossLanguageDefinitionId.
-         *
-         * @param crossLanguageDefinitionId the crossLanguageDefinitionId.
-         * @return the Builder itself
-         */
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
         public MethodGroupClient build() {
             return new MethodGroupClient(packageName, className, interfaceName, implementedInterfaces, proxy,
                 serviceClientName, variableType, variableName, clientMethods, supportedInterfaces, classBaseName,
-                properties, crossLanguageDefinitionId);
+                properties, apiMetadata);
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ServiceClient.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ServiceClient.java
@@ -110,7 +110,7 @@ public class ServiceClient {
         ClientMethodParameter defaultPollIntervalParameter, String defaultCredentialScopes, boolean builderDisabled,
         String builderPackageName, SecurityInfo securityInfo, String baseUrl,
         PipelinePolicyDetails pipelinePolicyDetails, List<ClientAccessorMethod> clientAccessorMethods,
-        String crossLanguageDefinitionId) {
+        ApiMetadata apiMetadata) {
         this.packageName = packageName;
         this.className = className;
         this.interfaceName = interfaceName;
@@ -132,7 +132,7 @@ public class ServiceClient {
         this.baseUrl = baseUrl;
         this.pipelinePolicyDetails = pipelinePolicyDetails;
         this.clientAccessorMethods = clientAccessorMethods;
-        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
+        this.apiMetadata = apiMetadata;
     }
 
     public final String getPackage() {
@@ -274,10 +274,6 @@ public class ServiceClient {
         this.syncClient = syncClient;
     }
 
-    public String getCrossLanguageDefinitionId() {
-        return apiMetadata.getCrossLanguageDefinitionId();
-    }
-
     public ApiMetadata getApiMetadata() {
         return apiMetadata;
     }
@@ -396,7 +392,7 @@ public class ServiceClient {
         protected String baseUrl;
         protected PipelinePolicyDetails pipelinePolicyDetails;
         protected List<ClientAccessorMethod> clientAccessorMethods = List.of();
-        private String crossLanguageDefinitionId;
+        private ApiMetadata apiMetadata = new ApiMetadata.Builder().build();
 
         /**
          * Sets the package that this service client belongs to.
@@ -612,8 +608,8 @@ public class ServiceClient {
             return this;
         }
 
-        public Builder crossLanguageDefinitionId(String crossLanguageDefinitionId) {
-            this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        public Builder apiMetadata(ApiMetadata apiMetadata) {
+            this.apiMetadata = apiMetadata;
             return this;
         }
 
@@ -621,8 +617,7 @@ public class ServiceClient {
             return new ServiceClient(packageName, className, interfaceName, proxy, methodGroupClients, properties,
                 constructors, clientMethods, azureEnvironmentParameter, tokenCredentialParameter, httpPipelineParameter,
                 serializerAdapterParameter, defaultPollIntervalParameter, defaultCredentialScopes, builderDisabled,
-                builderPackageName, securityInfo, baseUrl, pipelinePolicyDetails, clientAccessorMethods,
-                crossLanguageDefinitionId);
+                builderPackageName, securityInfo, baseUrl, pipelinePolicyDetails, clientAccessorMethods, apiMetadata);
         }
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ServiceClient.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ServiceClient.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * The details of a ServiceClient.
  */
 public class ServiceClient {
-    private final String crossLanguageDefinitionId;
+    private final ApiMetadata apiMetadata;
     /**
      * The package that this service client belongs to.
      */
@@ -132,7 +132,7 @@ public class ServiceClient {
         this.baseUrl = baseUrl;
         this.pipelinePolicyDetails = pipelinePolicyDetails;
         this.clientAccessorMethods = clientAccessorMethods;
-        this.crossLanguageDefinitionId = crossLanguageDefinitionId;
+        this.apiMetadata = new ApiMetadata.Builder().crossLanguageDefinitionId(crossLanguageDefinitionId).build();
     }
 
     public final String getPackage() {
@@ -275,7 +275,11 @@ public class ServiceClient {
     }
 
     public String getCrossLanguageDefinitionId() {
-        return crossLanguageDefinitionId;
+        return apiMetadata.getCrossLanguageDefinitionId();
+    }
+
+    public ApiMetadata getApiMetadata() {
+        return apiMetadata;
     }
 
     /**

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/WrapperClientMethodTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/WrapperClientMethodTemplate.java
@@ -70,9 +70,8 @@ public class WrapperClientMethodTemplate extends ClientMethodTemplateBase {
         Consumer<JavaBlock> method = function -> {
 
             // API comment
-            if (clientMethod.getImplementationDetails() != null
-                && !CoreUtils.isNullOrEmpty(clientMethod.getImplementationDetails().getComment())) {
-                function.line("// " + clientMethod.getImplementationDetails().getComment());
+            if (!CoreUtils.isNullOrEmpty(clientMethod.getApiMetadata().getDevMessage())) {
+                function.line("// " + clientMethod.getApiMetadata().getDevMessage());
             }
 
             boolean shouldReturn = true;

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ClientModelUtil.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/util/ClientModelUtil.java
@@ -13,6 +13,7 @@ import com.microsoft.typespec.http.client.generator.core.extension.model.codemod
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Parameter;
 import com.microsoft.typespec.http.client.generator.core.extension.plugin.JavaSettings;
 import com.microsoft.typespec.http.client.generator.core.mapper.Mappers;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ApiMetadata;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.AsyncSyncClient;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClassType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientMethod;
@@ -92,9 +93,12 @@ public class ClientModelUtil {
             // 1. ServiceClient has operations
             // 2. ServiceClient has sub clients
 
-            AsyncSyncClient.Builder builder = new AsyncSyncClient.Builder().packageName(packageName)
-                .serviceClient(serviceClient)
-                .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(client));
+            AsyncSyncClient.Builder builder
+                = new AsyncSyncClient.Builder().packageName(packageName)
+                    .serviceClient(serviceClient)
+                    .apiMetadata(new ApiMetadata.Builder()
+                        .crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(client))
+                        .build());
 
             final List<ConvenienceMethod> convenienceMethods = client.getOperationGroups()
                 .stream()
@@ -129,7 +133,7 @@ public class ClientModelUtil {
             AsyncSyncClient.Builder builder = new AsyncSyncClient.Builder().packageName(packageName)
                 .serviceClient(serviceClient)
                 .methodGroupClient(methodGroupClient)
-                .crossLanguageDefinitionId(methodGroupClient.getCrossLanguageDefinitionId());
+                .apiMetadata(methodGroupClient.getApiMetadata());
 
             final List<ConvenienceMethod> convenienceMethods = client.getOperationGroups()
                 .stream()

--- a/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadataTests.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadataTests.java
@@ -36,7 +36,7 @@ public class ApiMetadataTests {
             .description("Gets a widget.")
             .parameters(List.of())
             .returnValue(new ReturnValue("the widget", ClassType.STRING))
-            .setCrossLanguageDefinitionId("Example.Widget.get")
+            .crossLanguageDefinitionId("Example.Widget.get")
             .devMessage("Convenience API is not generated.")
             .build();
 

--- a/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadataTests.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadataTests.java
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.typespec.http.client.generator.core.model.clientmodel;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ApiMetadataTests {
+    @Test
+    public void storesApiMetadata() {
+        ApiMetadata metadata = new ApiMetadata.Builder().crossLanguageDefinitionId("Example.Widget.get")
+            .devMessage("Convenience API is not generated.")
+            .build();
+
+        Assertions.assertEquals("Example.Widget.get", metadata.getCrossLanguageDefinitionId());
+        Assertions.assertEquals("Convenience API is not generated.", metadata.getDevMessage());
+    }
+
+    @Test
+    public void newBuilderPreservesExistingValues() {
+        ApiMetadata metadata = new ApiMetadata.Builder().crossLanguageDefinitionId("Example.Widget.get")
+            .devMessage("Original message")
+            .build();
+
+        ApiMetadata updated = metadata.newBuilder().devMessage("Updated message").build();
+
+        Assertions.assertEquals("Example.Widget.get", updated.getCrossLanguageDefinitionId());
+        Assertions.assertEquals("Updated message", updated.getDevMessage());
+    }
+
+    @Test
+    public void clientMethodStoresApiMetadata() {
+        ClientMethod method = new ClientMethod.Builder().name("get")
+            .description("Gets a widget.")
+            .parameters(List.of())
+            .returnValue(new ReturnValue("the widget", ClassType.STRING))
+            .setCrossLanguageDefinitionId("Example.Widget.get")
+            .devMessage("Convenience API is not generated.")
+            .build();
+
+        Assertions.assertEquals("Example.Widget.get", method.getApiMetadata().getCrossLanguageDefinitionId());
+        Assertions.assertEquals("Convenience API is not generated.", method.getApiMetadata().getDevMessage());
+    }
+}

--- a/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadataTests.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/test/java/com/microsoft/typespec/http/client/generator/core/model/clientmodel/ApiMetadataTests.java
@@ -36,8 +36,9 @@ public class ApiMetadataTests {
             .description("Gets a widget.")
             .parameters(List.of())
             .returnValue(new ReturnValue("the widget", ClassType.STRING))
-            .crossLanguageDefinitionId("Example.Widget.get")
-            .devMessage("Convenience API is not generated.")
+            .apiMetadata(new ApiMetadata.Builder().crossLanguageDefinitionId("Example.Widget.get")
+                .devMessage("Convenience API is not generated.")
+                .build())
             .build();
 
         Assertions.assertEquals("Example.Widget.get", method.getApiMetadata().getCrossLanguageDefinitionId());

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/TypeSpecPlugin.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/TypeSpecPlugin.java
@@ -374,17 +374,17 @@ public class TypeSpecPlugin extends Javagen {
         client.getAsyncClients()
             .forEach(asyncClient -> crossLanguageDefinitionsMap.put(
                 asyncClient.getPackageName() + "." + asyncClient.getClassName(),
-                asyncClient.getCrossLanguageDefinitionId()));
+                asyncClient.getApiMetadata().getCrossLanguageDefinitionId()));
 
         client.getSyncClients()
             .forEach(syncClient -> crossLanguageDefinitionsMap.put(
                 syncClient.getPackageName() + "." + syncClient.getClassName(),
-                syncClient.getCrossLanguageDefinitionId()));
+                syncClient.getApiMetadata().getCrossLanguageDefinitionId()));
 
         client.getClientBuilders()
             .forEach(clientBuilder -> crossLanguageDefinitionsMap.put(
                 clientBuilder.getPackageName() + "." + clientBuilder.getClassName(),
-                clientBuilder.getCrossLanguageDefinitionId()));
+                clientBuilder.getApiMetadata().getCrossLanguageDefinitionId()));
 
         // Method
         for (AsyncSyncClient asyncClient : client.getAsyncClients()) {
@@ -395,13 +395,13 @@ public class TypeSpecPlugin extends Javagen {
                     .filter(method -> !method.getName().endsWith("Async"))
                     .forEach(method -> crossLanguageDefinitionsMap.put(
                         asyncClient.getPackageName() + "." + asyncClient.getClassName() + "." + method.getName(),
-                        method.getCrossLanguageDefinitionId()));
+                        method.getApiMetadata().getCrossLanguageDefinitionId()));
 
                 if (!convenienceMethod.getProtocolMethod().getName().endsWith("Async")) {
                     crossLanguageDefinitionsMap.put(
                         asyncClient.getPackageName() + "." + asyncClient.getClassName() + "."
                             + convenienceMethod.getProtocolMethod().getName(),
-                        convenienceMethod.getProtocolMethod().getCrossLanguageDefinitionId());
+                        convenienceMethod.getProtocolMethod().getApiMetadata().getCrossLanguageDefinitionId());
                 }
             }
         }
@@ -414,13 +414,13 @@ public class TypeSpecPlugin extends Javagen {
                     .filter(method -> !method.getName().endsWith("Async"))
                     .forEach(method -> crossLanguageDefinitionsMap.put(
                         syncClient.getPackageName() + "." + syncClient.getClassName() + "." + method.getName(),
-                        method.getCrossLanguageDefinitionId()));
+                        method.getApiMetadata().getCrossLanguageDefinitionId()));
 
                 if (!convenienceMethod.getProtocolMethod().getName().endsWith("Async")) {
                     crossLanguageDefinitionsMap.put(
                         syncClient.getPackageName() + "." + syncClient.getClassName() + "."
                             + convenienceMethod.getProtocolMethod().getName(),
-                        convenienceMethod.getProtocolMethod().getCrossLanguageDefinitionId());
+                        convenienceMethod.getProtocolMethod().getApiMetadata().getCrossLanguageDefinitionId());
                 }
             }
         }
@@ -428,13 +428,13 @@ public class TypeSpecPlugin extends Javagen {
         // Client model
         client.getModels().stream().filter(ModelUtil::isGeneratingModel).forEach(model -> {
             crossLanguageDefinitionsMap.put(model.getPackage() + "." + model.getName(),
-                model.getCrossLanguageDefinitionId());
+                model.getApiMetadata().getCrossLanguageDefinitionId());
         });
 
         // Enum
         client.getEnums().stream().filter(ModelUtil::isGeneratingModel).forEach(model -> {
             crossLanguageDefinitionsMap.put(model.getPackage() + "." + model.getName(),
-                model.getCrossLanguageDefinitionId());
+                model.getApiMetadata().getCrossLanguageDefinitionId());
         });
 
         return crossLanguageDefinitionsMap;

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/fluent/TypeSpecFluentPlugin.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/fluent/TypeSpecFluentPlugin.java
@@ -232,18 +232,18 @@ public class TypeSpecFluentPlugin extends FluentGen {
 
         // Client interface
         crossLanguageDefinitionsMap.put(interfacePackage + "." + client.getServiceClient().getInterfaceName(),
-            client.getServiceClient().getCrossLanguageDefinitionId());
+            client.getServiceClient().getApiMetadata().getCrossLanguageDefinitionId());
 
         client.getServiceClient()
             .getMethodGroupClients()
             .forEach(methodGroupClient -> crossLanguageDefinitionsMap.put(
                 interfacePackage + "." + methodGroupClient.getInterfaceName(),
-                methodGroupClient.getCrossLanguageDefinitionId()));
+                methodGroupClient.getApiMetadata().getCrossLanguageDefinitionId()));
 
         client.getClientBuilders()
             .forEach(clientBuilder -> crossLanguageDefinitionsMap.put(
                 clientBuilder.getPackageName() + "." + clientBuilder.getClassName(),
-                clientBuilder.getCrossLanguageDefinitionId()));
+                clientBuilder.getApiMetadata().getCrossLanguageDefinitionId()));
 
         // Methods
         client.getServiceClient()
@@ -252,20 +252,20 @@ public class TypeSpecFluentPlugin extends FluentGen {
                 if (method.getMethodVisibility() == JavaVisibility.Public) {
                     crossLanguageDefinitionsMap.put(
                         interfacePackage + "." + methodGroupClient.getInterfaceName() + "." + method.getName(),
-                        method.getCrossLanguageDefinitionId());
+                        method.getApiMetadata().getCrossLanguageDefinitionId());
                 }
             }));
 
         // Client model
         client.getModels().forEach(model -> {
             crossLanguageDefinitionsMap.put(model.getPackage() + "." + model.getName(),
-                model.getCrossLanguageDefinitionId());
+                model.getApiMetadata().getCrossLanguageDefinitionId());
         });
 
         // Enum
         client.getEnums().forEach(model -> {
             crossLanguageDefinitionsMap.put(model.getPackage() + "." + model.getName(),
-                model.getCrossLanguageDefinitionId());
+                model.getApiMetadata().getCrossLanguageDefinitionId());
         });
 
         return crossLanguageDefinitionsMap;

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/mapper/TypeSpecServiceClientMapper.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/mapper/TypeSpecServiceClientMapper.java
@@ -9,6 +9,7 @@ import com.microsoft.typespec.http.client.generator.core.extension.model.codemod
 import com.microsoft.typespec.http.client.generator.core.extension.model.codemodel.Parameter;
 import com.microsoft.typespec.http.client.generator.core.mapper.Mappers;
 import com.microsoft.typespec.http.client.generator.core.mapper.ServiceClientMapper;
+import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ApiMetadata;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.ClientAccessorMethod;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.EnumType;
 import com.microsoft.typespec.http.client.generator.core.model.clientmodel.IType;
@@ -86,7 +87,9 @@ public class TypeSpecServiceClientMapper extends ServiceClientMapper {
 
         processPipelinePolicyDetails(builder, client);
 
-        builder.crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(client));
+        builder.apiMetadata(
+            new ApiMetadata.Builder().crossLanguageDefinitionId(SchemaUtil.getCrossLanguageDefinitionId(client))
+                .build());
 
         List<ClientAccessorMethod> clientAccessorMethods = new ArrayList<>();
         for (Client subClient : client.getSubClients()) {


### PR DESCRIPTION
## Summary

- add a dedicated ApiMetadata model for generated API information
- centralize cross-language definition IDs and developer messages
- preserve existing generated API comments and compatibility getters

## Validation

- npm run build
- npm run format
- pnpm exec oxlint packages/http-client-java/emitter --type-aware --deny-warnings
- focused generator core tests

Fixes Azure/autorest.java#2447