### PR TITLE
fix(vscode): drop the contradictory compiler-not-found popup

### DIFF
--- a/packages/typespec-vscode/src/tsp-executable-resolver.ts
+++ b/packages/typespec-vscode/src/tsp-executable-resolver.ts
@@ -52,10 +52,26 @@ export async function resolveTypeSpecCli(
   }
 }
 
+let missingRuntimeDiagnosisReported = false;
+
+/**
+ * Whether the last {@link resolveTypeSpecServer} call already told the user, with
+ * specific guidance, that the compiler was found but no runtime is on PATH.
+ *
+ * That resolution still returns a `tsp` command as a last resort, so the spawn
+ * usually fails afterwards and the caller reports a generic "executable was not
+ * found". Since the compiler *was* found, that generic message contradicts the
+ * specific one; callers use this to keep it out of the notification area.
+ */
+export function wasMissingRuntimeDiagnosisReported(): boolean {
+  return missingRuntimeDiagnosisReported;
+}
+
 export async function resolveTypeSpecServer(
   activityId: string,
   context: ExtensionContext,
 ): Promise<Executable | undefined> {
+  missingRuntimeDiagnosisReported = false;
   const checkNodePromise = checkInstalledNode();
   const nodeOptions = process.env.TYPESPEC_SERVER_NODE_OPTIONS;
   const args = ["--stdio"];
@@ -184,6 +200,7 @@ export async function resolveTypeSpecServer(
       [],
       { showPopup: true, showOutput: true },
     );
+    missingRuntimeDiagnosisReported = true;
     telemetryClient.logOperationDetailTelemetry(activityId, {
       compilerStartType: "standalone-tsp-cli-fallback",
       error: "Neither node nor tsp is available in PATH. Compiler found but cannot be started.",

--- a/packages/typespec-vscode/src/tsp-language-client.ts
+++ b/packages/typespec-vscode/src/tsp-language-client.ts
@@ -22,7 +22,10 @@ import { TspConfigFileName } from "./const.js";
 import { sendLmChatRequest } from "./lm/language-model.js";
 import logger from "./log/logger.js";
 import telemetryClient from "./telemetry/telemetry-client.js";
-import { resolveTypeSpecServer } from "./tsp-executable-resolver.js";
+import {
+  resolveTypeSpecServer,
+  wasMissingRuntimeDiagnosisReported,
+} from "./tsp-executable-resolver.js";
 import type {
   LspClientCustomRequest_ChatComplete_Name,
   LspClientCustomRequest_ChatCompletion_Params,
@@ -211,7 +214,11 @@ export class TspLanguageClient {
             .filter((m) => m.trim() !== "")
             .join("\n"),
           [],
-          { showOutput: false, showPopup: true },
+          // The resolver may have already reported that the compiler was found but
+          // no runtime is on PATH, then handed back a `tsp` command as a last
+          // resort. Popping this up too would contradict that message ("not found"
+          // vs "found at ..."), so keep it in the output channel only.
+          { showOutput: false, showPopup: !wasMissingRuntimeDiagnosisReported() },
         );
         logger.error("Error detail", [e]);
       } else {


### PR DESCRIPTION
Fixes #11343

## The problem in plain terms

When the TypeSpec extension can't start its language server, it throws three error popups at you at once. They stack up and cover a good chunk of the screen.

Worse, two of them say opposite things. From the screenshot in the issue:

- Popup 1: "TypeSpec server executable was not found: 'tsp' is not found"
- Popup 3: "TypeSpec compiler **was found at** '/Users/.../tsp-server.js', but it cannot be started because neither 'node' nor 'tsp' is available in PATH"

So one popup says it couldn't find the compiler, and another says it found it and tells you the actual reason it won't start. Popup 3 is the correct one, and it's the only one with useful advice (this is the classic nvm/fnm/volta situation where VS Code doesn't inherit your shell's PATH).

## Why all three appear

The resolver figures out the real problem, shows popup 3, and then **still hands back a `tsp` command anyway** as a last resort, with a comment explaining that it might work in environments where the lookup fails but the shell can still find the command.

That last-resort attempt then fails with `spawn tsp ENOENT`, which produces the other two popups: one from `vscode-languageclient` itself, and the generic "was not found" one from our own start handler.

## What this changes

The generic "was not found" popup no longer appears when the resolver has already given the specific diagnosis. It still goes to the TypeSpec output channel, so nothing is lost from the logs; it just stops competing with the accurate message.

Result: two popups instead of three, and the contradiction is gone. The one you're left with is the one that actually tells you what to do.

The last-resort spawn is untouched, so anyone currently relying on it keeps working.

## Being upfront: this doesn't get you to one popup

The third popup ("client: couldn't create connection to server ... spawn tsp ENOENT") comes from `vscode-languageclient`, not from this repo. It calls `error(..., 'force')` internally, and `'force'` deliberately bypasses the `revealOutputChannelOn` setting we'd normally use to quiet it. I confirmed that in the installed library.

Getting down to a single popup needs one of two decisions that felt like yours to make rather than mine:

1. **Don't attempt the doomed spawn.** If neither runtime is on PATH, return `undefined` so the client never starts. Cleanest result, one popup. But it removes the deliberate fallback, so anyone in the "lookup fails, shell works" case would break.
2. **Override the client's `error` method** in a `LanguageClient` subclass to swallow that specific message. Keeps the fallback, but reaches into library behaviour.

Worth noting that today's code shows the scary popup *even when the fallback succeeds*, which is arguably its own small bug. Happy to follow up with either option if you tell me which direction you prefer.

## How I checked it

I couldn't reproduce the original conditions here (it needs macOS VS Code launched with a PATH that's missing node), so I want to be clear that this is verified by reading the flow plus type checking, not by watching the popups disappear.

What I did run, in `packages/typespec-vscode`:

- `tsc --noEmit`: 28 errors before my change, 28 after, and none of them in the two files I touched. The pre-existing ones are all "Cannot find module '@typespec/compiler'" from workspace packages that aren't built in my sparse checkout.
- `vitest run test/unit/task-command.test.ts`: 4 passed. I couldn't add a unit test for this path because it needs the VS Code extension host and a broken PATH; the sibling `extension.test.ts` doesn't even run without a built compiler. If there's a harness for this I missed, point me at it and I'll add one.
- Prettier: clean (run with the repo's settings; I had to drop the local `prettier-plugin-typespec` plugin since it isn't built in my checkout).

To confirm by hand: launch VS Code so that `node` isn't on its PATH (e.g. install Node via nvm and open VS Code from Finder rather than from a terminal) and open a `.tsp` file. Before, three popups; after, two, and neither claims the compiler is missing.

*An AI coding agent helped me write this. I reviewed the change, read the screenshot in the issue to identify each popup's source, and ran the checks above myself.*
