### PR TITLE
Fix doc comments that document things that don't exist in @typespec/rest

### DIFF
--- a/.chronus/changes/docs-rest-2026-8-11.md
+++ b/.chronus/changes/docs-rest-2026-8-11.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/rest"
+---
+
+Remove doc comment `@template` tags that referenced the enclosing interface, and document the remaining operation body parameters

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -110,7 +110,7 @@ Specify this operation is a collection action. (Scopped to a resource, /pets/my-
 
 | Name         | Type             | Description                                                                   |
 | ------------ | ---------------- | ----------------------------------------------------------------------------- |
-| resourceType | `Model`          | Resource marked with                                                          |
+| resourceType | `Model`          | Resource marked with `@resource`                                              |
 | name         | `valueof string` | Name of the action. If not specified, the name of the operation will be used. |
 
 #### `@copyResourceKeyParameters`
@@ -145,9 +145,9 @@ Specify that this is a CreateOrReplace operation for a given resource.
 
 ##### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 #### `@createsOrUpdatesResource`
 
@@ -163,9 +163,9 @@ Specify that this is a CreatesOrUpdate operation for a given resource.
 
 ##### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 #### `@createsResource`
 
@@ -181,9 +181,9 @@ Specify that this is a Create operation for a given resource.
 
 ##### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 #### `@deletesResource`
 
@@ -199,9 +199,9 @@ Specify that this is a Delete operation for a given resource.
 
 ##### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 #### `@listsResource`
 
@@ -217,9 +217,9 @@ Specify that this is a List operation for a given resource.
 
 ##### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 #### `@parentResource`
 
@@ -253,9 +253,9 @@ Specify that this is a Read operation for a given resource.
 
 ##### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 #### `@resource`
 
@@ -277,7 +277,7 @@ Mark this model as a resource type with a name.
 
 #### `@segment`
 
-Defines the preceding path segment for a
+Defines the preceding path segment for a `@path` parameter in auto-generated routes.
 
 ```typespec
 @TypeSpec.Rest.segment(name: valueof string)
@@ -294,6 +294,13 @@ Defines the preceding path segment for a
 | name | `valueof string` | Segment that will be inserted into the operation route before the path parameter's name field. |
 
 ##### Examples
+
+```typespec
+@autoRoute
+interface Pets {
+  get(@segment("pets") @path id: string): void; //-> route: /pets/{id}
+}
+```
 
 #### `@segmentOf`
 
@@ -327,6 +334,6 @@ Specify that this is a Update operation for a given resource.
 
 ##### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |

--- a/packages/rest/generated-defs/TypeSpec.Rest.ts
+++ b/packages/rest/generated-defs/TypeSpec.Rest.ts
@@ -25,19 +25,16 @@ export type AutoRouteDecorator = (
 ) => DecoratorValidatorCallbacks | void;
 
 /**
- * Defines the preceding path segment for a
+ * Defines the preceding path segment for a `@path` parameter in auto-generated routes.
  *
- * @path parameter in auto-generated routes.
  * @param name Segment that will be inserted into the operation route before the path parameter's name field.
  * @example
- *
- *
+ * ```typespec
  * @autoRoute
  * interface Pets {
- * get(
- * @segment ("pets")
- * @path id: string): void; //-> route: /pets/{id}
+ *   get(@segment("pets") @path id: string): void; //-> route: /pets/{id}
  * }
+ * ```
  */
 export type SegmentDecorator = (
   context: DecoratorContext,
@@ -96,10 +93,7 @@ export type ParentResourceDecorator = (
 /**
  * Specify that this is a Read operation for a given resource.
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  */
 export type ReadsResourceDecorator = (
   context: DecoratorContext,
@@ -110,10 +104,7 @@ export type ReadsResourceDecorator = (
 /**
  * Specify that this is a Create operation for a given resource.
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  */
 export type CreatesResourceDecorator = (
   context: DecoratorContext,
@@ -124,10 +115,7 @@ export type CreatesResourceDecorator = (
 /**
  * Specify that this is a CreateOrReplace operation for a given resource.
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  */
 export type CreatesOrReplacesResourceDecorator = (
   context: DecoratorContext,
@@ -138,10 +126,7 @@ export type CreatesOrReplacesResourceDecorator = (
 /**
  * Specify that this is a CreatesOrUpdate operation for a given resource.
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  */
 export type CreatesOrUpdatesResourceDecorator = (
   context: DecoratorContext,
@@ -152,10 +137,7 @@ export type CreatesOrUpdatesResourceDecorator = (
 /**
  * Specify that this is a Update operation for a given resource.
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  */
 export type UpdatesResourceDecorator = (
   context: DecoratorContext,
@@ -166,10 +148,7 @@ export type UpdatesResourceDecorator = (
 /**
  * Specify that this is a Delete operation for a given resource.
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  */
 export type DeletesResourceDecorator = (
   context: DecoratorContext,
@@ -180,10 +159,7 @@ export type DeletesResourceDecorator = (
 /**
  * Specify that this is a List operation for a given resource.
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  */
 export type ListsResourceDecorator = (
   context: DecoratorContext,
@@ -205,10 +181,7 @@ export type ActionDecorator = (
 /**
  * Specify this operation is a collection action. (Scopped to a resource, /pets/my-action)
  *
- * @param resourceType Resource marked with
- * @resource
- *
- *
+ * @param resourceType Resource marked with `@resource`
  * @param name Name of the action. If not specified, the name of the operation will be used.
  */
 export type CollectionActionDecorator = (

--- a/packages/rest/lib/resource.tsp
+++ b/packages/rest/lib/resource.tsp
@@ -65,8 +65,6 @@ model ResourceCollectionParameters<Resource extends {}> {
 interface ResourceRead<Resource extends {}, Error> {
   /**
    * Gets an instance of the resource.
-   *
-   * @template Resource The resource model.
    */
   @autoRoute
   @doc("Gets an instance of the resource.")
@@ -82,6 +80,8 @@ interface ResourceRead<Resource extends {}, Error> {
 @doc("Resource create operation completed successfully.")
 model ResourceCreatedResponse<Resource> {
   ...CreatedResponse;
+
+  /** The created resource. */
   @bodyRoot body: Resource;
 }
 
@@ -94,16 +94,17 @@ model ResourceCreatedResponse<Resource> {
 interface ResourceCreateOrReplace<Resource extends {}, Error> {
   /**
    * Creates or replaces a instance of the resource.
-   *
-   * @template Resource The resource model to create or replace.
-   * @template Error The error response.
    */
   @autoRoute
   @doc("Creates or replaces an instance of the resource.")
   @createsOrReplacesResource(Resource)
   createOrReplace(
     ...ResourceParameters<Resource>,
-    @bodyRoot resource: ResourceCreateModel<Resource>,
+
+    /** The properties of the resource to create or replace. */
+    @doc("")
+    @bodyRoot
+    resource: ResourceCreateModel<Resource>,
   ): Resource | ResourceCreatedResponse<Resource> | Error;
 }
 
@@ -125,9 +126,6 @@ model ResourceCreateOrUpdateModel<Resource extends {}>
 interface ResourceCreateOrUpdate<Resource extends {}, Error> {
   /**
    * Creates or update an instance of the resource.
-   *
-   * @template Resource The resource model to create or update.
-   * @template Error The error response.
    */
   #suppress "@typespec/http/deprecated-implicit-optionality" "for legacy behavior"
   @autoRoute
@@ -136,7 +134,11 @@ interface ResourceCreateOrUpdate<Resource extends {}, Error> {
   @patch(#{ implicitOptionality: true }) // for legacy behavior
   createOrUpdate(
     ...ResourceParameters<Resource>,
-    @bodyRoot resource: ResourceCreateOrUpdateModel<Resource>,
+
+    /** The properties of the resource to create or update. */
+    @doc("")
+    @bodyRoot
+    resource: ResourceCreateOrUpdateModel<Resource>,
   ): Resource | ResourceCreatedResponse<Resource> | Error;
 }
 
@@ -158,16 +160,17 @@ model ResourceCreateModel<Resource extends {}> is DefaultKeyVisibility<Resource,
 interface ResourceCreate<Resource extends {}, Error> {
   /**
    * Creates a new instance of the resource.
-   *
-   * @template Resource The resource model to create.
-   * @template Error The error response.
    */
   @autoRoute
   @doc("Creates a new instance of the resource.")
   @createsResource(Resource)
   create(
     ...ResourceCollectionParameters<Resource>,
-    @bodyRoot resource: ResourceCreateModel<Resource>,
+
+    /** The properties of the resource to create. */
+    @doc("")
+    @bodyRoot
+    resource: ResourceCreateModel<Resource>,
   ): Resource | ResourceCreatedResponse<Resource> | Error;
 }
 
@@ -182,9 +185,6 @@ interface ResourceCreate<Resource extends {}, Error> {
 interface ResourceUpdate<Resource extends {}, Error> {
   /**
    * Updates an existing instance of the resource.
-   *
-   * @template Resource The resource model to update.
-   * @template Error The error response.
    */
   #suppress "@typespec/http/deprecated-implicit-optionality" "for legacy behavior"
   @autoRoute
@@ -193,7 +193,11 @@ interface ResourceUpdate<Resource extends {}, Error> {
   @patch(#{ implicitOptionality: true }) // for legacy behavior
   update(
     ...ResourceParameters<Resource>,
-    @bodyRoot properties: ResourceCreateOrUpdateModel<Resource>,
+
+    /** The properties of the resource to update. */
+    @doc("")
+    @bodyRoot
+    properties: ResourceCreateOrUpdateModel<Resource>,
   ): Resource | Error;
 }
 
@@ -215,9 +219,6 @@ model ResourceDeletedResponse {
 interface ResourceDelete<Resource extends {}, Error> {
   /**
    * Deletes an existing instance of the resource.
-   *
-   * @template Resource The resource model to delete.
-   * @template Error The error response.
    */
   @autoRoute
   @doc("Deletes an existing instance of the resource.")
@@ -251,9 +252,6 @@ model CollectionWithNextLink<Resource extends {}> {
 interface ResourceList<Resource extends {}, Error> {
   /**
    * Lists all instances of the resource.
-   *
-   * @template Resource The resource model to list.
-   * @template Error The error response.
    */
   @autoRoute
   @doc("Lists all instances of the resource.")
@@ -310,9 +308,6 @@ interface ResourceOperations<Resource extends {}, Error>
 interface SingletonResourceRead<Singleton extends {}, Resource extends {}, Error> {
   /**
    * Gets the singleton resource.
-   *
-   * @template Singleton The singleton resource model.
-   * @template Resource The resource model.
    */
   @autoRoute
   @doc("Gets the singleton resource.")
@@ -333,9 +328,6 @@ interface SingletonResourceRead<Singleton extends {}, Resource extends {}, Error
 interface SingletonResourceUpdate<Singleton extends {}, Resource extends {}, Error> {
   /**
    * Updates the singleton resource.
-   *
-   * @template Singleton The singleton resource model.
-   * @template Resource The resource model.
    */
   #suppress "@typespec/http/deprecated-implicit-optionality" "for legacy behavior"
   @autoRoute
@@ -346,6 +338,8 @@ interface SingletonResourceUpdate<Singleton extends {}, Resource extends {}, Err
   update(
     ...ResourceParameters<Resource>,
 
+    /** The properties of the singleton resource to update. */
+    @doc("")
     @body
     properties: ResourceCreateOrUpdateModel<Singleton>,
   ): Singleton | Error;
@@ -374,9 +368,6 @@ interface SingletonResourceOperations<Singleton extends {}, Resource extends {},
 interface ExtensionResourceRead<Extension extends {}, Resource extends {}, Error> {
   /**
    * Gets an instance of the extension resource.
-   *
-   * @template Extension The extension resource model.
-   * @template Resource The resource model.
    */
   @autoRoute
   @doc("Gets an instance of the extension resource.")
@@ -394,9 +385,6 @@ interface ExtensionResourceRead<Extension extends {}, Resource extends {}, Error
 interface ExtensionResourceCreateOrUpdate<Extension extends {}, Resource extends {}, Error> {
   /**
    * Creates or update an instance of the extension resource.
-   *
-   * @template Extension The extension resource model.
-   * @template Resource The resource model.
    */
   #suppress "@typespec/http/deprecated-implicit-optionality" "for legacy behavior"
   @autoRoute
@@ -406,7 +394,11 @@ interface ExtensionResourceCreateOrUpdate<Extension extends {}, Resource extends
   createOrUpdate(
     ...ResourceParameters<Resource>,
     ...ResourceParameters<Extension>,
-    @bodyRoot resource: ResourceCreateOrUpdateModel<Extension>,
+
+    /** The properties of the extension resource to create or update. */
+    @doc("")
+    @bodyRoot
+    resource: ResourceCreateOrUpdateModel<Extension>,
   ): Extension | ResourceCreatedResponse<Extension> | Error;
 }
 
@@ -420,17 +412,18 @@ interface ExtensionResourceCreateOrUpdate<Extension extends {}, Resource extends
 interface ExtensionResourceCreate<Extension extends {}, Resource extends {}, Error> {
   /**
    * Creates a new instance of the extension resource.
-   *
-   * @template Extension The extension resource model.
-   * @template Resource The resource model.
    */
   @autoRoute
   @doc("Creates a new instance of the extension resource.")
   @createsResource(Extension)
-  create(...ResourceParameters<Resource>, @bodyRoot resource: ResourceCreateModel<Extension>):
-    | Extension
-    | ResourceCreatedResponse<Extension>
-    | Error;
+  create(
+    ...ResourceParameters<Resource>,
+
+    /** The properties of the extension resource to create. */
+    @doc("")
+    @bodyRoot
+    resource: ResourceCreateModel<Extension>,
+  ): Extension | ResourceCreatedResponse<Extension> | Error;
 }
 
 /**
@@ -443,9 +436,6 @@ interface ExtensionResourceCreate<Extension extends {}, Resource extends {}, Err
 interface ExtensionResourceUpdate<Extension extends {}, Resource extends {}, Error> {
   /**
    * Updates an existing instance of the extension resource.
-   *
-   * @template Extension The extension resource model.
-   * @template Resource The resource model.
    */
   #suppress "@typespec/http/deprecated-implicit-optionality" "for legacy behavior"
   @autoRoute
@@ -456,6 +446,8 @@ interface ExtensionResourceUpdate<Extension extends {}, Resource extends {}, Err
     ...ResourceParameters<Resource>,
     ...ResourceParameters<Extension>,
 
+    /** The properties of the extension resource to update. */
+    @doc("")
     @body
     properties: ResourceCreateOrUpdateModel<Extension>,
   ): Extension | Error;
@@ -471,9 +463,6 @@ interface ExtensionResourceUpdate<Extension extends {}, Resource extends {}, Err
 interface ExtensionResourceDelete<Extension extends {}, Resource extends {}, Error> {
   /**
    * Deletes an existing instance of the extension resource.
-   *
-   * @template Extension The extension resource model.
-   * @template Resource The resource model.
    */
   @autoRoute
   @doc("Deletes an existing instance of the extension resource.")
@@ -493,9 +482,6 @@ interface ExtensionResourceDelete<Extension extends {}, Resource extends {}, Err
 interface ExtensionResourceList<Extension extends {}, Resource extends {}, Error> {
   /**
    * Lists all instances of the extension resource.
-   *
-   * @template Extension The extension resource model.
-   * @template Resource The resource model.
    */
   @autoRoute
   @doc("Lists all instances of the extension resource.")

--- a/packages/rest/lib/rest-decorators.tsp
+++ b/packages/rest/lib/rest-decorators.tsp
@@ -17,15 +17,18 @@ using TypeSpec.Reflection;
 extern dec autoRoute(target: Interface | Operation);
 
 /**
- * Defines the preceding path segment for a @path parameter in auto-generated routes.
+ * Defines the preceding path segment for a `@path` parameter in auto-generated routes.
  *
  * @param name Segment that will be inserted into the operation route before the path parameter's name field.
  *
  * @example
+ *
+ * ```typespec
  * @autoRoute
  * interface Pets {
  *   get(@segment("pets") @path id: string): void; //-> route: /pets/{id}
  * }
+ * ```
  */
 extern dec segment(target: Model | ModelProperty | Operation, name: valueof string);
 
@@ -65,49 +68,49 @@ extern dec parentResource(target: Model, parent: Model);
 /**
  * Specify that this is a Read operation for a given resource.
  *
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  */
 extern dec readsResource(target: Operation, resourceType: Model);
 
 /**
  * Specify that this is a Create operation for a given resource.
  *
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  */
 extern dec createsResource(target: Operation, resourceType: Model);
 
 /**
  * Specify that this is a CreateOrReplace operation for a given resource.
  *
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  */
 extern dec createsOrReplacesResource(target: Operation, resourceType: Model);
 
 /**
  * Specify that this is a CreatesOrUpdate operation for a given resource.
  *
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  */
 extern dec createsOrUpdatesResource(target: Operation, resourceType: Model);
 
 /**
  * Specify that this is a Update operation for a given resource.
  *
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  */
 extern dec updatesResource(target: Operation, resourceType: Model);
 
 /**
  * Specify that this is a Delete operation for a given resource.
  *
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  */
 extern dec deletesResource(target: Operation, resourceType: Model);
 
 /**
  * Specify that this is a List operation for a given resource.
  *
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  */
 extern dec listsResource(target: Operation, resourceType: Model);
 
@@ -119,7 +122,7 @@ extern dec action(target: Operation, name?: valueof string);
 
 /**
  * Specify this operation is a collection action. (Scopped to a resource, /pets/my-action)
- * @param resourceType Resource marked with @resource
+ * @param resourceType Resource marked with `@resource`
  * @param name Name of the action. If not specified, the name of the operation will be used.
  */
 extern dec collectionAction(target: Operation, resourceType: Model, name?: valueof string);

--- a/website/src/content/docs/docs/libraries/rest/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/rest/reference/data-types.md
@@ -107,10 +107,10 @@ model TypeSpec.Rest.Resource.ResourceCreatedResponse<Resource>
 
 #### Properties
 
-| Name       | Type       | Description      |
-| ---------- | ---------- | ---------------- |
-| statusCode | `201`      | The status code. |
-| body       | `Resource` |                  |
+| Name       | Type       | Description           |
+| ---------- | ---------- | --------------------- |
+| statusCode | `201`      | The status code.      |
+| body       | `Resource` | The created resource. |
 
 ### `ResourceCreateModel` {#TypeSpec.Rest.Resource.ResourceCreateModel}
 

--- a/website/src/content/docs/docs/libraries/rest/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/rest/reference/decorators.md
@@ -89,7 +89,7 @@ Specify this operation is a collection action. (Scopped to a resource, /pets/my-
 
 | Name         | Type             | Description                                                                   |
 | ------------ | ---------------- | ----------------------------------------------------------------------------- |
-| resourceType | `Model`          | Resource marked with                                                          |
+| resourceType | `Model`          | Resource marked with `@resource`                                              |
 | name         | `valueof string` | Name of the action. If not specified, the name of the operation will be used. |
 
 ### `@copyResourceKeyParameters` {#@TypeSpec.Rest.copyResourceKeyParameters}
@@ -124,9 +124,9 @@ Specify that this is a CreateOrReplace operation for a given resource.
 
 #### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 ### `@createsOrUpdatesResource` {#@TypeSpec.Rest.createsOrUpdatesResource}
 
@@ -142,9 +142,9 @@ Specify that this is a CreatesOrUpdate operation for a given resource.
 
 #### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 ### `@createsResource` {#@TypeSpec.Rest.createsResource}
 
@@ -160,9 +160,9 @@ Specify that this is a Create operation for a given resource.
 
 #### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 ### `@deletesResource` {#@TypeSpec.Rest.deletesResource}
 
@@ -178,9 +178,9 @@ Specify that this is a Delete operation for a given resource.
 
 #### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 ### `@listsResource` {#@TypeSpec.Rest.listsResource}
 
@@ -196,9 +196,9 @@ Specify that this is a List operation for a given resource.
 
 #### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 ### `@parentResource` {#@TypeSpec.Rest.parentResource}
 
@@ -232,9 +232,9 @@ Specify that this is a Read operation for a given resource.
 
 #### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |
 
 ### `@resource` {#@TypeSpec.Rest.resource}
 
@@ -256,7 +256,7 @@ Mark this model as a resource type with a name.
 
 ### `@segment` {#@TypeSpec.Rest.segment}
 
-Defines the preceding path segment for a
+Defines the preceding path segment for a `@path` parameter in auto-generated routes.
 
 ```typespec
 @TypeSpec.Rest.segment(name: valueof string)
@@ -273,6 +273,13 @@ Defines the preceding path segment for a
 | name | `valueof string` | Segment that will be inserted into the operation route before the path parameter's name field. |
 
 #### Examples
+
+```typespec
+@autoRoute
+interface Pets {
+  get(@segment("pets") @path id: string): void; //-> route: /pets/{id}
+}
+```
 
 ### `@segmentOf` {#@TypeSpec.Rest.segmentOf}
 
@@ -306,6 +313,6 @@ Specify that this is a Update operation for a given resource.
 
 #### Parameters
 
-| Name         | Type    | Description          |
-| ------------ | ------- | -------------------- |
-| resourceType | `Model` | Resource marked with |
+| Name         | Type    | Description                      |
+| ------------ | ------- | -------------------------------- |
+| resourceType | `Model` | Resource marked with `@resource` |


### PR DESCRIPTION
This is the package that motivated microsoft/typespec#2090.

Every operation inside the resource interface templates carries a copy of its **enclosing interface's** `@template` tags, documenting template parameters the operation does not have:

```tsp
interface ResourceCreateOrUpdate<Resource extends {}, Error> {
  /**
   * Creates or update an instance of the resource.
   *
   * @template Resource The resource model to create or update.   // `createOrUpdate` is not templated
   * @template Error The error response.                          // neither is this
   */
  createOrUpdate(...): ...;
}
```

29 of these are removed.

`rest-decorators.tsp` has the other flavour of the bug — code references the doc parser mistakes for tags, which truncate the published text:

```tsp
 * Defines the preceding path segment for a @path parameter in auto-generated routes.
 * @param resourceType Resource marked with @resource
```

These are now backticked, and the `@segment` example gets the ```` ```typespec ```` fence it was missing.

The remaining change documents the request body parameters (`resource`, `properties`) of the resource operation templates.

Prerequisite for microsoft/typespec#1229 and microsoft/typespec#2090. The library linter rule that catches this is in microsoft/typespec#11543, which must merge after this one: `lint-typespec-library` runs with `--warn-as-error` inside every package's `build`, so the docs have to exist before the rule is turned on.

Independent of the other documentation PRs (microsoft/typespec#11539, microsoft/typespec#11540, microsoft/typespec#11542) — they touch disjoint packages and can merge in any order.
