### PR TITLE
[graphql] Add ./mutation-engine subpath export for standalone mutation pipeline usage

### DIFF
--- a/.chronus/changes/graphql-mutation-engine-exports-2026-7-5-18-8-56.md
+++ b/.chronus/changes/graphql-mutation-engine-exports-2026-7-5-18-8-56.md
@@ -5,4 +5,4 @@ packages:
   - "@typespec/graphql"
 ---
 
-[graphql] Add ./mutation-engine subpath export for standalone mutation pipeline usage
+Add `./mutation-engine` subpath export for standalone mutation pipeline usage

--- a/.chronus/changes/graphql-mutation-engine-exports-2026-7-5-18-8-56.md
+++ b/.chronus/changes/graphql-mutation-engine-exports-2026-7-5-18-8-56.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@typespec/graphql"
+---
+
+[graphql] Add ./mutation-engine subpath export for standalone mutation pipeline usage

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -24,6 +24,10 @@
       "typespec": "./lib/main.tsp",
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
+    },
+    "./mutation-engine": {
+      "types": "./dist/src/mutation-engine/index.d.ts",
+      "default": "./dist/src/mutation-engine/index.js"
     }
   },
   "engines": {

--- a/packages/graphql/src/mutation-engine/index.ts
+++ b/packages/graphql/src/mutation-engine/index.ts
@@ -1,3 +1,4 @@
+export { resolveTypeUsage, type TypeUsageResolver } from "../type-usage.js";
 export { GraphQLMutationEngine, createGraphQLMutationEngine } from "./engine.js";
 export {
   GraphQLEnumMemberMutation,


### PR DESCRIPTION
## Summary

Add a `./mutation-engine` subpath export to `@typespec/graphql` to enable consumers to use the GraphQL mutation pipeline independently of the emitter. This allows for other future GraphQL related packages to use the GraphQL mutation engine to transform the input TSP into GraphQL compatible shapes in using the same library, reducing duplicate implementations.

The subpath exports:
- `mutateSchema`, `createGraphQLMutationEngine` — orchestration
- `resolveTypeUsage` — type usage analysis (input vs output)
- `GraphQLTypeContext`, `TypeGraph` — types
- Mutation classes (`GraphQLModelMutation`, etc.)

## Test plan

- [x] Existing tests pass (368 tests)
- [x] Package builds successfully
- [x] Subpath resolves correctly
