### PR TITLE
[http-client-csharp] Initialize patch propagators in public constructors

### DIFF
--- a/.chronus/changes/fix-csharp-patch-propagators-2026-08-05-10-55-00.md
+++ b/.chronus/changes/fix-csharp-patch-propagators-2026-08-05-10-55-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Ensure JSON patch changes propagate through nested dynamic models created with public constructors.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmModelProvider.cs
@@ -216,40 +216,65 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         if (JsonPatchField != null)
                         {
                             updatedBody.Add(JsonPatchField.Assign(JsonPatchProperty!.AsParameter).Terminate());
-                            if (HasDynamicProperties)
-                            {
-#pragma warning disable SCME0001
-                                updatedBody.Add(JsonPatchField.As<JsonPatch>().SetPropagators(new MemberExpression(null, "PropagateSet"), new MemberExpression(null, "PropagateGet")));
-#pragma warning restore SCME0001
-                            }
-                        }
-                        else if (HasDynamicProperties && BaseJsonPatchProperty.Value is not null)
-                        {
-                            // Derived model has dynamic properties but inherits the JsonPatch field from base
-                            // We need to call SetPropagators on the inherited patch field
-#pragma warning disable SCME0001
-                            updatedBody.Add(BaseJsonPatchProperty.Value.As<JsonPatch>().SetPropagators(new MemberExpression(null, "PropagateSet"), new MemberExpression(null, "PropagateGet")));
-#pragma warning restore SCME0001
                         }
 
+                        AddJsonPatchPropagators(updatedBody);
                         constructor.Update(bodyStatements: updatedBody);
                     }
                 }
-                else if (JsonPatchField != null && SupportsBinaryDataAdditionalProperties && !NeedsBackCompatAdditionalProperties && constructor.BodyStatements != null)
+                else if (constructor.BodyStatements != null)
                 {
-                    // Remove the additional binary data properties initialization from the init constructor
-                    var updatedBody = constructor.BodyStatements
-                        .Where(s => s is not ExpressionStatement
-                        {
-                            Expression: AssignmentExpression
+                    List<MethodBodyStatement> updatedBody;
+                    if (JsonPatchField != null && SupportsBinaryDataAdditionalProperties && !NeedsBackCompatAdditionalProperties)
+                    {
+                        // Remove the additional binary data properties initialization from the init constructor
+                        updatedBody = constructor.BodyStatements
+                            .Where(s => s is not ExpressionStatement
                             {
-                                Variable: MemberExpression { MemberName: AdditionalPropertiesHelper.AdditionalBinaryDataPropsFieldName }
-                            }
-                        })
-                        .ToList();
-                    constructor.Update(bodyStatements: updatedBody);
+                                Expression: AssignmentExpression
+                                {
+                                    Variable: MemberExpression { MemberName: AdditionalPropertiesHelper.AdditionalBinaryDataPropsFieldName }
+                                }
+                            })
+                            .ToList();
+                    }
+                    else
+                    {
+                        updatedBody = [.. constructor.BodyStatements];
+                    }
+
+                    bool addedPropagators = AddJsonPatchPropagators(updatedBody);
+                    constructor.Update(
+                        bodyStatements: updatedBody,
+                        suppressions: addedPropagators
+                            ? [JsonPatchSuppression, .. constructor.Suppressions]
+                            : constructor.Suppressions);
                 }
             }
+        }
+
+        private bool AddJsonPatchPropagators(List<MethodBodyStatement> statements)
+        {
+            if (!HasDynamicProperties)
+            {
+                return false;
+            }
+
+#pragma warning disable SCME0001
+            if (JsonPatchField != null)
+            {
+                statements.Add(JsonPatchField.As<JsonPatch>().SetPropagators(new MemberExpression(null, "PropagateSet"), new MemberExpression(null, "PropagateGet")));
+                return true;
+            }
+
+            if (BaseJsonPatchProperty.Value is not null)
+            {
+                statements.Add(BaseJsonPatchProperty.Value.As<JsonPatch>().SetPropagators(new MemberExpression(null, "PropagateSet"), new MemberExpression(null, "PropagateGet")));
+                return true;
+            }
+#pragma warning restore SCME0001
+
+            return false;
         }
 
         private List<ConstructorProvider>? BuildMultipartFileConstructors(List<ConstructorProvider> existingConstructors)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DynamicModelSerializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DynamicModelSerializationTests.cs
@@ -86,11 +86,17 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
 
             Assert.AreEqual(Helpers.GetExpectedFromFile(), file.Content);
 
-            // Also validate that the propagate method is called from the serialization constructor
-            var constructor =
+            // Also validate that the propagate method is called from every construction path
+            var serializationConstructor =
                 model.Constructors.FirstOrDefault(c => c.Signature.Parameters.Any(p => p.Name == "patch"));
-            Assert.IsNotNull(constructor);
-            StringAssert.Contains("_patch.SetPropagators(PropagateSet, PropagateGet);", constructor!.BodyStatements!.ToDisplayString());
+            Assert.IsNotNull(serializationConstructor);
+            StringAssert.Contains("_patch.SetPropagators(PropagateSet, PropagateGet);", serializationConstructor!.BodyStatements!.ToDisplayString());
+
+            var publicConstructor =
+                model.Constructors.FirstOrDefault(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.IsNotNull(publicConstructor);
+            StringAssert.Contains("_patch.SetPropagators(PropagateSet, PropagateGet);", publicConstructor!.BodyStatements!.ToDisplayString());
+            Assert.IsNotEmpty(publicConstructor.Suppressions);
         }
 
         [Test]
@@ -1420,12 +1426,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             Assert.IsFalse(methods.Any(m => m.Signature.Name == "PropagateGet"), "Derived model should not have PropagateGet method when no dynamic properties exist");
             Assert.IsFalse(methods.Any(m => m.Signature.Name == "PropagateSet"), "Derived model should not have PropagateSet method when no dynamic properties exist");
 
-            // The derived model constructor should NOT call SetPropagators
-            var derivedConstructor =
-                model.Constructors.FirstOrDefault(c => c.Signature.Parameters.Any(p => p.Name == "patch"));
-            if (derivedConstructor != null)
+            // No constructor should call SetPropagators when there are no dynamic properties
+            foreach (var constructor in model.Constructors.Where(c => c.BodyStatements != null))
             {
-                StringAssert.DoesNotContain("SetPropagators", derivedConstructor.BodyStatements!.ToDisplayString(), "Derived model constructor should not call SetPropagators when no dynamic properties exist");
+                StringAssert.DoesNotContain("SetPropagators", constructor.BodyStatements!.ToDisplayString(), "Model constructors should not call SetPropagators when no dynamic properties exist");
             }
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/TestData/ScmModelProviderTests/TestDynamicModelWithPropagators.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/TestData/ScmModelProviderTests/TestDynamicModelWithPropagators.cs
@@ -14,9 +14,12 @@ namespace Sample.Models
         [global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0001")]
         private global::System.ClientModel.Primitives.JsonPatch _patch;
 
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         public DynamicModel()
         {
+            _patch.SetPropagators(PropagateSet, PropagateGet);
         }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
 #pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         internal DynamicModel(global::Sample.Models.AnotherDynamic p1, in global::System.ClientModel.Primitives.JsonPatch patch)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/DynamicModel.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/DynamicModel.cs
@@ -35,6 +35,7 @@ namespace SampleTypeSpec
         /// <param name="dictionaryListFoo"></param>
         /// <param name="listOfDictionaryFoo"></param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/>, <paramref name="primitiveDictionary"/>, <paramref name="foo"/>, <paramref name="listFoo"/>, <paramref name="listOfListFoo"/>, <paramref name="dictionaryFoo"/>, <paramref name="dictionaryOfDictionaryFoo"/>, <paramref name="dictionaryListFoo"/> or <paramref name="listOfDictionaryFoo"/> is null. </exception>
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         public DynamicModel(string name, IEnumerable<int> requiredNullableList, IDictionary<string, int> requiredNullableDictionary, IDictionary<string, int> primitiveDictionary, AnotherDynamicModel foo, IEnumerable<AnotherDynamicModel> listFoo, IEnumerable<IList<AnotherDynamicModel>> listOfListFoo, IDictionary<string, AnotherDynamicModel> dictionaryFoo, IDictionary<string, IDictionary<string, AnotherDynamicModel>> dictionaryOfDictionaryFoo, IDictionary<string, IList<AnotherDynamicModel>> dictionaryListFoo, IEnumerable<IDictionary<string, AnotherDynamicModel>> listOfDictionaryFoo)
         {
             Argument.AssertNotNull(name, nameof(name));
@@ -60,7 +61,9 @@ namespace SampleTypeSpec
             DictionaryOfDictionaryFoo = dictionaryOfDictionaryFoo;
             DictionaryListFoo = dictionaryListFoo;
             ListOfDictionaryFoo = listOfDictionaryFoo.ToList();
+            _patch.SetPropagators(PropagateSet, PropagateGet);
         }
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
         /// <summary> Initializes a new instance of <see cref="DynamicModel"/>. </summary>
         /// <param name="name"></param>


### PR DESCRIPTION
## Summary
- initialize JSON patch propagators for every generated dynamic-model constructor
- add regression coverage for public and MRW construction paths
- regenerate the local sample output

## Validation
- npm run build
- ClientModel tests (1547 passed)
- npm run cop
- Sample-TypeSpec regeneration