### PR TITLE
[spector] Compare JSON Lines request bodies semantically

### DIFF
--- a/.chronus/changes/jsonl-spector-body-2026-08-05-22-25.md
+++ b/.chronus/changes/jsonl-spector-body-2026-08-05-22-25.md
@@ -1,7 +1,7 @@
 ---
 changeKind: internal
 packages:
-  - "@typespec/http-specs"
+  - "@typespec/spector"
 ---
 
 Compare JSON Lines request bodies semantically instead of requiring exact JSON whitespace.

--- a/.chronus/changes/jsonl-spector-body-2026-08-05-22-25.md
+++ b/.chronus/changes/jsonl-spector-body-2026-08-05-22-25.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/http-specs"
+---
+
+Compare JSON Lines request bodies semantically instead of requiring exact JSON whitespace.

--- a/packages/http-specs/specs/streaming/jsonl/mockapi.ts
+++ b/packages/http-specs/specs/streaming/jsonl/mockapi.ts
@@ -7,22 +7,13 @@ Scenarios.Streaming_Jsonl_Basic_send = passOnSuccess({
   uri: "/streaming/jsonl/basic/send",
   method: "post",
   request: {
-    headers: {
-      "content-type": "application/jsonl",
+    body: {
+      rawContent: Buffer.from('{"desc": "one"}\n{"desc": "two"}\n{"desc": "three"}'),
+      contentType: "application/jsonl",
     },
   },
   response: {
     status: 204,
-  },
-  handler: (req) => {
-    const rawBody = req.originalRequest.rawBody;
-    const content = Buffer.isBuffer(rawBody) ? rawBody.toString("utf8") : rawBody;
-    const values = content
-      ?.trimEnd()
-      .split(/\r?\n/)
-      .map((line) => JSON.parse(line));
-    req.expect.deepEqual(values, [{ desc: "one" }, { desc: "two" }, { desc: "three" }]);
-    return { status: 204 };
   },
   kind: "MockApiDefinition",
 });

--- a/packages/http-specs/specs/streaming/jsonl/mockapi.ts
+++ b/packages/http-specs/specs/streaming/jsonl/mockapi.ts
@@ -7,13 +7,22 @@ Scenarios.Streaming_Jsonl_Basic_send = passOnSuccess({
   uri: "/streaming/jsonl/basic/send",
   method: "post",
   request: {
-    body: {
-      rawContent: Buffer.from('{"desc": "one"}\n{"desc": "two"}\n{"desc": "three"}'),
-      contentType: "application/jsonl",
+    headers: {
+      "content-type": "application/jsonl",
     },
   },
   response: {
     status: 204,
+  },
+  handler: (req) => {
+    const rawBody = req.originalRequest.rawBody;
+    const content = Buffer.isBuffer(rawBody) ? rawBody.toString("utf8") : rawBody;
+    const values = content
+      ?.trimEnd()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    req.expect.deepEqual(values, [{ desc: "one" }, { desc: "two" }, { desc: "three" }]);
+    return { status: 204 };
   },
   kind: "MockApiDefinition",
 });

--- a/packages/spector/src/app/app.ts
+++ b/packages/spector/src/app/app.ts
@@ -17,6 +17,7 @@ import { logger } from "../logger.js";
 import { internalRouter } from "../routes/index.js";
 import { loadScenarioMockApis } from "../scenarios-resolver.js";
 import { MockApiServer } from "../server/index.js";
+import { parseJsonLines } from "../utils/body-utils.js";
 import type { ApiMockAppConfig } from "./config.js";
 import { processRequest } from "./request-processor.js";
 
@@ -103,7 +104,22 @@ function validateBody(
   if ("kind" in body) {
     // custom handler for now.
   } else {
-    if (Buffer.isBuffer(body.rawContent)) {
+    if (body.contentType === "application/jsonl") {
+      const expected =
+        typeof body.rawContent === "string" || Buffer.isBuffer(body.rawContent)
+          ? body.rawContent
+          : body.rawContent?.serialize(config);
+      const actual = req.originalRequest.rawBody;
+      if (expected === undefined || actual === undefined) {
+        req.expect.rawBodyEquals(expected);
+      } else {
+        req.expect.deepEqual(
+          parseJsonLines(actual),
+          parseJsonLines(expected),
+          "JSON Lines bodies not equal",
+        );
+      }
+    } else if (Buffer.isBuffer(body.rawContent)) {
       req.expect.rawBodyEquals(body.rawContent);
     } else {
       switch (body.contentType) {

--- a/packages/spector/src/utils/body-utils.test.ts
+++ b/packages/spector/src/utils/body-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { cleanupBody } from "./body-utils.js";
+import { cleanupBody, parseJsonLines } from "./body-utils.js";
 
 describe("cleanupBody()", () => {
   it("remove trailing whitespaces", () => {
@@ -12,5 +12,25 @@ describe("cleanupBody()", () => {
 
   it("replace windows line endings", () => {
     expect(cleanupBody("foo\r\nbar")).toEqual("foo\nbar");
+  });
+});
+
+describe("parseJsonLines()", () => {
+  it("parses compact and spaced JSON equivalently", () => {
+    const compact = '{"desc":"one"}\n{"desc":"two"}';
+    const spaced = '{"desc": "one"}\n{"desc": "two"}';
+
+    expect(parseJsonLines(compact)).toEqual(parseJsonLines(spaced));
+  });
+
+  it("accepts CRLF and a final line terminator", () => {
+    expect(parseJsonLines('{"desc":"one"}\r\n{"desc":"two"}\r\n')).toEqual([
+      { desc: "one" },
+      { desc: "two" },
+    ]);
+  });
+
+  it("rejects blank JSON Lines", () => {
+    expect(() => parseJsonLines('{"desc":"one"}\n\n{"desc":"two"}')).toThrow();
   });
 });

--- a/packages/spector/src/utils/body-utils.ts
+++ b/packages/spector/src/utils/body-utils.ts
@@ -6,3 +6,12 @@
  */
 export const cleanupBody = (rawContent: string): string =>
   rawContent.trim().replace(/\r?\n|\r/g, "\n");
+
+export function parseJsonLines(rawContent: string | Buffer): unknown[] {
+  const content = Buffer.isBuffer(rawContent) ? rawContent.toString("utf8") : rawContent;
+  const lines = content.split(/\r?\n/);
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  return lines.map((line) => JSON.parse(line));
+}


### PR DESCRIPTION
## Summary

- compare `application/jsonl` request bodies as sequences of parsed JSON values
- allow insignificant JSON whitespace, LF or CRLF delimiters, and an optional final line terminator
- retain the existing JSONL scenario body so Spector's generated self-test request remains unchanged

## Validation

- added focused `parseJsonLines` tests for whitespace, delimiters, trailing terminators, and invalid blank lines
- `pnpm --dir packages/spector test -- src/utils/body-utils.test.ts`
