### PR TITLE
Fix inherited paging item lookup in C# generator

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -1838,7 +1838,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
                 foreach (var segment in _pagingServiceMethod!.PagingMetadata.ItemPropertySegments)
                 {
-                    var property = modelType!.Properties.FirstOrDefault(p => p.SerializedName == segment);
+                    var property = modelType!
+                        .GetSelfAndBaseModels()
+                        .SelectMany(m => m.Properties)
+                        .FirstOrDefault(p => p.SerializedName == segment);
                     var propertyType = property?.Type;
 
                     if (propertyType is InputArrayType arrayType)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -658,6 +658,46 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             Assert.IsTrue(signature.ReturnType!.Equals(expectedReturnType));
         }
 
+        [Test]
+        public void ListMethodWithInheritedPageItems()
+        {
+            var pagingMetadata = InputFactory.PagingMetadata(
+                ["value"],
+                null,
+                null);
+            var itemModel = InputFactory.Model("cat");
+            var basePageModel = InputFactory.Model(
+                "basePage",
+                properties: [InputFactory.Property("value", InputFactory.Array(itemModel))]);
+            var responseModel = InputFactory.Model(
+                "page",
+                properties: [InputFactory.Property("summary", InputPrimitiveType.String)],
+                baseModel: basePageModel);
+            var response = InputFactory.OperationResponse([200], responseModel);
+            var operation = InputFactory.Operation("getCats", responses: [response]);
+            var inputServiceMethod = InputFactory.PagingServiceMethod(
+                "Test",
+                operation,
+                response: InputFactory.ServiceMethodResponse(responseModel, null),
+                pagingMetadata: pagingMetadata);
+            var inputClient = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+
+            MockHelpers.LoadMockGenerator(
+                inputModels: () => [itemModel, basePageModel, responseModel],
+                clients: () => [inputClient]);
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+            var itemModelType = ScmCodeModelGenerator.Instance.TypeFactory.CreateCSharpType(itemModel);
+
+            var methodCollection = new ScmMethodProviderCollection(inputClient.Methods.First(), client!);
+            var listMethod = methodCollection.FirstOrDefault(
+                m => !m.Signature.Parameters.Any(p => p.Name == "options") && m.Signature.Name == "GetCats");
+            Assert.IsNotNull(listMethod);
+
+            var expectedReturnType = new CSharpType(typeof(CollectionResult<>), itemModelType!);
+            Assert.IsTrue(listMethod!.Signature.ReturnType!.Equals(expectedReturnType));
+        }
+
         [TestCase(true, InputRequestLocation.Header)]
         [TestCase(true, InputRequestLocation.Body)]
         [TestCase(false, InputRequestLocation.Header)]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -698,6 +698,47 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
             Assert.IsTrue(listMethod!.Signature.ReturnType!.Equals(expectedReturnType));
         }
 
+        [Test]
+        public void ListMethodWithRedeclaredPageItemsUsesDerivedProperty()
+        {
+            var pagingMetadata = InputFactory.PagingMetadata(
+                ["value"],
+                null,
+                null);
+            var baseItemModel = InputFactory.Model("baseCat");
+            var derivedItemModel = InputFactory.Model("derivedCat");
+            var basePageModel = InputFactory.Model(
+                "basePage",
+                properties: [InputFactory.Property("value", InputFactory.Array(baseItemModel))]);
+            var responseModel = InputFactory.Model(
+                "page",
+                properties: [InputFactory.Property("value", InputFactory.Array(derivedItemModel))],
+                baseModel: basePageModel);
+            var response = InputFactory.OperationResponse([200], responseModel);
+            var operation = InputFactory.Operation("getCats", responses: [response]);
+            var inputServiceMethod = InputFactory.PagingServiceMethod(
+                "Test",
+                operation,
+                response: InputFactory.ServiceMethodResponse(responseModel, null),
+                pagingMetadata: pagingMetadata);
+            var inputClient = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+
+            MockHelpers.LoadMockGenerator(
+                inputModels: () => [baseItemModel, derivedItemModel, basePageModel, responseModel],
+                clients: () => [inputClient]);
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+            var derivedItemModelType = ScmCodeModelGenerator.Instance.TypeFactory.CreateCSharpType(derivedItemModel);
+
+            var methodCollection = new ScmMethodProviderCollection(inputClient.Methods.First(), client!);
+            var listMethod = methodCollection.FirstOrDefault(
+                m => !m.Signature.Parameters.Any(p => p.Name == "options") && m.Signature.Name == "GetCats");
+            Assert.IsNotNull(listMethod);
+
+            var expectedReturnType = new CSharpType(typeof(CollectionResult<>), derivedItemModelType!);
+            Assert.IsTrue(listMethod!.Signature.ReturnType!.Equals(expectedReturnType));
+        }
+
         [TestCase(true, InputRequestLocation.Header)]
         [TestCase(true, InputRequestLocation.Body)]
         [TestCase(false, InputRequestLocation.Header)]


### PR DESCRIPTION
Fixes #11576.

### Summary

- Resolve paging item-property segments across the response model and its base-model chain.
- Preserve derived-model precedence when a property is redeclared.
- Add a regression test for a derived paging response whose `value` array is inherited.

### Validation

- The regression test fails before the production change and passes afterward.
- `Microsoft.TypeSpec.Generator.ClientModel.Tests`: 1,555 passed.
- Azure SDK management-plane E2E fixture generates and builds.
- Azure Resource Manager Billing regenerates with the previously excluded operation and builds successfully.

\- by copilot
