### PR TITLE
Fix unsupported client settings bindings

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
+using Microsoft.TypeSpec.Generator.ClientModel.Utilities;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
@@ -24,6 +25,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
         internal const string ClientSettingsDiagnosticId = "SCME0002";
 
         private readonly ClientProvider _clientProvider;
+        private readonly HashSet<string> _reportedUnsupportedCustomParameters = [];
 
 #pragma warning disable SCME0002 // ClientSettings is for evaluation purposes only
         internal static readonly CSharpType ClientSettingsType = typeof(ClientSettings);
@@ -126,9 +128,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     foreach (var param in ctor.Signature.Parameters)
                     {
                         var propName = param.Name.ToIdentifierName();
-                        if (!knownProps.Contains(propName) &&
-                            !IsStandardParameterType(param.Type) &&
-                            IsBindableCustomParameterType(param.Type))
+                        if (ShouldIncludeCustomParameter(param, propName, knownProps))
                         {
                             properties.Add(new PropertyProvider(
                                 null,
@@ -202,9 +202,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     foreach (var param in ctor.Signature.Parameters)
                     {
                         var propName = param.Name.ToIdentifierName();
-                        if (!knownProps.Contains(propName) &&
-                            !IsStandardParameterType(param.Type) &&
-                            IsBindableCustomParameterType(param.Type))
+                        if (ShouldIncludeCustomParameter(param, propName, knownProps))
                         {
                             AppendBindingForProperty(body, sectionParam, propName, param.Name.ToVariableName(), param.Type);
                             knownProps.Add(propName);
@@ -640,6 +638,31 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 frameworkType == typeof(double) ||
                 frameworkType == typeof(TimeSpan) ||
                 frameworkType == typeof(Uri);
+        }
+
+        private bool ShouldIncludeCustomParameter(
+            ParameterProvider parameter,
+            string propertyName,
+            HashSet<string> knownProperties)
+        {
+            if (knownProperties.Contains(propertyName) || IsStandardParameterType(parameter.Type))
+            {
+                return false;
+            }
+
+            if (IsBindableCustomParameterType(parameter.Type))
+            {
+                return true;
+            }
+
+            if (_reportedUnsupportedCustomParameters.Add(propertyName))
+            {
+                ScmCodeModelGenerator.Instance.Emitter.ReportDiagnostic(
+                    DiagnosticCodes.UnsupportedClientSettingsParameter,
+                    $"Client settings for '{_clientProvider.Name}' omitted custom constructor parameter '{parameter.Name}' of type '{parameter.Type.Name}' because it cannot be bound from configuration. Construct the client directly or use a configuration-bindable parameter type.");
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientSettingsProvider.cs
@@ -126,7 +126,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     foreach (var param in ctor.Signature.Parameters)
                     {
                         var propName = param.Name.ToIdentifierName();
-                        if (!knownProps.Contains(propName) && !IsStandardParameterType(param.Type))
+                        if (!knownProps.Contains(propName) &&
+                            !IsStandardParameterType(param.Type) &&
+                            IsBindableCustomParameterType(param.Type))
                         {
                             properties.Add(new PropertyProvider(
                                 null,
@@ -200,7 +202,9 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     foreach (var param in ctor.Signature.Parameters)
                     {
                         var propName = param.Name.ToIdentifierName();
-                        if (!knownProps.Contains(propName) && !IsStandardParameterType(param.Type))
+                        if (!knownProps.Contains(propName) &&
+                            !IsStandardParameterType(param.Type) &&
+                            IsBindableCustomParameterType(param.Type))
                         {
                             AppendBindingForProperty(body, sectionParam, propName, param.Name.ToVariableName(), param.Type);
                             knownProps.Add(propName);
@@ -580,6 +584,62 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Checks if a custom constructor parameter can be populated from configuration.
+        /// </summary>
+        internal static bool IsBindableCustomParameterType(CSharpType type)
+        {
+            var effectiveType = type.IsNullable ? type.WithNullable(false) : type;
+
+            if (!effectiveType.IsFrameworkType)
+            {
+                if (effectiveType.IsEnum)
+                {
+                    return true;
+                }
+
+                if (effectiveType.IsStruct)
+                {
+                    var underlyingType = TryGetStructUnderlyingType(effectiveType);
+                    if (underlyingType == null || !underlyingType.IsFrameworkType)
+                    {
+                        return false;
+                    }
+
+                    var underlyingFrameworkType = underlyingType.FrameworkType;
+                    return underlyingFrameworkType == typeof(string) ||
+                        underlyingFrameworkType == typeof(int) ||
+                        underlyingFrameworkType == typeof(long) ||
+                        underlyingFrameworkType == typeof(float) ||
+                        underlyingFrameworkType == typeof(double);
+                }
+
+                var typeProvider = CodeModelGenerator.Instance.SourceInputModel
+                    .FindForTypeInCurrentCompilation(effectiveType.Namespace, effectiveType.Name);
+                return typeProvider?.Constructors.Any(ctor =>
+                    ctor.Signature.Parameters.Count == 1 &&
+                    ctor.Signature.Parameters[0].Type.Name == IConfigurationSectionType.Name &&
+                    ctor.Signature.Parameters[0].Type.Namespace == IConfigurationSectionType.Namespace) == true;
+            }
+
+            if (effectiveType.IsList)
+            {
+                return effectiveType.Arguments.Count > 0 &&
+                    effectiveType.Arguments[0].IsFrameworkType &&
+                    effectiveType.Arguments[0].FrameworkType == typeof(string);
+            }
+
+            var frameworkType = effectiveType.FrameworkType;
+            return frameworkType == typeof(string) ||
+                frameworkType == typeof(bool) ||
+                frameworkType == typeof(int) ||
+                frameworkType == typeof(long) ||
+                frameworkType == typeof(float) ||
+                frameworkType == typeof(double) ||
+                frameworkType == typeof(TimeSpan) ||
+                frameworkType == typeof(Uri);
         }
 
         /// <summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Utilities/DiagnosticCodes.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Utilities/DiagnosticCodes.cs
@@ -10,6 +10,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Utilities
         public const string NoMatchingItemsProperty = "no-matching-items-property";
         public const string UnsupportedSerialization = "unsupported-serialization";
         public const string UnsupportedFrameworkType = "unsupported-framework-type";
+        public const string UnsupportedClientSettingsParameter = "unsupported-client-settings-parameter";
         public const string UnsupportedStreamingType = "unsupported-streaming-type";
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientSettingsProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientSettingsProviderTests.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
@@ -1052,8 +1054,11 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         [Test]
         public async Task TestSettings_ExcludesUnsupportedFrameworkConstructorParameters()
         {
-            await MockHelpers.LoadMockGeneratorAsync(
+            using var diagnosticStream = new MemoryStream();
+            using var emitter = new Emitter(diagnosticStream);
+            var generator = await MockHelpers.LoadMockGeneratorAsync(
                 compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            generator.SetupGet(g => g.Emitter).Returns(emitter);
 
             var client = InputFactory.Client("TestClient", clientNamespace: "SampleNamespace");
             var clientProvider = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(client);
@@ -1073,6 +1078,17 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
                 "BindCore should not bind custom constructor parameters that cannot be constructed from IConfigurationSection");
             Assert.IsTrue(bodyString.Contains("TenantId"),
                 "BindCore should continue to bind supported parameters from the same custom constructor");
+
+            diagnosticStream.Position = 0;
+            using var reader = new StreamReader(diagnosticStream, leaveOpen: true);
+            var diagnostics = reader.ReadToEnd();
+            Assert.That(diagnostics, Does.Contain("\"code\":\"unsupported-client-settings-parameter\""));
+            Assert.That(diagnostics, Does.Contain("omitted custom constructor parameter"));
+            Assert.That(diagnostics, Does.Contain("clientCertificate"));
+            Assert.That(diagnostics, Does.Contain("X509Certificate2"));
+            Assert.That(diagnostics, Does.Contain("\"severity\":\"warning\""));
+            Assert.AreEqual(1, diagnostics.Split("unsupported-client-settings-parameter").Length - 1,
+                "The warning should only be emitted once when both properties and methods are built");
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientSettingsProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientSettingsProviderTests.cs
@@ -1050,6 +1050,32 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         }
 
         [Test]
+        public async Task TestSettings_ExcludesUnsupportedFrameworkConstructorParameters()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(
+                compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var client = InputFactory.Client("TestClient", clientNamespace: "SampleNamespace");
+            var clientProvider = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(client);
+            Assert.IsNotNull(clientProvider);
+
+            var settings = clientProvider!.ClientSettings;
+            Assert.IsNotNull(settings);
+            Assert.IsNull(settings!.Properties.FirstOrDefault(p => p.Name == "ClientCertificate"),
+                "Settings should not include custom constructor parameters that cannot be bound from configuration");
+            Assert.IsNotNull(settings.Properties.FirstOrDefault(p => p.Name == "TenantId"),
+                "Settings should continue to include bindable parameters from the same custom constructor");
+
+            var bindCoreMethod = settings.Methods.FirstOrDefault(m => m.Signature.Name == "BindCore");
+            Assert.IsNotNull(bindCoreMethod);
+            var bodyString = bindCoreMethod!.BodyStatements!.ToDisplayString();
+            Assert.IsFalse(bodyString.Contains("ClientCertificate"),
+                "BindCore should not bind custom constructor parameters that cannot be constructed from IConfigurationSection");
+            Assert.IsTrue(bodyString.Contains("TenantId"),
+                "BindCore should continue to bind supported parameters from the same custom constructor");
+        }
+
+        [Test]
         public async Task TestSettingsType_DoesNotContainSelfReferentialSettingsProperty()
         {
             await MockHelpers.LoadMockGeneratorAsync(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientSettingsProviderTests/TestSettings_ExcludesUnsupportedFrameworkConstructorParameters/TestClient.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/TestData/ClientSettingsProviderTests/TestSettings_ExcludesUnsupportedFrameworkConstructorParameters/TestClient.cs
@@ -1,0 +1,11 @@
+#nullable disable
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace SampleNamespace
+{
+    public partial class TestClient
+    {
+        public TestClient(X509Certificate2 clientCertificate, string tenantId) { }
+    }
+}


### PR DESCRIPTION
## Summary
- only add custom constructor parameters to generated client settings when their types have a supported configuration binding
- avoid invalid generated constructor calls for types such as X509Certificate2
- add regression coverage that preserves supported parameters from the same constructor

## Testing
- dotnet test packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj --filter FullyQualifiedName~ClientSettingsProviderTests