### PR TITLE
skip union spector test cases for go

### DIFF
--- a/packages/http-specs/package.json
+++ b/packages/http-specs/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/microsoft/typespec#readme",
   "dependencies": {
-    "@azure-tools/typespec-client-generator-core": "0.70.0",
+    "@azure-tools/typespec-client-generator-core": "^0.70.0",
     "@typespec/spec-api": "workspace:^",
     "@typespec/spector": "workspace:^"
   },

--- a/packages/http-specs/package.json
+++ b/packages/http-specs/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/microsoft/typespec#readme",
   "dependencies": {
+    "@azure-tools/typespec-client-generator-core": "0.70.0",
     "@typespec/spec-api": "workspace:^",
     "@typespec/spector": "workspace:^"
   },

--- a/packages/http-specs/specs/special-headers/repeatability/main.tsp
+++ b/packages/http-specs/specs/special-headers/repeatability/main.tsp
@@ -1,10 +1,12 @@
 import "@typespec/http";
 import "@typespec/versioning";
 import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
 
 using Http;
 using Spector;
 using Versioning;
+using Azure.ClientGenerator.Core;
 
 @doc("Illustrates OASIS repeatability headers")
 @scenarioService("/special-headers/repeatability")
@@ -17,6 +19,8 @@ model RepeatableResponse {
 
   @visibility(Lifecycle.Read)
   @header("Repeatability-Result")
+  // Go does not support the union-valued response header.
+  @scope("!go")
   @doc("Indicates whether the repeatable request was accepted or rejected.")
   repeatabilityResult?: "accepted" | "rejected";
 }

--- a/packages/http-specs/specs/type/property/additional-properties/main.tsp
+++ b/packages/http-specs/specs/type/property/additional-properties/main.tsp
@@ -1,8 +1,10 @@
 import "@typespec/http";
 import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
 
 using Http;
 using Spector;
+using Azure.ClientGenerator.Core;
 
 @doc("Tests for additional properties of models")
 @scenarioService("/type/property/additionalProperties")
@@ -34,6 +36,32 @@ interface ModelOperations<TModel, TDoc extends valueof string> {
   @put
   @doc("Put operation")
   put(@body @doc("body") body: TModel): void;
+}
+
+interface UnionModelOperations<TModel, TDoc extends valueof string> {
+  @scenario
+  @scenarioDoc("""
+    Expected response body:
+    ```json
+    ${TDoc}
+    ```
+    """)
+  // Go does not support union-valued additional properties.
+  @scope("!go")
+  @get
+  get(): TModel;
+
+  @scenario
+  @scenarioDoc("""
+    Expected input body:
+    ```json
+    ${TDoc}
+    ```
+    """)
+  // Go does not support union-valued additional properties.
+  @scope("!go")
+  @put
+  put(@body body: TModel): void;
 }
 
 // ********************************************** Record<unknown> **********************************************
@@ -441,7 +469,7 @@ model MultipleSpreadRecord {
 
 @route("/multipleSpreadRecord")
 interface MultipleSpread
-  extends ModelOperations<
+  extends UnionModelOperations<
       MultipleSpreadRecord,
       "{'flag': true, 'prop1': 'abc', 'prop2': 43.125}"
     > {}
@@ -457,7 +485,7 @@ model SpreadRecordForUnion {
 
 @route("/spreadRecordUnion")
 interface SpreadRecordUnion
-  extends ModelOperations<
+  extends UnionModelOperations<
       SpreadRecordForUnion,
       "{'flag': true, 'prop1': 'abc', 'prop2': 43.125}"
     > {}
@@ -511,7 +539,7 @@ model SpreadRecordForNonDiscriminatedUnion {
 
 @route("/spreadRecordNonDiscriminatedUnion")
 interface SpreadRecordNonDiscriminatedUnion
-  extends ModelOperations<
+  extends UnionModelOperations<
       SpreadRecordForNonDiscriminatedUnion,
       "{'name': 'abc', 'prop1': {'kind': 'kind0', 'fooProp': 'abc'}, 'prop2': {'kind': 'kind1', 'start': '2021-01-01T00:00:00Z', 'end': '2021-01-02T00:00:00Z'}}"
     > {}
@@ -527,7 +555,7 @@ model SpreadRecordForNonDiscriminatedUnion2 {
 
 @route("/spreadRecordNonDiscriminatedUnion2")
 interface SpreadRecordNonDiscriminatedUnion2
-  extends ModelOperations<
+  extends UnionModelOperations<
       SpreadRecordForNonDiscriminatedUnion2,
       "{'name': 'abc', 'prop1': {'kind': 'kind1', 'start': '2021-01-01T00:00:00Z'}, 'prop2': {'kind': 'kind1', 'start': '2021-01-01T00:00:00Z', 'end': '2021-01-02T00:00:00Z'}}"
     > {}
@@ -543,7 +571,7 @@ model SpreadRecordForNonDiscriminatedUnion3 {
 
 @route("/spreadRecordNonDiscriminatedUnion3")
 interface SpreadRecordNonDiscriminatedUnion3
-  extends ModelOperations<
+  extends UnionModelOperations<
       SpreadRecordForNonDiscriminatedUnion3,
       "{'name': 'abc', 'prop1': [{'kind': 'kind1', 'start': '2021-01-01T00:00:00Z'}, {'kind': 'kind1', 'start': '2021-01-01T00:00:00Z'], 'prop2': {'kind': 'kind1', 'start': '2021-01-01T00:00:00Z', 'end': '2021-01-02T00:00:00Z'}}"
     > {}

--- a/packages/http-specs/specs/type/union/discriminated/main.tsp
+++ b/packages/http-specs/specs/type/union/discriminated/main.tsp
@@ -1,8 +1,10 @@
 import "@typespec/http";
 import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
 
 using Http;
 using Spector;
+using Azure.ClientGenerator.Core;
 
 /**
  * Describe scenarios for discriminated unions.
@@ -62,6 +64,8 @@ namespace Envelope {
         }
         ```
         """)
+      // Go does not support discriminated union types.
+      @scope("!go")
       @get
       get(@query kind?: string): PetWithEnvelope;
 
@@ -79,6 +83,8 @@ namespace Envelope {
         }
         ```
         """)
+      // Go does not support discriminated union types.
+      @scope("!go")
       @put
       put(@body input: PetWithEnvelope): PetWithEnvelope;
     }
@@ -109,6 +115,8 @@ namespace Envelope {
         }
         ```
         """)
+      // Go does not support discriminated union types.
+      @scope("!go")
       @get
       get(@query petType?: string): PetWithCustomNames;
 
@@ -126,6 +134,8 @@ namespace Envelope {
         }
         ```
         """)
+      // Go does not support discriminated union types.
+      @scope("!go")
       @put
       put(@body input: PetWithCustomNames): PetWithCustomNames;
     }
@@ -189,6 +199,8 @@ namespace NoEnvelope {
       }
       ```
       """)
+    // Go does not support discriminated union types.
+    @scope("!go")
     @get
     get(@query kind?: string): PetInline;
 
@@ -204,6 +216,8 @@ namespace NoEnvelope {
       }
       ```
       """)
+    // Go does not support discriminated union types.
+    @scope("!go")
     @put
     put(@body input: PetInline): PetInline;
   }
@@ -230,6 +244,8 @@ namespace NoEnvelope {
       }
       ```
       """)
+    // Go does not support discriminated union types.
+    @scope("!go")
     @get
     get(@query type?: string): PetInlineWithCustomDiscriminator;
 
@@ -245,6 +261,8 @@ namespace NoEnvelope {
       }
       ```
       """)
+    // Go does not support discriminated union types.
+    @scope("!go")
     @put
     put(@body input: PetInlineWithCustomDiscriminator): PetInlineWithCustomDiscriminator;
   }

--- a/packages/http-specs/specs/type/union/main.tsp
+++ b/packages/http-specs/specs/type/union/main.tsp
@@ -1,8 +1,10 @@
 import "@typespec/http";
 import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
 
 using Http;
 using Spector;
+using Azure.ClientGenerator.Core;
 
 /**
  * Describe scenarios for various combinations of unions.
@@ -224,6 +226,8 @@ interface GetAndSend<Union, Payload extends valueof string, Cases = Union> {
       type: Union,
     }
   )
+  // Go does not support union types.
+  @scope("!go")
   get(): {
     prop: Cases;
   };
@@ -245,5 +249,7 @@ interface GetAndSend<Union, Payload extends valueof string, Cases = Union> {
       type: Union,
     }
   )
+  // Go does not support union types.
+  @scope("!go")
   send(prop: Cases): void;
 }

--- a/packages/http-specs/specs/versioning/added/main.tsp
+++ b/packages/http-specs/specs/versioning/added/main.tsp
@@ -1,10 +1,12 @@
 import "@typespec/http";
 import "@typespec/spector";
 import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
 
 using Http;
 using Spector;
 using TypeSpec.Versioning;
+using Azure.ClientGenerator.Core;
 
 /**
  * Test for the `@added` decorator.
@@ -100,6 +102,8 @@ scalar V2Scalar extends int32;
   
   """)
 @route("/v1")
+// Go does not support the union properties in ModelV1.
+@scope("!go")
 @post
 op v1(@body body: ModelV1, @added(Versions.v2) @header headerV2: string): ModelV1;
 
@@ -114,6 +118,8 @@ op v1(@body body: ModelV1, @added(Versions.v2) @header headerV2: string): ModelV
   """)
 @route("/v2")
 @added(Versions.v2)
+// Go does not support the union properties in ModelV2.
+@scope("!go")
 @post
 op v2(@body body: ModelV2): ModelV2;
 
@@ -130,6 +136,8 @@ op v2(@body body: ModelV2): ModelV2;
   """)
 @route("/interface-v2")
 interface InterfaceV2 {
+  // Go does not support the union properties in ModelV2.
+  @scope("!go")
   @post
   @route("/v2")
   v2InInterface(@body body: ModelV2): ModelV2;

--- a/packages/http-specs/specs/versioning/removed/main.tsp
+++ b/packages/http-specs/specs/versioning/removed/main.tsp
@@ -1,10 +1,12 @@
 import "@typespec/http";
 import "@typespec/spector";
 import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
 
 using Http;
 using Spector;
 using TypeSpec.Versioning;
+using Azure.ClientGenerator.Core;
 
 /**
  * Test for the `@removed` decorator.
@@ -131,6 +133,8 @@ op v1(@body body: ModelV1): ModelV1;
   ```
   """)
 @route("/v2")
+// Go does not support the union properties in ModelV2.
+@scope("!go")
 @post
 op v2(@body body: ModelV2, @removed(Versions.v2) @query param: string): ModelV2;
 

--- a/packages/http-specs/specs/versioning/renamedFrom/main.tsp
+++ b/packages/http-specs/specs/versioning/renamedFrom/main.tsp
@@ -1,10 +1,12 @@
 import "@typespec/http";
 import "@typespec/spector";
 import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
 
 using Http;
 using Spector;
 using TypeSpec.Versioning;
+using Azure.ClientGenerator.Core;
 
 /**
  * Test for the `@renamedFrom` decorator.
@@ -85,6 +87,8 @@ scalar NewScalar extends int32;
 @route("/test")
 @post
 @renamedFrom(Versions.v2, "oldOp")
+// Go does not support the union properties in NewModel.
+@scope("!go")
 op newOp(
   @body body: NewModel,
 
@@ -106,6 +110,8 @@ op newOp(
   """)
 @route("/interface")
 interface NewInterface {
+  // Go does not support the union properties in NewModel.
+  @scope("!go")
   @post
   @route("/test")
   newOpInNewInterface(@body body: NewModel): NewModel;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1442,6 +1442,9 @@ importers:
 
   packages/http-specs:
     dependencies:
+      '@azure-tools/typespec-client-generator-core':
+        specifier: 0.70.0
+        version: 0.70.0(@typespec/compiler@packages+compiler)(@typespec/events@packages+events(@typespec/compiler@packages+compiler))(@typespec/http@packages+http(@typespec/compiler@packages+compiler)(@typespec/streams@packages+streams(@typespec/compiler@packages+compiler)(@typespec/http@packages+http)))(@typespec/openapi@packages+openapi(@typespec/compiler@packages+compiler)(@typespec/http@packages+http))(@typespec/rest@packages+rest(@typespec/compiler@packages+compiler)(@typespec/http@packages+http))(@typespec/sse@packages+sse(@typespec/compiler@packages+compiler)(@typespec/events@packages+events(@typespec/compiler@packages+compiler))(@typespec/http@packages+http))(@typespec/streams@packages+streams(@typespec/compiler@packages+compiler)(@typespec/http@packages+http))(@typespec/versioning@packages+versioning(@typespec/compiler@packages+compiler))(@typespec/xml@packages+xml(@typespec/compiler@packages+compiler))
       '@typespec/compiler':
         specifier: workspace:^
         version: link:../compiler


### PR DESCRIPTION
skip union spector test cases for go by adding tcgc's decorator `scope("!go")` 