### PR TITLE
Fix system model base provider resolution

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -405,6 +405,16 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 return modelProvider;
             }
 
+            if (CustomCodeView?.BaseType is null && _inputModel.BaseModel is not null)
+            {
+                var inputBaseModelProvider = CodeModelGenerator.Instance.TypeFactory.CreateModel(_inputModel.BaseModel);
+                if (inputBaseModelProvider is not null && inputBaseModelProvider.Type.AreNamesEqual(baseType))
+                {
+                    CodeModelGenerator.Instance.TypeFactory.CSharpTypeMap[baseType] = inputBaseModelProvider;
+                    return inputBaseModelProvider;
+                }
+            }
+
             if (CustomCodeView?.BaseType != null && !string.IsNullOrEmpty(baseType.Namespace))
             {
                 foreach (var (mapKey, mapValue) in CodeModelGenerator.Instance.TypeFactory.CSharpTypeMap)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/SystemObjectModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/SystemObjectModelProviderTests.cs
@@ -160,6 +160,34 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.AreEqual("ResourceType", provider.Properties[0].Name);
         }
 
+        [Test]
+        public void BaseSystemProviderIsCreatedFromInputModelHierarchy()
+        {
+            var baseInputModel = InputFactory.Model(
+                "SystemException",
+                properties: [InputFactory.Property("message", InputPrimitiveType.String)]);
+            var derivedInputModel = InputFactory.Model(
+                "ArgumentException",
+                properties: [InputFactory.Property("paramName", InputPrimitiveType.String)],
+                baseModel: baseInputModel);
+
+            var baseSystemType = new CSharpType(typeof(SystemException));
+            var derivedSystemType = new CSharpType(typeof(ArgumentException));
+            MockHelpers.LoadMockGenerator(
+                inputModelTypes: [baseInputModel, derivedInputModel],
+                createModelCore: model => model == baseInputModel
+                    ? new SystemObjectModelProvider(baseSystemType, model)
+                    : new SystemObjectModelProvider(derivedSystemType, model));
+
+            var provider = CodeModelGenerator.Instance.TypeFactory.CreateModel(derivedInputModel);
+
+            Assert.IsNotNull(provider);
+            Assert.IsNotNull(provider!.BaseModelProvider);
+            Assert.IsInstanceOf<SystemObjectModelProvider>(provider.BaseModelProvider);
+            Assert.AreEqual("SystemException", provider.BaseModelProvider!.Name);
+            Assert.AreEqual("Message", provider.BaseModelProvider.Properties.Single().Name);
+        }
+
         // -------------------------------------------------------------------
         // 3. Property deduplication: properties matching framework base are skipped
         // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ensure MTG creates and resolves the corresponding input base model provider when a `SystemObjectModelProvider` wraps a framework type with an existing CLR base type.

`SystemObjectModelProvider.BuildBaseType()` prefers `SystemType.BaseType`, so the normal `ModelProvider.BuildBaseType()` path does not create the declared TypeSpec base model. `BuildBaseModelProvider()` previously only checked `CSharpTypeMap`, which could leave the base provider `null` depending on model creation order.

The fallback now:

- Creates the declared input base model when no mapped provider exists.
- Verifies that its generated type matches the resolved base type by name.
- Registers the resolved `CSharpType` alias for subsequent lookups.

Added a regression test using `ArgumentException` and `SystemException` to cover both automatic system base-provider creation and framework/non-framework `CSharpType` equivalence.

Contributes to #10787.

## Validation

- `SystemObjectModelProviderTests`: 27 passed
- Full `npm run test:generator`
- Azure management generator with local MTG project references and its base-provider visitor workaround removed:
  - 269 management generator tests passed
  - Full management test-project regeneration passed, including `Mgmt-TypeSpec-MultiService`
