### PR TITLE
feat(http-client-python): generate structured JSONL/SSE streaming (Azure flavor)

### DIFF
--- a/.chronus/changes/structured-streaming-2026-0-0.md
+++ b/.chronus/changes/structured-streaming-2026-0-0.md
@@ -1,0 +1,17 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-python"
+---
+
+Generate structured streaming client methods for the **Azure flavor**: operations whose HTTP response is a JSONL (`application/jsonl`) or SSE (`text/event-stream`) stream now return `Stream[T]` / `AsyncStream[T]`, yielding deserialized model instances instead of raw bytes.
+
+
+The `Stream` / `AsyncStream` runtime (plus the JSONL / SSE decoders) is vendored into the generated package at `_utils/streaming_base.py` (like `_utils/model_base.py`), so it depends only on the released `azure.core.rest` — not on an unreleased `azure.core.streaming`.
+
+```python
+# For an operation returning JsonlStream<Thing> (Azure flavor):
+stream = client.receive()          # -> Stream[Thing]
+for thing in stream:               # deserialized model instances
+    ...
+```

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -7,11 +7,15 @@ dictionaries:
 words:
   - Ablack
   - Adoptium
+  - aenter
+  - aexit
   - agentic
   - agentics
   - aiohttp
+  - aiter
   - alzimmer
   - amqp
+  - anext
   - AQID
   - Arize
   - arizeaiobservabilityeval
@@ -120,6 +124,7 @@ words:
   - intrinsics
   - ints
   - IOHTTP
+  - isascii
   - isdigit
   - isinstance
   - issecret

--- a/packages/http-client-python/README.md
+++ b/packages/http-client-python/README.md
@@ -153,3 +153,20 @@ Whether to clear the output folder before generating the code. Defaults to `fals
 **Type:** `boolean`
 
 Emit YAML code model only, without running Python generator. For batch processing.
+
+## Structured streaming (JSONL / SSE)
+
+For the **Azure flavor**, operations whose HTTP response is a JSONL (`application/jsonl`) or SSE (`text/event-stream`) stream generate client methods that return `Stream[T]` (sync) / `AsyncStream[T]` (async), yielding deserialized model instances instead of raw bytes. This is driven by the TCGC response stream metadata (the response stream type) — there is no opt-in emitter option. For the unbranded flavor, streaming responses keep the existing raw byte-iterator behavior (`Iterator[bytes]` / `AsyncIterator[bytes]`).
+
+For an operation returning `JsonlStream<Thing>`, the generated method returns `Stream[Thing]` (sync) / `AsyncStream[Thing]` (async), yielding deserialized `Thing` instances as each JSONL line arrives. Similarly, `SSEStream<Events>` produces a `Stream` / `AsyncStream` over the SSE event payloads.
+
+```python
+# For an operation returning JsonlStream<Thing> (Azure flavor):
+stream = client.receive()          # -> Stream[Thing]
+for thing in stream:               # deserialized model instances
+    ...
+```
+
+The `Stream` / `AsyncStream` runtime (plus the JSONL and SSE decoders) is **vendored** into the generated package at `_utils/streaming_base.py` (alongside `_utils/model_base.py`). It depends only on the released `azure.core.rest`, so no unreleased `azure.core.streaming` dependency is required at runtime.
+
+SSE `@events` unions use TCGC event metadata to deserialize each named event into its corresponding generated model. Events marked with `@terminalEvent` stop iteration without being yielded.

--- a/packages/http-client-python/emitter/src/http.ts
+++ b/packages/http-client-python/emitter/src/http.ts
@@ -42,6 +42,88 @@ export enum ReferredByOperationTypes {
   NonPagingOnly = 2,
 }
 
+/**
+ * Determine whether a stream's payload type is "structured" (a model or union
+ * that can be deserialized into an item `T`), as opposed to a bare byte/string
+ * stream that should keep the existing raw byte-iterator behavior.
+ */
+export function isStructuredStreamType(type: SdkType): boolean {
+  switch (type.kind) {
+    case "model":
+    case "union":
+      return true;
+    case "nullable":
+      return isStructuredStreamType(type.type);
+    default:
+      return false;
+  }
+}
+
+export function getStructuredStreamKind(
+  response: SdkHttpResponse | SdkHttpErrorResponse,
+): "jsonl" | "sse" | undefined {
+  if (response.sseMetadata) return "sse";
+
+  const contentTypes = response.streamMetadata?.contentTypes ?? response.contentTypes ?? [];
+  for (const contentType of contentTypes) {
+    const mediaType = contentType.split(";", 1)[0].trim().toLowerCase();
+    if (mediaType === "text/event-stream") return "sse";
+    if (mediaType === "application/jsonl") return "jsonl";
+  }
+  return undefined;
+}
+
+function getStringConstantValue(type: SdkType): string | undefined {
+  if (type.kind === "nullable") return getStringConstantValue(type.type);
+  return type.kind === "constant" && typeof type.value === "string" ? type.value : undefined;
+}
+
+/**
+ * Build the `streaming` block for a response YAML when the response is a JSONL/SSE
+ * stream with a structured payload type (driven by the TCGC stream metadata).
+ *
+ * Returns `undefined` when structured streaming should not apply, in which case
+ * the existing raw byte-iterator behavior is preserved.
+ *
+ * For SSE, TCGC `sseMetadata` supplies each event's wire name, payload type, and
+ * terminal marker. JSONL only needs the common stream item type.
+ */
+function getStreamingInfo(
+  context: PythonSdkContext,
+  response: SdkHttpResponse | SdkHttpErrorResponse,
+): Record<string, any> | undefined {
+  const streamMetadata = response.streamMetadata;
+  if (!streamMetadata) return undefined;
+  if (!isStructuredStreamType(streamMetadata.streamType)) return undefined;
+  const kind = getStructuredStreamKind(response);
+  if (!kind) return undefined;
+
+  const streaming: Record<string, any> = {
+    kind,
+    itemType: getType(context, streamMetadata.streamType),
+  };
+
+  if (kind === "sse" && response.sseMetadata) {
+    const events: Record<string, any>[] = [];
+    let terminalEvent: string | undefined;
+    for (const event of response.sseMetadata.events) {
+      if (event.isTerminalEvent) {
+        terminalEvent =
+          getStringConstantValue(event.payloadType) ?? getStringConstantValue(event.type);
+      } else {
+        events.push({
+          eventType: event.eventType,
+          itemType: getType(context, event.payloadType),
+        });
+      }
+    }
+    if (events.length > 0) streaming.events = events;
+    if (terminalEvent !== undefined) streaming.terminalEvent = terminalEvent;
+  }
+
+  return streaming;
+}
+
 function isEtagType(type: SdkType): boolean {
   if (type.kind === "nullable") return isEtagType(type.type);
   const raw = type.__raw;
@@ -682,6 +764,7 @@ function emitHttpResponse(
       "invalid-lro-result",
       method,
     ),
+    streaming: isException ? undefined : getStreamingInfo(context, response),
   };
 }
 

--- a/packages/http-client-python/emitter/test/streaming.test.ts
+++ b/packages/http-client-python/emitter/test/streaming.test.ts
@@ -1,0 +1,45 @@
+import { strictEqual } from "assert";
+import { describe, it } from "vitest";
+import { getStructuredStreamKind, isStructuredStreamType } from "../src/http.js";
+
+describe("typespec-python: structured streaming", () => {
+  it("treats model and union payloads as structured", () => {
+    strictEqual(isStructuredStreamType({ kind: "model" } as any), true);
+    strictEqual(isStructuredStreamType({ kind: "union" } as any), true);
+  });
+
+  it("unwraps nullable payloads", () => {
+    strictEqual(isStructuredStreamType({ kind: "nullable", type: { kind: "model" } } as any), true);
+    strictEqual(
+      isStructuredStreamType({ kind: "nullable", type: { kind: "bytes" } } as any),
+      false,
+    );
+  });
+
+  it("treats bare byte/string payloads as unstructured", () => {
+    strictEqual(isStructuredStreamType({ kind: "bytes" } as any), false);
+    strictEqual(isStructuredStreamType({ kind: "string" } as any), false);
+  });
+
+  it("detects the stream protocol explicitly", () => {
+    strictEqual(getStructuredStreamKind({ sseMetadata: { events: [] } } as any), "sse");
+    strictEqual(
+      getStructuredStreamKind({
+        streamMetadata: { contentTypes: ["text/event-stream; charset=utf-8"] },
+      } as any),
+      "sse",
+    );
+    strictEqual(
+      getStructuredStreamKind({
+        streamMetadata: { contentTypes: ["application/jsonl"] },
+      } as any),
+      "jsonl",
+    );
+    strictEqual(
+      getStructuredStreamKind({
+        streamMetadata: { contentTypes: ["application/json"] },
+      } as any),
+      undefined,
+    );
+  });
+});

--- a/packages/http-client-python/generator/pygen/codegen/models/code_model.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/code_model.py
@@ -279,11 +279,28 @@ class CodeModel:  # pylint: disable=too-many-public-methods, disable=too-many-in
             self.need_utils_utils(async_mode, client_namespace)
             or self.need_utils_serialization
             or self.options["models-mode"] == "dpg"
+            or self.need_streaming_base
         )
 
     @property
     def need_utils_serialization(self) -> bool:
         return not self.options["client-side-validation"]
+
+    @property
+    def has_structured_stream(self) -> bool:
+        return any(
+            op.has_structured_stream_response
+            for client in self.clients
+            for og in client.operation_groups
+            for op in og.operations
+        )
+
+    @property
+    def need_streaming_base(self) -> bool:
+        # Whether to emit the vendored ``_utils/streaming_base.py`` (Stream / AsyncStream
+        # + JSONL / SSE decoders). Only needed when at least one operation returns a
+        # structured stream.
+        return self.has_structured_stream
 
     def need_utils_utils(self, async_mode: bool, client_namespace: str) -> bool:
         return (

--- a/packages/http-client-python/generator/pygen/codegen/models/operation.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/operation.py
@@ -98,11 +98,20 @@ class OperationBase(  # pylint: disable=too-many-public-methods,too-many-instanc
 
     @property
     def stream_value(self) -> Union[str, bool]:
+        # Structured streams (JSONL / SSE) must always run the pipeline with
+        # stream=True so the body can be consumed incrementally by Stream/AsyncStream.
+        if self.has_structured_stream_response:
+            return True
         return (
             f'kwargs.pop("stream", {self.has_stream_response})'
             if self.expose_stream_keyword and self.has_response_body and "stream" not in self.exact_name_params
             else self.has_stream_response
         )
+
+    @property
+    def has_structured_stream_response(self) -> bool:
+        """Whether any success response is a structured (JSONL / SSE) stream returning Stream[T]."""
+        return any(getattr(r, "is_structured_stream", False) for r in self.responses)
 
     @property
     def has_form_data_body(self):

--- a/packages/http-client-python/generator/pygen/codegen/models/response.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/response.py
@@ -58,6 +58,15 @@ class Response(BaseModel):
         self.type = type
         self.nullable = yaml_data.get("nullable")
         self.default_content_type = yaml_data.get("defaultContentType")
+        streaming = yaml_data.get("streaming")
+        self.streaming_kind: Optional[str] = streaming["kind"] if streaming else None
+        self.streaming_events: list[tuple[Optional[str], BaseType]] = []
+        self._streaming_terminal_event: Optional[str] = streaming.get("terminalEvent") if streaming else None
+        if streaming:
+            self.streaming_events = [
+                (event.get("eventType"), self.code_model.lookup_type(id(event["itemType"])))
+                for event in streaming.get("events", [])
+            ]
 
     @property
     def result_property(self) -> str:
@@ -92,12 +101,65 @@ class Response(BaseModel):
         )
         return retval
 
+    @property
+    def is_structured_stream(self) -> bool:
+        """Is the response a structured (JSONL / SSE) stream rendered as Stream[T] / AsyncStream[T]."""
+        return self.streaming_kind is not None
+
+    @property
+    def terminal_event(self) -> Optional[str]:
+        """Terminal event marker for a heterogeneous SSE stream, if any.
+
+        TCGC ``sseMetadata`` supplies this marker directly. For compatibility with
+        older metadata, a string-literal member of the item union is used as a fallback.
+        """
+        if self.streaming_kind != "sse":
+            return None
+        if self._streaming_terminal_event is not None:
+            return self._streaming_terminal_event
+        if not isinstance(self.type, CombinedType):
+            return None
+        from .constant_type import ConstantType
+
+        for member in self.type.types:
+            if isinstance(member, ConstantType) and isinstance(member.value, str):
+                return member.value
+        return None
+
+    def stream_class_name(self, async_mode: bool) -> str:
+        return "AsyncStream" if async_mode else "Stream"
+
+    @property
+    def stream_item_type(self) -> Optional[BaseType]:
+        if len(self.streaming_events) == 1:
+            return self.streaming_events[0][1]
+        return self.type
+
     def serialization_type(self, **kwargs: Any) -> str:
         if self.type:
             return self.type.serialization_type(**kwargs)
         return "None"
 
+    def stream_item_annotation(self, **kwargs: Any) -> str:
+        """Valid type expression for a structured stream's item type.
+
+        A named ``CombinedType`` (``@events`` union) renders its ``type_annotation`` as the
+        ``_unions.<Name>`` alias, which is a module-level variable and therefore rejected by
+        pyright/mypy inside ``Stream[...]`` ("Variable not allowed in type expression"). Expand
+        the union inline (``Union[Model, ...]`` / the single member) so the annotation is a
+        valid type expression.
+        """
+        item_type = self.stream_item_type
+        if isinstance(item_type, CombinedType):
+            return item_type.type_definition(**kwargs)
+        return item_type.type_annotation(**kwargs) if item_type else "None"
+
     def type_annotation(self, **kwargs: Any) -> str:
+        if self.is_structured_stream and self.type:
+            kwargs["is_operation_file"] = True
+            kwargs["is_response"] = True
+            stream_class = self.stream_class_name(kwargs.get("async_mode", False))
+            return f"{stream_class}[{self.stream_item_annotation(**kwargs)}]"
         if self.type:
             kwargs["is_operation_file"] = True
             kwargs["is_response"] = True
@@ -109,30 +171,63 @@ class Response(BaseModel):
 
     def docstring_text(self, **kwargs: Any) -> str:
         kwargs["is_response"] = True
+        if self.is_structured_stream and self.type:
+            stream_class = self.stream_class_name(kwargs.get("async_mode", False))
+            item_type = self.stream_item_type or self.type
+            return f"An instance of {stream_class} that iterates over {item_type.docstring_text(**kwargs)}"
         if self.nullable and self.type:
             return f"{self.type.docstring_text(**kwargs)} or None"
         return self.type.docstring_text(**kwargs) if self.type else "None"
 
     def docstring_type(self, **kwargs: Any) -> str:
         kwargs["is_response"] = True
+        if self.is_structured_stream and self.type:
+            stream_class = self.stream_class_name(kwargs.get("async_mode", False))
+            item_type = (self.stream_item_type or self.type).docstring_type(**kwargs)
+            return f"~{self.code_model.namespace}._utils.streaming_base.{stream_class}[{item_type}]"
         if self.nullable and self.type:
             return f"{self.type.docstring_type(**kwargs)} or None"
         return self.type.docstring_type(**kwargs) if self.type else "None"
 
     def imports(self, **kwargs: Any) -> FileImport:
         file_import = FileImport(self.code_model)
-        if self.type:
-            file_import.merge(self.type.imports(**kwargs))
+        item_type = self.stream_item_type if self.is_structured_stream else self.type
+        # For a structured stream whose item type is a named ``@events`` union, the annotation
+        # is expanded inline (see ``stream_item_annotation``), so import the union member types
+        # rather than the ``_unions`` alias.
+        if self.is_structured_stream and isinstance(item_type, CombinedType):
+            for member in item_type.types:
+                file_import.merge(member.imports(**kwargs))
+            # ``Union`` is only needed when the inline expansion actually yields a union of
+            # 2+ distinct member types (a single member collapses to that member; a union of
+            # only literals collapses to a single ``Literal[...]``).
+            distinct = list(dict.fromkeys(m.type_annotation(**kwargs) for m in item_type.types))
+            all_constant = all(t.type == "constant" for t in item_type.types)
+            if len(distinct) > 1 and not all_constant:
+                file_import.add_submodule_import("typing", "Union", ImportType.STDLIB)
+        elif item_type:
+            file_import.merge(item_type.imports(**kwargs))
+            if not self.is_structured_stream and isinstance(item_type, CombinedType) and item_type.name:
+                serialize_namespace = kwargs.get("serialize_namespace", self.code_model.namespace)
+                file_import.add_submodule_import(
+                    self.code_model.get_relative_import_path(serialize_namespace),
+                    "_unions",
+                    ImportType.LOCAL,
+                    TypingSection.TYPING,
+                )
         if self.nullable:
             file_import.add_submodule_import("typing", "Optional", ImportType.STDLIB)
-        if isinstance(self.type, CombinedType) and self.type.name:
+        if self.is_structured_stream:
+            stream_class = self.stream_class_name(kwargs.get("async_mode", False))
             serialize_namespace = kwargs.get("serialize_namespace", self.code_model.namespace)
-            file_import.add_submodule_import(
-                self.code_model.get_relative_import_path(serialize_namespace),
-                "_unions",
-                ImportType.LOCAL,
-                TypingSection.TYPING,
+            relative_path = self.code_model.get_relative_import_path(
+                serialize_namespace, module_name="_utils.streaming_base"
             )
+            file_import.add_submodule_import(relative_path, stream_class, ImportType.LOCAL)
+            if self.streaming_kind == "sse":
+                file_import.add_import("json", ImportType.STDLIB)
+                for _event_type, event_item_type in self.streaming_events:
+                    file_import.merge(event_item_type.imports(**kwargs))
         return file_import
 
     def _get_import_type(self, input_path: str) -> ImportType:
@@ -143,6 +238,14 @@ class Response(BaseModel):
 
     @classmethod
     def from_yaml(cls, yaml_data: dict[str, Any], code_model: "CodeModel") -> "Response":
+        streaming = yaml_data.get("streaming")
+        if streaming:
+            return cls(
+                yaml_data=yaml_data,
+                code_model=code_model,
+                headers=[ResponseHeader.from_yaml(header, code_model) for header in yaml_data["headers"]],
+                type=code_model.lookup_type(id(streaming["itemType"])),
+            )
         type = code_model.lookup_type(id(yaml_data["type"])) if yaml_data.get("type") else None
         # use ByteIteratorType if we are returning a binary type
         default_content_type = yaml_data.get("defaultContentType", "application/json")

--- a/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/__init__.py
@@ -525,6 +525,13 @@ class JinjaSerializer(ReaderAndWriter):
                 general_serializer.serialize_model_base_file(),
             )
 
+        # write _utils/streaming_base.py (vendored Stream/AsyncStream + JSONL/SSE decoders)
+        if self.code_model.need_streaming_base:
+            self.write_file(
+                utils_folder_path / Path("streaming_base.py"),
+                general_serializer.serialize_streaming_base_file(),
+            )
+
     def _serialize_and_write_top_level_folder(self, env: Environment, namespace: str) -> None:
         root_dir = self.code_model.get_root_dir()
         generation_dir = self.code_model.get_generation_dir(namespace)

--- a/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/builder_serializer.py
@@ -1256,15 +1256,75 @@ class _OperationSerializer(_BuilderBaseSerializer[OperationType]):
         )
         return retval
 
-    def handle_response(self, builder: OperationType) -> list[str]:
-        retval: list[str] = ["response = pipeline_response.http_response"]
+    def handle_structured_stream_response(self, builder: OperationType) -> list[str]:
+        """Emit the body for an operation returning a structured (JSONL / SSE) stream.
+
+        Produces a per-event deserialization callback and returns a ``Stream`` /
+        ``AsyncStream`` wrapping the streamed HTTP response.
+        """
+        response = next(r for r in builder.responses if getattr(r, "is_structured_stream", False))
+        item_annotation = response.type.type_annotation(  # type: ignore[union-attr]
+            is_operation_file=True, serialize_namespace=self.serialize_namespace
+        )
+        stream_class = response.stream_class_name(self.async_mode)  # type: ignore[attr-defined]
+        terminal_event = getattr(response, "terminal_event", None)
+        streaming_events = getattr(response, "streaming_events", [])
+        retval: list[str] = []
+        retval.append("def _callback(_http_response, _event):")
+        if response.streaming_kind == "sse":  # type: ignore[attr-defined]
+            retval.append("    _event_json = json.loads(_event.data)")
+            named_events = [
+                (event_type, event_item_type)
+                for event_type, event_item_type in streaming_events
+                if event_type is not None
+            ]
+            unnamed_events = [event_item_type for event_type, event_item_type in streaming_events if event_type is None]
+            if named_events:
+                for index, (event_type, event_item_type) in enumerate(named_events):
+                    event_annotation = event_item_type.type_annotation(
+                        is_operation_file=True,
+                        serialize_namespace=self.serialize_namespace,
+                    )
+                    keyword = "if" if index == 0 else "elif"
+                    retval.append(f"    {keyword} _event.event == {event_type!r}:")
+                    retval.append(f"        deserialized = _deserialize({event_annotation}, _event_json)")
+                retval.append("    else:")
+                if len(unnamed_events) == 1:
+                    event_annotation = unnamed_events[0].type_annotation(
+                        is_operation_file=True,
+                        serialize_namespace=self.serialize_namespace,
+                    )
+                    retval.append(f"        deserialized = _deserialize({event_annotation}, _event_json)")
+                else:
+                    retval.append("        deserialized = _event_json")
+            elif len(unnamed_events) == 1:
+                event_annotation = unnamed_events[0].type_annotation(
+                    is_operation_file=True,
+                    serialize_namespace=self.serialize_namespace,
+                )
+                retval.append(f"    deserialized = _deserialize({event_annotation}, _event_json)")
+            else:
+                retval.append(f"    deserialized = _deserialize({item_annotation}, _event_json)")
+        else:
+            retval.append("    _event_json = _event.json()")
+            retval.append(f"    deserialized = _deserialize({item_annotation}, _event_json)")
+        retval.append("    if cls:")
+        retval.append("        return cls(pipeline_response, deserialized, {})  # type: ignore")
+        retval.append("    return deserialized")
         retval.append("")
-        retval.extend(self.handle_error_response(builder))
-        retval.append("")
-        if builder.has_optional_return_type:
-            retval.append("deserialized = None")
-        if builder.any_response_has_headers:
-            retval.append("response_headers = {}")
+        if terminal_event is not None:
+            retval.append(
+                f"return {stream_class}(response=response, deserialization_callback=_callback, "
+                f"terminal_event={terminal_event!r})  # type: ignore"
+            )
+        else:
+            retval.append(
+                f"return {stream_class}(response=response, deserialization_callback=_callback)  # type: ignore"
+            )
+        return retval
+
+    def _handle_response_body(self, builder: OperationType) -> list[str]:
+        retval: list[str] = []
         if builder.has_response_body or builder.any_response_has_headers:  # pylint: disable=too-many-nested-blocks
             if len(builder.responses) > 1:
                 status_codes, res_headers, res_deserialization = [], [], []
@@ -1299,6 +1359,21 @@ class _OperationSerializer(_BuilderBaseSerializer[OperationType]):
             else:
                 retval.extend(self.response_headers_and_deserialization(builder, builder.responses[0]))
                 retval.append("")
+        return retval
+
+    def handle_response(self, builder: OperationType) -> list[str]:
+        retval: list[str] = ["response = pipeline_response.http_response"]
+        retval.append("")
+        retval.extend(self.handle_error_response(builder))
+        retval.append("")
+        if builder.has_structured_stream_response:
+            retval.extend(self.handle_structured_stream_response(builder))
+            return retval
+        if builder.has_optional_return_type:
+            retval.append("deserialized = None")
+        if builder.any_response_has_headers:
+            retval.append("response_headers = {}")
+        retval.extend(self._handle_response_body(builder))
         if (
             builder.has_optional_return_type
             or self.code_model.options["models-mode"]

--- a/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/general_serializer.py
@@ -318,6 +318,10 @@ class GeneralSerializer(BaseSerializer):
         template = self.env.get_template("model_base.py.jinja2")
         return template.render(code_model=self.code_model, file_import=FileImport(self.code_model))
 
+    def serialize_streaming_base_file(self) -> str:
+        template = self.env.get_template("streaming_base.py.jinja2")
+        return template.render(code_model=self.code_model, file_import=FileImport(self.code_model))
+
     def serialize_validation_file(self) -> str:
         template = self.env.get_template("validation.py.jinja2")
         return template.render(

--- a/packages/http-client-python/generator/pygen/codegen/templates/streaming_base.py.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/streaming_base.py.jinja2
@@ -1,0 +1,562 @@
+# coding=utf-8
+{% if code_model.license_header %}
+{{ code_model.license_header }}
+{% endif %}
+# pylint: disable=line-too-long,useless-suppression,unnecessary-ellipsis
+# --------------------------------------------------------------------------
+# This file is vendored from azure-core (azure.core.streaming). It provides the
+# Stream / AsyncStream helpers (plus the JSONL / SSE decoders and event types)
+# used by generated structured-streaming operations, so the generated package
+# does not take a hard dependency on an azure-core version that ships
+# azure.core.streaming. Do not edit by hand.
+# --------------------------------------------------------------------------
+import codecs
+import json
+from types import TracebackType
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+    runtime_checkable,
+)
+
+from typing_extensions import Self
+
+from azure.core.rest import AsyncHttpResponse, HttpResponse
+
+DecodedType = TypeVar("DecodedType")
+ReturnType_co = TypeVar("ReturnType_co", covariant=True)
+T_co = TypeVar("T_co", covariant=True)
+
+
+@runtime_checkable
+class StreamDecoder(Protocol[T_co]):
+    """Protocol for stream decoders."""
+
+    def iter_events(self, iter_bytes: Iterator[bytes]) -> Iterator[T_co]:
+        """Iterate over events from a byte iterator.
+
+        :param iter_bytes: An iterator of byte chunks.
+        :type iter_bytes: Iterator[bytes]
+        :return: An iterator of decoded data.
+        :rtype: Iterator[DecodedType_co]
+        """
+        ...
+
+
+@runtime_checkable
+class AsyncStreamDecoder(Protocol[T_co]):
+    """Protocol for async stream decoders."""
+
+    # Why this isn't async def: https://mypy.readthedocs.io/en/stable/more_types.html#asynchronous-iterators
+    def aiter_events(self, iter_bytes: AsyncIterator[bytes]) -> AsyncIterator[T_co]:
+        """Asynchronously iterate over events from a byte iterator.
+
+        :param iter_bytes: An asynchronous iterator of byte chunks.
+        :type iter_bytes: AsyncIterator[bytes]
+        :return: An asynchronous iterator of decoded data.
+        :rtype: AsyncIterator[DecodedType_co]
+        """
+        ...
+
+
+class JSONLEvent:
+    """A single JSON Lines (JSONL) event.
+
+    :ivar data: The raw JSONL record.
+    :vartype data: str or None
+    :keyword data: The raw JSONL record.
+    :paramtype data: str or None
+    """
+
+    def __init__(
+        self,
+        *,
+        data: Optional[str] = None,
+    ) -> None:
+        self.data = data
+
+    def json(self) -> Any:
+        """Parse the event data as JSON.
+
+        :return: The parsed JSON value.
+        :rtype: Any
+        """
+        return json.loads(cast(str, self.data))
+
+
+def iter_lines(iter_bytes: Iterator[bytes]) -> Iterator[str]:
+    """Iterate over lines from a byte iterator.
+
+    :param iter_bytes: An iterator of byte chunks.
+    :type iter_bytes: Iterator[bytes]
+    :rtype: Iterator[str]
+    :return: An iterator of lines.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")()
+
+    # Split only on "\n" (tolerating "\r\n") rather than using str.splitlines(),
+    # which would also break on other Unicode boundaries (\v, \f, \x1c-\x1e, \x85,
+    # \u2028, \u2029) that are valid inside a JSONL record's string value.
+    decoded = ""
+    for chunk in iter_bytes:
+        decoded += decoder.decode(chunk)
+        if decoded:
+            decoded_lines = [line[:-1] if line.endswith("\r") else line for line in decoded.split("\n")]
+            yield from decoded_lines[:-1]
+            decoded = decoded_lines[-1]
+
+    decoded += decoder.decode(b"", final=True)
+    if decoded:
+        yield decoded[:-1] if decoded.endswith("\r") else decoded
+
+
+async def aiter_lines(iter_bytes: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """Iterate over lines from a byte iterator.
+
+    :param iter_bytes: An iterator of byte chunks.
+    :type iter_bytes: Iterator[bytes]
+    :rtype: Iterator[str]
+    :return: An iterator of lines.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")()
+
+    # Split only on "\n" (tolerating "\r\n") rather than using str.splitlines(),
+    # which would also break on other Unicode boundaries (\v, \f, \x1c-\x1e, \x85,
+    # \u2028, \u2029) that are valid inside a JSONL record's string value.
+    decoded = ""
+    async for chunk in iter_bytes:
+        decoded += decoder.decode(chunk)
+        if decoded:
+            decoded_lines = [line[:-1] if line.endswith("\r") else line for line in decoded.split("\n")]
+            for line in decoded_lines[:-1]:
+                yield line
+            decoded = decoded_lines[-1]
+
+    decoded += decoder.decode(b"", final=True)
+    if decoded:
+        yield decoded[:-1] if decoded.endswith("\r") else decoded
+
+
+class JSONLDecoder:
+    """Decoder for JSON Lines (JSONL) format. https://jsonlines.org/"""
+
+    def iter_events(self, iter_bytes: Iterator[bytes]) -> Iterator[JSONLEvent]:
+        """Iterate over JSONL events from a byte iterator.
+
+        :param iter_bytes: An iterator of byte chunks.
+        :type iter_bytes: Iterator[bytes]
+        :rtype: Iterator[JSONLEvent]
+        :return: An iterator of JSONL events.
+        """
+
+        yield from (JSONLEvent(data=line) for line in iter_lines(iter_bytes))
+
+
+class AsyncJSONLDecoder:
+    """Asynchronous decoder for JSON Lines (JSONL) format. https://jsonlines.org/"""
+
+    # pylint: disable=invalid-overridden-method
+    async def aiter_events(self, iter_bytes: AsyncIterator[bytes]) -> AsyncIterator[JSONLEvent]:
+        """Asynchronously iterate over JSONL events from a byte iterator.
+
+        :param iter_bytes: An asynchronous iterator of byte chunks.
+        :type iter_bytes: AsyncIterator[bytes]
+        :rtype: AsyncIterator[JSONLEvent]
+        :return: An asynchronous iterator of JSONL events.
+        """
+
+        async for line in aiter_lines(iter_bytes):
+            yield JSONLEvent(data=line)
+
+
+class ServerSentEvent:
+    """A single Server-Sent Event (SSE).
+
+    https://html.spec.whatwg.org/multipage/server-sent-events.html
+
+    :ivar event: The event type. Defaults to ``"message"`` when the stream does not
+        specify one.
+    :vartype event: str
+    :ivar data: The event payload. Multiple ``data`` lines are joined with ``"\\n"``.
+        Left as a raw string; the caller is responsible for any further parsing.
+    :vartype data: str
+    :ivar id: The last event ID. Defaults to an empty string until the stream
+        provides one.
+    :vartype id: str
+    :ivar retry: The reconnection time in milliseconds, if the stream provided one.
+    :vartype retry: int or None
+    :keyword event: The event type. Defaults to ``"message"`` when the stream does not
+        specify one.
+    :paramtype event: str
+    :keyword data: The event payload. Multiple ``data`` lines are joined with ``"\\n"``.
+        Left as a raw string; the caller is responsible for any further parsing.
+    :paramtype data: str
+    :keyword id: The last event ID. Defaults to an empty string until the stream
+        provides one.
+    :paramtype id: str
+    :keyword retry: The reconnection time in milliseconds, if the stream provided one.
+    :paramtype retry: int or None
+    """
+
+    def __init__(
+        self,
+        *,
+        event: str = "message",
+        data: str = "",
+        id: str = "",  # pylint: disable=redefined-builtin
+        retry: Optional[int] = None,
+    ) -> None:
+        self.event = event
+        self.data = data
+        self.id = id
+        self.retry = retry
+
+    def __repr__(self) -> str:
+        return f"ServerSentEvent(event={self.event!r}, data={self.data!r}, " f"id={self.id!r}, retry={self.retry!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ServerSentEvent):
+            return NotImplemented
+        return (self.event, self.data, self.id, self.retry) == (
+            other.event,
+            other.data,
+            other.id,
+            other.retry,
+        )
+
+
+def _split_sse_lines(buf: str) -> Tuple[List[str], str]:
+    """Split ``buf`` into complete SSE lines plus a trailing remainder.
+
+    Per the SSE spec, lines may be separated by ``\\r\\n``, ``\\r`` or ``\\n``. A lone
+    trailing ``\\r`` is kept in the remainder because it may be the first half of a
+    ``\\r\\n`` that arrives in a later chunk.
+
+    :param buf: The buffered, already UTF-8 decoded text.
+    :type buf: str
+    :return: A tuple of ``(complete_lines, remainder)`` where ``remainder`` is the
+        unterminated tail (never containing a line separator, except a single trailing
+        ``\\r`` awaiting a possible ``\\n``).
+    :rtype: tuple[list[str], str]
+    """
+    lines: List[str] = []
+    start = 0
+    i = 0
+    n = len(buf)
+    while i < n:
+        char = buf[i]
+        if char == "\n":
+            lines.append(buf[start:i])
+            i += 1
+            start = i
+        elif char == "\r":
+            if i + 1 < n:
+                lines.append(buf[start:i])
+                i += 2 if buf[i + 1] == "\n" else 1
+                start = i
+            else:
+                # Trailing lone "\r": ambiguous, defer until the next chunk.
+                break
+        else:
+            i += 1
+    return lines, buf[start:]
+
+
+def _iter_sse_lines(iter_bytes: Iterator[bytes]) -> Iterator[str]:
+    """Iterate over SSE lines (line separators stripped) from a byte iterator.
+
+    :param iter_bytes: An iterator of byte chunks.
+    :type iter_bytes: Iterator[bytes]
+    :rtype: Iterator[str]
+    :return: An iterator of decoded lines.
+    """
+    # SSE is always UTF-8 (WHATWG spec). Use utf-8-sig to drop one leading BOM and
+    # errors="replace" so invalid byte sequences become U+FFFD instead of crashing.
+    decoder = codecs.getincrementaldecoder("utf-8-sig")(errors="replace")
+
+    buf = ""
+    for chunk in iter_bytes:
+        buf += decoder.decode(chunk)
+        lines, buf = _split_sse_lines(buf)
+        yield from lines
+
+    buf += decoder.decode(b"", final=True)
+    lines, remainder = _split_sse_lines(buf)
+    yield from lines
+    if remainder:
+        yield remainder[:-1] if remainder.endswith("\r") else remainder
+
+
+async def _aiter_sse_lines(iter_bytes: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """Asynchronously iterate over SSE lines (separators stripped) from a byte iterator.
+
+    :param iter_bytes: An asynchronous iterator of byte chunks.
+    :type iter_bytes: AsyncIterator[bytes]
+    :rtype: AsyncIterator[str]
+    :return: An asynchronous iterator of decoded lines.
+    """
+    # SSE is always UTF-8 (WHATWG spec). Use utf-8-sig to drop one leading BOM and
+    # errors="replace" so invalid byte sequences become U+FFFD instead of crashing.
+    decoder = codecs.getincrementaldecoder("utf-8-sig")(errors="replace")
+
+    buf = ""
+    async for chunk in iter_bytes:
+        buf += decoder.decode(chunk)
+        lines, buf = _split_sse_lines(buf)
+        for line in lines:
+            yield line
+
+    buf += decoder.decode(b"", final=True)
+    lines, remainder = _split_sse_lines(buf)
+    for line in lines:
+        yield line
+    if remainder:
+        yield remainder[:-1] if remainder.endswith("\r") else remainder
+
+
+class _SSEEventBuilder:
+    """Accumulates SSE field lines and builds :class:`ServerSentEvent` instances."""
+
+    def __init__(self) -> None:
+        self._data: List[str] = []
+        self._event_type = ""
+        self._last_id = ""
+        self._retry: Optional[int] = None
+
+    def add_line(self, line: str) -> Optional[ServerSentEvent]:
+        """Process a single SSE line, dispatching an event on a blank line.
+
+        :param line: A single SSE line with its terminator already stripped.
+        :type line: str
+        :return: A :class:`ServerSentEvent` when ``line`` is blank and an event is
+            pending, otherwise ``None``.
+        :rtype: ServerSentEvent or None
+        """
+        if line == "":
+            return self._dispatch()
+        if line.startswith(":"):
+            # Comment line, ignored.
+            return None
+
+        field, _, value = line.partition(":")
+        if value.startswith(" "):
+            value = value[1:]
+
+        if field == "event":
+            self._event_type = value
+        elif field == "data":
+            self._data.append(value)
+        elif field == "id":
+            if "\x00" not in value:
+                self._last_id = value
+        elif field == "retry":
+            if value.isascii() and value.isdigit():
+                try:
+                    self._retry = int(value)
+                except ValueError:
+                    # All ASCII digits but too long for int() (CPython's int-string
+                    # conversion limit). Ignore rather than crashing the stream.
+                    pass
+        # Unknown fields are ignored per spec.
+        return None
+
+    def _dispatch(self) -> Optional[ServerSentEvent]:
+        if not self._data:
+            # No data accumulated: reset and dispatch nothing.
+            self._event_type = ""
+            return None
+        event = ServerSentEvent(
+            event=self._event_type or "message",
+            data="\n".join(self._data),
+            id=self._last_id,
+            retry=self._retry,
+        )
+        self._data = []
+        self._event_type = ""
+        return event
+
+
+class SSEDecoder:
+    """Decoder for Server-Sent Events (SSE).
+
+    https://html.spec.whatwg.org/multipage/server-sent-events.html
+    """
+
+    def iter_events(self, iter_bytes: Iterator[bytes]) -> Iterator[ServerSentEvent]:
+        """Iterate over SSE events from a byte iterator.
+
+        :param iter_bytes: An iterator of byte chunks.
+        :type iter_bytes: Iterator[bytes]
+        :rtype: Iterator[ServerSentEvent]
+        :return: An iterator of server-sent events.
+        """
+        builder = _SSEEventBuilder()
+        for line in _iter_sse_lines(iter_bytes):
+            event = builder.add_line(line)
+            if event is not None:
+                yield event
+
+
+class AsyncSSEDecoder:
+    """Asynchronous decoder for Server-Sent Events (SSE).
+
+    https://html.spec.whatwg.org/multipage/server-sent-events.html
+    """
+
+    # pylint: disable=invalid-overridden-method
+    async def aiter_events(self, iter_bytes: AsyncIterator[bytes]) -> AsyncIterator[ServerSentEvent]:
+        """Asynchronously iterate over SSE events from a byte iterator.
+
+        :param iter_bytes: An asynchronous iterator of byte chunks.
+        :type iter_bytes: AsyncIterator[bytes]
+        :rtype: AsyncIterator[ServerSentEvent]
+        :return: An asynchronous iterator of server-sent events.
+        """
+        builder = _SSEEventBuilder()
+        async for line in _aiter_sse_lines(iter_bytes):
+            event = builder.add_line(line)
+            if event is not None:
+                yield event
+
+
+class Stream(Iterator[ReturnType_co]):
+    """Stream class for consuming a decoded event stream (e.g. JSONL or SSE).
+
+    :keyword response: The response object.
+    :paramtype response: ~azure.core.rest.HttpResponse
+    :keyword decoder: A decoder to use for the stream. If omitted, the decoder is
+        inferred from the response ``Content-Type`` header.
+    :paramtype decoder: StreamDecoder
+    :keyword deserialization_callback: A callback that takes the response and the decoded event and
+        returns a deserialized object.
+    :paramtype deserialization_callback: Callable[[~azure.core.rest.HttpResponse, Any], ReturnType]
+    :keyword terminal_event: Optional event ``data`` value that terminates the stream (e.g.
+        ``"[DONE]"``). When an event's ``data`` equals this value, iteration stops and the
+        event is not passed to ``deserialization_callback``.
+    :paramtype terminal_event: str or None
+    """
+
+    def __init__(
+        self,
+        *,
+        response: HttpResponse,
+        deserialization_callback: Callable[[HttpResponse, DecodedType], ReturnType_co],
+        decoder: Optional[StreamDecoder[DecodedType]] = None,
+        terminal_event: Optional[str] = None,
+    ) -> None:
+        self._response = response
+        content_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        self._decoder: StreamDecoder[Any] = (
+            decoder if decoder is not None else (SSEDecoder() if content_type == "text/event-stream" else JSONLDecoder())
+        )
+        self._deserialization_callback = deserialization_callback
+        self._terminal_event = terminal_event
+        self._iterator = self._iter_results()
+
+    def __next__(self) -> ReturnType_co:
+        return self._iterator.__next__()
+
+    def __iter__(self) -> Self:
+        return self
+
+    def _iter_results(self) -> Iterator[ReturnType_co]:
+        for event in self._decoder.iter_events(self._response.iter_bytes()):
+            if self._terminal_event is not None and getattr(event, "data", None) == self._terminal_event:
+                break
+            result = self._deserialization_callback(self._response, event)
+            yield result
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        self.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def close(self) -> None:
+        self._response.close()
+
+
+class AsyncStream(AsyncIterator[ReturnType_co]):
+    """AsyncStream class for asynchronously consuming a decoded event stream (e.g. JSONL or SSE).
+
+    :keyword response: The response object.
+    :paramtype response: ~azure.core.rest.AsyncHttpResponse
+    :keyword decoder: A decoder to use for the stream. If omitted, the decoder is
+        inferred from the response ``Content-Type`` header.
+    :paramtype decoder: AsyncStreamDecoder
+    :keyword deserialization_callback: A callback that takes the response and the decoded event and
+        returns a deserialized object.
+    :paramtype deserialization_callback: Callable[[~azure.core.rest.AsyncHttpResponse, Any], ReturnType]
+    :keyword terminal_event: Optional event ``data`` value that terminates the stream (e.g.
+        ``"[DONE]"``). When an event's ``data`` equals this value, iteration stops and the
+        event is not passed to ``deserialization_callback``.
+    :paramtype terminal_event: str or None
+    """
+
+    def __init__(
+        self,
+        *,
+        response: AsyncHttpResponse,
+        deserialization_callback: Callable[[AsyncHttpResponse, DecodedType], ReturnType_co],
+        decoder: Optional[AsyncStreamDecoder[DecodedType]] = None,
+        terminal_event: Optional[str] = None,
+    ) -> None:
+        self._response = response
+        content_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        self._decoder: AsyncStreamDecoder[Any] = (
+            decoder
+            if decoder is not None
+            else (AsyncSSEDecoder() if content_type == "text/event-stream" else AsyncJSONLDecoder())
+        )
+        self._deserialization_callback = deserialization_callback
+        self._terminal_event = terminal_event
+        self._iterator = self._iter_results()
+
+    async def __anext__(self) -> ReturnType_co:
+        return await self._iterator.__anext__()
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def _iter_results(self) -> AsyncIterator[ReturnType_co]:
+        async for event in self._decoder.aiter_events(self._response.iter_bytes()):
+            if self._terminal_event is not None and getattr(event, "data", None) == self._terminal_event:
+                break
+            result = self._deserialization_callback(self._response, event)
+            yield result
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        await self.close()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def close(self) -> None:
+        await self._response.close()
+
+
+__all__ = [
+    "Stream",
+    "AsyncStream",
+    "JSONLEvent",
+    "ServerSentEvent",
+]

--- a/packages/http-client-python/generator/pygen/preprocess/__init__.py
+++ b/packages/http-client-python/generator/pygen/preprocess/__init__.py
@@ -35,6 +35,8 @@ def update_overload_section(
         for overload_s, original_s in zip(overload[section], yaml_data[section]):
             if overload_s.get("type"):
                 overload_s["type"] = original_s["type"]
+            if overload_s.get("streaming"):
+                overload_s["streaming"] = original_s["streaming"]
             if overload_s.get("headers"):
                 for overload_h, original_h in zip(overload_s["headers"], original_s["headers"]):
                     if overload_h.get("type"):

--- a/packages/http-client-python/package-lock.json
+++ b/packages/http-client-python/package-lock.json
@@ -18,22 +18,22 @@
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-        "@azure-tools/typespec-autorest": "~0.70.0",
+        "@azure-tools/typespec-autorest": "0.71.0-dev.4",
         "@azure-tools/typespec-azure-core": "~0.70.0",
         "@azure-tools/typespec-azure-resource-manager": "~0.70.0",
-        "@azure-tools/typespec-azure-rulesets": "~0.70.0",
-        "@azure-tools/typespec-client-generator-core": "~0.70.0",
+        "@azure-tools/typespec-azure-rulesets": "0.71.0-dev.5",
+        "@azure-tools/typespec-client-generator-core": "0.71.0-dev.11",
         "@types/js-yaml": "~4.0.5",
         "@types/node": "~25.0.2",
         "@types/semver": "7.5.8",
-        "@typespec/compiler": "^1.14.0",
+        "@typespec/compiler": "1.15.0-dev.17",
         "@typespec/events": "~0.84.0",
         "@typespec/http": "^1.14.0",
-        "@typespec/http-specs": "0.1.0-alpha.39",
+        "@typespec/http-specs": "0.1.0-alpha.40",
         "@typespec/openapi": "^1.14.0",
         "@typespec/rest": "~0.84.0",
         "@typespec/spec-api": "0.1.0-alpha.15",
-        "@typespec/spector": "0.1.0-alpha.26",
+        "@typespec/spector": "0.1.0-alpha.27",
         "@typespec/sse": "~0.84.0",
         "@typespec/streams": "~0.84.0",
         "@typespec/versioning": "~0.84.0",
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.70.0.tgz",
-      "integrity": "sha512-OaxLkgMcuOXAbaqTNpezmFF24jtkiIH1+2PBwAeRo3ZG7C1r7Hf8xZwCK6KVtBEgMbqnrd5eCqxsPl1zy3y9/Q==",
+      "version": "0.71.0-dev.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-autorest/-/typespec-autorest-0.71.0-dev.4.tgz",
+      "integrity": "sha1-p920uaoYRzfFVIeEUDW6+uUri1w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -101,9 +101,9 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
-        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@azure-tools/typespec-azure-core": "^0.70.0 || >= 0.71.0-dev.3",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0 || >= 0.71.0-dev.10",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0 || >= 0.71.0-dev.11",
         "@typespec/compiler": "^1.14.0",
         "@typespec/http": "^1.14.0",
         "@typespec/openapi": "^1.14.0",
@@ -119,8 +119,8 @@
     },
     "node_modules/@azure-tools/typespec-azure-core": {
       "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.70.0.tgz",
-      "integrity": "sha512-8MojHWRtTLKycJJ98IMoXX/5b9tTo3F0d3Iu20OKoCsORnSDG2NfjOWHJVW63oxA2t8VTlqC6J8BDcnRihygQQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.70.0.tgz",
+      "integrity": "sha1-k3VYRkt7yNAA1kiBElz71YbZH7A=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -134,8 +134,8 @@
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
       "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.70.0.tgz",
-      "integrity": "sha512-hVrbbsOhU3EQ2yQTppCqsGQwY/HcVZPOINtFkoUo+PUVBmCFXyqLkTO4jvUbsp/LvJEwoQ8aEA8Y35f7VWT5uw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.70.0.tgz",
+      "integrity": "sha1-+Skz0cnW1LADE60g/JnqYk0nixg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -155,25 +155,25 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.70.0.tgz",
-      "integrity": "sha512-Uxxl/18oryDwk2S+aYx6cIqiyjmoMeFDGmjuQ72a+aw6u8mZjgahMxNsY0ShvGLSchjsDqsVGaUlazXGXakVrw==",
+      "version": "0.71.0-dev.5",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.71.0-dev.5.tgz",
+      "integrity": "sha1-bpzvEq9boKSAhUwBc+EKXvxNOwI=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
-        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@azure-tools/typespec-azure-core": "^0.70.0 || >= 0.71.0-dev.4",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0 || >= 0.71.0-dev.11",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0 || >= 0.71.0-dev.11",
         "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.70.0.tgz",
-      "integrity": "sha512-8yxOYJfID3wp3FLQYNIa3kbmR5YLWjYtpB+i4u66quHTTQWWANHV1/o9f8xymAf+8fO9jbLo5tw1JerumxISWg==",
+      "version": "0.71.0-dev.11",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.71.0-dev.11.tgz",
+      "integrity": "sha1-uBy0avXoMit1nkolVuXXLg2gbmw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -185,7 +185,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-core": "^0.70.0 || >= 0.71.0-dev.3",
         "@typespec/compiler": "^1.14.0",
         "@typespec/events": "^0.84.0",
         "@typespec/http": "^1.14.0",
@@ -999,8 +999,8 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha1-8p4iBXrVMWzyODbO6aNMgf/8t+Y=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1014,9 +1014,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1027,8 +1027,8 @@
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -1041,8 +1041,8 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha1-G9AGzut+LlWyt3OrMY0wDhpmrto=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1055,8 +1055,8 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha1-dyJYIEE9lhdQnak0IZCiAZ54dhw=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha1-0iv9azp9jh8sCy8ubeERtT7G4T4=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1081,7 +1081,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -1093,9 +1093,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1111,9 +1111,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1124,16 +1124,16 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -1145,9 +1145,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha1-by+8/3VQDSKdU14KlJrhNHLIR4c=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1160,8 +1160,8 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha1-biEmoTR+hqTe34cG7Gf/jhB+u60=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1171,8 +1171,8 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha1-l3nj/Zt+4zVxpXQ1z0M1oXlKbLI=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1185,48 +1185,52 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha1-qCcsoDsqz0kmcCIrIyC2xCG/3mA=",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.8",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha1-j4AMzME/T4zTEW4tnAqUk52j4+0=",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha1-8qCfYgEjkLK/8/xvskjd7IwJoJA=",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": ">=12.22"
@@ -1237,10 +1241,11 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "version": "0.4.3",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha1-wrnS43TuYsWG062+qHGZsdenpro=",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": ">=18.18"
@@ -2061,8 +2066,8 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2327,9 +2332,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.14.0.tgz",
-      "integrity": "sha512-RRN0LGVDlonG/IbB2b4mvRjdCo6LywwB9/J8lOp6UaH7vtaFnKe5FL+rpxhof4rXx/zI/4OWnQO6c01bTCz4/Q==",
+      "version": "1.15.0-dev.17",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/compiler/-/compiler-1.15.0-dev.17.tgz",
+      "integrity": "sha1-hrlL0q3kmaR0fWNddCfI7LA2BCY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2341,7 +2346,7 @@
         "is-unicode-supported": "^2.1.0",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
-        "prettier": "^3.8.1",
+        "prettier": "^3.9.5",
         "semver": "^7.7.4",
         "tar": "^7.5.13",
         "temporal-polyfill": "^1.0.1",
@@ -2441,8 +2446,8 @@
     },
     "node_modules/@typespec/events": {
       "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.84.0.tgz",
-      "integrity": "sha512-UroDIu6t6Z+cOLyX8I+GJWhSFmYGrp1L93F7ZVt0Ypmj0ndmC9YYa4cpeEyS5PDDIC8u49WfCIwfGegxt4rPVQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/events/-/events-0.84.0.tgz",
+      "integrity": "sha1-U6JW0cqeb0+n5fCjTbaW3DlOYPk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2454,8 +2459,8 @@
     },
     "node_modules/@typespec/http": {
       "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.14.0.tgz",
-      "integrity": "sha512-W+heCzu8K63AVcoX8MachVWaRxSAMFWOI1yBTc2Kq8QHaJeDiLL5JbU8VfTZ4tL/6EoGSdKfIT5ZNRW7oVCzhg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/http/-/http-1.14.0.tgz",
+      "integrity": "sha1-La9yB2Ny8FhnXSBbst9wYQBiOq4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2472,30 +2477,32 @@
       }
     },
     "node_modules/@typespec/http-specs": {
-      "version": "0.1.0-alpha.39",
-      "resolved": "https://registry.npmjs.org/@typespec/http-specs/-/http-specs-0.1.0-alpha.39.tgz",
-      "integrity": "sha512-x3ORyF/qLSLt+QDyievKT90STB0tT9J4s0Yu/Isio8zK16U+eRbCFHi69T7FZ94ZrRpPDWJ2u9+dEZv/SCPj+w==",
+      "version": "0.1.0-alpha.40",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/http-specs/-/http-specs-0.1.0-alpha.40.tgz",
+      "integrity": "sha1-Jbgrft+poBvuGMqqGR+shaf07Kk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typespec/spec-api": "^0.1.0-alpha.15",
-        "@typespec/spector": "^0.1.0-alpha.26"
+        "@typespec/spector": "^0.1.0-alpha.27"
       },
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
         "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
         "@typespec/http": "^1.14.0",
         "@typespec/rest": "^0.84.0",
+        "@typespec/sse": "^0.84.0",
         "@typespec/versioning": "^0.84.0",
         "@typespec/xml": "^0.84.0"
       }
     },
     "node_modules/@typespec/openapi": {
       "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.14.0.tgz",
-      "integrity": "sha512-KL7kImPhCXRmxpHVt1k7TWaa4bb3NbSeUx2rxyxeq7lYZFllI6/NYRCTOI/5JOrbElWmmSxrajU9K9IAKI6PkQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/openapi/-/openapi-1.14.0.tgz",
+      "integrity": "sha1-uwjWOV3VwWP59UXlR2xVUuzyCGc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2508,8 +2515,8 @@
     },
     "node_modules/@typespec/rest": {
       "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.84.0.tgz",
-      "integrity": "sha512-9s5dDfRoHRPdtbVvkBasUx/RnMvwWMTuXRieSQDEji4gWGgxVu4Zt4MiEEKSfQrkMr3Aw0QjRCSxBxjMCHIOmA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/rest/-/rest-0.84.0.tgz",
+      "integrity": "sha1-kMLB39G8geZbiA3EEdQBaqteuuA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2582,9 +2589,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/spector": {
-      "version": "0.1.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@typespec/spector/-/spector-0.1.0-alpha.26.tgz",
-      "integrity": "sha512-WtaWIJE+Xh80G11Bi/3zC1GIrK4EVYBSCnkmSvm9bEYcBMH8QuryPDbUeTXYUyozcCrMYXaKnBboHN91IEi8ug==",
+      "version": "0.1.0-alpha.27",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/spector/-/spector-0.1.0-alpha.27.tgz",
+      "integrity": "sha1-aA4cucLEbAIR6ZLH0llZuaVOMMY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2682,8 +2689,8 @@
     },
     "node_modules/@typespec/sse": {
       "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.84.0.tgz",
-      "integrity": "sha512-9joNgVisRCWDFfV1d79iTAuR1W/6r+AKJrKUfcjsaTrq5A8OWW3v5TTsfxbHAZArn7n2WxQkqhNGgNyc8LjEng==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/sse/-/sse-0.84.0.tgz",
+      "integrity": "sha1-dkP/3P+tvI4Q2SV3oRz/F2JMVXo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2698,8 +2705,8 @@
     },
     "node_modules/@typespec/streams": {
       "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.84.0.tgz",
-      "integrity": "sha512-SDneR8+zY+ueOpzg9yJtttfDe/ikB99JgddZSXKPwiDPlAIEeEvI8auipcYfB58EEOB21h8Oq0tEm8HqiAAWdQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/streams/-/streams-0.84.0.tgz",
+      "integrity": "sha1-Bm3D76chBKlcou2jj913xFfTBI4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2726,8 +2733,8 @@
     },
     "node_modules/@typespec/versioning": {
       "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.84.0.tgz",
-      "integrity": "sha512-ZoDasTDj4z0mgFK+0cJL2+7DduCaTjvICHL2nQ/RBWc7nLgObaIYCjvXLno8WneDXnpxCAr7larN4/nlHEv9fg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/versioning/-/versioning-0.84.0.tgz",
+      "integrity": "sha1-YS06C7uMMWXKp7vwuy8qV8kjr38=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2739,8 +2746,8 @@
     },
     "node_modules/@typespec/xml": {
       "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.84.0.tgz",
-      "integrity": "sha512-3x0spgIrr4u3azkYaOxrlumtjoqPiUnJ/G5RwGBmUCAeE5F413MHf/AeIkmZ2ULT1gY3myabfZp8bOijTbMk7A==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@typespec/xml/-/xml-0.84.0.tgz",
+      "integrity": "sha1-aP99jZ3+wHS7f9mMJbEUT4Py7+g=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2878,9 +2885,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2893,8 +2900,8 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3216,8 +3223,8 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3233,6 +3240,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/change-case": {
@@ -3342,8 +3367,8 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -3448,9 +3473,10 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/default-browser": {
@@ -3685,9 +3711,10 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -3697,9 +3724,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha1-Kk48iw91MZbvrpQ8j/qocw/Go/o=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3709,8 +3736,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3759,8 +3786,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha1-iOZGogf61hQ2/6OetQUUcgBlXII=",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -3789,9 +3816,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3807,9 +3834,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3818,35 +3845,18 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -3859,8 +3869,8 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha1-1U9JSdRikAWh+haNk3w/8ffiqDc=",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -3877,10 +3887,11 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -3891,8 +3902,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -3905,9 +3916,10 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
       "dev": true,
+      "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -3925,9 +3937,10 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true,
+      "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4015,17 +4028,18 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/fast-string-truncated-width": {
@@ -4115,9 +4129,10 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha1-d4e93PETG/+5JjbGlFe7wO3W2B8=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -4179,9 +4194,10 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha1-Ds45/LFO4BL0sEEL0z3ZwfAREnw=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
@@ -4192,9 +4208,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha1-ruyipQYwPwzuYcWebJ8qiNLyn8Y=",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -4350,9 +4366,10 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
       "dev": true,
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -4402,8 +4419,8 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha1-iY10E8Kbq89rr+Vvyt3thYrack4=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4536,8 +4553,8 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4547,8 +4564,8 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha1-nOy1ZQPAraHydB271lRuSxO1fM8=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4565,8 +4582,8 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4609,9 +4626,10 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4628,9 +4646,10 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4779,9 +4798,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "funding": [
         {
           "type": "github",
@@ -4802,9 +4821,10 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/json-schema-traverse": {
@@ -4816,9 +4836,10 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/jsonwebtoken": {
@@ -4869,9 +4890,10 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -4879,9 +4901,10 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -5211,9 +5234,10 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/lodash.once": {
@@ -5625,9 +5649,10 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -5679,8 +5704,8 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5829,9 +5854,10 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -5869,8 +5895,8 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5972,8 +5998,8 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6452,8 +6478,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6744,9 +6770,10 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -6852,8 +6879,8 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -7158,9 +7185,10 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -104,24 +104,24 @@
     "tsx": "^4.21.0"
   },
   "devDependencies": {
-    "@azure-tools/typespec-autorest": "~0.70.0",
+    "@azure-tools/typespec-autorest": "0.71.0-dev.4",
     "@azure-tools/typespec-azure-core": "~0.70.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.70.0",
-    "@azure-tools/typespec-azure-rulesets": "~0.70.0",
-    "@azure-tools/typespec-client-generator-core": "~0.70.0",
+    "@azure-tools/typespec-azure-rulesets": "0.71.0-dev.5",
+    "@azure-tools/typespec-client-generator-core": "0.71.0-dev.11",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-    "@typespec/compiler": "^1.14.0",
+    "@typespec/compiler": "1.15.0-dev.17",
     "@typespec/http": "^1.14.0",
     "@typespec/openapi": "^1.14.0",
     "@typespec/rest": "~0.84.0",
     "@typespec/versioning": "~0.84.0",
     "@typespec/events": "~0.84.0",
-    "@typespec/spector": "0.1.0-alpha.26",
+    "@typespec/spector": "0.1.0-alpha.27",
     "@typespec/spec-api": "0.1.0-alpha.15",
     "@typespec/sse": "~0.84.0",
     "@typespec/streams": "~0.84.0",
     "@typespec/xml": "~0.84.0",
-    "@typespec/http-specs": "0.1.0-alpha.39",
+    "@typespec/http-specs": "0.1.0-alpha.40",
     "@types/js-yaml": "~4.0.5",
     "@types/node": "~25.0.2",
     "@types/semver": "7.5.8",
@@ -132,5 +132,8 @@
     "typescript-eslint": "^8.49.0",
     "vitest": "^4.0.15",
     "prettier": "^3.9.5"
+  },
+  "overrides": {
+    "@typespec/compiler": "$@typespec/compiler"
   }
 }


### PR DESCRIPTION
## Summary

- Generate Azure-flavor client methods that return `Stream[T]` / `AsyncStream[T]` for JSONL (`application/jsonl`) and SSE (`text/event-stream`) response streams.
- Use TCGC `streamMetadata` / `sseMetadata` to deserialize JSONL items and dispatch named SSE events to their concrete generated models, including terminal-event handling.
- Vendor the JSONL/SSE streaming runtime in generated packages while preserving unbranded raw-byte iterator behavior.
- Preserve registered stream item-type references across request overloads.

```python
stream = client.receive()  # Stream[Thing]
for thing in stream:
    ...
```

## Coverage

- Emitter structured-streaming tests
- Pygen response and serializer coverage
- Azure JSONL/SSE regeneration
- Sync and async Spector smoke coverage for homogeneous and heterogeneous streams

## Notes

This uses the TCGC prerelease containing `sseMetadata`. The external Azure mock API streaming test still asserts the previous raw-byte contract and is expected to remain failing until that test is aligned with the type-driven behavior.