### PR TITLE
Make the C# TypeExpression handle every type kind

### DIFF
--- a/.chronus/changes/ef-csharp-type-expression-total-2026-8-5.md
+++ b/.chronus/changes/ef-csharp-type-expression-total-2026-8-5.md
@@ -1,0 +1,15 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/emitter-framework"
+---
+
+Make the C# `TypeExpression` handle every type kind instead of throwing
+
+`Tuple`, `StringTemplate`, `EnumMember`, `ModelProperty`, `UnionVariant`, template parameters and the full `Intrinsic` set are now supported, and an unsupported type reports a diagnostic and falls back to `object` rather than throwing. The diagnostics now name the offending type instead of saying only "Unsupported scalar type":
+
+```
+warning emitter-framework/csharp-unsupported-scalar: Scalar 'Currency' has no C# equivalent, using 'object' instead. Extend a built-in scalar to control how it is emitted.
+```
+
+Also fixes the C# components reporting a TypeScript diagnostic for unsupported scalars, and corrects the C# expressions for the `null` and `never` intrinsics.

--- a/packages/emitter-framework/src/csharp/components/type-expression.test.tsx
+++ b/packages/emitter-framework/src/csharp/components/type-expression.test.tsx
@@ -1,11 +1,12 @@
 import { Tester } from "#test/test-host.js";
 import { type Children } from "@alloy-js/core";
 import { SourceFile } from "@alloy-js/csharp";
-import type { ModelProperty } from "@typespec/compiler";
-import { t, type TesterInstance } from "@typespec/compiler/testing";
+import type { ModelProperty, StringTemplate } from "@typespec/compiler";
+import { expectDiagnostics, t, type TesterInstance } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
 import { Output } from "../../core/index.js";
 import { ClassDeclaration } from "./class/declaration.js";
+import { EnumDeclaration } from "./enum/declaration.jsx";
 import { TypeExpression } from "./type-expression.jsx";
 
 let runner: TesterInstance;
@@ -141,5 +142,95 @@ describe("Literal types", () => {
           public required string stringName { get; set; }
       }
     `);
+  });
+});
+
+describe("types with no direct C# equivalent", () => {
+  it.each([
+    ["string template", "string", `"a-\${string}"`],
+    ["tuple", "int[]", "[int32, int32]"],
+    ["unknown", "object", "unknown"],
+    ["void", "void", "void"],
+    ["never", "void", "never"],
+    ["null", "object", "null"],
+  ])("%s => %s", async (_label, csType, tspType) => {
+    const type = await compileType(tspType);
+    expect(
+      <Wrapper>
+        <TypeExpression type={type} />
+      </Wrapper>,
+    ).toRenderTo(csType);
+  });
+
+  it("falls back to object instead of throwing", async () => {
+    const type = await compileType("int32 | boolean");
+    expect(
+      <Wrapper>
+        <TypeExpression type={type} />
+      </Wrapper>,
+    ).toRenderTo("object");
+  });
+});
+
+it("renders an enum member using the enum it belongs to", async () => {
+  const { test, Color } = await runner.compile(t.code`
+    enum ${t.enum("Color")} { red, blue }
+    model Test {
+      ${t.modelProperty("test")}: Color.red;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <EnumDeclaration type={Color} />
+      <hbr />
+      <TypeExpression type={test.type} />
+    </Wrapper>,
+  ).toRenderTo(`
+    enum Color
+    {
+        red,
+        blue
+    }
+    Color
+  `);
+});
+
+describe("diagnostics", () => {
+  it("names the scalar that could not be mapped", async () => {
+    const { test } = await runner.compile(`
+      scalar Currency;
+      model Test {
+        @test test: Currency;
+      }
+    `);
+
+    expect(
+      <Wrapper>
+        <TypeExpression type={(test as ModelProperty).type} />
+      </Wrapper>,
+    ).toRenderTo("object");
+
+    expectDiagnostics(runner.program.diagnostics, {
+      code: "emitter-framework/csharp-unsupported-scalar",
+      message:
+        "Scalar 'Currency' has no C# equivalent, using 'object' instead. Extend a built-in scalar to control how it is emitted.",
+    });
+  });
+
+  it("names the type and kind that could not be mapped", async () => {
+    const template = (await compileType(`"a-\${string}"`)) as StringTemplate;
+    const span = template.spans[1];
+
+    expect(
+      <Wrapper>
+        <TypeExpression type={span} />
+      </Wrapper>,
+    ).toRenderTo("object");
+
+    const [diagnostic] = runner.program.diagnostics;
+    expect(diagnostic.code).toBe("emitter-framework/csharp-unsupported-type");
+    expect(diagnostic.message).toContain("of kind 'StringTemplateSpan'");
+    expect(diagnostic.message).toContain("using 'object' instead");
   });
 });

--- a/packages/emitter-framework/src/csharp/components/type-expression.tsx
+++ b/packages/emitter-framework/src/csharp/components/type-expression.tsx
@@ -1,16 +1,10 @@
 import { Experimental_OverridableComponent } from "#core/index.js";
 import { code, type Children } from "@alloy-js/core";
 import { Reference } from "@alloy-js/csharp";
-import {
-  getTypeName,
-  isVoidType,
-  type IntrinsicType,
-  type Scalar,
-  type Type,
-} from "@typespec/compiler";
+import { getTypeName, type IntrinsicType, type Scalar, type Type } from "@typespec/compiler";
 import type { Typekit } from "@typespec/compiler/typekit";
 import { useTsp } from "../../core/index.js";
-import { reportTypescriptDiagnostic } from "../../typescript/lib.js";
+import { reportCsharpDiagnostic } from "../lib.js";
 import { getNullableUnionInnerType } from "./utils/nullable-util.js";
 import { efRefkey } from "./utils/refkey.js";
 
@@ -21,40 +15,80 @@ export interface TypeExpressionProps {
 export function TypeExpression(props: TypeExpressionProps): Children {
   return (
     <Experimental_OverridableComponent reference type={props.type}>
-      {() => {
-        if (props.type.kind === "Union") {
-          const nullabletype = getNullableUnionInnerType(props.type);
-          if (nullabletype) {
-            return code`${(<TypeExpression type={nullabletype} />)}?`;
-          }
-        }
-        const { $ } = useTsp();
-        if (isDeclaration($, props.type)) {
-          return <Reference refkey={efRefkey(props.type)} />;
-        }
-        if ($.scalar.is(props.type)) {
-          return getScalarIntrinsicExpression($, props.type);
-        } else if ($.array.is(props.type)) {
-          return code`${(<TypeExpression type={props.type.indexer.value} />)}[]`;
-        } else if ($.record.is(props.type)) {
-          return code`IDictionary<string, ${(<TypeExpression type={props.type.indexer.value} />)}>`;
-        } else if ($.literal.isString(props.type)) {
-          // c# doesn't have literal types, so we map them to their corresponding C# types in general
-          return code`string`;
-        } else if ($.literal.isNumeric(props.type)) {
-          return Number.isInteger(props.type.value) ? code`int` : code`double`;
-        } else if ($.literal.isBoolean(props.type)) {
-          return code`bool`;
-        } else if (isVoidType(props.type)) {
-          return code`void`;
-        }
-
-        throw new Error(
-          `Unsupported type for TypeExpression: ${props.type.kind} (${getTypeName(props.type)})`,
-        );
-      }}
+      {() => <TypeExpressionBody type={props.type} />}
     </Experimental_OverridableComponent>
   );
+}
+
+/**
+ * Resolves a TypeSpec type to the C# type expression that represents it.
+ *
+ * This never throws: type kinds with no C# equivalent report a diagnostic and fall back to
+ * `object`, so that a single unsupported type does not abort the whole emit.
+ */
+function TypeExpressionBody(props: TypeExpressionProps): Children {
+  const { $ } = useTsp();
+  const type = props.type;
+
+  switch (type.kind) {
+    // Wrappers that carry the type we actually want to render.
+    case "ModelProperty":
+    case "UnionVariant":
+      return <TypeExpression type={type.type} />;
+
+    // C# has no way to type something as one specific enum member, so a property typed
+    // `kind: Color.red` is rendered using the enum the member belongs to.
+    case "EnumMember":
+      return <TypeExpression type={type.enum} />;
+
+    case "Union": {
+      const innerType = getNullableUnionInnerType(type);
+      if (innerType) {
+        return code`${(<TypeExpression type={innerType} />)}?`;
+      }
+      break; // Named unions are declarations; anything else falls through.
+    }
+
+    // C# has no tuple-of-values type; an array of the element type is the closest match.
+    case "Tuple":
+      return type.values.length > 0
+        ? code`${(<TypeExpression type={type.values[0]} />)}[]`
+        : code`object[]`;
+
+    case "StringTemplate":
+      return "string";
+
+    case "TemplateParameter":
+      return getTypeName(type);
+
+    case "Intrinsic":
+      return getScalarIntrinsicExpression($, type);
+  }
+
+  if (isDeclaration($, type)) {
+    return <Reference refkey={efRefkey(type)} />;
+  }
+  if ($.scalar.is(type)) {
+    return getScalarIntrinsicExpression($, type);
+  } else if ($.array.is(type)) {
+    return code`${(<TypeExpression type={type.indexer.value} />)}[]`;
+  } else if ($.record.is(type)) {
+    return code`IDictionary<string, ${(<TypeExpression type={type.indexer.value} />)}>`;
+  } else if ($.literal.isString(type)) {
+    // c# doesn't have literal types, so we map them to their corresponding C# types in general
+    return code`string`;
+  } else if ($.literal.isNumeric(type)) {
+    return Number.isInteger(type.value) ? code`int` : code`double`;
+  } else if ($.literal.isBoolean(type)) {
+    return code`bool`;
+  }
+
+  reportCsharpDiagnostic($.program, {
+    code: "csharp-unsupported-type",
+    format: { typeName: getTypeName(type), kind: type.kind },
+    target: type,
+  });
+  return "object";
 }
 
 const intrinsicNameToCSharpType = new Map<string, string | null>([
@@ -62,9 +96,9 @@ const intrinsicNameToCSharpType = new Map<string, string | null>([
   ["unknown", "object"], // Matches C#'s `object`
   ["string", "string"], // Matches C#'s `string`
   ["boolean", "bool"], // Matches C#'s `bool`
-  ["null", "null"], // Matches C#'s `null`
+  ["null", "object"], // C# has no null type; `object` is the only thing null inhabits
   ["void", "void"], // Matches C#'s `void`
-  ["never", null], // No direct equivalent in C#
+  ["never", "void"], // C# has no bottom type; `void` is the closest equivalent
   ["bytes", "byte[]"], // Matches C#'s `byte[]`
 
   // Numeric types
@@ -96,10 +130,7 @@ const intrinsicNameToCSharpType = new Map<string, string | null>([
   ["url", "Uri"], // Matches C#'s `Uri`
 ]);
 
-export function getScalarIntrinsicExpression(
-  $: Typekit,
-  type: Scalar | IntrinsicType,
-): string | null {
+export function getScalarIntrinsicExpression($: Typekit, type: Scalar | IntrinsicType): string {
   let intrinsicName: string;
 
   if ($.scalar.isUtcDateTime(type) || $.scalar.extendsUtcDateTime(type)) {
@@ -114,7 +145,11 @@ export function getScalarIntrinsicExpression(
   const csType = intrinsicNameToCSharpType.get(intrinsicName);
 
   if (!csType) {
-    reportTypescriptDiagnostic($.program, { code: "typescript-unsupported-scalar", target: type });
+    reportCsharpDiagnostic($.program, {
+      code: "csharp-unsupported-scalar",
+      format: { typeName: getTypeName(type) },
+      target: type,
+    });
     return "object"; // Fallback to object if unsupported
   }
 
@@ -127,10 +162,7 @@ function isDeclaration($: Typekit, type: Type): boolean {
     case "Interface":
     case "Enum":
     case "Operation":
-    case "EnumMember":
       return true;
-    case "UnionVariant":
-      return false;
 
     case "Model":
       if ($.array.is(type) || $.record.is(type)) {

--- a/packages/emitter-framework/src/csharp/components/utils/index.ts
+++ b/packages/emitter-framework/src/csharp/components/utils/index.ts
@@ -1,3 +1,4 @@
 export { getDocComments } from "./doc-comments.jsx";
 export { getNullableUnionInnerType } from "./nullable-util.js";
 export { declarationRefkeys, efRefkey } from "./refkey.js";
+export { isCSharpValueType } from "./value-type.js";

--- a/packages/emitter-framework/src/csharp/components/utils/value-type.ts
+++ b/packages/emitter-framework/src/csharp/components/utils/value-type.ts
@@ -1,0 +1,64 @@
+import type { Type } from "@typespec/compiler";
+import type { Typekit } from "@typespec/compiler/typekit";
+
+/**
+ * TypeSpec std scalars whose C# representation is a value type (struct) rather than a
+ * reference type. Anything not listed here — notably `string`, `bytes` and `url` — maps to
+ * a C# reference type.
+ */
+const valueTypeScalarNames: ReadonlySet<string> = new Set([
+  "numeric",
+  "integer",
+  "float",
+  "int8",
+  "int16",
+  "int32",
+  "int64",
+  "uint8",
+  "uint16",
+  "uint32",
+  "uint64",
+  "safeint",
+  "float32",
+  "float64",
+  "decimal",
+  "decimal128",
+  "boolean",
+  "plainDate",
+  "plainTime",
+  "utcDateTime",
+  "offsetDateTime",
+  "duration",
+  "unixTimestamp32",
+]);
+
+/**
+ * Returns true when the TypeSpec type is emitted as a C# value type (struct).
+ *
+ * This is what decides whether an optional value needs an explicit `?` suffix: reference
+ * types are already nullable under `#nullable enable`, value types are not.
+ */
+export function isCSharpValueType($: Typekit, type: Type): boolean {
+  switch (type.kind) {
+    case "Boolean":
+    case "Number":
+      return true;
+    case "String":
+    case "StringTemplate":
+      return false;
+    case "Enum":
+      return true;
+    case "EnumMember":
+      return true;
+    case "Union":
+      // A union that maps onto a C# enum is a value type; any other union degrades to
+      // `object`, which is not.
+      return Boolean(type.name) && $.union.isValidEnum(type);
+    case "ModelProperty":
+      return isCSharpValueType($, type.type);
+    case "Scalar":
+      return valueTypeScalarNames.has($.scalar.getStdBase(type)?.name ?? type.name);
+    default:
+      return false;
+  }
+}

--- a/packages/emitter-framework/src/csharp/lib.ts
+++ b/packages/emitter-framework/src/csharp/lib.ts
@@ -1,0 +1,26 @@
+import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
+
+export const $csharpLib = createTypeSpecLibrary({
+  name: "emitter-framework",
+  diagnostics: {
+    "csharp-unsupported-scalar": {
+      severity: "warning",
+      messages: {
+        default: paramMessage`Scalar '${"typeName"}' has no C# equivalent, using 'object' instead. Extend a built-in scalar to control how it is emitted.`,
+      },
+      description: "This scalar has no C# equivalent",
+    },
+    "csharp-unsupported-type": {
+      severity: "warning",
+      messages: {
+        default: paramMessage`Type '${"typeName"}' of kind '${"kind"}' is not supported in C#, using 'object' instead.`,
+      },
+      description: "This type has no C# equivalent",
+    },
+  },
+});
+
+export const {
+  reportDiagnostic: reportCsharpDiagnostic,
+  createDiagnostic: createCsharpDiagnostic,
+} = $csharpLib;


### PR DESCRIPTION
The C# `TypeExpression` threw a hard `Error` for anything it did not recognise — tuples, string templates, enum members, template parameters and most of the intrinsics. An emitter hitting one of those got a crash with no source location instead of a diagnostic, so `@typespec/http-server-csharp` had to wrap every call site in `try`/`catch`.

Those kinds are now handled, and a genuinely unsupported type reports a diagnostic against the offending type and falls back to `object`, so compilation continues and the user gets a pointer to the spec that caused it. The diagnostics name the type, so it is actionable without bisecting the spec:

```
warning emitter-framework/csharp-unsupported-scalar: Scalar 'MyLib.ipAddress' has no
  C# equivalent, using 'object' instead. Extend a built-in scalar to control how it is emitted.

warning emitter-framework/csharp-unsupported-type: Type '@myLib.flag' of kind 'Decorator'
  is not supported in C#, using 'object' instead.
```

The two are kept separate because they call for different actions: the scalar one is fixable in the spec by extending a built-in scalar, while the other reports a gap in the emitter.

Two smaller bugs fixed along the way:

- Unsupported scalars reported a **TypeScript** diagnostic (`typescript-unsupported-scalar`) from the C# components. C# now has its own `src/csharp/lib.ts`, matching the existing `typescript/lib.ts` and `python/lib.ts`, which makes that class of mistake a type error.
- The `null` and `never` intrinsics emitted `null` and `never`, neither of which is a C# type. They now emit `object` and `void`.

Also adds an `isCSharpValueType` util, since deciding whether a TypeSpec type maps to a C# struct is something every C# emitter needs and every C# emitter was reimplementing.

---

Independent — targets `main` and can merge on its own.

One of 7 PRs moving `@typespec/http-server-csharp` onto the emitter framework instead of its private forks: #11596, #11597, #11598, #11599, #11600, #11601, #11602.

