### PR TITLE
Make the C# declaration components authorable

### DIFF
--- a/.chronus/changes/ef-csharp-authorable-declarations-2026-8-5.md
+++ b/.chronus/changes/ef-csharp-authorable-declarations-2026-8-5.md
@@ -1,0 +1,18 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/emitter-framework"
+---
+
+Let emitters author the C# declaration components instead of forking them
+
+- `ClassDeclaration` accepts an explicit `properties` list and extra members as `children`.
+- `Property` accepts every Alloy property prop, plus `name` and `csharpType` overrides.
+- `EnumDeclaration` accepts an explicit `members` list and a `jsonAttributes` prop.
+- `JsonConverter` accepts `doc`, access modifiers, extra members, an explicit `csharpType`, and a `readReturns` override.
+
+```tsx
+<ClassDeclaration type={model} properties={model.properties.values().filter(isVisible)} partial>
+  <Constructor />
+</ClassDeclaration>
+```

--- a/packages/emitter-framework/src/csharp/components/class/declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/class/declaration.tsx
@@ -1,6 +1,6 @@
 import { For, type Children } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
-import type { Interface, Model } from "@typespec/compiler";
+import type { Interface, Model, ModelProperty } from "@typespec/compiler";
 import { isVoidType } from "@typespec/compiler";
 import { Experimental_OverridableComponent, useTsp } from "../../../core/index.js";
 import { Property } from "../property/property.jsx";
@@ -15,10 +15,18 @@ export interface ClassDeclarationProps extends Omit<cs.ClassDeclarationProps, "n
   type: Model | Interface;
   /** If set the property will add the json serialization attributes(using System.Text.Json). */
   jsonAttributes?: boolean;
+  /**
+   * The properties to render. Defaults to every property of the model.
+   * Only applies when {@link ClassDeclarationProps.type} is a `Model`.
+   */
+  properties?: ModelProperty[];
+  /** Extra members rendered before the type's properties or methods. */
+  children?: Children;
 }
 
 interface ClassPropertiesProps {
   type: Model;
+  properties?: ModelProperty[];
   /** If set the property will add the json serialization attributes(using System.Text.Json). */
   jsonAttributes?: boolean;
 }
@@ -42,43 +50,44 @@ export function ClassDeclaration(props: ClassDeclarationProps): Children {
 
 function ClassDeclarationBody(props: ClassDeclarationProps): Children {
   const { $ } = useTsp();
+  const { type, name, jsonAttributes, properties, children, refkey, baseType, ...classProps } =
+    props;
 
   const namePolicy = cs.useCSharpNamePolicy();
-  const className = props.name ?? namePolicy.getName(props.type.name, "class");
+  const className = name ?? namePolicy.getName(type.name, "class");
 
-  const refkeys = declarationRefkeys(props.refkey, props.type)[0]; // TODO: support multiple refkeys for declarations in alloy
+  const refkeys = declarationRefkeys(refkey, type)[0]; // TODO: support multiple refkeys for declarations in alloy
 
   return (
-    <>
-      <cs.ClassDeclaration
-        {...props}
-        name={className}
-        refkey={refkeys}
-        baseType={
-          props.baseType ??
-          (props.type.kind === "Model" && props.type.baseModel ? (
-            <TypeExpression type={props.type.baseModel} />
-          ) : undefined)
-        }
-        doc={getDocComments($, props.type)}
-      >
-        {props.type.kind === "Model" && (
-          <ClassProperties type={props.type} jsonAttributes={props.jsonAttributes} />
-        )}
-        {props.type.kind === "Interface" && <ClassMethods type={props.type} />}
-      </cs.ClassDeclaration>
-    </>
+    <cs.ClassDeclaration
+      name={className}
+      refkey={refkeys}
+      baseType={
+        baseType ??
+        (type.kind === "Model" && type.baseModel ? (
+          <TypeExpression type={type.baseModel} />
+        ) : undefined)
+      }
+      doc={getDocComments($, type)}
+      {...classProps}
+    >
+      {children}
+      {type.kind === "Model" && (
+        <ClassProperties type={type} properties={properties} jsonAttributes={jsonAttributes} />
+      )}
+      {type.kind === "Interface" && <ClassMethods type={type} />}
+    </cs.ClassDeclaration>
   );
 }
 
 function ClassProperties(props: ClassPropertiesProps): Children {
   // Ignore 'void' type properties which is not valid in csharp
-  const properties = Array.from(props.type.properties.entries()).filter(
-    ([_, p]) => !isVoidType(p.type),
+  const properties = (props.properties ?? Array.from(props.type.properties.values())).filter(
+    (p) => !isVoidType(p.type),
   );
   return (
     <For each={properties} doubleHardline>
-      {([name, property]) => <Property type={property} jsonAttributes={props.jsonAttributes} />}
+      {(property) => <Property type={property} jsonAttributes={props.jsonAttributes} />}
     </For>
   );
 }

--- a/packages/emitter-framework/src/csharp/components/enum/declaration.test.tsx
+++ b/packages/emitter-framework/src/csharp/components/enum/declaration.test.tsx
@@ -256,3 +256,62 @@ it("renders an enum with a type-level doc comment", async () => {
     }
   `);
 });
+
+it("adds json serialization attributes", async () => {
+  const { TestEnum } = await runner.compile(t.code`
+    enum ${t.enum("TestEnum")} {
+      Value1: "value-1";
+      Value2: "value-2";
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <EnumDeclaration type={TestEnum} jsonAttributes />
+    </Wrapper>,
+  ).toRenderTo(`
+    using System.Text.Json.Serialization;
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    enum TestEnum
+    {
+        [JsonStringEnumMemberName("value-1")]
+        Value1,
+        [JsonStringEnumMemberName("value-2")]
+        Value2
+    }
+  `);
+});
+
+it("renders an explicit member list", async () => {
+  const { TestEnum } = await runner.compile(t.code`
+    enum ${t.enum("TestEnum")} {
+      Value1;
+      Value2;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <EnumDeclaration
+        type={TestEnum}
+        members={[
+          { name: "only_me", jsonValue: "onlyMe" },
+          { name: "and_me", jsonValue: "andMe" },
+        ]}
+        jsonAttributes
+      />
+    </Wrapper>,
+  ).toRenderTo(`
+    using System.Text.Json.Serialization;
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    enum TestEnum
+    {
+        [JsonStringEnumMemberName("onlyMe")]
+        OnlyMe,
+        [JsonStringEnumMemberName("andMe")]
+        AndMe
+    }
+  `);
+});

--- a/packages/emitter-framework/src/csharp/components/enum/declaration.tsx
+++ b/packages/emitter-framework/src/csharp/components/enum/declaration.tsx
@@ -1,14 +1,42 @@
-import { Experimental_OverridableComponent, useTsp } from "#core/index.js";
-import { type Children, For } from "@alloy-js/core";
+import { Experimental_OverridableComponent } from "#core/components/index.js";
+import { useTsp } from "#core/context/tsp-context.js";
+import { code, For, REFKEYABLE, type Children, type Refkey } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
+import { Serialization } from "@alloy-js/csharp/global/System/Text/Json";
 import type { Enum, Union } from "@typespec/compiler";
 import { reportDiagnostic } from "../../../lib.js";
 import { getDocComments } from "../utils/doc-comments.jsx";
 import { declarationRefkeys, efRefkey } from "../utils/refkey.js";
 
+/** A single member of a generated C# enum. */
+export interface EnumDeclarationMember {
+  /** Member name, before the C# name policy is applied. */
+  name: string;
+  /** Refkey references to this member resolve to. */
+  refkey?: Refkey;
+  /** Doc comment for the member. */
+  doc?: Children;
+  /**
+   * Name this member serializes to in JSON. Only used when
+   * {@link EnumDeclarationProps.jsonAttributes} is set. Defaults to the member name.
+   */
+  jsonValue?: string;
+}
+
 export interface EnumDeclarationProps extends Omit<cs.EnumDeclarationProps, "name"> {
   name?: string;
   type: Union | Enum;
+  /**
+   * The members to render. Defaults to every member of the enum, or every variant of the
+   * union.
+   */
+  members?: EnumDeclarationMember[];
+  /**
+   * If set the enum will add the json serialization attributes (using System.Text.Json):
+   * `[JsonConverter(typeof(JsonStringEnumConverter))]` on the enum and
+   * `[JsonStringEnumMemberName]` on each member.
+   */
+  jsonAttributes?: boolean;
 }
 
 export function EnumDeclaration(props: EnumDeclarationProps): Children {
@@ -26,44 +54,75 @@ export function EnumDeclaration(props: EnumDeclarationProps): Children {
 
 function EnumDeclarationBody(props: EnumDeclarationProps): Children {
   const { $ } = useTsp();
-  let type: Enum;
-  if ($.union.is(props.type)) {
-    if (!$.union.isValidEnum(props.type)) {
-      throw new Error("The provided union type cannot be represented as an enum");
-    }
-    type = $.enum.createFromUnion(props.type);
-  } else {
-    type = props.type;
-  }
+  const { type: tspType, name, members, jsonAttributes, refkey, ...enumProps } = props;
 
-  if (!props.type.name) {
-    reportDiagnostic($.program, { code: "type-declaration-missing-name", target: props.type });
+  if (!tspType.name) {
+    reportDiagnostic($.program, { code: "type-declaration-missing-name", target: tspType });
   }
-  const refkeys = declarationRefkeys(props.refkey, props.type)[0]; // TODO: support multiple refkeys for declarations in alloy
-  const name = props.name ?? cs.useCSharpNamePolicy().getName(props.type.name!, "enum");
-  const members = Array.from(type.members.entries());
+  const refkeys = declarationRefkeys(refkey, tspType)[0]; // TODO: support multiple refkeys for declarations in alloy
+  const enumName = name ?? cs.useCSharpNamePolicy().getName(tspType.name!, "enum");
+  const enumMembers = members ?? defaultMembers($, tspType);
 
   return (
     <>
-      <cs.EnumDeclaration name={name} refkey={refkeys} {...props} doc={getDocComments($, type)}>
-        <For each={members} joiner={",\n"}>
-          {([key, value]) => {
-            return (
-              <>
-                <cs.DocWhen doc={getDocComments($, value)} />
-                <cs.EnumMember
-                  name={cs.useCSharpNamePolicy().getName(key, "enum-member")}
-                  refkey={
-                    $.union.is(props.type)
-                      ? efRefkey(props.type.variants.get(key))
-                      : efRefkey(value)
-                  }
-                />
-              </>
-            );
-          }}
+      {jsonAttributes && (
+        <>
+          <cs.Attribute
+            name={Serialization.JsonConverterAttribute[REFKEYABLE]()}
+            args={[code`typeof(${Serialization.JsonStringEnumConverter[REFKEYABLE]()})`]}
+          />
+          <hbr />
+        </>
+      )}
+      <cs.EnumDeclaration
+        name={enumName}
+        refkey={refkeys}
+        doc={getDocComments($, tspType)}
+        {...enumProps}
+      >
+        <For each={enumMembers} comma hardline>
+          {(member) => (
+            <>
+              <cs.DocWhen doc={member.doc} />
+              {jsonAttributes && (
+                <>
+                  <cs.Attribute
+                    name={Serialization.JsonStringEnumMemberNameAttribute[REFKEYABLE]()}
+                    args={[JSON.stringify(member.jsonValue ?? member.name)]}
+                  />
+                  <hbr />
+                </>
+              )}
+              <cs.EnumMember
+                name={cs.useCSharpNamePolicy().getName(member.name, "enum-member")}
+                refkey={member.refkey}
+              />
+            </>
+          )}
         </For>
       </cs.EnumDeclaration>
     </>
   );
+}
+
+function defaultMembers(
+  $: ReturnType<typeof useTsp>["$"],
+  tspType: Union | Enum,
+): EnumDeclarationMember[] {
+  let type: Enum;
+  if ($.union.is(tspType)) {
+    if (!$.union.isValidEnum(tspType)) {
+      throw new Error("The provided union type cannot be represented as an enum");
+    }
+    type = $.enum.createFromUnion(tspType);
+  } else {
+    type = tspType;
+  }
+
+  return Array.from(type.members.entries()).map(([key, member]) => ({
+    name: key,
+    refkey: $.union.is(tspType) ? efRefkey(tspType.variants.get(key)) : efRefkey(member),
+    doc: getDocComments($, member),
+    jsonValue: typeof member.value === "string" ? member.value : key,
+  }));
 }

--- a/packages/emitter-framework/src/csharp/components/json-converter/json-converter.tsx
+++ b/packages/emitter-framework/src/csharp/components/json-converter/json-converter.tsx
@@ -8,10 +8,31 @@ import { type Type } from "@typespec/compiler";
 import { capitalize } from "@typespec/compiler/casing";
 import { TypeExpression } from "../type-expression.jsx";
 
-interface JsonConverterProps {
+export interface JsonConverterProps {
   name: string | Namekey;
-  type: Type;
+  /** The TypeSpec type being converted. Required unless {@link csharpType} is set. */
+  type?: Type;
+  /**
+   * The C# type being converted. Defaults to the C# expression for {@link type}. Set this
+   * for converters of types that have no TypeSpec equivalent (e.g. `DateTimeOffset`).
+   */
+  csharpType?: Children;
   refkey?: Refkey;
+  /** Doc comment for the generated class. */
+  doc?: Children;
+  /** Emit the class as `public`. Defaults to `internal`. */
+  public?: boolean;
+  /** Emit the class as `internal`. Defaults to `true` unless {@link public} is set. */
+  internal?: boolean;
+  /** Emit the class as `sealed`. Defaults to `true`. */
+  sealed?: boolean;
+  /** Extra class members rendered before `Read` and `Write`. */
+  children?: Children;
+  /**
+   * Return type of `Read`. Defaults to the converted type. Set this to make the converter
+   * return a nullable value.
+   */
+  readReturns?: Children;
   /** Decode and return value from reader*/
   decodeAndReturn: (reader: Namekey, typeToConvert: Namekey, options: Namekey) => Children;
   /** Encode the given value and send to writer*/
@@ -29,16 +50,22 @@ export function JsonConverter(props: JsonConverterProps) {
   const writeParamWriter: Namekey = namekey("writer");
   const writeParamValue: Namekey = namekey("value");
   const writeParamOptions: Namekey = namekey("options");
-  const propTypeExpression = code`${(<TypeExpression type={props.type} />)}`;
+  if (!props.type && !props.csharpType) {
+    throw new Error("JsonConverter requires either a `type` or a `csharpType`.");
+  }
+  const propTypeExpression = props.csharpType ?? code`${(<TypeExpression type={props.type!} />)}`;
   return (
     <ClassDeclaration
       refkey={props.refkey}
-      sealed
-      internal
+      sealed={props.sealed ?? true}
+      internal={props.internal ?? !props.public}
+      public={props.public}
+      doc={props.doc}
       name={props.name}
       baseType={code`${Serialization.JsonConverter}<${propTypeExpression}>`}
     >
       <List doubleHardline>
+        {props.children}
         <Method
           name={"Read"}
           public
@@ -55,7 +82,7 @@ export function JsonConverter(props: JsonConverterProps) {
               type: code`${Json.JsonSerializerOptions}`,
             },
           ]}
-          returns={propTypeExpression}
+          returns={props.readReturns ?? propTypeExpression}
         >
           {code`${props.decodeAndReturn(readParamReader, readParamTypeToConvert, readParamOptions)}`}
         </Method>

--- a/packages/emitter-framework/src/csharp/components/property/property.test.tsx
+++ b/packages/emitter-framework/src/csharp/components/property/property.test.tsx
@@ -281,3 +281,62 @@ describe("jsonAttributes", () => {
     `);
   });
 });
+
+describe("overriding the framework defaults", () => {
+  it("uses an alternative name", async () => {
+    const { prop1 } = await tester.compile(t.code`
+      model TestModel {
+        ${t.modelProperty("prop1")}: string;
+      }
+    `);
+
+    expect(
+      <Wrapper>
+        <Property type={prop1} name="Renamed" />
+      </Wrapper>,
+    ).toRenderTo(`
+      class Test
+      {
+          public required string Renamed { get; set; }
+      }
+    `);
+  });
+
+  it("uses an alternative C# type", async () => {
+    const { prop1 } = await tester.compile(t.code`
+      model TestModel {
+        ${t.modelProperty("prop1")}: string[];
+      }
+    `);
+
+    expect(
+      <Wrapper>
+        <Property type={prop1} csharpType="ISet<string>" />
+      </Wrapper>,
+    ).toRenderTo(`
+      class Test
+      {
+          public required ISet<string> Prop1 { get; set; }
+      }
+    `);
+  });
+
+  it("forwards Alloy property props and lets them win over the defaults", async () => {
+    const { prop1 } = await tester.compile(t.code`
+      model TestModel {
+        ${t.modelProperty("prop1")}: string;
+      }
+    `);
+
+    expect(
+      <Wrapper>
+        <Property type={prop1} required={false} set={false} initializer={`"fixed"`} />
+      </Wrapper>,
+    ).toRenderTo(`
+      class Test
+      {
+          public string Prop1 { get; } = "fixed";
+      }
+    `);
+  });
+});

--- a/packages/emitter-framework/src/csharp/components/property/property.tsx
+++ b/packages/emitter-framework/src/csharp/components/property/property.tsx
@@ -1,4 +1,4 @@
-import { code, REFKEYABLE, type Children } from "@alloy-js/core";
+import { code, REFKEYABLE, type Children, type Namekey } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
 import { Attribute } from "@alloy-js/csharp";
 import { Serialization } from "@alloy-js/csharp/global/System/Text/Json";
@@ -15,8 +15,16 @@ import { TypeExpression } from "../type-expression.jsx";
 import { getDocComments } from "../utils/doc-comments.jsx";
 import { getNullableUnionInnerType } from "../utils/nullable-util.js";
 
-export interface PropertyProps {
+export interface PropertyProps extends Omit<cs.PropertyProps, "name" | "type"> {
+  /** The TypeSpec property to create the C# property from. */
   type: ModelProperty;
+  /** Set an alternative name for the property. Otherwise default to the TypeSpec property name. */
+  name?: Namekey | string;
+  /**
+   * Set an alternative C# type for the property. Otherwise default to rendering
+   * {@link PropertyProps.type}, unwrapping a nullable union if there is one.
+   */
+  csharpType?: Children;
   /** If set the property will add the json serialization attributes(using System.Text.Json.Serialization).
    *  - the JsonPropertyName attribute
    *  - the JsonConverter attribute if the property has encoding and a JsonConverterResolver context is available
@@ -42,14 +50,15 @@ export function Property(props: PropertyProps): Children {
 
 function PropertyBody(props: PropertyProps): Children {
   const { $ } = useTsp();
-  const result = preprocessPropertyType(props.type);
+  const { type: tspProperty, name, csharpType, jsonAttributes, ...propertyProps } = props;
+  const result = preprocessPropertyType(tspProperty);
 
   let overrideType: "" | "override" | "new" = "";
   let isVirtual = false;
-  if (props.type.model) {
-    if (props.type.model.baseModel) {
-      const base = props.type.model.baseModel;
-      const baseProperty = getProperty(base, props.type.name);
+  if (tspProperty.model) {
+    if (tspProperty.model.baseModel) {
+      const base = tspProperty.model.baseModel;
+      const baseProperty = getProperty(base, tspProperty.name);
       if (baseProperty) {
         const baseResult = preprocessPropertyType(baseProperty);
         if (baseResult.nullable === result.nullable && baseResult.type === result.type) {
@@ -61,11 +70,11 @@ function PropertyBody(props: PropertyProps): Children {
     }
     if (
       overrideType === "" &&
-      props.type.model.derivedModels &&
-      props.type.model.derivedModels.length > 0
+      tspProperty.model.derivedModels &&
+      tspProperty.model.derivedModels.length > 0
     ) {
-      isVirtual = props.type.model.derivedModels.some((derived) => {
-        const derivedProperty = derived.properties.get(props.type.name);
+      isVirtual = tspProperty.model.derivedModels.some((derived) => {
+        const derivedProperty = derived.properties.get(tspProperty.name);
         if (derivedProperty) {
           const derivedResult = preprocessPropertyType(derivedProperty);
           return derivedResult.nullable === result.nullable && derivedResult.type === result.type;
@@ -74,9 +83,9 @@ function PropertyBody(props: PropertyProps): Children {
     }
   }
   const attributes = [];
-  if (props.jsonAttributes) {
-    attributes.push(<JsonNameAttribute type={props.type} />);
-    const encodeData = getEncode($.program, props.type);
+  if (jsonAttributes) {
+    attributes.push(<JsonNameAttribute type={tspProperty} />);
+    const encodeData = getEncode($.program, tspProperty);
     if (encodeData) {
       const JsonConverterResolver = useJsonConverterResolver();
       if (JsonConverterResolver) {
@@ -92,18 +101,19 @@ function PropertyBody(props: PropertyProps): Children {
 
   return (
     <cs.Property
-      name={props.type.name}
-      type={<TypeExpression type={result.type} />}
+      name={name ?? tspProperty.name}
+      type={csharpType ?? <TypeExpression type={result.type} />}
       override={overrideType === "override"}
       new={overrideType === "new"}
       public
       virtual={isVirtual}
-      required={!props.type.optional}
+      required={!tspProperty.optional}
       nullable={result.nullable}
-      doc={getDocComments($, props.type)}
+      doc={getDocComments($, tspProperty)}
       attributes={attributes}
       get
       set
+      {...propertyProps}
     />
   );
 }


### PR DESCRIPTION
The C# declaration components rendered exactly one shape and dropped anything the caller passed. `ClassDeclaration` always emitted every property of the model and nothing else, `Property` accepted three props out of the ~15 Alloy supports, `EnumDeclaration` always derived its members from the type, and `JsonConverter` had a fixed body with no way to document it or change its visibility. An emitter that needed a constructor in the class, or a filtered property list, or a differently-named property, had to fork the component.

They now take props:

```tsx
<ClassDeclaration type={model} properties={visibleProperties} partial>
  <Constructor />
</ClassDeclaration>
```

- `ClassDeclaration` — explicit `properties` list, extra members as `children`.
- `Property` — the full Alloy property prop set, plus `name` and `csharpType` overrides.
- `EnumDeclaration` — explicit `members` list and a `jsonAttributes` prop.
- `JsonConverter` — `doc`, access modifiers, extra members, an explicit `csharpType`, and a `readReturns` override.

Caller-supplied props are spread last so they win over the framework defaults, and every prop is optional, so existing behavior is unchanged.

---

Independent now that #11597 has merged — targets `main` and can merge on its own.

One of 7 PRs moving `@typespec/http-server-csharp` onto the emitter framework instead of its private forks. Merged: #11596, #11597, #11599. Remaining: #11598, #11600, #11601, #11602.