### PR TITLE
Fix generated error constructors and constraint attributes using the wrong C# types

### DIFF
--- a/.chronus/changes/http-server-csharp-error-model-scalars-2026-8-5.md
+++ b/.chronus/changes/http-server-csharp-error-model-scalars-2026-8-5.md
@@ -1,0 +1,9 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Fix generated error model constructors and numeric constraint attributes using the wrong C# types
+
+Error model constructors declared parameters such as `DateOnly` and `Uri` while the matching properties were `DateTime` and `string`, producing code that did not compile. `NumericConstraintAttribute<T>` had the same mismatch, which stopped the converter from binding.

--- a/packages/http-server-csharp/src/components/models/error-models.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.tsx
@@ -1,7 +1,8 @@
 import { type Children } from "@alloy-js/core";
 import type { ParameterProps } from "@alloy-js/csharp";
 import * as cs from "@alloy-js/csharp";
-import { isErrorModel, type Model, type Program } from "@typespec/compiler";
+import { isErrorModel, type Model } from "@typespec/compiler";
+import type { Typekit } from "@typespec/compiler/typekit";
 import { getHeaderFieldName, isHeader, isStatusCode } from "@typespec/http";
 import {
   getAllProperties,
@@ -13,18 +14,20 @@ import {
 } from "./model-helpers.js";
 
 /** Generates the constructor for an error model. */
-export function getErrorConstructor(program: Program, model: Model, className: string): Children {
-  const statusCode = getErrorStatusCode(program, model);
-  const isChild = model.baseModel && isErrorModel(program, model.baseModel);
+export function getErrorConstructor($: Typekit, model: Model, className: string): Children {
+  const statusCode = getErrorStatusCode($.program, model);
+  const isChild = model.baseModel && isErrorModel($.program, model.baseModel);
   const namePolicy = cs.createCSharpNamePolicy();
 
   // For child error models, only use own properties (not inherited)
   // For root error models, use all properties including inherited
-  const props = isChild ? Array.from(model.properties.values()) : getAllProperties(program, model);
+  const props = isChild
+    ? Array.from(model.properties.values())
+    : getAllProperties($.program, model);
 
   // Separate properties into required and optional/default
   const sortedProps = props
-    .filter((p) => !isStatusCode(program, p))
+    .filter((p) => !isStatusCode($.program, p))
     .map((prop) => {
       const defaultValue = prop.defaultValue ? getDefaultValueString(prop.defaultValue) : undefined;
       const literalValue = getLiteralValue(prop.type);
@@ -53,13 +56,13 @@ export function getErrorConstructor(program: Program, model: Model, className: s
       propName = propName === "Value" ? "ValueName" : `${propName}Prop`;
     }
 
-    const csharpType = getCSharpTypeString(program, prop.type);
+    const csharpType = getCSharpTypeString($, prop.type);
     const defaultStr = defaultValue ? defaultValue : prop.optional ? "default" : undefined;
     parameters.push({ name: prop.name, type: csharpType, default: defaultStr });
     bodyParts.push(`${propName} = ${prop.name};`);
 
-    if (isHeader(program, prop)) {
-      const headerName = getHeaderFieldName(program, prop);
+    if (isHeader($.program, prop)) {
+      const headerName = getHeaderFieldName($.program, prop);
       headerParts.push(`{"${headerName}", ${prop.name}}`);
     } else {
       valueParts.push(`${prop.name} = ${prop.name}`);

--- a/packages/http-server-csharp/src/components/models/model-helpers.ts
+++ b/packages/http-server-csharp/src/components/models/model-helpers.ts
@@ -13,6 +13,7 @@ import {
 import type { useTsp } from "@typespec/emitter-framework";
 import { isStatusCode } from "@typespec/http";
 import { getUnionEnumMembers, isUnionEnum } from "../enums/enums.jsx";
+import { getServerScalarName } from "../type-expression/scalar-overrides.js";
 import { assignAnonymousName } from "./anonymous-models.js";
 
 /** Gets the string representation of a literal or default value. */
@@ -246,34 +247,16 @@ export function getErrorStatusCode(
   return { value: minVal ?? "default" };
 }
 
-/** Gets a simple C# type name string for a TypeSpec type. */
-export function getCSharpTypeString(program: Program, type: Type): string {
+/**
+ * Gets a simple C# type name string for a TypeSpec type.
+ *
+ * Used where a type name is needed as plain text rather than a rendered reference, such as
+ * error-model constructor parameters. Scalars resolve through {@link getServerScalarName} so
+ * the parameter type always agrees with the type of the property it is assigned to.
+ */
+export function getCSharpTypeString($: ReturnType<typeof useTsp>["$"], type: Type): string {
   if (type.kind === "Scalar") {
-    const scalarMap: Record<string, string> = {
-      string: "string",
-      int8: "sbyte",
-      int16: "short",
-      int32: "int",
-      int64: "long",
-      uint8: "byte",
-      uint16: "ushort",
-      uint32: "uint",
-      uint64: "ulong",
-      float32: "float",
-      float64: "double",
-      boolean: "bool",
-      plainDate: "DateOnly",
-      plainTime: "TimeOnly",
-      utcDateTime: "DateTimeOffset",
-      offsetDateTime: "DateTimeOffset",
-      duration: "TimeSpan",
-      bytes: "byte[]",
-      decimal: "decimal",
-      decimal128: "decimal",
-      url: "Uri",
-      safeint: "long",
-    };
-    return scalarMap[type.name] ?? type.name;
+    return getServerScalarName($, type);
   }
   if (type.kind === "String") return "string";
   if (type.kind === "Boolean") return "bool";

--- a/packages/http-server-csharp/src/components/models/models.tsx
+++ b/packages/http-server-csharp/src/components/models/models.tsx
@@ -117,9 +117,7 @@ function ServerClassDeclaration(props: ServerClassDeclarationProps): Children {
   }
 
   // Generate constructor for error models
-  const errorConstructor = isError
-    ? getErrorConstructor($.program, props.type, className)
-    : undefined;
+  const errorConstructor = isError ? getErrorConstructor($, props.type, className) : undefined;
 
   // For error models with base model, check if base is also an error (child constructor)
   const hasChildConstructor =
@@ -179,7 +177,7 @@ function ServerProperty(props: ServerPropertyProps): Children {
   const { $ } = useTsp();
   const namePolicy = cs.useCSharpNamePolicy();
   const propType = props.type.type;
-  const attrs = getPropertyAttributes($.program, props.type);
+  const attrs = getPropertyAttributes($, props.type);
 
   // Determine property name, handling error model conflicts
   let propName = props.type.name;

--- a/packages/http-server-csharp/src/components/type-expression/scalar-overrides.test.ts
+++ b/packages/http-server-csharp/src/components/type-expression/scalar-overrides.test.ts
@@ -1,0 +1,60 @@
+import { Tester } from "#test/tester.js";
+import { type TesterInstance } from "@typespec/compiler/testing";
+import { $ } from "@typespec/compiler/typekit";
+import { beforeEach, expect, it } from "vitest";
+import { getServerScalarName } from "./scalar-overrides.js";
+
+let runner: TesterInstance;
+
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
+
+async function scalarName(ref: string): Promise<string> {
+  await runner.compile(`
+    model Test { test: ${ref}; }
+  `);
+  const tk = $(runner.program);
+  const model = runner.program.resolveTypeReference("Test")[0];
+  const scalar = (model as any).properties.get("test").type;
+  return getServerScalarName(tk, scalar);
+}
+
+it.each([
+  // Server overrides of the emitter-framework defaults.
+  ["plainDate", "DateTime"],
+  ["plainTime", "DateTime"],
+  ["url", "string"],
+  ["safeint", "long"],
+  ["int8", "SByte"],
+  ["uint8", "Byte"],
+  ["int16", "Int16"],
+  ["uint16", "UInt16"],
+  ["uint32", "UInt32"],
+  ["uint64", "UInt64"],
+  // Inherited from the emitter-framework defaults.
+  ["string", "string"],
+  ["int32", "int"],
+  ["int64", "long"],
+  ["float32", "float"],
+  ["float64", "double"],
+  ["boolean", "bool"],
+  ["bytes", "byte[]"],
+  ["decimal", "decimal"],
+  ["utcDateTime", "DateTimeOffset"],
+  ["offsetDateTime", "DateTimeOffset"],
+  ["duration", "TimeSpan"],
+])("%s => %s", async (tspType, csType) => {
+  expect(await scalarName(tspType)).toBe(csType);
+});
+
+it("resolves custom scalars through the base they extend", async () => {
+  await runner.compile(`
+    scalar myDate extends plainDate;
+    model Test { test: myDate; }
+  `);
+  const tk = $(runner.program);
+  const model = runner.program.resolveTypeReference("Test")[0];
+  const scalar = (model as any).properties.get("test").type;
+  expect(getServerScalarName(tk, scalar)).toBe("DateTime");
+});

--- a/packages/http-server-csharp/src/components/type-expression/scalar-overrides.ts
+++ b/packages/http-server-csharp/src/components/type-expression/scalar-overrides.ts
@@ -1,0 +1,59 @@
+import type { Scalar } from "@typespec/compiler";
+import type { Typekit } from "@typespec/compiler/typekit";
+import { getScalarIntrinsicExpression } from "@typespec/emitter-framework/csharp";
+
+/**
+ * The scalars whose C# representation differs from the emitter-framework defaults:
+ *
+ * - `plainDate` / `plainTime` → `DateTime` (not `DateOnly` / `TimeOnly`)
+ * - `url` → `string` (not `Uri`)
+ * - `safeint` → `long` (not `int`)
+ * - sized integers use CLR type names (`SByte`, `Int16`, …) rather than C# keywords
+ *
+ * These reproduce the output of the pre-Alloy emitter and are deliberate, not oversights.
+ */
+export function getServerScalarOverrides($: Typekit): [Scalar, string][] {
+  return [
+    [$.builtin.plainDate, "DateTime"],
+    [$.builtin.plainTime, "DateTime"],
+    [$.builtin.url, "string"],
+    [$.builtin.int8, "SByte"],
+    [$.builtin.uint8, "Byte"],
+    [$.builtin.int16, "Int16"],
+    [$.builtin.uint16, "UInt16"],
+    [$.builtin.uint32, "UInt32"],
+    [$.builtin.uint64, "UInt64"],
+    [$.builtin.safeInt, "long"],
+  ];
+}
+
+/**
+ * Resolves the C# type name for a scalar, applying the server overrides on top of the
+ * emitter-framework defaults.
+ *
+ * This is the single source of truth for scalar naming. Anywhere a C# type *name* is needed
+ * outside of a rendering context — constraint attribute type arguments, error constructor
+ * parameter types — must go through here so that the name always agrees with what
+ * `TypeExpression` renders for the same scalar.
+ */
+export function getServerScalarName($: Typekit, scalar: Scalar): string {
+  const overrides = new Map(getServerScalarOverrides($));
+  // Custom scalars (`scalar myDate extends plainDate`) inherit their base's mapping.
+  let current: Scalar | undefined = scalar;
+  while (current) {
+    const override = overrides.get(current);
+    if (override) return override;
+    current = current.baseScalar;
+  }
+  // Falls back to `object` (with a diagnostic) for scalars with no C# equivalent.
+  return getScalarIntrinsicExpression($, scalar);
+}
+
+/**
+ * Like {@link getServerScalarName}, but returns undefined for scalars that do not derive
+ * from a TypeSpec std scalar, where no meaningful C# type name can be produced.
+ */
+export function tryGetServerScalarName($: Typekit, scalar: Scalar): string | undefined {
+  if (!$.scalar.getStdBase(scalar)) return undefined;
+  return getServerScalarName($, scalar);
+}

--- a/packages/http-server-csharp/src/utils/attributes.tsx
+++ b/packages/http-server-csharp/src/utils/attributes.tsx
@@ -15,68 +15,27 @@ import {
   isArrayModelType,
   resolveEncodedName,
   type ModelProperty,
-  type Program,
   type Scalar,
   type Type,
 } from "@typespec/compiler";
+import type { Typekit } from "@typespec/compiler/typekit";
 import { isUnionEnum } from "../components/enums/enums.jsx";
+import { tryGetServerScalarName } from "../components/type-expression/scalar-overrides.js";
 
-/**
- * Maps a TypeSpec scalar name to the C# type name used in attributes.
- * This follows the old emitter's mapping.
- */
-function scalarToCSharpTypeName(program: Program, scalar: Scalar): string | undefined {
-  const stdBase = getStdBase(program, scalar);
-  if (!stdBase) return undefined;
-  const map: Record<string, string> = {
-    int8: "SByte",
-    uint8: "Byte",
-    int16: "Int16",
-    int32: "int",
-    int64: "long",
-    uint16: "UInt16",
-    uint32: "UInt32",
-    uint64: "UInt64",
-    safeint: "long",
-    float32: "float",
-    float64: "double",
-    decimal: "decimal",
-    decimal128: "decimal",
-    numeric: "double",
-    integer: "int",
-    float: "double",
-    boolean: "bool",
-    string: "string",
-    bytes: "byte[]",
-    plainDate: "DateTime",
-    plainTime: "DateTime",
-    utcDateTime: "DateTimeOffset",
-    offsetDateTime: "DateTimeOffset",
-    duration: "TimeSpan",
-    url: "string",
-  };
-  return map[stdBase.name];
-}
-
-function getStdBase(program: Program, scalar: Scalar): Scalar | undefined {
-  if (program.checker.isStdType(scalar)) return scalar;
-  if (scalar.baseScalar) return getStdBase(program, scalar.baseScalar);
-  return undefined;
+function getStdBase($: Typekit, scalar: Scalar): Scalar | undefined {
+  return $.scalar.getStdBase(scalar) ?? undefined;
 }
 
 type WireEncoding = { encoding: string; type: Type };
 
-function getScalarEncoding(
-  program: Program,
-  type: Scalar | ModelProperty,
-): WireEncoding | undefined {
-  const encode = getEncode(program, type);
+function getScalarEncoding($: Typekit, type: Scalar | ModelProperty): WireEncoding | undefined {
+  const encode = getEncode($.program, type);
   if (encode) return { encoding: encode.encoding ?? "string", type: encode.type };
   if (type.kind === "ModelProperty" && type.type.kind === "Scalar") {
-    return getScalarEncoding(program, type.type);
+    return getScalarEncoding($, type.type);
   }
   if (type.kind === "Scalar" && type.baseScalar) {
-    return getScalarEncoding(program, type.baseScalar);
+    return getScalarEncoding($, type.baseScalar);
   }
   return undefined;
 }
@@ -85,11 +44,11 @@ function getScalarEncoding(
  * Get all C# attributes for a model property.
  * Returns an array of attribute strings like `[JsonConverter(typeof(TimeSpanDurationConverter))]`
  */
-export function getPropertyAttributes(program: Program, property: ModelProperty): Children[] {
+export function getPropertyAttributes($: Typekit, property: ModelProperty): Children[] {
   const attrs: Children[] = [];
 
   // Encoding attributes (JsonConverter)
-  const encodingAttrs = getEncodingAttributes(program, property);
+  const encodingAttrs = getEncodingAttributes($, property);
   attrs.push(...encodingAttrs);
 
   // JsonStringEnumConverter for enum and union-as-enum properties
@@ -106,36 +65,36 @@ export function getPropertyAttributes(program: Program, property: ModelProperty)
   }
 
   // Constraint attributes
-  const numericAttr = getNumericConstraintAttribute(program, property);
+  const numericAttr = getNumericConstraintAttribute($, property);
   if (numericAttr) attrs.push(numericAttr);
 
-  const stringAttr = getStringConstraintAttribute(program, property);
+  const stringAttr = getStringConstraintAttribute($, property);
   if (stringAttr) attrs.push(stringAttr);
 
-  const arrayAttr = getArrayConstraintAttribute(program, property);
+  const arrayAttr = getArrayConstraintAttribute($, property);
   if (arrayAttr) attrs.push(arrayAttr);
 
   // JsonPropertyName (only when encoded name differs)
-  const nameAttr = getEncodedNameAttribute(program, property);
+  const nameAttr = getEncodedNameAttribute($, property);
   if (nameAttr) attrs.push(nameAttr);
 
   // SafeInt constraint
   if (property.type.kind === "Scalar") {
-    const safeIntAttr = getSafeIntAttribute(program, property.type);
+    const safeIntAttr = getSafeIntAttribute($, property.type);
     if (safeIntAttr) attrs.push(safeIntAttr);
   }
 
   return attrs;
 }
 
-function getEncodingAttributes(program: Program, property: ModelProperty): Children[] {
+function getEncodingAttributes($: Typekit, property: ModelProperty): Children[] {
   const result: Children[] = [];
   if (property.type.kind !== "Scalar") return result;
 
-  const stdBase = getStdBase(program, property.type);
+  const stdBase = getStdBase($, property.type);
   if (!stdBase) return result;
 
-  const encoding = getScalarEncoding(program, property);
+  const encoding = getScalarEncoding($, property);
 
   switch (stdBase.name) {
     case "duration":
@@ -180,16 +139,13 @@ function getEncodingAttributes(program: Program, property: ModelProperty): Child
   return result;
 }
 
-function getNumericConstraintAttribute(
-  program: Program,
-  property: ModelProperty,
-): Children | undefined {
+function getNumericConstraintAttribute($: Typekit, property: ModelProperty): Children | undefined {
   if (property.type.kind !== "Scalar") return undefined;
 
-  const minVal = getMinValue(program, property);
-  const maxVal = getMaxValue(program, property);
-  const minExcl = getMinValueExclusive(program, property);
-  const maxExcl = getMaxValueExclusive(program, property);
+  const minVal = getMinValue($.program, property);
+  const maxVal = getMaxValue($.program, property);
+  const minExcl = getMinValueExclusive($.program, property);
+  const maxExcl = getMaxValueExclusive($.program, property);
 
   if (
     minVal === undefined &&
@@ -200,7 +156,7 @@ function getNumericConstraintAttribute(
     return undefined;
   }
 
-  const csharpType = scalarToCSharpTypeName(program, property.type);
+  const csharpType = tryGetServerScalarName($, property.type);
   if (!csharpType) return undefined;
 
   const params: string[] = [];
@@ -215,13 +171,10 @@ function getNumericConstraintAttribute(
   return <Attribute name={`NumericConstraint<${csharpType}>`} args={params} />;
 }
 
-function getStringConstraintAttribute(
-  program: Program,
-  property: ModelProperty,
-): Children | undefined {
-  const minLen = getMinLength(program, property);
-  const maxLen = getMaxLength(program, property);
-  const pattern = getPattern(program, property);
+function getStringConstraintAttribute($: Typekit, property: ModelProperty): Children | undefined {
+  const minLen = getMinLength($.program, property);
+  const maxLen = getMaxLength($.program, property);
+  const pattern = getPattern($.program, property);
 
   if (minLen === undefined && maxLen === undefined && pattern === undefined) return undefined;
 
@@ -233,12 +186,9 @@ function getStringConstraintAttribute(
   return <Attribute name="StringConstraint" args={params} />;
 }
 
-function getArrayConstraintAttribute(
-  program: Program,
-  property: ModelProperty,
-): Children | undefined {
-  const minItems = getMinItems(program, property);
-  const maxItems = getMaxItems(program, property);
+function getArrayConstraintAttribute($: Typekit, property: ModelProperty): Children | undefined {
+  const minItems = getMinItems($.program, property);
+  const maxItems = getMaxItems($.program, property);
 
   if (minItems === undefined && maxItems === undefined) return undefined;
   if (property.type.kind !== "Model" || !isArrayModelType(property.type)) return undefined;
@@ -246,7 +196,7 @@ function getArrayConstraintAttribute(
   const elementType = property.type.indexer.value;
   if (elementType.kind !== "Scalar") return undefined;
 
-  const csharpType = scalarToCSharpTypeName(program, elementType);
+  const csharpType = tryGetServerScalarName($, elementType);
   if (!csharpType) return undefined;
 
   const params: string[] = [];
@@ -256,16 +206,16 @@ function getArrayConstraintAttribute(
   return <Attribute name={`ArrayConstraint<${csharpType}>`} args={params} />;
 }
 
-function getEncodedNameAttribute(program: Program, property: ModelProperty): Children | undefined {
-  const encodedName = resolveEncodedName(program, property, "application/json");
+function getEncodedNameAttribute($: Typekit, property: ModelProperty): Children | undefined {
+  const encodedName = resolveEncodedName($.program, property, "application/json");
   if (encodedName !== property.name) {
     return <Attribute name={Serialization.JsonPropertyNameAttribute} args={[`"${encodedName}"`]} />;
   }
   return undefined;
 }
 
-function getSafeIntAttribute(program: Program, scalar: Scalar): Children | undefined {
-  const stdBase = getStdBase(program, scalar);
+function getSafeIntAttribute($: Typekit, scalar: Scalar): Children | undefined {
+  const stdBase = getStdBase($, scalar);
   if (!stdBase || stdBase.name !== "safeint") return undefined;
   return (
     <Attribute


### PR DESCRIPTION
The emitter had **three** separate TypeSpec-scalar-to-C#-type-name maps, and they disagreed. Properties were rendered from one, error-model constructor parameters from another, and constraint attribute type arguments from a third — so the generated code did not compile:

```tsp
@error model ValidationError {
  occurredAt: utcDateTime;
  docs: url;
  severity: int8;
}
```

```diff
  public partial class ValidationError : HttpServiceException
  {
      public required DateTimeOffset OccurredAt { get; set; }
      public required string Docs { get; set; }
      public required SByte Severity { get; set; }

-     public ValidationError(DateTimeOffset occurredAt, Uri docs, sbyte severity)
+     public ValidationError(DateTimeOffset occurredAt, string docs, SByte severity)
```

`NumericConstraint<T>` had the same problem — the attribute was instantiated with a different type than the property it annotated, so it failed to bind.

The three maps collapse into one `scalar-overrides.ts` that layers the emitter's deliberate divergences (`plainDate`/`plainTime` → `DateTime`, `url` → `string`, `safeint` → `long`, CLR names for sized integers) over the emitter framework defaults. Anywhere a C# type *name* is needed outside a rendering context now goes through it, so it cannot drift from what `TypeExpression` renders again.

---

Independent — targets `main` and can merge on its own.

One of 7 PRs moving `@typespec/http-server-csharp` onto the emitter framework instead of its private forks. Merged: #11596, #11597, #11599. Remaining: #11598, #11600, #11601, #11602.