### PR TITLE
fix(http-client-python): generate valid Python type annotations in types.py

### DIFF
--- a/.chronus/changes/fix-python-emitter-invalid-type-annotations-2026-4-18-0-0-0.md
+++ b/.chronus/changes/fix-python-emitter-invalid-type-annotations-2026-4-18-0-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix invalid Python type annotations generated in `types.py` files. Internal enums used as TypedDict fields are now imported (as a bare symbol) from their private `_enums` submodule so the annotation resolves; duplicate runtime + `TYPE_CHECKING` imports of the same symbol are deduplicated to avoid `no-redef`; and TypedDicts that change an inherited field's requiredness are emitted as a flat (non-inheriting) TypedDict to satisfy PEP 589.

--- a/packages/http-client-python/generator/pygen/codegen/models/enum_type.py
+++ b/packages/http-client-python/generator/pygen/codegen/models/enum_type.py
@@ -203,6 +203,10 @@ class EnumType(BaseType):
                 model_alias = self.code_model.get_unique_models_alias(serialize_namespace, self.client_namespace)
                 module_name = f"{model_alias}."
             file_name = f"{self.code_model.enums_filename}." if self.internal else ""
+            if serialize_namespace_type == NamespaceType.TYPES_FILE:
+                # In types.py the enum symbol is imported directly (bare name), so no ``_enums.``
+                # module prefix even for internal enums — the prefix would be an undefined name.
+                file_name = ""
             model_name = module_name + file_name + self.name
             # we don't need quoted annotation in operation files, and need it in model folder files.
             if not kwargs.get("is_operation_file", False):
@@ -305,9 +309,21 @@ class EnumType(BaseType):
                         typing_section=TypingSection.REGULAR,
                     )
                 elif serialize_namespace_type == NamespaceType.TYPES_FILE:
-                    # Import enum name directly to avoid dotted forward refs in TypedDict annotations
+                    # Import the enum symbol directly to avoid dotted forward refs in TypedDict
+                    # annotations. Internal enums are not re-exported from the public ``models``
+                    # package, so import them from the private ``_enums`` submodule instead — the
+                    # bare-symbol import (rather than the ``_enums`` module) also avoids name
+                    # collisions when internal enums come from several sibling namespaces.
+                    if self.internal:
+                        enums_module = (
+                            f"{relative_path}models.{self.code_model.enums_filename}"
+                            if relative_path != "."
+                            else f".models.{self.code_model.enums_filename}"
+                        )
+                    else:
+                        enums_module = f"{relative_path}models" if relative_path != "." else ".models"
                     file_import.add_submodule_import(
-                        f"{relative_path}models" if relative_path != "." else ".models",
+                        enums_module,
                         self.name,
                         ImportType.LOCAL,
                         typing_section=TypingSection.TYPING,

--- a/packages/http-client-python/generator/pygen/codegen/serializers/import_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/import_serializer.py
@@ -84,6 +84,32 @@ class FileImportSerializer:
         if any(self.file_import.get_imports_from_section(TypingSection.TYPING)):
             self.file_import.add_submodule_import("typing", "TYPE_CHECKING", ImportType.STDLIB)
 
+    def _dedupe_typing_imports(self):
+        """Drop TYPE_CHECKING imports whose bound name is already imported at runtime.
+
+        A name imported in the regular (runtime) section is also available during type checking, so a
+        duplicate import under ``if TYPE_CHECKING:`` is redundant and triggers mypy's ``no-redef``
+        error. This can happen when the same symbol is imported from two different modules — e.g. a
+        cross-namespace enum imported at runtime from its ``_enums`` submodule and again for its
+        annotation from the public ``models`` package. The runtime import is sufficient.
+        """
+        regular_bound_names = {
+            (i.alias or i.submodule_name)
+            for i in self.file_import.get_imports_from_section(TypingSection.REGULAR)
+            if i.submodule_name
+        }
+        if not regular_bound_names:
+            return
+        self.file_import.imports = [
+            i
+            for i in self.file_import.imports
+            if not (
+                i.typing_section == TypingSection.TYPING
+                and i.submodule_name
+                and (i.alias or i.submodule_name) in regular_bound_names
+            )
+        ]
+
     def _add_sys_import_if_needed(self):
         all_imports = list(self.file_import.get_imports_from_section(TypingSection.REGULAR)) + list(
             self.file_import.get_imports_from_section(TypingSection.TYPING)
@@ -106,6 +132,7 @@ class FileImportSerializer:
         return "\n".join(declarations)
 
     def __str__(self) -> str:
+        self._dedupe_typing_imports()
         self._add_type_checking_import()
         self._add_sys_import_if_needed()
         regular_imports = ""

--- a/packages/http-client-python/generator/pygen/codegen/serializers/types_serializer.py
+++ b/packages/http-client-python/generator/pygen/codegen/serializers/types_serializer.py
@@ -248,6 +248,39 @@ class TypesSerializer(BaseSerializer):
         """Whether any property wire_name is a Python keyword or requires functional TypedDict form."""
         return any(keyword.iskeyword(p.wire_name) or not p.wire_name.isidentifier() for p in model.properties)
 
+    @staticmethod
+    def needs_flat_typeddict(model: ModelType) -> bool:
+        """Whether a TypedDict must be emitted in flat (non-inheriting) form.
+
+        PEP 589 forbids changing an inherited TypedDict field's requiredness in a subclass. When a
+        child redeclares an inherited field with a different requiredness (e.g. the parent renders it
+        as optional via ``total=False`` while the child needs ``Required[...]``), subclassing would
+        emit an illegal ``Overwriting TypedDict field ... while extending`` construct. Such models are
+        instead rendered as a flat TypedDict that lists every field (inherited + own) directly.
+
+        Models with keyword wire_names already flatten all fields via the functional form, so they
+        never hit this path.
+        """
+        if TypesSerializer.has_keyword_wire_names(model):
+            return False
+        non_discriminated_parents = [p for p in model.parents if not p.discriminated_subtypes]
+        if not non_discriminated_parents:
+            return False
+        for parent in non_discriminated_parents:
+            for parent_prop in parent.properties:
+                child_prop = next(
+                    (p for p in model.properties if p.client_name == parent_prop.client_name),
+                    None,
+                )
+                if child_prop is None or child_prop is parent_prop:
+                    # Not overridden by the child (same object is reused when inherited unchanged).
+                    continue
+                parent_required = not (parent_prop.optional or parent_prop.client_default_value is not None)
+                child_required = not (child_prop.optional or child_prop.client_default_value is not None)
+                if parent_required != child_required:
+                    return True
+        return False
+
     def get_shadowed_builtins(self, model: ModelType) -> frozenset[str]:
         """Return the set of builtin type names shadowed by property wire_names in this model.
 
@@ -308,7 +341,11 @@ class TypesSerializer(BaseSerializer):
                 if self.get_shadowed_builtins(model):
                     needs_builtins = True
                 for parent in model.parents:
-                    if parent.client_namespace != model.client_namespace and not parent.discriminated_subtypes:
+                    if (
+                        parent.client_namespace != model.client_namespace
+                        and not parent.discriminated_subtypes
+                        and not self.needs_flat_typeddict(model)
+                    ):
                         # Import parent class from sibling namespace's types module
                         file_import.add_submodule_import(
                             self.code_model.get_relative_import_path(
@@ -334,7 +371,7 @@ class TypesSerializer(BaseSerializer):
         if self.has_keyword_wire_names(model):
             return ""  # functional form is rendered separately
         non_discriminated_parents = [p for p in model.parents if not p.discriminated_subtypes]
-        if non_discriminated_parents:
+        if non_discriminated_parents and not self.needs_flat_typeddict(model):
             basename = ", ".join([m.name for m in non_discriminated_parents])
             return f"class {model.name}({basename}):{model.pylint_disable()}"
         return f"class {model.name}(TypedDict, total=False):{model.pylint_disable()}"
@@ -367,7 +404,7 @@ class TypesSerializer(BaseSerializer):
         if TypesSerializer.has_keyword_wire_names(model):
             return []  # functional form handles all properties
         non_discriminated_parents = [p for p in model.parents if not p.discriminated_subtypes]
-        if non_discriminated_parents:
+        if non_discriminated_parents and not TypesSerializer.needs_flat_typeddict(model):
             parent_properties = [p for bm in non_discriminated_parents for p in bm.properties]
             return [
                 p

--- a/packages/http-client-python/tests/unit/test_typeddict.py
+++ b/packages/http-client-python/tests/unit/test_typeddict.py
@@ -9,11 +9,13 @@
 from jinja2 import PackageLoader, Environment
 
 from pygen.codegen.models import CodeModel, JSONModelType, DPGModelType, build_type
-from pygen.codegen.models.imports import ImportType
+from pygen.codegen.models.imports import ImportType, FileImport, TypingSection
 from pygen.codegen.models.model_type import TypedDictModelType
 from pygen.codegen.models.property import Property
 from pygen.codegen.models.list_type import ListType
+from pygen.codegen.models.utils import NamespaceType
 from pygen.codegen.serializers.types_serializer import TypesSerializer, _qualify_shadowed_builtins
+from pygen.codegen.serializers.import_serializer import FileImportSerializer
 from pygen.codegen.serializers.unions_serializer import UnionsSerializer
 
 
@@ -721,3 +723,197 @@ def test_type_changing_under_types_file_does_not_cause_spurious_builtins_import(
 
     output = ts.serialize()
     assert "import builtins" not in output
+
+
+# ---------- Bug 3: TypedDict requiredness override via inheritance (issue #11626) ----------
+
+
+def _make_typed_property(code_model, name, prop_type, *, optional):
+    """Create a Property with an explicit requiredness."""
+    return Property(
+        yaml_data={"wireName": name, "clientName": name, "optional": optional},
+        code_model=code_model,
+        type=prop_type,
+    )
+
+
+def test_typeddict_requiredness_override_uses_flat_form():
+    """A child that changes an inherited field's requiredness must render as a flat TypedDict.
+
+    Regression for mypy ``Overwriting TypedDict field "generatedKeyName" while extending [misc]``.
+    PEP 589 forbids changing an inherited key's requiredness via subclassing, so the child is
+    emitted as a flat ``class Child(TypedDict, total=False):`` listing every field (inherited + own)
+    rather than subclassing the parent.
+    """
+    code_model = _make_code_model(models_mode="dpg")
+    str_type = build_type({"type": "string"}, code_model)
+
+    parent = _make_model_with_usage(code_model, "SearchIndexerKnowledgeStoreProjectionSelector", 2, DPGModelType)
+    parent.properties = [
+        _make_typed_property(code_model, "referenceKeyName", str_type, optional=True),
+        _make_typed_property(code_model, "generatedKeyName", str_type, optional=True),
+    ]
+
+    child = DPGModelType(
+        yaml_data={
+            "name": "SearchIndexerKnowledgeStoreTableProjectionSelector",
+            "type": "model",
+            "snakeCaseName": "searchindexerknowledgestoretableprojectionselector",
+            "usage": 2,
+        },
+        code_model=code_model,
+        # Merged property list: the inherited field is the *same object*, the overridden field is new.
+        properties=[
+            parent.properties[0],  # referenceKeyName inherited unchanged
+            _make_typed_property(code_model, "generatedKeyName", str_type, optional=False),  # now required
+        ],
+        parents=[parent],
+    )
+    code_model.model_types = [parent, child]
+
+    assert TypesSerializer.needs_flat_typeddict(child) is True
+
+    env = _make_env()
+    output = TypesSerializer(code_model=code_model, env=env, models=[parent, child]).serialize()
+
+    # Parent renders normally.
+    assert "class SearchIndexerKnowledgeStoreProjectionSelector(TypedDict, total=False):" in output
+    # Child renders flat — NOT subclassing the parent (which would violate PEP 589).
+    assert "class SearchIndexerKnowledgeStoreTableProjectionSelector(TypedDict, total=False):" in output
+    assert (
+        "class SearchIndexerKnowledgeStoreTableProjectionSelector(SearchIndexerKnowledgeStoreProjectionSelector)"
+        not in output
+    )
+    # The overridden field is required and the inherited field is flattened in.
+    assert "generatedKeyName: Required[str]" in output
+    assert "referenceKeyName: str" in output
+
+
+def test_typeddict_inheritance_without_requiredness_change_still_subclasses():
+    """A child that only adds fields (no requiredness change) keeps normal subclassing."""
+    code_model = _make_code_model(models_mode="dpg")
+    str_type = build_type({"type": "string"}, code_model)
+
+    parent = _make_model_with_usage(code_model, "Base", 2, DPGModelType)
+    parent.properties = [_make_typed_property(code_model, "name", str_type, optional=True)]
+
+    child = DPGModelType(
+        yaml_data={"name": "Derived", "type": "model", "snakeCaseName": "derived", "usage": 2},
+        code_model=code_model,
+        properties=[
+            parent.properties[0],  # inherited unchanged
+            _make_typed_property(code_model, "extra", str_type, optional=True),  # new, same requiredness
+        ],
+        parents=[parent],
+    )
+    code_model.model_types = [parent, child]
+
+    assert TypesSerializer.needs_flat_typeddict(child) is False
+
+    env = _make_env()
+    output = TypesSerializer(code_model=code_model, env=env, models=[parent, child]).serialize()
+    assert "class Derived(Base):" in output
+
+
+# ---------- Bug 1: internal enum reference/import in types.py (issue #11626) ----------
+
+
+def _make_enum_type(code_model, name, *, internal, client_namespace=None):
+    """Build an EnumType (with no members) attached to code_model."""
+    yaml_data = {
+        "type": "enum",
+        "name": name,
+        "valueType": {"type": "string"},
+        "values": [],
+        "internal": internal,
+    }
+    if client_namespace is not None:
+        yaml_data["clientNamespace"] = client_namespace
+    return build_type(yaml_data, code_model)
+
+
+def test_internal_enum_types_file_annotation_uses_bare_name():
+    """An internal enum annotated in types.py must use the bare name, not ``_enums.Name``.
+
+    Regression for mypy ``Name "_enums" is not defined [name-defined]``: types.py imports the enum
+    symbol directly, so the annotation must reference the bare name.
+    """
+    code_model = _make_code_model(models_mode="dpg")
+    enum = _make_enum_type(code_model, "SemanticQueryRewritesResultType", internal=True)
+    annotation = enum.type_annotation(serialize_namespace_type=NamespaceType.TYPES_FILE)
+    assert annotation == 'Union[str, "SemanticQueryRewritesResultType"]'
+    assert "_enums." not in annotation
+
+
+def test_internal_enum_types_file_imports_from_private_enums_submodule():
+    """Internal enums are not public, so types.py imports them from the private ``_enums`` submodule."""
+    code_model = _make_code_model(models_mode="dpg")
+    enum = _make_enum_type(code_model, "SemanticQueryRewritesResultType", internal=True)
+    modules = _local_import_modules(enum.imports(serialize_namespace_type=NamespaceType.TYPES_FILE))
+    suffix = f"models.{code_model.enums_filename}"
+    assert any(module.endswith(suffix) for module in modules), modules
+
+
+def test_public_enum_types_file_imports_from_models_package():
+    """A non-internal enum keeps importing from the public ``models`` package (bare symbol)."""
+    code_model = _make_code_model(models_mode="dpg")
+    enum = _make_enum_type(code_model, "PublicEnum", internal=False)
+    modules = _local_import_modules(enum.imports(serialize_namespace_type=NamespaceType.TYPES_FILE))
+    assert any(module.endswith("models") for module in modules), modules
+    assert not any(module.endswith(code_model.enums_filename) for module in modules), modules
+
+
+def test_internal_enum_property_types_file_serialize_is_consistent():
+    """End-to-end: the internal enum annotation and its import agree in generated types.py."""
+    code_model = _make_code_model(models_mode="dpg")
+    enum = _make_enum_type(code_model, "SemanticQueryRewritesResultType", internal=True)
+    model = _make_model_with_usage(code_model, "SearchDocumentsResult", 2, DPGModelType)
+    model.properties = [_make_property(code_model, "semanticQueryRewritesResultType", enum)]
+    code_model.model_types = [model]
+
+    env = _make_env()
+    output = TypesSerializer(code_model=code_model, env=env, models=[model]).serialize()
+    # The undefined ``_enums.`` prefix must never appear in types.py.
+    assert f"{code_model.enums_filename}.SemanticQueryRewritesResultType" not in output
+    # The enum symbol is imported (from the private submodule) so the forward ref resolves.
+    assert "import SemanticQueryRewritesResultType" in output
+    assert f"models.{code_model.enums_filename}" in output
+
+
+# ---------- Bug 2: duplicate runtime + TYPE_CHECKING import (issue #11626) ----------
+
+
+def test_duplicate_runtime_and_type_checking_import_is_deduped():
+    """A symbol imported at runtime must not be re-imported under ``if TYPE_CHECKING:``.
+
+    Regression for mypy ``Name "KnowledgeSourceKind" already defined [no-redef]``: the same enum was
+    imported at runtime from its ``_enums`` submodule and again for its annotation from the public
+    ``models`` package. The runtime import is sufficient; the TYPE_CHECKING duplicate is dropped.
+    """
+    code_model = _make_code_model(models_mode="dpg")
+    file_import = FileImport(code_model)
+    # Runtime import from the private submodule.
+    file_import.add_submodule_import(
+        "..indexes.models._enums", "KnowledgeSourceKind", ImportType.LOCAL, TypingSection.REGULAR
+    )
+    # TYPE_CHECKING import of the same bound name from a different module.
+    file_import.add_submodule_import(
+        "..indexes.models", "KnowledgeSourceKind", ImportType.LOCAL, typing_section=TypingSection.TYPING
+    )
+
+    output = str(FileImportSerializer(file_import))
+    assert output.count("import KnowledgeSourceKind") == 1
+    # No TYPE_CHECKING duplicate remains (that was the only typing import).
+    assert "if TYPE_CHECKING:" not in output
+
+
+def test_type_checking_import_kept_when_no_runtime_duplicate():
+    """A TYPE_CHECKING import with no runtime counterpart is preserved."""
+    code_model = _make_code_model(models_mode="dpg")
+    file_import = FileImport(code_model)
+    file_import.add_submodule_import(
+        "..indexes.models", "OnlyForTyping", ImportType.LOCAL, typing_section=TypingSection.TYPING
+    )
+    output = str(FileImportSerializer(file_import))
+    assert "if TYPE_CHECKING:" in output
+    assert "import OnlyForTyping" in output


### PR DESCRIPTION
The Python client emitter generated `types.py` files with invalid type annotations for `azure-search-documents`, producing 4 MyPy errors across three generated files. This fixes the three distinct codegen bugs behind them.

## What was wrong and how it's fixed

**1. Internal enum annotation/import mismatch.** An internal enum used as a TypedDict field was annotated as `_enums.Name` while `_enums` was never imported (and the enum is not re-exported from the public `models` package), yielding `Name '_enums' is not defined` and `Module has no attribute` errors. The enum is now imported as a bare symbol from its private `_enums` submodule, and the `TYPES_FILE` annotation drops the undefined `_enums.` prefix. Enums stay private (no change to the public `__all__`).

**2. Duplicate enum import.** The same symbol could be imported once at runtime and again under `if TYPE_CHECKING:` (from different modules), triggering mypy `no-redef`. Added a dedup pass that drops a `TYPE_CHECKING` submodule import when its bound name is already imported at runtime; the runtime import is sufficient for the annotations.

**3. TypedDict requiredness override via inheritance.** A child TypedDict that redeclared an inherited field with different requiredness produced `Overwriting TypedDict field ... while extending`, which PEP 589 forbids. Such models are now emitted as a flat, non-inheriting TypedDict that lists every field (inherited plus own) directly, so requiredness is expressed without subclassing.

## Notes for reviewers

- The internal-enum import intentionally imports the bare symbol from `_enums` rather than the `_enums` module, which also avoids name collisions when internal enums come from several sibling namespaces.
- Regression tests were added to `tests/unit/test_typeddict.py` covering all three cases.

## Validation

- `test_typeddict.py` + `test_enums.py`: 50 passed (42 existing + 8 new).
- pylint 10.00/10 on the changed files; black clean under the project config; mypy introduces no new errors (the pre-existing errors are unchanged on the baseline).

Fixes: #11626