### PR TITLE
Allow extending ScmModelProvider

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmModelProvider.cs
@@ -27,7 +27,7 @@ using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 {
-    public sealed class ScmModelProvider : ModelProvider
+    public class ScmModelProvider : ModelProvider
     {
         private readonly InputModelType _inputModel;
         private const string JsonPatchFieldName = "_patch";

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/ScmModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/ScmModelProviderTests.cs
@@ -16,10 +16,25 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ScmModelProvi
 {
     public class ScmModelProviderTests
     {
+        private sealed class DerivedScmModelProvider : ScmModel
+        {
+            public DerivedScmModelProvider(InputModelType inputModel) : base(inputModel)
+            {
+            }
+        }
+
         [SetUp]
         public void SetUp()
         {
             MockHelpers.LoadMockGenerator();
+        }
+
+        [Test]
+        public void CanBeInherited()
+        {
+            var provider = new DerivedScmModelProvider(InputFactory.Model("model"));
+
+            Assert.IsInstanceOf<ScmModel>(provider);
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- make \ScmModelProvider\ inheritable
- add regression coverage proving derived providers can be constructed

This allows specialized generators such as the Azure management generator to retain their model-provider customizations while inheriting shared ClientModel behavior, including dynamic model patch support.

Fixes the upstream prerequisite for Azure/azure-sdk-for-net#61851.