### PR TITLE
[http-client-csharp] Bounds check dynamic model collection paths

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.Dynamic.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.Dynamic.cs
@@ -423,12 +423,14 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                         });
                     }
 
+                    var collection = accessorChain.Last();
+                    string lengthPropertyName = currentType.IsArray ? "Length" : "Count";
                     statements.Add(new IfStatement(Not(currentSlice.Invoke(
                         "TryGetIndex",
                         [
                             new DeclarationExpression(typeof(int), "index", out var indexVariable, isOut: true),
                             new DeclarationExpression(typeof(int), "bytesConsumed", out var bytesConsumedVariable, isOut: true)
-                        ]).As<bool>()))
+                        ]).As<bool>()).Or(indexVariable.GreaterThanOrEqual(collection.Property(lengthPropertyName))))
                     {
                         Return(False)
                     });

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ModelReaderWriterValidation/TestProjects/Sample_TypeSpec/DynamicModelTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ModelReaderWriterValidation/TestProjects/Sample_TypeSpec/DynamicModelTests.cs
@@ -99,7 +99,30 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.ModelReaderWriterValida
         [Test]
         public void JsonPatchTryGetValue_CollectionIndexIsBoundsChecked()
         {
-            var model = ModelReaderWriter.Read<DynamicModel>(
+            var model = ReadDynamicModel();
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            Assert.That(model.Patch.TryGetValue("$.listFoo[0].bar"u8, out string? value), Is.True);
+            Assert.That(value, Is.EqualTo("bar"));
+            Assert.That(model.Patch.TryGetValue("$.listFoo[1].bar"u8, out string? _), Is.False);
+            Assert.That(model.Patch.TryGetValue("$.listOfListFoo[0][0].bar"u8, out string? _), Is.False);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        }
+
+        [Test]
+        public void JsonPatchSet_CollectionIndexIsBoundsChecked()
+        {
+            var model = ReadDynamicModel();
+
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            model.Patch.Set("$.listFoo[1].bar"u8, "\"patched\""u8);
+            model.Patch.Set("$.listOfListFoo[0][0].bar"u8, "\"patched\""u8);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        }
+
+        private static DynamicModel ReadDynamicModel()
+        {
+            return ModelReaderWriter.Read<DynamicModel>(
                 BinaryData.FromString(
                     """
                     {
@@ -117,15 +140,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.ModelReaderWriterValida
                     }
                     """),
                 ModelReaderWriterOptions.Json,
-                SampleTypeSpecContext.Default);
-
-            Assert.That(model, Is.Not.Null);
-#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
-            Assert.That(model!.Patch.TryGetValue("$.listFoo[0].bar"u8, out string? value), Is.True);
-            Assert.That(value, Is.EqualTo("bar"));
-            Assert.That(model.Patch.TryGetValue("$.listFoo[1].bar"u8, out string? _), Is.False);
-            Assert.That(model.Patch.TryGetValue("$.listOfListFoo[0][0].bar"u8, out string? _), Is.False);
-#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+                SampleTypeSpecContext.Default)!;
         }
 
         private static int GetRootPropertyCount(JsonElement root, string propertyName) => root.EnumerateObject().Count(property => property.NameEquals(propertyName));

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ModelReaderWriterValidation/TestProjects/Sample_TypeSpec/DynamicModelTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/ModelReaderWriterValidation/TestProjects/Sample_TypeSpec/DynamicModelTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ClientModel.Primitives;
 using System.Linq;
 using System.Text.Json;
@@ -93,6 +94,38 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.ModelReaderWriterValida
             var foo = document.RootElement.GetProperty("foo");
             Assert.That(foo.GetProperty("bar").GetString(), Is.EqualTo("bar"));
             Assert.That(foo.GetProperty("baz").GetString(), Is.EqualTo("patched"));
+        }
+
+        [Test]
+        public void JsonPatchTryGetValue_CollectionIndexIsBoundsChecked()
+        {
+            var model = ModelReaderWriter.Read<DynamicModel>(
+                BinaryData.FromString(
+                    """
+                    {
+                      "name": "dynamic-model",
+                      "requiredNullableList": [],
+                      "requiredNullableDictionary": {},
+                      "primitiveDictionary": {},
+                      "foo": { "bar": "foo" },
+                      "listFoo": [{ "bar": "bar" }],
+                      "listOfListFoo": [],
+                      "dictionaryFoo": {},
+                      "dictionaryOfDictionaryFoo": {},
+                      "dictionaryListFoo": {},
+                      "listOfDictionaryFoo": []
+                    }
+                    """),
+                ModelReaderWriterOptions.Json,
+                SampleTypeSpecContext.Default);
+
+            Assert.That(model, Is.Not.Null);
+#pragma warning disable SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            Assert.That(model!.Patch.TryGetValue("$.listFoo[0].bar"u8, out string? value), Is.True);
+            Assert.That(value, Is.EqualTo("bar"));
+            Assert.That(model.Patch.TryGetValue("$.listFoo[1].bar"u8, out string? _), Is.False);
+            Assert.That(model.Patch.TryGetValue("$.listOfListFoo[0][0].bar"u8, out string? _), Is.False);
+#pragma warning restore SCME0001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         }
 
         private static int GetRootPropertyCount(JsonElement root, string propertyName) => root.EnumerateObject().Count(property => property.NameEquals(propertyName));

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateCustomizedDynamicListProperty.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateCustomizedDynamicListProperty.cs
@@ -23,7 +23,7 @@ namespace Sample
                 {
                     return TryResolveProp2Array(out value);
                 }
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= Prop2.Count)))
                 {
                     return false;
                 }
@@ -42,7 +42,7 @@ namespace Sample
             {
                 int propertyLength = "prop1"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= Prop2.Count)))
                 {
                     return false;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateCustomizedDynamicListPropertyMixed.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateCustomizedDynamicListPropertyMixed.cs
@@ -23,7 +23,7 @@ namespace Sample
                 {
                     return TryResolveProp2Array(out value);
                 }
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= Prop2.Count)))
                 {
                     return false;
                 }
@@ -42,7 +42,7 @@ namespace Sample
             {
                 int propertyLength = "prop1"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= Prop2.Count)))
                 {
                     return false;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateModelListProperty.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateModelListProperty.cs
@@ -23,7 +23,7 @@ namespace Sample
                 {
                     return TryResolveP1Array(out value);
                 }
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P1.Count)))
                 {
                     return false;
                 }
@@ -42,7 +42,7 @@ namespace Sample
             {
                 int propertyLength = "p1"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P1.Count)))
                 {
                     return false;
                 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateMultipleDynamicProperties.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/TestData/DynamicModelSerializationTests/PropagateMultipleDynamicProperties.cs
@@ -36,7 +36,7 @@ namespace Sample
                 {
                     return TryResolveP2Array(out value);
                 }
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P2.Count)))
                 {
                     return false;
                 }
@@ -50,7 +50,7 @@ namespace Sample
                 {
                     return TryResolveP3Array(out value);
                 }
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P3.Count)))
                 {
                     return false;
                 }
@@ -60,12 +60,12 @@ namespace Sample
             {
                 int propertyLength = "p4"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P4.Count)))
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed);
-                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0))
+                if ((!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0) || (index0 >= P4[index].Count)))
                 {
                     return false;
                 }
@@ -75,17 +75,17 @@ namespace Sample
             {
                 int propertyLength = "p5"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P5.Count)))
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed);
-                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0))
+                if ((!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0) || (index0 >= P5[index].Count)))
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed0);
-                if (!currentSlice.TryGetIndex(out int index1, out int bytesConsumed1))
+                if ((!currentSlice.TryGetIndex(out int index1, out int bytesConsumed1) || (index1 >= P5[index][index0].Count)))
                 {
                     return false;
                 }
@@ -101,7 +101,7 @@ namespace Sample
                     return false;
                 }
                 currentSlice = currentSlice.GetRemainder(i);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= item.Count)))
                 {
                     return false;
                 }
@@ -132,7 +132,7 @@ namespace Sample
             {
                 int propertyLength = "p2"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P2.Count)))
                 {
                     return false;
                 }
@@ -143,7 +143,7 @@ namespace Sample
             {
                 int propertyLength = "p3"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P3.Count)))
                 {
                     return false;
                 }
@@ -154,12 +154,12 @@ namespace Sample
             {
                 int propertyLength = "p4"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P4.Count)))
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed);
-                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0))
+                if ((!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0) || (index0 >= P4[index].Count)))
                 {
                     return false;
                 }
@@ -170,17 +170,17 @@ namespace Sample
             {
                 int propertyLength = "p5"u8.Length;
                 global::System.ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= P5.Count)))
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed);
-                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0))
+                if ((!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0) || (index0 >= P5[index].Count)))
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed0);
-                if (!currentSlice.TryGetIndex(out int index1, out int bytesConsumed1))
+                if ((!currentSlice.TryGetIndex(out int index1, out int bytesConsumed1) || (index1 >= P5[index][index0].Count)))
                 {
                     return false;
                 }
@@ -197,7 +197,7 @@ namespace Sample
                     return false;
                 }
                 currentSlice = currentSlice.GetRemainder(i);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if ((!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || (index >= item.Count)))
                 {
                     return false;
                 }

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/DynamicModel.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/DynamicModel.Serialization.cs
@@ -777,7 +777,7 @@ namespace SampleTypeSpec
                 {
                     return TryResolveListFooArray(out value);
                 }
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ListFoo.Count)
                 {
                     return false;
                 }
@@ -787,12 +787,12 @@ namespace SampleTypeSpec
             {
                 int propertyLength = "listOfListFoo"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ListOfListFoo.Count)
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed);
-                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0))
+                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0) || index0 >= ListOfListFoo[index].Count)
                 {
                     return false;
                 }
@@ -836,7 +836,7 @@ namespace SampleTypeSpec
                     return false;
                 }
                 currentSlice = currentSlice.GetRemainder(i);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= item.Count)
                 {
                     return false;
                 }
@@ -846,7 +846,7 @@ namespace SampleTypeSpec
             {
                 int propertyLength = "listOfDictionaryFoo"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ListOfDictionaryFoo.Count)
                 {
                     return false;
                 }
@@ -880,7 +880,7 @@ namespace SampleTypeSpec
             {
                 int propertyLength = "listFoo"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ListFoo.Count)
                 {
                     return false;
                 }
@@ -891,12 +891,12 @@ namespace SampleTypeSpec
             {
                 int propertyLength = "listOfListFoo"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ListOfListFoo.Count)
                 {
                     return false;
                 }
                 currentSlice = currentSlice.Slice(bytesConsumed);
-                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0))
+                if (!currentSlice.TryGetIndex(out int index0, out int bytesConsumed0) || index0 >= ListOfListFoo[index].Count)
                 {
                     return false;
                 }
@@ -943,7 +943,7 @@ namespace SampleTypeSpec
                     return false;
                 }
                 currentSlice = currentSlice.GetRemainder(i);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= item.Count)
                 {
                     return false;
                 }
@@ -954,7 +954,7 @@ namespace SampleTypeSpec
             {
                 int propertyLength = "listOfDictionaryFoo"u8.Length;
                 ReadOnlySpan<byte> currentSlice = local.Slice(propertyLength);
-                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed))
+                if (!currentSlice.TryGetIndex(out int index, out int bytesConsumed) || index >= ListOfDictionaryFoo.Count)
                 {
                     return false;
                 }


### PR DESCRIPTION
## Summary

- bounds-check generated dynamic model collection indexes before accessing list or array elements
- apply the guard to both `PropagateGet` and `PropagateSet`, including nested collections
- add generated-output coverage and end-to-end regression tests for `JsonPatch.TryGetValue` and `JsonPatch.Set`

Fixes #11616

## Validation

- `npm run build`
- `npm test`
- `npm run cop`
- `dotnet test Microsoft.TypeSpec.Generator.ClientModel.Tests.csproj` (1,560 passed)