### PR TITLE
Fix Java sample client routing

### DIFF
--- a/.chronus/changes/java-premium-sample-client-routing-2026-08-12-13-27-00.md
+++ b/.chronus/changes/java-premium-sample-client-routing-2026-08-12-13-27-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+Fix Fluent Premium samples to use the correct service client for resource metadata suffixes.

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/clientmodel/examplemodel/FluentClientMethodExample.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/clientmodel/examplemodel/FluentClientMethodExample.java
@@ -115,9 +115,9 @@ public class FluentClientMethodExample implements FluentMethodExample {
     }
 
     private static final Set<String> SUPPORTED_PREMIUM_PACKAGES
-        = Set.of("appplatform", "appservice", "authorization", "cdn", "compute", "containerinstance",
-            "containerregistry", "containerservice", "cosmos", "dns", "eventhubs", "keyvault", "monitor", "msi",
-            "network", "privatedns", "redis", "resources", "search", "servicebus", "sql", "storage", "trafficmanager");
+        = Set.of("appservice", "authorization", "cdn", "compute", "containerinstance", "containerregistry",
+            "containerservice", "cosmos", "dns", "eventhubs", "keyvault", "monitor", "msi", "network", "privatedns",
+            "redis", "resources", "search", "servicebus", "sql", "storage", "trafficmanager");
 
     private static final Map<String, String> RESOURCE_SERVICE_CLIENT_REFERENCES = Map.of("feature", "featureClient()",
         "policy", "policyClient()", "subscription", "subscriptionClient()", "lock", "managementLockClient()", "change",

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/clientmodel/examplemodel/FluentClientMethodExample.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/main/java/com/microsoft/typespec/http/client/generator/mgmt/model/clientmodel/examplemodel/FluentClientMethodExample.java
@@ -12,9 +12,9 @@ import com.microsoft.typespec.http.client.generator.mgmt.model.clientmodel.Fluen
 import com.microsoft.typespec.http.client.generator.mgmt.model.clientmodel.ModelNaming;
 import com.microsoft.typespec.http.client.generator.mgmt.util.FluentUtils;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Model of example for service client method (usually for Fluent Premium).
@@ -88,13 +88,25 @@ public class FluentClientMethodExample implements FluentMethodExample {
         String lastIdentifier = namespace.substring(namespace.lastIndexOf('.') + 1);
 
         // Guard against accidental premium code generation for non-premium libraries
-        if (!MANAGER_REFERENCE.containsKey(lastIdentifier)) {
+        if (!SUPPORTED_PREMIUM_PACKAGES.contains(lastIdentifier)) {
             throw new IllegalStateException("Package '" + namespace + "' is not supported by Fluent Premium");
         }
 
-        String serviceClientReference = ModelNaming.METHOD_SERVICE_CLIENT + "()";
+        String metadataSuffix = FluentStatic.getFluentJavaSettings().getMetadataSuffix().orElse(null);
+        String serviceClientReference = getServiceClientReference(lastIdentifier, metadataSuffix);
         String methodGroupReference = "get" + CodeNamer.toPascalCase(methodGroup.getVariableName()) + "()";
         return serviceClientReference + "." + methodGroupReference;
+    }
+
+    static String getServiceClientReference(String packageIdentifier, String metadataSuffix) {
+        if ("authorization".equals(packageIdentifier)) {
+            return "roleServiceClient()";
+        }
+        if ("resources".equals(packageIdentifier) && metadataSuffix != null) {
+            return RESOURCE_SERVICE_CLIENT_REFERENCES.getOrDefault(metadataSuffix,
+                ModelNaming.METHOD_SERVICE_CLIENT + "()");
+        }
+        return ModelNaming.METHOD_SERVICE_CLIENT + "()";
     }
 
     @Override
@@ -102,30 +114,12 @@ public class FluentClientMethodExample implements FluentMethodExample {
         return clientMethod.getName();
     }
 
-    private static final Map<String, String> MANAGER_REFERENCE = new HashMap<>();
-    static {
-        MANAGER_REFERENCE.put("appplatform", "springServices()");
-        MANAGER_REFERENCE.put("appservice", "webApps()");
-        MANAGER_REFERENCE.put("authorization", "accessManagement().roleAssignments()");
-        MANAGER_REFERENCE.put("cdn", "cdnProfiles()");
-        MANAGER_REFERENCE.put("compute", "virtualMachines()");
-        MANAGER_REFERENCE.put("containerinstance", "containerGroups()");
-        MANAGER_REFERENCE.put("containerregistry", "containerRegistries()");
-        MANAGER_REFERENCE.put("containerservice", "kubernetesClusters()");
-        MANAGER_REFERENCE.put("cosmos", "cosmosDBAccounts()");
-        MANAGER_REFERENCE.put("dns", "dnsZones()");
-        MANAGER_REFERENCE.put("eventhubs", "eventHubs()");
-        MANAGER_REFERENCE.put("keyvault", "vaults()");
-        MANAGER_REFERENCE.put("monitor", "diagnosticSettings()");
-        MANAGER_REFERENCE.put("msi", "identities()");
-        MANAGER_REFERENCE.put("network", "networks()");
-        MANAGER_REFERENCE.put("privatedns", "privateDnsZones()");
-        MANAGER_REFERENCE.put("redis", "redisCaches()");
-        MANAGER_REFERENCE.put("resources", "genericResources()");
-        MANAGER_REFERENCE.put("search", "searchServices()");
-        MANAGER_REFERENCE.put("servicebus", "serviceBusNamespaces()");
-        MANAGER_REFERENCE.put("sql", "sqlServers()");
-        MANAGER_REFERENCE.put("storage", "storageAccounts()");
-        MANAGER_REFERENCE.put("trafficmanager", "trafficManagerProfiles()");
-    }
+    private static final Set<String> SUPPORTED_PREMIUM_PACKAGES
+        = Set.of("appplatform", "appservice", "authorization", "cdn", "compute", "containerinstance",
+            "containerregistry", "containerservice", "cosmos", "dns", "eventhubs", "keyvault", "monitor", "msi",
+            "network", "privatedns", "redis", "resources", "search", "servicebus", "sql", "storage", "trafficmanager");
+
+    private static final Map<String, String> RESOURCE_SERVICE_CLIENT_REFERENCES = Map.of("feature", "featureClient()",
+        "policy", "policyClient()", "subscription", "subscriptionClient()", "lock", "managementLockClient()", "change",
+        "resourceChangeClient()", "databoundary", "dataBoundaryClient()", "deployments", "deploymentClient()");
 }

--- a/packages/http-client-java/generator/http-client-generator-mgmt/src/test/java/com/microsoft/typespec/http/client/generator/mgmt/model/clientmodel/examplemodel/FluentClientMethodExampleTests.java
+++ b/packages/http-client-java/generator/http-client-generator-mgmt/src/test/java/com/microsoft/typespec/http/client/generator/mgmt/model/clientmodel/examplemodel/FluentClientMethodExampleTests.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.typespec.http.client.generator.mgmt.model.clientmodel.examplemodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class FluentClientMethodExampleTests {
+
+    @Test
+    public void mapsResourceMetadataSuffixToServiceClient() {
+        assertEquals("featureClient()", FluentClientMethodExample.getServiceClientReference("resources", "feature"));
+        assertEquals("policyClient()", FluentClientMethodExample.getServiceClientReference("resources", "policy"));
+        assertEquals("subscriptionClient()",
+            FluentClientMethodExample.getServiceClientReference("resources", "subscription"));
+        assertEquals("managementLockClient()",
+            FluentClientMethodExample.getServiceClientReference("resources", "lock"));
+        assertEquals("resourceChangeClient()",
+            FluentClientMethodExample.getServiceClientReference("resources", "change"));
+        assertEquals("dataBoundaryClient()",
+            FluentClientMethodExample.getServiceClientReference("resources", "databoundary"));
+        assertEquals("deploymentClient()",
+            FluentClientMethodExample.getServiceClientReference("resources", "deployments"));
+    }
+
+    @Test
+    public void usesDefaultServiceClientWithoutMatchingMetadataSuffix() {
+        assertEquals("serviceClient()", FluentClientMethodExample.getServiceClientReference("resources", null));
+        assertEquals("serviceClient()", FluentClientMethodExample.getServiceClientReference("resources", "unknown"));
+        assertEquals("serviceClient()", FluentClientMethodExample.getServiceClientReference("compute", "feature"));
+    }
+
+    @Test
+    public void usesRoleServiceClientForAuthorization() {
+        assertEquals("roleServiceClient()", FluentClientMethodExample.getServiceClientReference("authorization", null));
+    }
+}


### PR DESCRIPTION
## Summary

- restore Fluent Premium sample routing for resource service clients
- use `metadata-suffix` instead of the removed AutoRest tag
- replace the obsolete manager-reference map with a package allowlist

## Testing

- Java emitter build
- management generator tests
- formatting and lint
