### PR TITLE
Preserve customized properties during SDK integration

### DIFF
--- a/.chronus/changes/http-client-java-preserve-sdk-integration-properties-2026-08-12.md
+++ b/.chronus/changes/http-client-java-preserve-sdk-integration-properties-2026-08-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+Preserve existing properties files for certain libraries during SDK integration.

--- a/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/Main.java
+++ b/packages/http-client-java/generator/http-client-generator/src/main/java/com/microsoft/typespec/http/client/generator/Main.java
@@ -50,6 +50,7 @@ import org.yaml.snakeyaml.representer.Representer;
 public class Main {
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
     private static final String DEFAULT_OUTPUT_DIR = "http-client-generator-test/tsp-output/";
+    private static final String RESOURCES_ARTIFACT_ID = "azure-resourcemanager-resources";
     // private static final String DEFAULT_OUTPUT_DIR = "http-client-generator-clientcore-test/tsp-output/";
 
     private static Yaml yaml = null;
@@ -134,7 +135,8 @@ public class Main {
 
         // properties file
         String artifactId = FluentUtils.getArtifactId();
-        if (!CoreUtils.isNullOrEmpty(artifactId)) {
+        if (!CoreUtils.isNullOrEmpty(artifactId)
+            && shouldWriteFluentPropertiesFile(emitterOptions.getOutputDir(), artifactId, sdkIntegration)) {
             fluentPlugin.writeFile("src/main/resources/" + artifactId + ".properties", "version=${project.version}\n",
                 null);
         }
@@ -142,6 +144,15 @@ public class Main {
         // Others
         javaPackage.getTextFiles()
             .forEach(textFile -> fluentPlugin.writeFile(textFile.getFilePath(), textFile.getContents(), null));
+    }
+
+    static boolean shouldWriteFluentPropertiesFile(String outputDir, String artifactId, boolean sdkIntegration) {
+        if (!sdkIntegration || !RESOURCES_ARTIFACT_ID.equals(artifactId)) {
+            return true;
+        }
+
+        // This library maintains additional properties by hand, so SDK integration must not overwrite the file.
+        return Files.notExists(Paths.get(outputDir, "src/main/resources", artifactId + ".properties"));
     }
 
     private static void handleDPG(CodeModel codeModel, EmitterOptions emitterOptions, boolean sdkIntegration,

--- a/packages/http-client-java/generator/http-client-generator/src/test/java/com/microsoft/typespec/http/client/generator/MainTest.java
+++ b/packages/http-client-java/generator/http-client-generator/src/test/java/com/microsoft/typespec/http/client/generator/MainTest.java
@@ -1,10 +1,40 @@
 package com.microsoft.typespec.http.client.generator;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class MainTest {
 
     @Test
-    public void testHello() {
+    public void testWriteFluentPropertiesFileForNewProject(@TempDir Path tempDir) {
+        Assertions.assertTrue(
+            Main.shouldWriteFluentPropertiesFile(tempDir.toString(), "azure-resourcemanager-resources", true));
+    }
+
+    @Test
+    public void testWriteFluentPropertiesFileForOtherArtifact(@TempDir Path tempDir) throws IOException {
+        Path propertiesFile = tempDir.resolve("src/main/resources/azure-resourcemanager-compute.properties");
+        Files.createDirectories(propertiesFile.getParent());
+        Files.writeString(propertiesFile, "version=${project.version}\n");
+
+        Assertions.assertTrue(
+            Main.shouldWriteFluentPropertiesFile(tempDir.toString(), "azure-resourcemanager-compute", true));
+    }
+
+    @Test
+    public void testPreserveResourcesPropertiesFileDuringSdkIntegration(@TempDir Path tempDir) throws IOException {
+        Path propertiesFile = tempDir.resolve("src/main/resources/azure-resourcemanager-resources.properties");
+        Files.createDirectories(propertiesFile.getParent());
+        Files.writeString(propertiesFile,
+            "version=${project.version}\npremium-libraries=azure-resourcemanager-compute\n");
+
+        Assertions.assertFalse(
+            Main.shouldWriteFluentPropertiesFile(tempDir.toString(), "azure-resourcemanager-resources", true));
+        Assertions.assertTrue(
+            Main.shouldWriteFluentPropertiesFile(tempDir.toString(), "azure-resourcemanager-resources", false));
     }
 }


### PR DESCRIPTION
## Summary

- Preserve manually maintained properties files during SDK integration.
- Continue generating properties files for new projects and other libraries.
- Add regression coverage for both behaviors.
