### PR TITLE
[http-client-csharp] Normalize common acronyms in model names

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
@@ -53,7 +53,15 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.cs");
 
-        protected override string BuildName() => _inputType!.IsExactName ? _inputType.Name : _inputType.Name.ToIdentifierName();
+        protected override string BuildName()
+        {
+            if (_inputType!.IsExactName)
+            {
+                return _inputType.Name;
+            }
+
+            return NormalizeTypeNameForNewContract(_inputType.Name.ToIdentifierName());
+        }
         protected override FormattableString BuildDescription() => DocHelpers.GetFormattableDescription(_inputType!.Summary, _inputType.Doc) ?? FormattableStringHelpers.Empty;
 
         protected override TypeProvider[] BuildSerializationProviders()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -295,7 +295,15 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected override string BuildRelativeFilePath() => Path.Combine("src", "Generated", "Models", $"{Name}.cs");
 
-        protected override string BuildName() => _inputModel.IsExactName ? _inputModel.Name : _inputModel.Name.ToIdentifierName();
+        protected override string BuildName()
+        {
+            if (_inputModel.IsExactName)
+            {
+                return _inputModel.Name;
+            }
+
+            return NormalizeTypeNameForNewContract(_inputModel.Name.ToIdentifierName());
+        }
 
         protected override TypeSignatureModifiers BuildDeclarationModifiers()
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -102,6 +102,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var hasOutputUsage = inputProperty.EnclosingType?.Usage.HasFlag(InputModelTypeUsage.Output) ?? false;
             Modifiers = IsDiscriminator || (!hasOutputUsage && _isRequiredNonNullableConstant) ? MethodSignatureModifiers.Internal : MethodSignatureModifiers.Public;
             var identifierName = inputProperty.IsExactName ? inputProperty.Name : inputProperty.Name.ToIdentifierName();
+            var lastContractProperties = enclosingType.LastContractView?.Properties;
+            if (!inputProperty.IsExactName &&
+                (lastContractProperties is null ||
+                 !System.Linq.Enumerable.Any(lastContractProperties, p => p.Name == identifierName)))
+            {
+                identifierName = identifierName.NormalizeCSharpAcronyms();
+            }
             Name = identifierName == enclosingType.Name
                 ? $"{identifierName}Property"
                 : identifierName;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection.Metadata;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
@@ -105,7 +106,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var lastContractProperties = enclosingType.LastContractView?.Properties;
             if (!inputProperty.IsExactName &&
                 (lastContractProperties is null ||
-                 !System.Linq.Enumerable.Any(lastContractProperties, p => p.Name == identifierName)))
+                 !lastContractProperties.Any(p => p.Name == identifierName)))
             {
                 identifierName = identifierName.NormalizeCSharpAcronyms();
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -104,9 +104,12 @@ namespace Microsoft.TypeSpec.Generator.Providers
             Modifiers = IsDiscriminator || (!hasOutputUsage && _isRequiredNonNullableConstant) ? MethodSignatureModifiers.Internal : MethodSignatureModifiers.Public;
             var identifierName = inputProperty.IsExactName ? inputProperty.Name : inputProperty.Name.ToIdentifierName();
             var lastContractProperties = enclosingType.LastContractView?.Properties;
+            var legacyName = identifierName == enclosingType.Name
+                ? $"{identifierName}Property"
+                : identifierName;
             if (!inputProperty.IsExactName &&
                 (lastContractProperties is null ||
-                 !lastContractProperties.Any(p => p.Name == identifierName)))
+                 !lastContractProperties.Any(p => p.Name == legacyName)))
             {
                 identifierName = identifierName.NormalizeCSharpAcronyms();
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -626,6 +626,16 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
         protected string NormalizeTypeNameForNewContract(string name)
         {
+            var typeNamespace = BuildNamespace();
+            var currentType = CodeModelGenerator.Instance.SourceInputModel.FindForTypeInCurrentCompilation(
+                typeNamespace,
+                name,
+                _declaringTypeName.Value);
+            if (currentType is not null)
+            {
+                return name;
+            }
+
             var normalizedName = name.NormalizeCSharpAcronyms();
             if (normalizedName == name)
             {
@@ -633,7 +643,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             var lastContractType = CodeModelGenerator.Instance.SourceInputModel.FindForTypeInLastContract(
-                BuildNamespace(),
+                typeNamespace,
                 name,
                 _declaringTypeName.Value);
             return lastContractType is null ? normalizedName : name;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -624,6 +624,21 @@ namespace Microsoft.TypeSpec.Generator.Providers
         protected abstract string BuildRelativeFilePath();
         protected abstract string BuildName();
 
+        protected string NormalizeTypeNameForNewContract(string name)
+        {
+            var normalizedName = name.NormalizeCSharpAcronyms();
+            if (normalizedName == name)
+            {
+                return name;
+            }
+
+            var lastContractType = CodeModelGenerator.Instance.SourceInputModel.FindForTypeInLastContract(
+                BuildNamespace(),
+                name,
+                _declaringTypeName.Value);
+            return lastContractType is null ? normalizedName : name;
+        }
+
         /// <summary>
         /// Resets only the cached methods so they are rebuilt on next access.
         /// Use this instead of <see cref="Reset"/> when you need to force a method

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/CSharpNameExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/CSharpNameExtensions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.TypeSpec.Generator.Utilities
+{
+    internal static class CSharpNameExtensions
+    {
+        private static readonly (string Source, string Replacement)[] _acronymRenamingRules =
+        [
+            ("Ipv4", "IPv4"),
+            ("Ipv6", "IPv6"),
+            ("IpV4", "IPv4"),
+            ("IpV6", "IPv6"),
+            ("Ip", "IP"),
+            ("Db", "DB"),
+            ("Os", "OS")
+        ];
+
+        public static string NormalizeCSharpAcronyms(this string name)
+        {
+            char[]? normalizedName = null;
+            for (int index = 0; index < name.Length - 1; index++)
+            {
+                foreach (var rule in _acronymRenamingRules)
+                {
+                    if (!name.AsSpan(index).StartsWith(rule.Source, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    int boundaryIndex = index + rule.Source.Length;
+                    if (boundaryIndex < name.Length && !char.IsUpper(name[boundaryIndex]))
+                    {
+                        continue;
+                    }
+
+                    normalizedName ??= name.ToCharArray();
+                    rule.Replacement.CopyTo(0, normalizedName, index, rule.Replacement.Length);
+                    index = boundaryIndex - 1;
+                    break;
+                }
+            }
+
+            return normalizedName is null ? name : new string(normalizedName);
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/CSharpNameExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/CSharpNameExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Text;
 
 namespace Microsoft.TypeSpec.Generator.Utilities
 {
@@ -20,7 +21,8 @@ namespace Microsoft.TypeSpec.Generator.Utilities
 
         public static string NormalizeCSharpAcronyms(this string name)
         {
-            char[]? normalizedName = null;
+            StringBuilder? normalizedName = null;
+            int segmentStart = 0;
             for (int index = 0; index < name.Length - 1; index++)
             {
                 foreach (var rule in _acronymRenamingRules)
@@ -36,14 +38,22 @@ namespace Microsoft.TypeSpec.Generator.Utilities
                         continue;
                     }
 
-                    normalizedName ??= name.ToCharArray();
-                    rule.Replacement.CopyTo(0, normalizedName, index, rule.Replacement.Length);
+                    normalizedName ??= new StringBuilder(name.Length);
+                    normalizedName.Append(name, segmentStart, index - segmentStart);
+                    normalizedName.Append(rule.Replacement);
+                    segmentStart = boundaryIndex;
                     index = boundaryIndex - 1;
                     break;
                 }
             }
 
-            return normalizedName is null ? name : new string(normalizedName);
+            if (normalizedName is null)
+            {
+                return name;
+            }
+
+            normalizedName.Append(name, segmentStart, name.Length - segmentStart);
+            return normalizedName.ToString();
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
@@ -90,6 +90,44 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.IsNull(fields[1].InitializationValue);
         }
 
+        [TestCase(false, "CosmosDbOsIpKind", false, "CosmosDBOSIPKind")]
+        [TestCase(true, "IpDbOsValue", false, "IPDBOSValue")]
+        [TestCase(false, "Ipv4AddressIpv6", false, "IPv4AddressIPv6")]
+        [TestCase(true, "IpV4AddressIpV6", false, "IPv4AddressIPv6")]
+        [TestCase(false, "IPV4AddressIPV6", false, "IPV4AddressIPV6")]
+        [TestCase(true, "OsloIpsumOsmosisDbz", false, "OsloIpsumOsmosisDbz")]
+        [TestCase(false, "IpKind", true, "IpKind")]
+        public void BuildEnumType_NormalizesTypeAcronymCasing(
+            bool isExtensible,
+            string inputName,
+            bool isExactName,
+            string expectedName)
+        {
+            MockHelpers.LoadMockGenerator(createCSharpTypeCore: (inputType) => typeof(string));
+            var input = InputFactory.StringEnum(
+                inputName,
+                [("Value", "value")],
+                isExtensible: isExtensible,
+                isExactName: isExactName);
+
+            var enumType = EnumProvider.Create(input);
+
+            Assert.AreEqual(expectedName, enumType.Name);
+        }
+
+        [Test]
+        public async Task BuildEnumType_BackCompatTakesPrecedenceOverAcronymNormalization()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(
+                createCSharpTypeCore: (inputType) => typeof(string),
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var input = InputFactory.StringEnum("IpKind", [("Value", "value")]);
+
+            var enumType = EnumProvider.Create(input);
+
+            Assert.AreEqual("IpKind", enumType.Name);
+        }
+
         // Validates the api version enum
         [TestCase]
         public void BuildEnumType_ValidateApiVersionEnum()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// cspell:ignore readded
+// cspell:ignore DBOSIP IPDBOS readded
 
 using System;
 using System.Collections.Generic;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/TestData/EnumProviderTests/BuildEnumType_BackCompatTakesPrecedenceOverAcronymNormalization/IpKind.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/TestData/EnumProviderTests/BuildEnumType_BackCompatTakesPrecedenceOverAcronymNormalization/IpKind.cs
@@ -1,0 +1,7 @@
+namespace Sample.Models
+{
+    public enum IpKind
+    {
+        Value
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelCustomizationTests.cs
@@ -187,6 +187,28 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         }
 
         [Test]
+        public async Task CustomCodeWinsOverAcronymNormalizationOnModel()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var inputModel = InputFactory.Model("IpAddress");
+            var modelProvider = new ModelProvider(inputModel);
+
+            AssertCommon(modelProvider, "NewNamespace.Models", "CustomizedModel");
+        }
+
+        [Test]
+        public async Task CustomCodeWinsOverAcronymNormalizationOnEnum()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(compilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var inputEnum = InputFactory.StringEnum("IpKind", [("value", "value")]);
+            var enumProvider = new FixedEnumProvider(inputEnum, null);
+
+            AssertCommon(enumProvider, "NewNamespace.Models", "CustomizedEnum");
+        }
+
+        [Test]
         public async Task CanChangePropertyType()
         {
             var props = new[]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -58,6 +58,49 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.AreEqual(FieldModifiers.Private | FieldModifiers.Protected, prop1Field!.Modifiers);
         }
 
+        [TestCase("IpAddress", false, "IPAddress")]
+        [TestCase("CosmosDbAccount", false, "CosmosDBAccount")]
+        [TestCase("OsProfile", false, "OSProfile")]
+        [TestCase("IpDbOsIpAddressDb", false, "IPDBOSIPAddressDB")]
+        [TestCase("IPAddressCosmosDBOSProfile", false, "IPAddressCosmosDBOSProfile")]
+        [TestCase("Ipv4AddressIpv6", false, "IPv4AddressIPv6")]
+        [TestCase("IpV4AddressIpV6", false, "IPv4AddressIPv6")]
+        [TestCase("Ipv4address", false, "Ipv4address")]
+        [TestCase("Ipv42Address", false, "Ipv42Address")]
+        [TestCase("IPV4AddressIPV6", false, "IPV4AddressIPV6")]
+        [TestCase("OsloIpsumOsmosisDbz", false, "OsloIpsumOsmosisDbz")]
+        [TestCase("IpAddress", true, "IpAddress")]
+        public void TestBuildName_NormalizesAcronymCasing(string inputName, bool isExactName, string expectedName)
+        {
+            var inputModel = InputFactory.Model(inputName, isExactName: isExactName);
+
+            var modelProvider = new ModelProvider(inputModel);
+
+            Assert.AreEqual(expectedName, modelProvider.Name);
+        }
+
+        [Test]
+        public async Task TestBuildName_BackCompatTakesPrecedenceOverAcronymNormalization()
+        {
+            var inputModel = InputFactory.Model(
+                "IpAddress",
+                properties:
+                [
+                    InputFactory.Property("dbName", InputPrimitiveType.String),
+                    InputFactory.Property("osProfile", InputPrimitiveType.String)
+                ]);
+            await MockHelpers.LoadMockGeneratorAsync(
+                inputModelTypes: [inputModel],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var modelProvider = CodeModelGenerator.Instance.TypeFactory.CreateModel(inputModel);
+
+            Assert.IsNotNull(modelProvider);
+            Assert.AreEqual("IpAddress", modelProvider!.Name);
+            Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "DbName"));
+            Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "OSProfile"));
+        }
+
         // Validates that the property body's setter is correctly set based on the property type
         [TestCaseSource(nameof(BuildProperties_ValidatePropertySettersTestCases))]
         public void TestBuildProperties_ValidatePropertySetters(InputModelProperty inputModelProperty, CSharpType type, bool hasSetter)
@@ -1791,7 +1834,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.IsNotNull(modelProvider);
 
             // The property with external type should be resolved
-            var ipAddressProp = modelProvider!.Properties.FirstOrDefault(p => p.Name == "IpAddress");
+            var ipAddressProp = modelProvider!.Properties.FirstOrDefault(p => p.Name == "IPAddress");
             Assert.IsNotNull(ipAddressProp);
             Assert.IsNotNull(ipAddressProp!.Type.FrameworkType);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -89,7 +89,8 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                 properties:
                 [
                     InputFactory.Property("dbName", InputPrimitiveType.String),
-                    InputFactory.Property("osProfile", InputPrimitiveType.String)
+                    InputFactory.Property("osProfile", InputPrimitiveType.String),
+                    InputFactory.Property("IpAddress", InputPrimitiveType.String)
                 ]);
             await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: [inputModel],
@@ -101,6 +102,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.AreEqual("IpAddress", modelProvider!.Name);
             Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "DbName"));
             Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "OSProfile"));
+            Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "IpAddressProperty"));
         }
 
         // Validates that the property body's setter is correctly set based on the property type

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// cspell:ignore DBOS IPDBOSIP
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CustomCodeWinsOverAcronymNormalizationOnEnum/CustomizedEnum.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CustomCodeWinsOverAcronymNormalizationOnEnum/CustomizedEnum.cs
@@ -1,0 +1,10 @@
+#nullable disable
+
+using Microsoft.TypeSpec.Generator.Customizations;
+
+namespace NewNamespace.Models;
+
+[CodeGenType("IpKind")]
+public enum CustomizedEnum
+{
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CustomCodeWinsOverAcronymNormalizationOnModel/CustomizedModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelCustomizationTests/CustomCodeWinsOverAcronymNormalizationOnModel/CustomizedModel.cs
@@ -1,0 +1,10 @@
+#nullable disable
+
+using Microsoft.TypeSpec.Generator.Customizations;
+
+namespace NewNamespace.Models;
+
+[CodeGenType("IpAddress")]
+public partial class CustomizedModel
+{
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/TestBuildName_BackCompatTakesPrecedenceOverAcronymNormalization/IpAddress.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/TestBuildName_BackCompatTakesPrecedenceOverAcronymNormalization/IpAddress.cs
@@ -3,5 +3,6 @@ namespace Sample.Models
     public partial class IpAddress
     {
         public string DbName { get; }
+        public string IpAddressProperty { get; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/TestBuildName_BackCompatTakesPrecedenceOverAcronymNormalization/IpAddress.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/TestBuildName_BackCompatTakesPrecedenceOverAcronymNormalization/IpAddress.cs
@@ -1,0 +1,7 @@
+namespace Sample.Models
+{
+    public partial class IpAddress
+    {
+        public string DbName { get; }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -103,6 +103,30 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.AreEqual("my_model", modelProvider.Name);
         }
 
+        [TestCase("IpAddress", false, "IPAddress")]
+        [TestCase("CosmosDbAccount", false, "CosmosDBAccount")]
+        [TestCase("OsProfile", false, "OSProfile")]
+        [TestCase("IpDbOsIpAddressDb", false, "IPDBOSIPAddressDB")]
+        [TestCase("IPAddressCosmosDBOSProfile", false, "IPAddressCosmosDBOSProfile")]
+        [TestCase("Ipv4AddressIpv6", false, "IPv4AddressIPv6")]
+        [TestCase("IpV4AddressIpV6", false, "IPv4AddressIPv6")]
+        [TestCase("IPV4AddressIPV6", false, "IPV4AddressIPV6")]
+        [TestCase("OsloIpsumOsmosisDbz", false, "OsloIpsumOsmosisDbz")]
+        [TestCase("IpAddress", true, "IpAddress")]
+        public void TestPropertyNameNormalizesAcronymCasing(string inputName, bool isExactName, string expectedName)
+        {
+            var inputProperty = InputFactory.Property(
+                inputName,
+                InputPrimitiveType.String,
+                isRequired: true,
+                isExactName: isExactName);
+            InputFactory.Model("TestModel", properties: [inputProperty]);
+
+            var property = new PropertyProvider(inputProperty, new TestTypeProvider());
+
+            Assert.AreEqual(expectedName, property.Name);
+        }
+
         [TestCaseSource(nameof(CollectionPropertyTestCases))]
         public void CollectionProperty(CSharpType coreType, InputModelProperty collectionProperty, CSharpType expectedType)
         {
@@ -162,6 +186,18 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
 
             var property = new PropertyProvider(inputModelProperty, testTypeProvider);
             Assert.AreEqual("FilterProperty", property.Name);
+        }
+
+        [Test]
+        public void TestPropertyNameConflictsWithTypeNameAfterAcronymNormalization()
+        {
+            var testTypeProvider = new TestTypeProvider(name: "IPAddress");
+            InputModelProperty inputModelProperty = InputFactory.Property("IpAddress", InputPrimitiveType.String);
+            InputFactory.Model("IPAddress", properties: [inputModelProperty]);
+
+            var property = new PropertyProvider(inputModelProperty, testTypeProvider);
+
+            Assert.AreEqual("IPAddressProperty", property.Name);
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// cspell:ignore DBOS IPDBOSIP
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
## Summary
- normalize IP, DB, OS, IPv4, and IPv6 casing for new model, enum/union type, and model-property names
- preserve exact names and matching names from the last contract before applying automatic normalization
- exclude clients, operations, parameters, and enum values

## Validation
- C# generator test suite
- C# emitter build
- Cop static analysis
- focused tests on current main

Related to https://github.com/Azure/azure-sdk-for-net/issues/61942