### PR TITLE
[http-client-csharp] Support optional success response bodies

### DIFF
--- a/.chronus/changes/http-client-csharp-optional-response-2026-08-12.md
+++ b/.chronus/changes/http-client-csharp-optional-response-2026-08-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Support operations with successful responses that may omit the response body.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ScmMethodProviderCollection.cs
@@ -236,6 +236,10 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             // Recompute the response body type so we can branch the body accordingly.
             GetResponseType(ServiceMethod.Operation.Responses, true, isAsync, out var responseBodyType);
             var streamingResponse = _streamingResponse.Value;
+            var noBodySuccessStatusCodes = GetNoBodySuccessStatusCodes(ServiceMethod.Operation.Responses);
+            bool hasOptionalResponseBody = responseBodyType is not null
+                && noBodySuccessStatusCodes.Count > 0
+                && ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType.FrameworkType == typeof(ClientResult);
 
             MethodBodyStatement[] methodBody;
             TypeProvider? collection = null;
@@ -293,23 +297,32 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 [
                     .. GetStackVariablesForProtocolParamConversion(convenienceBodyParameters, out var paramDeclarations),
                     Declare("result", This.Invoke(protocolMethod.Signature, [.. GetProtocolMethodArguments(paramDeclarations)], isAsync).ToApi<ClientResponseApi>(), out ClientResponseApi result),
+                    .. hasOptionalResponseBody
+                        ? GetNoBodyResponseStatements(result, responseBodyType, noBodySuccessStatusCodes)
+                        : [],
                     .. GetStackVariablesForReturnValueConversion(result, responseBodyType, isAsync, out var resultDeclarations),
                     IsConvertibleFromBinaryData(responseBodyType)
-                        ? Return(result.FromValue(GetResultConversion(result, result.GetRawResponse(), responseBodyType, resultDeclarations), result.GetRawResponse()))
+                        ? Return(BuildResponseFromValue(
+                            result,
+                            GetResultConversion(result, result.GetRawResponse(), responseBodyType, resultDeclarations),
+                            responseBodyType,
+                            hasOptionalResponseBody))
                         :
                         new[]
                         {
                             Declare("data", result.GetRawResponse().Content(), out var data),
                             UsingDeclare("document", data.Parse(), out var jsonDocument),
                             Declare("element", jsonDocument.RootElement(), out var jsonElement),
-                            Return(result.FromValue(
+                            Return(BuildResponseFromValue(
+                                result,
                                 ScmCodeModelGenerator.Instance.TypeFactory.DeserializeJsonValue(
+                                    responseBodyType,
+                                    jsonElement,
+                                    data,
+                                    ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
+                                    SerializationFormat.Default),
                                 responseBodyType,
-                                jsonElement,
-                                data,
-                                ScmCodeModelGenerator.Instance.ModelSerializationExtensionsDefinition.WireOptionsField.As<ModelReaderWriterOptions>(),
-                                SerializationFormat.Default),
-                                result.GetRawResponse()))
+                                hasOptionalResponseBody))
                         },
                 ];
             }
@@ -1635,7 +1648,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         private CSharpType GetConvenienceReturnType(IReadOnlyList<InputOperationResponse> responses, bool isAsync, out CSharpType? responseBodyType)
         {
-            var response = responses.FirstOrDefault(r => !r.IsErrorResponse);
+            var response = responses.FirstOrDefault(r => !r.IsErrorResponse && r.BodyType is not null)
+                ?? responses.FirstOrDefault(r => !r.IsErrorResponse);
             if (response?.BodyType is InputStreamingType streamingType)
             {
                 responseBodyType = GetConvenienceStreamingItemType(streamingType);
@@ -1661,12 +1675,79 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                     responseBodyType);
             }
 
-            var returnType = responseBodyType == null
+            bool hasOptionalResponseBody = responseBodyType is not null
+                && GetNoBodySuccessStatusCodes(responses).Count > 0
+                && ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType.FrameworkType == typeof(ClientResult);
+            var responseValueType = hasOptionalResponseBody
+                ? responseBodyType?.OutputType.WithNullable(true)
+                : responseBodyType?.OutputType;
+            var returnType = responseValueType == null
                 ? ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType
-                : new CSharpType(ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseOfTType.FrameworkType, responseBodyType.OutputType);
+                : new CSharpType(
+                    ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseOfTType.FrameworkType,
+                    responseValueType);
 
             return isAsync ? new CSharpType(typeof(Task<>), returnType) : returnType;
         }
+
+        private static IReadOnlyList<int> GetNoBodySuccessStatusCodes(IReadOnlyList<InputOperationResponse> responses)
+            => [.. responses
+                .Where(r => !r.IsErrorResponse && r.BodyType is null)
+                .SelectMany(r => r.StatusCodes)
+                .Distinct()];
+
+        private static IEnumerable<MethodBodyStatement> GetNoBodyResponseStatements(
+            ClientResponseApi result,
+            CSharpType responseBodyType,
+            IReadOnlyList<int> noBodySuccessStatusCodes)
+        {
+            var rawResponse = result.GetRawResponse();
+            ScopedApi<bool>? noBodyResponseCondition = null;
+            foreach (int statusCode in noBodySuccessStatusCodes)
+            {
+                var statusCodeCondition = rawResponse.Property("Status").Equal(Literal(statusCode));
+                noBodyResponseCondition = noBodyResponseCondition is null
+                    ? statusCodeCondition
+                    : noBodyResponseCondition.Or(statusCodeCondition);
+            }
+
+            if (noBodyResponseCondition is null)
+            {
+                return [];
+            }
+
+            var optionalValueType = responseBodyType.OutputType.WithNullable(true);
+            return
+            [
+                new IfStatement(noBodyResponseCondition)
+                {
+                    Return(BuildOptionalResponse(
+                        DefaultOf(optionalValueType),
+                        rawResponse,
+                        responseBodyType))
+                }
+            ];
+        }
+
+        private static ValueExpression BuildResponseFromValue(
+            ClientResponseApi result,
+            ValueExpression value,
+            CSharpType responseBodyType,
+            bool hasOptionalResponseBody)
+            => hasOptionalResponseBody
+                ? BuildOptionalResponse(value, result.GetRawResponse(), responseBodyType)
+                : result.FromValue(value, result.GetRawResponse());
+
+        private static ValueExpression BuildOptionalResponse(
+            ValueExpression value,
+            HttpResponseApi response,
+            CSharpType responseBodyType)
+            => Static(ScmCodeModelGenerator.Instance.TypeFactory.ClientResponseApi.ClientResponseType)
+                .Invoke(
+                    nameof(ClientResult.FromOptionalValue),
+                    [value, response],
+                    [responseBodyType.OutputType],
+                    false);
 
         private static CSharpType GetRawStreamingItemType(InputStreamingType streamingType)
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmMethodProviderCollectionTests.cs
@@ -414,6 +414,45 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers
         }
 
         [Test]
+        public void ConvenienceMethodWithOptionalResponseBodyReturnsNullableClientResult()
+        {
+            var operation = InputFactory.Operation(
+                "GetLayout",
+                responses:
+                [
+                    InputFactory.OperationResponse([204]),
+                    InputFactory.OperationResponse([200], InputPrimitiveType.String)
+                ]);
+            var serviceMethod = InputFactory.BasicServiceMethod("GetLayout", operation);
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+
+            MockHelpers.LoadMockGenerator(
+                createCSharpTypeCore: inputType => inputType == InputPrimitiveType.String
+                    ? new CSharpType(typeof(string))
+                    : new CSharpType(typeof(bool)));
+
+            var client = ScmCodeModelGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(client);
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, client!);
+            var convenienceMethod = methodCollection.Single(
+                m => m is ScmMethodProvider { Kind: ScmMethodKind.Convenience }
+                    && m.Signature.Name == "GetLayout");
+
+            Assert.AreEqual(
+                new CSharpType(typeof(ClientResult<>), new CSharpType(typeof(string)).WithNullable(true)),
+                convenienceMethod.Signature.ReturnType);
+
+            var methodBody = convenienceMethod.BodyStatements!.ToDisplayString();
+            StringAssert.Contains("result.GetRawResponse().Status == 204", methodBody);
+            StringAssert.Contains(
+                "return global::System.ClientModel.ClientResult.FromOptionalValue<string>(((string)null), result.GetRawResponse());",
+                methodBody);
+            StringAssert.Contains(
+                "return global::System.ClientModel.ClientResult.FromOptionalValue<string>",
+                methodBody);
+        }
+
+        [Test]
         public void ProtocolMethodIsInternalWhenGenerateProtocolMethodIsFalse()
         {
             var operation = InputFactory.Operation(

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/Sample-TypeSpec.tsp
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/Sample-TypeSpec.tsp
@@ -934,3 +934,12 @@ op receiveJsonLines(): JsonlStream<StreamingItem>;
 @get
 @route("/streaming/sse/receive")
 op receiveSse(): SSEStream<SampleEvents>;
+
+@get
+@route("/optional-response")
+op getOptionalResponse(): {
+  @statusCode statusCode: 200;
+  @body body: Thing;
+} | {
+  @statusCode statusCode: 204;
+};

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.RestClient.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.RestClient.cs
@@ -15,9 +15,12 @@ namespace SampleTypeSpec
     public partial class SampleTypeSpecClient
     {
         private static PipelineMessageClassifier _pipelineMessageClassifier200;
+        private static PipelineMessageClassifier _pipelineMessageClassifier200204;
         private static PipelineMessageClassifier _pipelineMessageClassifier204;
 
         private static PipelineMessageClassifier PipelineMessageClassifier200 => _pipelineMessageClassifier200 ??= PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
+
+        private static PipelineMessageClassifier PipelineMessageClassifier200204 => _pipelineMessageClassifier200204 ??= PipelineMessageClassifier.Create(stackalloc ushort[] { 200, 204 });
 
         private static PipelineMessageClassifier PipelineMessageClassifier204 => _pipelineMessageClassifier204 ??= PipelineMessageClassifier.Create(stackalloc ushort[] { 204 });
 
@@ -496,6 +499,18 @@ namespace SampleTypeSpec
             PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "GET", PipelineMessageClassifier200);
             PipelineRequest request = message.Request;
             request.Headers.Set("Accept", "text/event-stream");
+            message.Apply(options);
+            return message;
+        }
+
+        internal PipelineMessage CreateGetOptionalResponseRequest(RequestOptions options)
+        {
+            ClientUriBuilder uri = new ClientUriBuilder();
+            uri.Reset(_endpoint);
+            uri.AppendPath("/optional-response", false);
+            PipelineMessage message = Pipeline.CreateMessage(uri.ToUri(), "GET", PipelineMessageClassifier200204);
+            PipelineRequest request = message.Request;
+            request.Headers.Set("Accept", "application/json");
             message.Apply(options);
             return message;
         }

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/SampleTypeSpecClient.cs
@@ -2059,6 +2059,66 @@ namespace SampleTypeSpec
         }
 #pragma warning restore SCME0005 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 
+        /// <summary>
+        /// [Protocol Method] GetOptionalResponse
+        /// <list type="bullet">
+        /// <item>
+        /// <description> This <see href="https://aka.ms/azsdk/net/protocol-methods">protocol method</see> allows explicit creation of the request and processing of the response for advanced scenarios. </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. </returns>
+        public virtual ClientResult GetOptionalResponse(RequestOptions options)
+        {
+            using PipelineMessage message = CreateGetOptionalResponseRequest(options);
+            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
+        }
+
+        /// <summary>
+        /// [Protocol Method] GetOptionalResponse
+        /// <list type="bullet">
+        /// <item>
+        /// <description> This <see href="https://aka.ms/azsdk/net/protocol-methods">protocol method</see> allows explicit creation of the request and processing of the response for advanced scenarios. </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. </returns>
+        public virtual async Task<ClientResult> GetOptionalResponseAsync(RequestOptions options)
+        {
+            using PipelineMessage message = CreateGetOptionalResponseRequest(options);
+            return ClientResult.FromResponse(await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false));
+        }
+
+        /// <summary> GetOptionalResponse. </summary>
+        /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+        /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+        public virtual ClientResult<Thing> GetOptionalResponse(CancellationToken cancellationToken = default)
+        {
+            ClientResult result = GetOptionalResponse(cancellationToken.ToRequestOptions());
+            if (result.GetRawResponse().Status == 204)
+            {
+                return ClientResult.FromOptionalValue((Thing)null, result.GetRawResponse());
+            }
+            return ClientResult.FromOptionalValue((Thing)result, result.GetRawResponse());
+        }
+
+        /// <summary> GetOptionalResponse. </summary>
+        /// <param name="cancellationToken"> The cancellation token that can be used to cancel the operation. </param>
+        /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+        public virtual async Task<ClientResult<Thing>> GetOptionalResponseAsync(CancellationToken cancellationToken = default)
+        {
+            ClientResult result = await GetOptionalResponseAsync(cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+            if (result.GetRawResponse().Status == 204)
+            {
+                return ClientResult.FromOptionalValue((Thing)null, result.GetRawResponse());
+            }
+            return ClientResult.FromOptionalValue((Thing)result, result.GetRawResponse());
+        }
+
         /// <summary> Initializes a new instance of AnimalOperations. </summary>
         public virtual AnimalOperations GetAnimalOperationsClient()
         {

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/tspCodeModel.json
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/tspCodeModel.json
@@ -2193,7 +2193,7 @@
     {
       "$id": "228",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType6",
+      "name": "GetTreeAsJsonResponseContentType38",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2203,14 +2203,14 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/xml",
+      "value": "application/json",
       "decorators": [],
       "isExactName": false
     },
     {
       "$id": "230",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType7",
+      "name": "GetXmlAdvancedModelResponseContentType6",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2227,7 +2227,7 @@
     {
       "$id": "232",
       "kind": "constant",
-      "name": "GetTreeAsJsonResponseContentType38",
+      "name": "GetXmlAdvancedModelResponseContentType7",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2237,7 +2237,7 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/json",
+      "value": "application/xml",
       "decorators": [],
       "isExactName": false
     },
@@ -2261,7 +2261,7 @@
     {
       "$id": "236",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType8",
+      "name": "GetTreeAsJsonResponseContentType40",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2271,14 +2271,14 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/xml",
+      "value": "application/json",
       "decorators": [],
       "isExactName": false
     },
     {
       "$id": "238",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType9",
+      "name": "GetXmlAdvancedModelResponseContentType8",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2295,7 +2295,7 @@
     {
       "$id": "240",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType10",
+      "name": "GetXmlAdvancedModelResponseContentType9",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2312,7 +2312,7 @@
     {
       "$id": "242",
       "kind": "constant",
-      "name": "GetXmlAdvancedModelResponseContentType11",
+      "name": "GetXmlAdvancedModelResponseContentType10",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2329,7 +2329,7 @@
     {
       "$id": "244",
       "kind": "constant",
-      "name": "GetTreeAsJsonResponseContentType40",
+      "name": "GetXmlAdvancedModelResponseContentType11",
       "namespace": "",
       "usage": "None",
       "valueType": {
@@ -2339,7 +2339,7 @@
         "crossLanguageDefinitionId": "TypeSpec.string",
         "decorators": []
       },
-      "value": "application/json",
+      "value": "application/xml",
       "decorators": [],
       "isExactName": false
     },
@@ -2427,11 +2427,28 @@
       "value": "application/json",
       "decorators": [],
       "isExactName": false
+    },
+    {
+      "$id": "256",
+      "kind": "constant",
+      "name": "GetTreeAsJsonResponseContentType46",
+      "namespace": "",
+      "usage": "None",
+      "valueType": {
+        "$id": "257",
+        "kind": "string",
+        "name": "string",
+        "crossLanguageDefinitionId": "TypeSpec.string",
+        "decorators": []
+      },
+      "value": "application/json",
+      "decorators": [],
+      "isExactName": false
     }
   ],
   "models": [
     {
-      "$id": "256",
+      "$id": "258",
       "kind": "model",
       "name": "Thing",
       "namespace": "SampleTypeSpec",
@@ -2447,13 +2464,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "257",
+          "$id": "259",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "name of the Thing",
           "type": {
-            "$id": "258",
+            "$id": "260",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2474,29 +2491,29 @@
           "isExactName": false
         },
         {
-          "$id": "259",
+          "$id": "261",
           "kind": "property",
           "name": "requiredUnion",
           "serializedName": "requiredUnion",
           "doc": "required Union",
           "type": {
-            "$id": "260",
+            "$id": "262",
             "kind": "union",
             "name": "ThingRequiredUnion",
             "variantTypes": [
               {
-                "$id": "261",
+                "$id": "263",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
                 "decorators": []
               },
               {
-                "$id": "262",
+                "$id": "264",
                 "kind": "array",
                 "name": "Array",
                 "valueType": {
-                  "$id": "263",
+                  "$id": "265",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2506,7 +2523,7 @@
                 "decorators": []
               },
               {
-                "$id": "264",
+                "$id": "266",
                 "kind": "int32",
                 "name": "int32",
                 "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2532,7 +2549,7 @@
           "isExactName": false
         },
         {
-          "$id": "265",
+          "$id": "267",
           "kind": "property",
           "name": "requiredLiteralString",
           "serializedName": "requiredLiteralString",
@@ -2555,16 +2572,16 @@
           "isExactName": false
         },
         {
-          "$id": "266",
+          "$id": "268",
           "kind": "property",
           "name": "requiredNullableString",
           "serializedName": "requiredNullableString",
           "doc": "required nullable string",
           "type": {
-            "$id": "267",
+            "$id": "269",
             "kind": "nullable",
             "type": {
-              "$id": "268",
+              "$id": "270",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2587,16 +2604,16 @@
           "isExactName": false
         },
         {
-          "$id": "269",
+          "$id": "271",
           "kind": "property",
           "name": "optionalNullableString",
           "serializedName": "optionalNullableString",
           "doc": "required optional string",
           "type": {
-            "$id": "270",
+            "$id": "272",
             "kind": "nullable",
             "type": {
-              "$id": "271",
+              "$id": "273",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2619,7 +2636,7 @@
           "isExactName": false
         },
         {
-          "$id": "272",
+          "$id": "274",
           "kind": "property",
           "name": "requiredLiteralInt",
           "serializedName": "requiredLiteralInt",
@@ -2642,7 +2659,7 @@
           "isExactName": false
         },
         {
-          "$id": "273",
+          "$id": "275",
           "kind": "property",
           "name": "requiredLiteralFloat",
           "serializedName": "requiredLiteralFloat",
@@ -2665,7 +2682,7 @@
           "isExactName": false
         },
         {
-          "$id": "274",
+          "$id": "276",
           "kind": "property",
           "name": "requiredLiteralBool",
           "serializedName": "requiredLiteralBool",
@@ -2688,7 +2705,7 @@
           "isExactName": false
         },
         {
-          "$id": "275",
+          "$id": "277",
           "kind": "property",
           "name": "optionalLiteralString",
           "serializedName": "optionalLiteralString",
@@ -2711,13 +2728,13 @@
           "isExactName": false
         },
         {
-          "$id": "276",
+          "$id": "278",
           "kind": "property",
           "name": "requiredNullableLiteralString",
           "serializedName": "requiredNullableLiteralString",
           "doc": "required nullable literal string",
           "type": {
-            "$id": "277",
+            "$id": "279",
             "kind": "nullable",
             "type": {
               "$ref": "5"
@@ -2739,7 +2756,7 @@
           "isExactName": false
         },
         {
-          "$id": "278",
+          "$id": "280",
           "kind": "property",
           "name": "optionalLiteralInt",
           "serializedName": "optionalLiteralInt",
@@ -2762,7 +2779,7 @@
           "isExactName": false
         },
         {
-          "$id": "279",
+          "$id": "281",
           "kind": "property",
           "name": "optionalLiteralFloat",
           "serializedName": "optionalLiteralFloat",
@@ -2785,7 +2802,7 @@
           "isExactName": false
         },
         {
-          "$id": "280",
+          "$id": "282",
           "kind": "property",
           "name": "optionalLiteralBool",
           "serializedName": "optionalLiteralBool",
@@ -2808,13 +2825,13 @@
           "isExactName": false
         },
         {
-          "$id": "281",
+          "$id": "283",
           "kind": "property",
           "name": "requiredBadDescription",
           "serializedName": "requiredBadDescription",
           "doc": "description with xml <|endoftext|>",
           "type": {
-            "$id": "282",
+            "$id": "284",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2835,20 +2852,20 @@
           "isExactName": false
         },
         {
-          "$id": "283",
+          "$id": "285",
           "kind": "property",
           "name": "optionalNullableList",
           "serializedName": "optionalNullableList",
           "doc": "optional nullable collection",
           "type": {
-            "$id": "284",
+            "$id": "286",
             "kind": "nullable",
             "type": {
-              "$id": "285",
+              "$id": "287",
               "kind": "array",
               "name": "Array1",
               "valueType": {
-                "$id": "286",
+                "$id": "288",
                 "kind": "int32",
                 "name": "int32",
                 "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -2874,16 +2891,16 @@
           "isExactName": false
         },
         {
-          "$id": "287",
+          "$id": "289",
           "kind": "property",
           "name": "requiredNullableList",
           "serializedName": "requiredNullableList",
           "doc": "required nullable collection",
           "type": {
-            "$id": "288",
+            "$id": "290",
             "kind": "nullable",
             "type": {
-              "$ref": "285"
+              "$ref": "287"
             },
             "namespace": "SampleTypeSpec"
           },
@@ -2902,13 +2919,13 @@
           "isExactName": false
         },
         {
-          "$id": "289",
+          "$id": "291",
           "kind": "property",
           "name": "propertyWithSpecialDocs",
           "serializedName": "propertyWithSpecialDocs",
           "doc": "This tests:\n- Simple bullet point. This bullet point is going to be very long to test how text wrapping is handled in bullet points within documentation comments. It should properly indent the wrapped lines.\n- Another bullet point with **bold text**. This bullet point is also intentionally long to see how the formatting is preserved when the text wraps onto multiple lines in the generated documentation.\n- Third bullet point with *italic text*. Similar to the previous points, this one is extended to ensure that the wrapping and formatting are correctly applied in the output.\n- Complex bullet point with **bold** and *italic* combined. This bullet point combines both bold and italic formatting and is long enough to test the wrapping behavior in such cases.\n- **Bold bullet point**: A bullet point that is entirely bolded. This point is also made lengthy to observe how the bold formatting is maintained across wrapped lines.\n- *Italic bullet point*: A bullet point that is entirely italicized. This final point is extended to verify that italic formatting is correctly applied even when the text spans multiple lines.",
           "type": {
-            "$id": "290",
+            "$id": "292",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2931,7 +2948,7 @@
       ]
     },
     {
-      "$id": "291",
+      "$id": "293",
       "kind": "model",
       "name": "RoundTripModel",
       "namespace": "SampleTypeSpec",
@@ -2947,13 +2964,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "292",
+          "$id": "294",
           "kind": "property",
           "name": "requiredString",
           "serializedName": "requiredString",
           "doc": "Required string, illustrating a reference type property.",
           "type": {
-            "$id": "293",
+            "$id": "295",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -2974,13 +2991,13 @@
           "isExactName": false
         },
         {
-          "$id": "294",
+          "$id": "296",
           "kind": "property",
           "name": "requiredInt",
           "serializedName": "requiredInt",
           "doc": "Required int, illustrating a value type property.",
           "type": {
-            "$id": "295",
+            "$id": "297",
             "kind": "int32",
             "name": "int32",
             "encode": "string",
@@ -3002,13 +3019,13 @@
           "isExactName": false
         },
         {
-          "$id": "296",
+          "$id": "298",
           "kind": "property",
           "name": "requiredCollection",
           "serializedName": "requiredCollection",
           "doc": "Required collection of enums",
           "type": {
-            "$id": "297",
+            "$id": "299",
             "kind": "array",
             "name": "ArrayStringFixedEnum",
             "valueType": {
@@ -3032,16 +3049,16 @@
           "isExactName": false
         },
         {
-          "$id": "298",
+          "$id": "300",
           "kind": "property",
           "name": "requiredDictionary",
           "serializedName": "requiredDictionary",
           "doc": "Required dictionary of enums",
           "type": {
-            "$id": "299",
+            "$id": "301",
             "kind": "dict",
             "keyType": {
-              "$id": "300",
+              "$id": "302",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3067,13 +3084,13 @@
           "isExactName": false
         },
         {
-          "$id": "301",
+          "$id": "303",
           "kind": "property",
           "name": "requiredModel",
           "serializedName": "requiredModel",
           "doc": "Required model",
           "type": {
-            "$ref": "256"
+            "$ref": "258"
           },
           "optional": false,
           "readOnly": false,
@@ -3090,7 +3107,7 @@
           "isExactName": false
         },
         {
-          "$id": "302",
+          "$id": "304",
           "kind": "property",
           "name": "intExtensibleEnum",
           "serializedName": "intExtensibleEnum",
@@ -3113,13 +3130,13 @@
           "isExactName": false
         },
         {
-          "$id": "303",
+          "$id": "305",
           "kind": "property",
           "name": "intExtensibleEnumCollection",
           "serializedName": "intExtensibleEnumCollection",
           "doc": "this is a collection of int based extensible enum",
           "type": {
-            "$id": "304",
+            "$id": "306",
             "kind": "array",
             "name": "ArrayIntExtensibleEnum",
             "valueType": {
@@ -3143,7 +3160,7 @@
           "isExactName": false
         },
         {
-          "$id": "305",
+          "$id": "307",
           "kind": "property",
           "name": "floatExtensibleEnum",
           "serializedName": "floatExtensibleEnum",
@@ -3166,7 +3183,7 @@
           "isExactName": false
         },
         {
-          "$id": "306",
+          "$id": "308",
           "kind": "property",
           "name": "floatExtensibleEnumWithIntValue",
           "serializedName": "floatExtensibleEnumWithIntValue",
@@ -3189,13 +3206,13 @@
           "isExactName": false
         },
         {
-          "$id": "307",
+          "$id": "309",
           "kind": "property",
           "name": "floatExtensibleEnumCollection",
           "serializedName": "floatExtensibleEnumCollection",
           "doc": "this is a collection of float based extensible enum",
           "type": {
-            "$id": "308",
+            "$id": "310",
             "kind": "array",
             "name": "ArrayFloatExtensibleEnum",
             "valueType": {
@@ -3219,7 +3236,7 @@
           "isExactName": false
         },
         {
-          "$id": "309",
+          "$id": "311",
           "kind": "property",
           "name": "floatFixedEnum",
           "serializedName": "floatFixedEnum",
@@ -3242,7 +3259,7 @@
           "isExactName": false
         },
         {
-          "$id": "310",
+          "$id": "312",
           "kind": "property",
           "name": "floatFixedEnumWithIntValue",
           "serializedName": "floatFixedEnumWithIntValue",
@@ -3265,13 +3282,13 @@
           "isExactName": false
         },
         {
-          "$id": "311",
+          "$id": "313",
           "kind": "property",
           "name": "floatFixedEnumCollection",
           "serializedName": "floatFixedEnumCollection",
           "doc": "this is a collection of float based fixed enum",
           "type": {
-            "$id": "312",
+            "$id": "314",
             "kind": "array",
             "name": "ArrayFloatFixedEnum",
             "valueType": {
@@ -3295,7 +3312,7 @@
           "isExactName": false
         },
         {
-          "$id": "313",
+          "$id": "315",
           "kind": "property",
           "name": "intFixedEnum",
           "serializedName": "intFixedEnum",
@@ -3318,13 +3335,13 @@
           "isExactName": false
         },
         {
-          "$id": "314",
+          "$id": "316",
           "kind": "property",
           "name": "intFixedEnumCollection",
           "serializedName": "intFixedEnumCollection",
           "doc": "this is a collection of int based fixed enum",
           "type": {
-            "$id": "315",
+            "$id": "317",
             "kind": "array",
             "name": "ArrayIntFixedEnum",
             "valueType": {
@@ -3348,7 +3365,7 @@
           "isExactName": false
         },
         {
-          "$id": "316",
+          "$id": "318",
           "kind": "property",
           "name": "stringFixedEnum",
           "serializedName": "stringFixedEnum",
@@ -3371,13 +3388,13 @@
           "isExactName": false
         },
         {
-          "$id": "317",
+          "$id": "319",
           "kind": "property",
           "name": "requiredUnknown",
           "serializedName": "requiredUnknown",
           "doc": "required unknown",
           "type": {
-            "$id": "318",
+            "$id": "320",
             "kind": "unknown",
             "name": "unknown",
             "crossLanguageDefinitionId": "",
@@ -3398,13 +3415,13 @@
           "isExactName": false
         },
         {
-          "$id": "319",
+          "$id": "321",
           "kind": "property",
           "name": "optionalUnknown",
           "serializedName": "optionalUnknown",
           "doc": "optional unknown",
           "type": {
-            "$id": "320",
+            "$id": "322",
             "kind": "unknown",
             "name": "unknown",
             "crossLanguageDefinitionId": "",
@@ -3425,23 +3442,23 @@
           "isExactName": false
         },
         {
-          "$id": "321",
+          "$id": "323",
           "kind": "property",
           "name": "requiredRecordUnknown",
           "serializedName": "requiredRecordUnknown",
           "doc": "required record of unknown",
           "type": {
-            "$id": "322",
+            "$id": "324",
             "kind": "dict",
             "keyType": {
-              "$id": "323",
+              "$id": "325",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$id": "324",
+              "$id": "326",
               "kind": "unknown",
               "name": "unknown",
               "crossLanguageDefinitionId": "",
@@ -3464,13 +3481,13 @@
           "isExactName": false
         },
         {
-          "$id": "325",
+          "$id": "327",
           "kind": "property",
           "name": "optionalRecordUnknown",
           "serializedName": "optionalRecordUnknown",
           "doc": "optional record of unknown",
           "type": {
-            "$ref": "322"
+            "$ref": "324"
           },
           "optional": true,
           "readOnly": false,
@@ -3487,13 +3504,13 @@
           "isExactName": false
         },
         {
-          "$id": "326",
+          "$id": "328",
           "kind": "property",
           "name": "readOnlyRequiredRecordUnknown",
           "serializedName": "readOnlyRequiredRecordUnknown",
           "doc": "required readonly record of unknown",
           "type": {
-            "$ref": "322"
+            "$ref": "324"
           },
           "optional": false,
           "readOnly": true,
@@ -3510,13 +3527,13 @@
           "isExactName": false
         },
         {
-          "$id": "327",
+          "$id": "329",
           "kind": "property",
           "name": "readOnlyOptionalRecordUnknown",
           "serializedName": "readOnlyOptionalRecordUnknown",
           "doc": "optional readonly record of unknown",
           "type": {
-            "$ref": "322"
+            "$ref": "324"
           },
           "optional": true,
           "readOnly": true,
@@ -3533,13 +3550,13 @@
           "isExactName": false
         },
         {
-          "$id": "328",
+          "$id": "330",
           "kind": "property",
           "name": "modelWithRequiredNullable",
           "serializedName": "modelWithRequiredNullable",
           "doc": "this is a model with required nullable properties",
           "type": {
-            "$id": "329",
+            "$id": "331",
             "kind": "model",
             "name": "ModelWithRequiredNullableProperties",
             "namespace": "SampleTypeSpec",
@@ -3555,16 +3572,16 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "330",
+                "$id": "332",
                 "kind": "property",
                 "name": "requiredNullablePrimitive",
                 "serializedName": "requiredNullablePrimitive",
                 "doc": "required nullable primitive type",
                 "type": {
-                  "$id": "331",
+                  "$id": "333",
                   "kind": "nullable",
                   "type": {
-                    "$id": "332",
+                    "$id": "334",
                     "kind": "int32",
                     "name": "int32",
                     "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -3587,13 +3604,13 @@
                 "isExactName": false
               },
               {
-                "$id": "333",
+                "$id": "335",
                 "kind": "property",
                 "name": "requiredExtensibleEnum",
                 "serializedName": "requiredExtensibleEnum",
                 "doc": "required nullable extensible enum type",
                 "type": {
-                  "$id": "334",
+                  "$id": "336",
                   "kind": "nullable",
                   "type": {
                     "$ref": "22"
@@ -3615,13 +3632,13 @@
                 "isExactName": false
               },
               {
-                "$id": "335",
+                "$id": "337",
                 "kind": "property",
                 "name": "requiredFixedEnum",
                 "serializedName": "requiredFixedEnum",
                 "doc": "required nullable fixed enum type",
                 "type": {
-                  "$id": "336",
+                  "$id": "338",
                   "kind": "nullable",
                   "type": {
                     "$ref": "17"
@@ -3659,13 +3676,13 @@
           "isExactName": false
         },
         {
-          "$id": "337",
+          "$id": "339",
           "kind": "property",
           "name": "requiredBytes",
           "serializedName": "requiredBytes",
           "doc": "Required bytes",
           "type": {
-            "$id": "338",
+            "$id": "340",
             "kind": "bytes",
             "name": "bytes",
             "encode": "base64",
@@ -3689,10 +3706,10 @@
       ]
     },
     {
-      "$ref": "329"
+      "$ref": "331"
     },
     {
-      "$id": "339",
+      "$id": "341",
       "kind": "model",
       "name": "Wrapper",
       "namespace": "SampleTypeSpec",
@@ -3703,12 +3720,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "340",
+          "$id": "342",
           "kind": "property",
           "name": "p1",
           "doc": "header parameter",
           "type": {
-            "$id": "341",
+            "$id": "343",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3725,12 +3742,12 @@
           "isExactName": false
         },
         {
-          "$id": "342",
+          "$id": "344",
           "kind": "property",
           "name": "action",
           "doc": "body parameter",
           "type": {
-            "$ref": "291"
+            "$ref": "293"
           },
           "optional": false,
           "readOnly": false,
@@ -3743,12 +3760,12 @@
           "isExactName": false
         },
         {
-          "$id": "343",
+          "$id": "345",
           "kind": "property",
           "name": "p2",
           "doc": "path parameter",
           "type": {
-            "$id": "344",
+            "$id": "346",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3767,7 +3784,7 @@
       ]
     },
     {
-      "$id": "345",
+      "$id": "347",
       "kind": "model",
       "name": "Friend",
       "namespace": "SampleTypeSpec",
@@ -3783,13 +3800,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "346",
+          "$id": "348",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "name of the NotFriend",
           "type": {
-            "$id": "347",
+            "$id": "349",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3812,7 +3829,7 @@
       ]
     },
     {
-      "$id": "348",
+      "$id": "350",
       "kind": "model",
       "name": "RenamedModel",
       "namespace": "SampleTypeSpec",
@@ -3828,13 +3845,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "349",
+          "$id": "351",
           "kind": "property",
           "name": "otherName",
           "serializedName": "otherName",
           "doc": "name of the ModelWithClientName",
           "type": {
-            "$id": "350",
+            "$id": "352",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -3857,7 +3874,7 @@
       ]
     },
     {
-      "$id": "351",
+      "$id": "353",
       "kind": "model",
       "name": "ReturnsAnonymousModelResponse",
       "namespace": "SampleTypeSpec",
@@ -3873,7 +3890,7 @@
       "properties": []
     },
     {
-      "$id": "352",
+      "$id": "354",
       "kind": "model",
       "name": "ListWithNextLinkResponse",
       "namespace": "SampleTypeSpec",
@@ -3888,16 +3905,16 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "353",
+          "$id": "355",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$id": "354",
+            "$id": "356",
             "kind": "array",
             "name": "ArrayThing",
             "valueType": {
-              "$ref": "256"
+              "$ref": "258"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -3917,12 +3934,12 @@
           "isExactName": false
         },
         {
-          "$id": "355",
+          "$id": "357",
           "kind": "property",
           "name": "next",
           "serializedName": "next",
           "type": {
-            "$id": "356",
+            "$id": "358",
             "kind": "url",
             "name": "url",
             "crossLanguageDefinitionId": "TypeSpec.url",
@@ -3945,7 +3962,7 @@
       ]
     },
     {
-      "$id": "357",
+      "$id": "359",
       "kind": "model",
       "name": "ListWithStringNextLinkResponse",
       "namespace": "SampleTypeSpec",
@@ -3960,12 +3977,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "358",
+          "$id": "360",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "354"
+            "$ref": "356"
           },
           "optional": false,
           "readOnly": false,
@@ -3982,12 +3999,12 @@
           "isExactName": false
         },
         {
-          "$id": "359",
+          "$id": "361",
           "kind": "property",
           "name": "next",
           "serializedName": "next",
           "type": {
-            "$id": "360",
+            "$id": "362",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4010,7 +4027,7 @@
       ]
     },
     {
-      "$id": "361",
+      "$id": "363",
       "kind": "model",
       "name": "ListWithContinuationTokenResponse",
       "namespace": "SampleTypeSpec",
@@ -4025,12 +4042,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "362",
+          "$id": "364",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "354"
+            "$ref": "356"
           },
           "optional": false,
           "readOnly": false,
@@ -4047,12 +4064,12 @@
           "isExactName": false
         },
         {
-          "$id": "363",
+          "$id": "365",
           "kind": "property",
           "name": "nextToken",
           "serializedName": "nextToken",
           "type": {
-            "$id": "364",
+            "$id": "366",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4075,7 +4092,7 @@
       ]
     },
     {
-      "$id": "365",
+      "$id": "367",
       "kind": "model",
       "name": "ListWithContinuationTokenHeaderResponseResponse",
       "namespace": "",
@@ -4090,12 +4107,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "366",
+          "$id": "368",
           "kind": "property",
           "name": "things",
           "serializedName": "things",
           "type": {
-            "$ref": "354"
+            "$ref": "356"
           },
           "optional": false,
           "readOnly": false,
@@ -4114,7 +4131,7 @@
       ]
     },
     {
-      "$id": "367",
+      "$id": "369",
       "kind": "model",
       "name": "PageThing",
       "namespace": "SampleTypeSpec",
@@ -4129,12 +4146,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "368",
+          "$id": "370",
           "kind": "property",
           "name": "items",
           "serializedName": "items",
           "type": {
-            "$ref": "354"
+            "$ref": "356"
           },
           "optional": false,
           "readOnly": false,
@@ -4153,7 +4170,7 @@
       ]
     },
     {
-      "$id": "369",
+      "$id": "371",
       "kind": "model",
       "name": "ModelWithEmbeddedNonBodyParameters",
       "namespace": "SampleTypeSpec",
@@ -4168,13 +4185,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "370",
+          "$id": "372",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "name of the ModelWithEmbeddedNonBodyParameters",
           "type": {
-            "$id": "371",
+            "$id": "373",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4195,13 +4212,13 @@
           "isExactName": false
         },
         {
-          "$id": "372",
+          "$id": "374",
           "kind": "property",
           "name": "requiredHeader",
           "serializedName": "requiredHeader",
           "doc": "required header parameter",
           "type": {
-            "$id": "373",
+            "$id": "375",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4222,13 +4239,13 @@
           "isExactName": false
         },
         {
-          "$id": "374",
+          "$id": "376",
           "kind": "property",
           "name": "optionalHeader",
           "serializedName": "optionalHeader",
           "doc": "optional header parameter",
           "type": {
-            "$id": "375",
+            "$id": "377",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4249,13 +4266,13 @@
           "isExactName": false
         },
         {
-          "$id": "376",
+          "$id": "378",
           "kind": "property",
           "name": "requiredQuery",
           "serializedName": "requiredQuery",
           "doc": "required query parameter",
           "type": {
-            "$id": "377",
+            "$id": "379",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4276,13 +4293,13 @@
           "isExactName": false
         },
         {
-          "$id": "378",
+          "$id": "380",
           "kind": "property",
           "name": "optionalQuery",
           "serializedName": "optionalQuery",
           "doc": "optional query parameter",
           "type": {
-            "$id": "379",
+            "$id": "381",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4305,7 +4322,7 @@
       ]
     },
     {
-      "$id": "380",
+      "$id": "382",
       "kind": "model",
       "name": "DynamicModel",
       "namespace": "SampleTypeSpec",
@@ -4326,12 +4343,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "381",
+          "$id": "383",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "type": {
-            "$id": "382",
+            "$id": "384",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4352,12 +4369,12 @@
           "isExactName": false
         },
         {
-          "$id": "383",
+          "$id": "385",
           "kind": "property",
           "name": "optionalUnknown",
           "serializedName": "optionalUnknown",
           "type": {
-            "$id": "384",
+            "$id": "386",
             "kind": "unknown",
             "name": "unknown",
             "crossLanguageDefinitionId": "",
@@ -4378,12 +4395,12 @@
           "isExactName": false
         },
         {
-          "$id": "385",
+          "$id": "387",
           "kind": "property",
           "name": "optionalInt",
           "serializedName": "optionalInt",
           "type": {
-            "$id": "386",
+            "$id": "388",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4404,15 +4421,15 @@
           "isExactName": false
         },
         {
-          "$id": "387",
+          "$id": "389",
           "kind": "property",
           "name": "optionalNullableList",
           "serializedName": "optionalNullableList",
           "type": {
-            "$id": "388",
+            "$id": "390",
             "kind": "nullable",
             "type": {
-              "$ref": "285"
+              "$ref": "287"
             },
             "namespace": "SampleTypeSpec"
           },
@@ -4431,15 +4448,15 @@
           "isExactName": false
         },
         {
-          "$id": "389",
+          "$id": "391",
           "kind": "property",
           "name": "requiredNullableList",
           "serializedName": "requiredNullableList",
           "type": {
-            "$id": "390",
+            "$id": "392",
             "kind": "nullable",
             "type": {
-              "$ref": "285"
+              "$ref": "287"
             },
             "namespace": "SampleTypeSpec"
           },
@@ -4458,25 +4475,25 @@
           "isExactName": false
         },
         {
-          "$id": "391",
+          "$id": "393",
           "kind": "property",
           "name": "optionalNullableDictionary",
           "serializedName": "optionalNullableDictionary",
           "type": {
-            "$id": "392",
+            "$id": "394",
             "kind": "nullable",
             "type": {
-              "$id": "393",
+              "$id": "395",
               "kind": "dict",
               "keyType": {
-                "$id": "394",
+                "$id": "396",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
                 "decorators": []
               },
               "valueType": {
-                "$id": "395",
+                "$id": "397",
                 "kind": "int32",
                 "name": "int32",
                 "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4501,15 +4518,15 @@
           "isExactName": false
         },
         {
-          "$id": "396",
+          "$id": "398",
           "kind": "property",
           "name": "requiredNullableDictionary",
           "serializedName": "requiredNullableDictionary",
           "type": {
-            "$id": "397",
+            "$id": "399",
             "kind": "nullable",
             "type": {
-              "$ref": "393"
+              "$ref": "395"
             },
             "namespace": "SampleTypeSpec"
           },
@@ -4528,12 +4545,12 @@
           "isExactName": false
         },
         {
-          "$id": "398",
+          "$id": "400",
           "kind": "property",
           "name": "primitiveDictionary",
           "serializedName": "primitiveDictionary",
           "type": {
-            "$ref": "393"
+            "$ref": "395"
           },
           "optional": false,
           "readOnly": false,
@@ -4550,12 +4567,12 @@
           "isExactName": false
         },
         {
-          "$id": "399",
+          "$id": "401",
           "kind": "property",
           "name": "foo",
           "serializedName": "foo",
           "type": {
-            "$id": "400",
+            "$id": "402",
             "kind": "model",
             "name": "AnotherDynamicModel",
             "namespace": "SampleTypeSpec",
@@ -4576,12 +4593,12 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "401",
+                "$id": "403",
                 "kind": "property",
                 "name": "bar",
                 "serializedName": "bar",
                 "type": {
-                  "$id": "402",
+                  "$id": "404",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4618,16 +4635,16 @@
           "isExactName": false
         },
         {
-          "$id": "403",
+          "$id": "405",
           "kind": "property",
           "name": "listFoo",
           "serializedName": "listFoo",
           "type": {
-            "$id": "404",
+            "$id": "406",
             "kind": "array",
             "name": "ArrayAnotherDynamicModel",
             "valueType": {
-              "$ref": "400"
+              "$ref": "402"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -4647,16 +4664,16 @@
           "isExactName": false
         },
         {
-          "$id": "405",
+          "$id": "407",
           "kind": "property",
           "name": "listOfListFoo",
           "serializedName": "listOfListFoo",
           "type": {
-            "$id": "406",
+            "$id": "408",
             "kind": "array",
             "name": "ArrayArray",
             "valueType": {
-              "$ref": "404"
+              "$ref": "406"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -4676,22 +4693,22 @@
           "isExactName": false
         },
         {
-          "$id": "407",
+          "$id": "409",
           "kind": "property",
           "name": "dictionaryFoo",
           "serializedName": "dictionaryFoo",
           "type": {
-            "$id": "408",
+            "$id": "410",
             "kind": "dict",
             "keyType": {
-              "$id": "409",
+              "$id": "411",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "400"
+              "$ref": "402"
             },
             "decorators": []
           },
@@ -4710,22 +4727,22 @@
           "isExactName": false
         },
         {
-          "$id": "410",
+          "$id": "412",
           "kind": "property",
           "name": "dictionaryOfDictionaryFoo",
           "serializedName": "dictionaryOfDictionaryFoo",
           "type": {
-            "$id": "411",
+            "$id": "413",
             "kind": "dict",
             "keyType": {
-              "$id": "412",
+              "$id": "414",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "408"
+              "$ref": "410"
             },
             "decorators": []
           },
@@ -4744,22 +4761,22 @@
           "isExactName": false
         },
         {
-          "$id": "413",
+          "$id": "415",
           "kind": "property",
           "name": "dictionaryListFoo",
           "serializedName": "dictionaryListFoo",
           "type": {
-            "$id": "414",
+            "$id": "416",
             "kind": "dict",
             "keyType": {
-              "$id": "415",
+              "$id": "417",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "404"
+              "$ref": "406"
             },
             "decorators": []
           },
@@ -4778,16 +4795,16 @@
           "isExactName": false
         },
         {
-          "$id": "416",
+          "$id": "418",
           "kind": "property",
           "name": "listOfDictionaryFoo",
           "serializedName": "listOfDictionaryFoo",
           "type": {
-            "$id": "417",
+            "$id": "419",
             "kind": "array",
             "name": "ArrayRecord",
             "valueType": {
-              "$ref": "408"
+              "$ref": "410"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -4809,10 +4826,10 @@
       ]
     },
     {
-      "$ref": "400"
+      "$ref": "402"
     },
     {
-      "$id": "418",
+      "$id": "420",
       "kind": "model",
       "name": "XmlAdvancedModel",
       "namespace": "SampleTypeSpec",
@@ -4837,13 +4854,13 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "419",
+          "$id": "421",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "A simple string property",
           "type": {
-            "$id": "420",
+            "$id": "422",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4866,13 +4883,13 @@
           "isExactName": false
         },
         {
-          "$id": "421",
+          "$id": "423",
           "kind": "property",
           "name": "age",
           "serializedName": "age",
           "doc": "An integer property",
           "type": {
-            "$id": "422",
+            "$id": "424",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4895,13 +4912,13 @@
           "isExactName": false
         },
         {
-          "$id": "423",
+          "$id": "425",
           "kind": "property",
           "name": "enabled",
           "serializedName": "enabled",
           "doc": "A boolean property",
           "type": {
-            "$id": "424",
+            "$id": "426",
             "kind": "boolean",
             "name": "boolean",
             "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -4924,13 +4941,13 @@
           "isExactName": false
         },
         {
-          "$id": "425",
+          "$id": "427",
           "kind": "property",
           "name": "score",
           "serializedName": "score",
           "doc": "A float property",
           "type": {
-            "$id": "426",
+            "$id": "428",
             "kind": "float32",
             "name": "float32",
             "crossLanguageDefinitionId": "TypeSpec.float32",
@@ -4953,13 +4970,13 @@
           "isExactName": false
         },
         {
-          "$id": "427",
+          "$id": "429",
           "kind": "property",
           "name": "optionalString",
           "serializedName": "optionalString",
           "doc": "An optional string",
           "type": {
-            "$id": "428",
+            "$id": "430",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4982,13 +4999,13 @@
           "isExactName": false
         },
         {
-          "$id": "429",
+          "$id": "431",
           "kind": "property",
           "name": "optionalInt",
           "serializedName": "optionalInt",
           "doc": "An optional integer",
           "type": {
-            "$id": "430",
+            "$id": "432",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -5011,16 +5028,16 @@
           "isExactName": false
         },
         {
-          "$id": "431",
+          "$id": "433",
           "kind": "property",
           "name": "nullableString",
           "serializedName": "nullableString",
           "doc": "A nullable string",
           "type": {
-            "$id": "432",
+            "$id": "434",
             "kind": "nullable",
             "type": {
-              "$id": "433",
+              "$id": "435",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5045,13 +5062,13 @@
           "isExactName": false
         },
         {
-          "$id": "434",
+          "$id": "436",
           "kind": "property",
           "name": "id",
           "serializedName": "id",
           "doc": "A string as XML attribute",
           "type": {
-            "$id": "435",
+            "$id": "437",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5079,13 +5096,13 @@
           "isExactName": false
         },
         {
-          "$id": "436",
+          "$id": "438",
           "kind": "property",
           "name": "version",
           "serializedName": "version",
           "doc": "An integer as XML attribute",
           "type": {
-            "$id": "437",
+            "$id": "439",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -5113,13 +5130,13 @@
           "isExactName": false
         },
         {
-          "$id": "438",
+          "$id": "440",
           "kind": "property",
           "name": "isActive",
           "serializedName": "isActive",
           "doc": "A boolean as XML attribute",
           "type": {
-            "$id": "439",
+            "$id": "441",
             "kind": "boolean",
             "name": "boolean",
             "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -5147,13 +5164,13 @@
           "isExactName": false
         },
         {
-          "$id": "440",
+          "$id": "442",
           "kind": "property",
           "name": "originalName",
           "serializedName": "RenamedProperty",
           "doc": "A property with a custom XML element name",
           "type": {
-            "$id": "441",
+            "$id": "443",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5183,13 +5200,13 @@
           "isExactName": false
         },
         {
-          "$id": "442",
+          "$id": "444",
           "kind": "property",
           "name": "xmlIdentifier",
           "serializedName": "xml-id",
           "doc": "An attribute with a custom XML name",
           "type": {
-            "$id": "443",
+            "$id": "445",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5223,13 +5240,13 @@
           "isExactName": false
         },
         {
-          "$id": "444",
+          "$id": "446",
           "kind": "property",
           "name": "content",
           "serializedName": "content",
           "doc": "Text content in the element (unwrapped string)",
           "type": {
-            "$id": "445",
+            "$id": "447",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5257,13 +5274,13 @@
           "isExactName": false
         },
         {
-          "$id": "446",
+          "$id": "448",
           "kind": "property",
           "name": "unwrappedStrings",
           "serializedName": "unwrappedStrings",
           "doc": "An unwrapped array of strings - items appear directly without wrapper",
           "type": {
-            "$ref": "262"
+            "$ref": "264"
           },
           "optional": false,
           "readOnly": false,
@@ -5288,13 +5305,13 @@
           "isExactName": false
         },
         {
-          "$id": "447",
+          "$id": "449",
           "kind": "property",
           "name": "unwrappedCounts",
           "serializedName": "unwrappedCounts",
           "doc": "An unwrapped array of integers",
           "type": {
-            "$ref": "285"
+            "$ref": "287"
           },
           "optional": false,
           "readOnly": false,
@@ -5319,17 +5336,17 @@
           "isExactName": false
         },
         {
-          "$id": "448",
+          "$id": "450",
           "kind": "property",
           "name": "unwrappedItems",
           "serializedName": "unwrappedItems",
           "doc": "An unwrapped array of models",
           "type": {
-            "$id": "449",
+            "$id": "451",
             "kind": "array",
             "name": "ArrayXmlItem",
             "valueType": {
-              "$id": "450",
+              "$id": "452",
               "kind": "model",
               "name": "XmlItem",
               "namespace": "SampleTypeSpec",
@@ -5354,13 +5371,13 @@
               "isExactName": false,
               "properties": [
                 {
-                  "$id": "451",
+                  "$id": "453",
                   "kind": "property",
                   "name": "itemName",
                   "serializedName": "itemName",
                   "doc": "The item name",
                   "type": {
-                    "$id": "452",
+                    "$id": "454",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5383,13 +5400,13 @@
                   "isExactName": false
                 },
                 {
-                  "$id": "453",
+                  "$id": "455",
                   "kind": "property",
                   "name": "itemValue",
                   "serializedName": "itemValue",
                   "doc": "The item value",
                   "type": {
-                    "$id": "454",
+                    "$id": "456",
                     "kind": "int32",
                     "name": "int32",
                     "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -5412,13 +5429,13 @@
                   "isExactName": false
                 },
                 {
-                  "$id": "455",
+                  "$id": "457",
                   "kind": "property",
                   "name": "itemId",
                   "serializedName": "itemId",
                   "doc": "Item ID as attribute",
                   "type": {
-                    "$id": "456",
+                    "$id": "458",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5473,13 +5490,13 @@
           "isExactName": false
         },
         {
-          "$id": "457",
+          "$id": "459",
           "kind": "property",
           "name": "wrappedColors",
           "serializedName": "wrappedColors",
           "doc": "A wrapped array of strings (default)",
           "type": {
-            "$ref": "262"
+            "$ref": "264"
           },
           "optional": false,
           "readOnly": false,
@@ -5499,13 +5516,13 @@
           "isExactName": false
         },
         {
-          "$id": "458",
+          "$id": "460",
           "kind": "property",
           "name": "items",
           "serializedName": "ItemCollection",
           "doc": "A wrapped array with custom wrapper name",
           "type": {
-            "$ref": "449"
+            "$ref": "451"
           },
           "optional": false,
           "readOnly": false,
@@ -5532,13 +5549,13 @@
           "isExactName": false
         },
         {
-          "$id": "459",
+          "$id": "461",
           "kind": "property",
           "name": "nestedModel",
           "serializedName": "nestedModel",
           "doc": "A nested model property",
           "type": {
-            "$id": "460",
+            "$id": "462",
             "kind": "model",
             "name": "XmlNestedModel",
             "namespace": "SampleTypeSpec",
@@ -5556,13 +5573,13 @@
             "isExactName": false,
             "properties": [
               {
-                "$id": "461",
+                "$id": "463",
                 "kind": "property",
                 "name": "value",
                 "serializedName": "value",
                 "doc": "The value of the nested model",
                 "type": {
-                  "$id": "462",
+                  "$id": "464",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5585,13 +5602,13 @@
                 "isExactName": false
               },
               {
-                "$id": "463",
+                "$id": "465",
                 "kind": "property",
                 "name": "nestedId",
                 "serializedName": "nestedId",
                 "doc": "An attribute on the nested model",
                 "type": {
-                  "$id": "464",
+                  "$id": "466",
                   "kind": "int32",
                   "name": "int32",
                   "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -5637,13 +5654,13 @@
           "isExactName": false
         },
         {
-          "$id": "465",
+          "$id": "467",
           "kind": "property",
           "name": "optionalNestedModel",
           "serializedName": "optionalNestedModel",
           "doc": "An optional nested model",
           "type": {
-            "$ref": "460"
+            "$ref": "462"
           },
           "optional": true,
           "readOnly": false,
@@ -5662,23 +5679,23 @@
           "isExactName": false
         },
         {
-          "$id": "466",
+          "$id": "468",
           "kind": "property",
           "name": "metadata",
           "serializedName": "metadata",
           "doc": "A dictionary property",
           "type": {
-            "$id": "467",
+            "$id": "469",
             "kind": "dict",
             "keyType": {
-              "$id": "468",
+              "$id": "470",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$id": "469",
+              "$id": "471",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5703,18 +5720,18 @@
           "isExactName": false
         },
         {
-          "$id": "470",
+          "$id": "472",
           "kind": "property",
           "name": "createdAt",
           "serializedName": "createdAt",
           "doc": "A date-time property",
           "type": {
-            "$id": "471",
+            "$id": "473",
             "kind": "utcDateTime",
             "name": "utcDateTime",
             "encode": "rfc3339",
             "wireType": {
-              "$id": "472",
+              "$id": "474",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5740,18 +5757,18 @@
           "isExactName": false
         },
         {
-          "$id": "473",
+          "$id": "475",
           "kind": "property",
           "name": "duration",
           "serializedName": "duration",
           "doc": "A duration property",
           "type": {
-            "$id": "474",
+            "$id": "476",
             "kind": "duration",
             "name": "duration",
             "encode": "ISO8601",
             "wireType": {
-              "$id": "475",
+              "$id": "477",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5777,13 +5794,13 @@
           "isExactName": false
         },
         {
-          "$id": "476",
+          "$id": "478",
           "kind": "property",
           "name": "data",
           "serializedName": "data",
           "doc": "A bytes property",
           "type": {
-            "$id": "477",
+            "$id": "479",
             "kind": "bytes",
             "name": "bytes",
             "encode": "base64",
@@ -5807,13 +5824,13 @@
           "isExactName": false
         },
         {
-          "$id": "478",
+          "$id": "480",
           "kind": "property",
           "name": "optionalRecordUnknown",
           "serializedName": "optionalRecordUnknown",
           "doc": "optional record of unknown",
           "type": {
-            "$ref": "322"
+            "$ref": "324"
           },
           "optional": true,
           "readOnly": false,
@@ -5832,7 +5849,7 @@
           "isExactName": false
         },
         {
-          "$id": "479",
+          "$id": "481",
           "kind": "property",
           "name": "fixedEnum",
           "serializedName": "fixedEnum",
@@ -5857,7 +5874,7 @@
           "isExactName": false
         },
         {
-          "$id": "480",
+          "$id": "482",
           "kind": "property",
           "name": "extensibleEnum",
           "serializedName": "extensibleEnum",
@@ -5882,7 +5899,7 @@
           "isExactName": false
         },
         {
-          "$id": "481",
+          "$id": "483",
           "kind": "property",
           "name": "optionalFixedEnum",
           "serializedName": "optionalFixedEnum",
@@ -5907,7 +5924,7 @@
           "isExactName": false
         },
         {
-          "$id": "482",
+          "$id": "484",
           "kind": "property",
           "name": "optionalExtensibleEnum",
           "serializedName": "optionalExtensibleEnum",
@@ -5932,12 +5949,12 @@
           "isExactName": false
         },
         {
-          "$id": "483",
+          "$id": "485",
           "kind": "property",
           "name": "label",
           "serializedName": "label",
           "type": {
-            "$id": "484",
+            "$id": "486",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5952,14 +5969,14 @@
               "name": "TypeSpec.Xml.@ns",
               "arguments": {
                 "ns": {
-                  "$id": "485",
+                  "$id": "487",
                   "kind": "enumvalue",
                   "decorators": [],
                   "name": "ns1",
                   "isExactName": false,
                   "value": "https://example.com/ns1",
                   "enumType": {
-                    "$id": "486",
+                    "$id": "488",
                     "kind": "enum",
                     "decorators": [
                       {
@@ -5972,7 +5989,7 @@
                     "isExactName": false,
                     "namespace": "SampleTypeSpec",
                     "valueType": {
-                      "$id": "487",
+                      "$id": "489",
                       "kind": "string",
                       "decorators": [],
                       "doc": "A sequence of textual characters.",
@@ -5981,32 +5998,32 @@
                     },
                     "values": [
                       {
-                        "$id": "488",
+                        "$id": "490",
                         "kind": "enumvalue",
                         "decorators": [],
                         "name": "ns1",
                         "isExactName": false,
                         "value": "https://example.com/ns1",
                         "enumType": {
-                          "$ref": "486"
+                          "$ref": "488"
                         },
                         "valueType": {
-                          "$ref": "487"
+                          "$ref": "489"
                         },
                         "crossLanguageDefinitionId": "SampleTypeSpec.XmlNamespaces.ns1"
                       },
                       {
-                        "$id": "489",
+                        "$id": "491",
                         "kind": "enumvalue",
                         "decorators": [],
                         "name": "ns2",
                         "isExactName": false,
                         "value": "https://example.com/ns2",
                         "enumType": {
-                          "$ref": "486"
+                          "$ref": "488"
                         },
                         "valueType": {
-                          "$ref": "487"
+                          "$ref": "489"
                         },
                         "crossLanguageDefinitionId": "SampleTypeSpec.XmlNamespaces.ns2"
                       }
@@ -6024,7 +6041,7 @@
                     "__accessSet": true
                   },
                   "valueType": {
-                    "$ref": "487"
+                    "$ref": "489"
                   },
                   "crossLanguageDefinitionId": "SampleTypeSpec.XmlNamespaces.ns1"
                 }
@@ -6051,12 +6068,12 @@
           "isExactName": false
         },
         {
-          "$id": "490",
+          "$id": "492",
           "kind": "property",
           "name": "daysUsed",
           "serializedName": "daysUsed",
           "type": {
-            "$id": "491",
+            "$id": "493",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -6071,17 +6088,17 @@
               "name": "TypeSpec.Xml.@ns",
               "arguments": {
                 "ns": {
-                  "$id": "492",
+                  "$id": "494",
                   "kind": "enumvalue",
                   "decorators": [],
                   "name": "ns2",
                   "isExactName": false,
                   "value": "https://example.com/ns2",
                   "enumType": {
-                    "$ref": "486"
+                    "$ref": "488"
                   },
                   "valueType": {
-                    "$ref": "487"
+                    "$ref": "489"
                   },
                   "crossLanguageDefinitionId": "SampleTypeSpec.XmlNamespaces.ns2"
                 }
@@ -6104,12 +6121,12 @@
           "isExactName": false
         },
         {
-          "$id": "493",
+          "$id": "495",
           "kind": "property",
           "name": "fooItems",
           "serializedName": "fooItems",
           "type": {
-            "$ref": "262"
+            "$ref": "264"
           },
           "optional": false,
           "readOnly": false,
@@ -6141,12 +6158,12 @@
           "isExactName": false
         },
         {
-          "$id": "494",
+          "$id": "496",
           "kind": "property",
           "name": "anotherModel",
           "serializedName": "anotherModel",
           "type": {
-            "$ref": "460"
+            "$ref": "462"
           },
           "optional": false,
           "readOnly": false,
@@ -6177,16 +6194,16 @@
           "isExactName": false
         },
         {
-          "$id": "495",
+          "$id": "497",
           "kind": "property",
           "name": "modelsWithNamespaces",
           "serializedName": "modelsWithNamespaces",
           "type": {
-            "$id": "496",
+            "$id": "498",
             "kind": "array",
             "name": "ArrayXmlModelWithNamespace",
             "valueType": {
-              "$id": "497",
+              "$id": "499",
               "kind": "model",
               "name": "XmlModelWithNamespace",
               "namespace": "SampleTypeSpec",
@@ -6215,12 +6232,12 @@
               "isExactName": false,
               "properties": [
                 {
-                  "$id": "498",
+                  "$id": "500",
                   "kind": "property",
                   "name": "foo",
                   "serializedName": "foo",
                   "type": {
-                    "$id": "499",
+                    "$id": "501",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6269,12 +6286,12 @@
           "isExactName": false
         },
         {
-          "$id": "500",
+          "$id": "502",
           "kind": "property",
           "name": "unwrappedModelsWithNamespaces",
           "serializedName": "unwrappedModelsWithNamespaces",
           "type": {
-            "$ref": "496"
+            "$ref": "498"
           },
           "optional": false,
           "readOnly": false,
@@ -6299,16 +6316,16 @@
           "isExactName": false
         },
         {
-          "$id": "501",
+          "$id": "503",
           "kind": "property",
           "name": "listOfListFoo",
           "serializedName": "listOfListFoo",
           "type": {
-            "$id": "502",
+            "$id": "504",
             "kind": "array",
             "name": "ArrayArray1",
             "valueType": {
-              "$ref": "449"
+              "$ref": "451"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -6331,22 +6348,22 @@
           "isExactName": false
         },
         {
-          "$id": "503",
+          "$id": "505",
           "kind": "property",
           "name": "dictionaryFoo",
           "serializedName": "dictionaryFoo",
           "type": {
-            "$id": "504",
+            "$id": "506",
             "kind": "dict",
             "keyType": {
-              "$id": "505",
+              "$id": "507",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "450"
+              "$ref": "452"
             },
             "decorators": []
           },
@@ -6367,22 +6384,22 @@
           "isExactName": false
         },
         {
-          "$id": "506",
+          "$id": "508",
           "kind": "property",
           "name": "dictionaryOfDictionaryFoo",
           "serializedName": "dictionaryOfDictionaryFoo",
           "type": {
-            "$id": "507",
+            "$id": "509",
             "kind": "dict",
             "keyType": {
-              "$id": "508",
+              "$id": "510",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "504"
+              "$ref": "506"
             },
             "decorators": []
           },
@@ -6403,22 +6420,22 @@
           "isExactName": false
         },
         {
-          "$id": "509",
+          "$id": "511",
           "kind": "property",
           "name": "dictionaryListFoo",
           "serializedName": "dictionaryListFoo",
           "type": {
-            "$id": "510",
+            "$id": "512",
             "kind": "dict",
             "keyType": {
-              "$id": "511",
+              "$id": "513",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "449"
+              "$ref": "451"
             },
             "decorators": []
           },
@@ -6439,16 +6456,16 @@
           "isExactName": false
         },
         {
-          "$id": "512",
+          "$id": "514",
           "kind": "property",
           "name": "listOfDictionaryFoo",
           "serializedName": "listOfDictionaryFoo",
           "type": {
-            "$id": "513",
+            "$id": "515",
             "kind": "array",
             "name": "ArrayRecord1",
             "valueType": {
-              "$ref": "504"
+              "$ref": "506"
             },
             "crossLanguageDefinitionId": "TypeSpec.Array",
             "decorators": []
@@ -6473,16 +6490,16 @@
       ]
     },
     {
-      "$ref": "450"
+      "$ref": "452"
     },
     {
-      "$ref": "460"
+      "$ref": "462"
     },
     {
-      "$ref": "497"
+      "$ref": "499"
     },
     {
-      "$id": "514",
+      "$id": "516",
       "kind": "model",
       "name": "Cat",
       "namespace": "SampleTypeSpec",
@@ -6493,12 +6510,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "515",
+          "$id": "517",
           "kind": "property",
           "name": "id",
           "serializedName": "id",
           "type": {
-            "$id": "516",
+            "$id": "518",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6525,12 +6542,12 @@
           "isExactName": false
         },
         {
-          "$id": "517",
+          "$id": "519",
           "kind": "property",
           "name": "boolPart",
           "serializedName": "boolPart",
           "type": {
-            "$id": "518",
+            "$id": "520",
             "kind": "boolean",
             "name": "boolean",
             "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -6557,12 +6574,12 @@
           "isExactName": false
         },
         {
-          "$id": "519",
+          "$id": "521",
           "kind": "property",
           "name": "int32Part",
           "serializedName": "int32Part",
           "type": {
-            "$id": "520",
+            "$id": "522",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -6589,12 +6606,12 @@
           "isExactName": false
         },
         {
-          "$id": "521",
+          "$id": "523",
           "kind": "property",
           "name": "int64Part",
           "serializedName": "int64Part",
           "type": {
-            "$id": "522",
+            "$id": "524",
             "kind": "int64",
             "name": "int64",
             "crossLanguageDefinitionId": "TypeSpec.int64",
@@ -6621,12 +6638,12 @@
           "isExactName": false
         },
         {
-          "$id": "523",
+          "$id": "525",
           "kind": "property",
           "name": "float32Part",
           "serializedName": "float32Part",
           "type": {
-            "$id": "524",
+            "$id": "526",
             "kind": "float32",
             "name": "float32",
             "crossLanguageDefinitionId": "TypeSpec.float32",
@@ -6653,12 +6670,12 @@
           "isExactName": false
         },
         {
-          "$id": "525",
+          "$id": "527",
           "kind": "property",
           "name": "float64Part",
           "serializedName": "float64Part",
           "type": {
-            "$id": "526",
+            "$id": "528",
             "kind": "float64",
             "name": "float64",
             "crossLanguageDefinitionId": "TypeSpec.float64",
@@ -6685,12 +6702,12 @@
           "isExactName": false
         },
         {
-          "$id": "527",
+          "$id": "529",
           "kind": "property",
           "name": "decimalPart",
           "serializedName": "decimalPart",
           "type": {
-            "$id": "528",
+            "$id": "530",
             "kind": "decimal128",
             "name": "decimal128",
             "crossLanguageDefinitionId": "TypeSpec.decimal128",
@@ -6717,12 +6734,12 @@
           "isExactName": false
         },
         {
-          "$id": "529",
+          "$id": "531",
           "kind": "property",
           "name": "int8Part",
           "serializedName": "int8Part",
           "type": {
-            "$id": "530",
+            "$id": "532",
             "kind": "int8",
             "name": "int8",
             "crossLanguageDefinitionId": "TypeSpec.int8",
@@ -6749,12 +6766,12 @@
           "isExactName": false
         },
         {
-          "$id": "531",
+          "$id": "533",
           "kind": "property",
           "name": "uint8Part",
           "serializedName": "uint8Part",
           "type": {
-            "$id": "532",
+            "$id": "534",
             "kind": "uint8",
             "name": "uint8",
             "crossLanguageDefinitionId": "TypeSpec.uint8",
@@ -6781,12 +6798,12 @@
           "isExactName": false
         },
         {
-          "$id": "533",
+          "$id": "535",
           "kind": "property",
           "name": "dictionaryPart",
           "serializedName": "dictionaryPart",
           "type": {
-            "$ref": "467"
+            "$ref": "469"
           },
           "optional": false,
           "readOnly": false,
@@ -6809,22 +6826,22 @@
           "isExactName": false
         },
         {
-          "$id": "534",
+          "$id": "536",
           "kind": "property",
           "name": "dictionaryModelPart",
           "serializedName": "dictionaryModelPart",
           "type": {
-            "$id": "535",
+            "$id": "537",
             "kind": "dict",
             "keyType": {
-              "$id": "536",
+              "$id": "538",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
               "decorators": []
             },
             "valueType": {
-              "$ref": "256"
+              "$ref": "258"
             },
             "decorators": []
           },
@@ -6849,12 +6866,12 @@
           "isExactName": false
         },
         {
-          "$id": "537",
+          "$id": "539",
           "kind": "property",
           "name": "listPart",
           "serializedName": "listPart",
           "type": {
-            "$ref": "262"
+            "$ref": "264"
           },
           "optional": false,
           "readOnly": false,
@@ -6877,12 +6894,12 @@
           "isExactName": false
         },
         {
-          "$id": "538",
+          "$id": "540",
           "kind": "property",
           "name": "listModelPart",
           "serializedName": "listModelPart",
           "type": {
-            "$ref": "354"
+            "$ref": "356"
           },
           "optional": false,
           "readOnly": false,
@@ -6905,16 +6922,16 @@
           "isExactName": false
         },
         {
-          "$id": "539",
+          "$id": "541",
           "kind": "property",
           "name": "multipleListPart",
           "serializedName": "multipleListPart",
           "type": {
-            "$id": "540",
+            "$id": "542",
             "kind": "array",
             "name": "ArrayHttpPart",
             "valueType": {
-              "$id": "541",
+              "$id": "543",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6944,12 +6961,12 @@
           "isExactName": false
         },
         {
-          "$id": "542",
+          "$id": "544",
           "kind": "property",
           "name": "profileImage",
           "serializedName": "profileImage",
           "type": {
-            "$id": "543",
+            "$id": "545",
             "kind": "model",
             "name": "File",
             "namespace": "TypeSpec.Http",
@@ -6963,13 +6980,13 @@
             "isFileType": true,
             "properties": [
               {
-                "$id": "544",
+                "$id": "546",
                 "kind": "property",
                 "name": "contentType",
                 "summary": "The allowed media (MIME) types of the file contents.",
                 "doc": "The allowed media (MIME) types of the file contents.\n\nIn file bodies, this value comes from the `Content-Type` header of the request or response. In JSON bodies,\nthis value is serialized as a field in the response.\n\nNOTE: this is not _necessarily_ the same as the `Content-Type` header of the request or response, but\nit will be for file bodies. It may be different if the file is serialized as a JSON object. It always refers to the\n_contents_ of the file, and not necessarily the way the file itself is transmitted or serialized.",
                 "type": {
-                  "$id": "545",
+                  "$id": "547",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6986,13 +7003,13 @@
                 "isExactName": false
               },
               {
-                "$id": "546",
+                "$id": "548",
                 "kind": "property",
                 "name": "filename",
                 "summary": "The name of the file, if any.",
                 "doc": "The name of the file, if any.\n\nIn file bodies, this value comes from the `filename` parameter of the `Content-Disposition` header of the response\nor multipart payload. In JSON bodies, this value is serialized as a field in the response.\n\nNOTE: By default, `filename` cannot be sent in request payloads and can only be sent in responses and multipart\npayloads, as the `Content-Disposition` header is not valid in requests. If you want to send the `filename` in a request,\nyou must extend the `File` model and override the `filename` property with a different location defined by HTTP metadata\ndecorators.",
                 "type": {
-                  "$id": "547",
+                  "$id": "549",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7009,13 +7026,13 @@
                 "isExactName": false
               },
               {
-                "$id": "548",
+                "$id": "550",
                 "kind": "property",
                 "name": "contents",
                 "summary": "The contents of the file.",
                 "doc": "The contents of the file.\n\nIn file bodies, this value comes from the body of the request, response, or multipart payload. In JSON bodies,\nthis value is serialized as a field in the response.",
                 "type": {
-                  "$id": "549",
+                  "$id": "551",
                   "kind": "bytes",
                   "name": "bytes",
                   "encode": "base64",
@@ -7045,12 +7062,12 @@
               "isFilePart": true,
               "isMulti": false,
               "filename": {
-                "$id": "550",
+                "$id": "552",
                 "doc": "The name of the file, if any.\n\nIn file bodies, this value comes from the `filename` parameter of the `Content-Disposition` header of the response\nor multipart payload. In JSON bodies, this value is serialized as a field in the response.\n\nNOTE: By default, `filename` cannot be sent in request payloads and can only be sent in responses and multipart\npayloads, as the `Content-Disposition` header is not valid in requests. If you want to send the `filename` in a request,\nyou must extend the `File` model and override the `filename` property with a different location defined by HTTP metadata\ndecorators.",
                 "summary": "The name of the file, if any.",
                 "apiVersions": [],
                 "type": {
-                  "$id": "551",
+                  "$id": "553",
                   "kind": "string",
                   "decorators": [],
                   "doc": "A sequence of textual characters.",
@@ -7081,12 +7098,12 @@
                 "serializationOptions": {}
               },
               "contentType": {
-                "$id": "552",
+                "$id": "554",
                 "doc": "The allowed media (MIME) types of the file contents.\n\nIn file bodies, this value comes from the `Content-Type` header of the request or response. In JSON bodies,\nthis value is serialized as a field in the response.\n\nNOTE: this is not _necessarily_ the same as the `Content-Type` header of the request or response, but\nit will be for file bodies. It may be different if the file is serialized as a JSON object. It always refers to the\n_contents_ of the file, and not necessarily the way the file itself is transmitted or serialized.",
                 "summary": "The allowed media (MIME) types of the file contents.",
                 "apiVersions": [],
                 "type": {
-                  "$id": "553",
+                  "$id": "555",
                   "kind": "string",
                   "decorators": [],
                   "doc": "A sequence of textual characters.",
@@ -7127,7 +7144,7 @@
           "isExactName": false
         },
         {
-          "$id": "554",
+          "$id": "556",
           "kind": "property",
           "name": "extensibleEnumPart",
           "serializedName": "extensibleEnumPart",
@@ -7155,7 +7172,7 @@
           "isExactName": false
         },
         {
-          "$id": "555",
+          "$id": "557",
           "kind": "property",
           "name": "fixedEnumPart",
           "serializedName": "fixedEnumPart",
@@ -7183,7 +7200,7 @@
           "isExactName": false
         },
         {
-          "$id": "556",
+          "$id": "558",
           "kind": "property",
           "name": "intExtensibleEnumPart",
           "serializedName": "intExtensibleEnumPart",
@@ -7211,7 +7228,7 @@
           "isExactName": false
         },
         {
-          "$id": "557",
+          "$id": "559",
           "kind": "property",
           "name": "intFixedEnumPart",
           "serializedName": "intFixedEnumPart",
@@ -7241,7 +7258,7 @@
       ]
     },
     {
-      "$id": "558",
+      "$id": "560",
       "kind": "model",
       "name": "File",
       "namespace": "TypeSpec.Http",
@@ -7255,38 +7272,33 @@
       "isFileType": true,
       "properties": [
         {
-          "$ref": "544"
-        },
-        {
           "$ref": "546"
         },
         {
           "$ref": "548"
+        },
+        {
+          "$ref": "550"
         }
       ]
     },
     {
-      "$id": "559",
+      "$id": "561",
       "kind": "model",
       "name": "StreamingItem",
       "namespace": "SampleTypeSpec",
       "crossLanguageDefinitionId": "SampleTypeSpec.StreamingItem",
       "usage": "Input,Output,Json",
       "decorators": [],
-      "serializationOptions": {
-        "json": {
-          "name": "StreamingItem"
-        }
-      },
+      "serializationOptions": {},
       "isExactName": false,
       "properties": [
         {
-          "$id": "560",
+          "$id": "562",
           "kind": "property",
           "name": "message",
-          "serializedName": "message",
           "type": {
-            "$id": "561",
+            "$id": "563",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7298,18 +7310,14 @@
           "flatten": false,
           "decorators": [],
           "crossLanguageDefinitionId": "SampleTypeSpec.StreamingItem.message",
-          "serializationOptions": {
-            "json": {
-              "name": "message"
-            }
-          },
+          "serializationOptions": {},
           "isHttpMetadata": false,
           "isExactName": false
         }
       ]
     },
     {
-      "$id": "562",
+      "$id": "564",
       "kind": "model",
       "name": "Animal",
       "namespace": "SampleTypeSpec",
@@ -7324,13 +7332,13 @@
       },
       "isExactName": false,
       "discriminatorProperty": {
-        "$id": "563",
+        "$id": "565",
         "kind": "property",
         "name": "kind",
         "serializedName": "kind",
         "doc": "The kind of animal",
         "type": {
-          "$id": "564",
+          "$id": "566",
           "kind": "string",
           "name": "string",
           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7352,16 +7360,16 @@
       },
       "properties": [
         {
-          "$ref": "563"
+          "$ref": "565"
         },
         {
-          "$id": "565",
+          "$id": "567",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "doc": "Name of the animal",
           "type": {
-            "$id": "566",
+            "$id": "568",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7384,7 +7392,7 @@
       ],
       "discriminatedSubtypes": {
         "pet": {
-          "$id": "567",
+          "$id": "569",
           "kind": "model",
           "name": "Pet",
           "namespace": "SampleTypeSpec",
@@ -7400,7 +7408,7 @@
           },
           "isExactName": false,
           "discriminatorProperty": {
-            "$id": "568",
+            "$id": "570",
             "kind": "property",
             "name": "kind",
             "serializedName": "kind",
@@ -7422,20 +7430,20 @@
             "isExactName": false
           },
           "baseModel": {
-            "$ref": "562"
+            "$ref": "564"
           },
           "properties": [
             {
-              "$ref": "568"
+              "$ref": "570"
             },
             {
-              "$id": "569",
+              "$id": "571",
               "kind": "property",
               "name": "trained",
               "serializedName": "trained",
               "doc": "Whether the pet is trained",
               "type": {
-                "$id": "570",
+                "$id": "572",
                 "kind": "boolean",
                 "name": "boolean",
                 "crossLanguageDefinitionId": "TypeSpec.boolean",
@@ -7458,7 +7466,7 @@
           ],
           "discriminatedSubtypes": {
             "dog": {
-              "$id": "571",
+              "$id": "573",
               "kind": "model",
               "name": "Dog",
               "namespace": "SampleTypeSpec",
@@ -7474,11 +7482,11 @@
               },
               "isExactName": false,
               "baseModel": {
-                "$ref": "567"
+                "$ref": "569"
               },
               "properties": [
                 {
-                  "$id": "572",
+                  "$id": "574",
                   "kind": "property",
                   "name": "kind",
                   "serializedName": "kind",
@@ -7500,13 +7508,13 @@
                   "isExactName": false
                 },
                 {
-                  "$id": "573",
+                  "$id": "575",
                   "kind": "property",
                   "name": "breed",
                   "serializedName": "breed",
                   "doc": "The breed of the dog",
                   "type": {
-                    "$id": "574",
+                    "$id": "576",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7531,18 +7539,18 @@
           }
         },
         "dog": {
-          "$ref": "571"
+          "$ref": "573"
         }
       }
     },
     {
-      "$ref": "567"
+      "$ref": "569"
     },
     {
-      "$ref": "571"
+      "$ref": "573"
     },
     {
-      "$id": "575",
+      "$id": "577",
       "kind": "model",
       "name": "Tree",
       "namespace": "SampleTypeSpec",
@@ -7563,7 +7571,7 @@
       },
       "isExactName": false,
       "baseModel": {
-        "$id": "576",
+        "$id": "578",
         "kind": "model",
         "name": "Plant",
         "namespace": "SampleTypeSpec",
@@ -7583,13 +7591,13 @@
         },
         "isExactName": false,
         "discriminatorProperty": {
-          "$id": "577",
+          "$id": "579",
           "kind": "property",
           "name": "species",
           "serializedName": "species",
           "doc": "The species of plant",
           "type": {
-            "$id": "578",
+            "$id": "580",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7616,16 +7624,16 @@
         },
         "properties": [
           {
-            "$ref": "577"
+            "$ref": "579"
           },
           {
-            "$id": "579",
+            "$id": "581",
             "kind": "property",
             "name": "id",
             "serializedName": "id",
             "doc": "The unique identifier of the plant",
             "type": {
-              "$id": "580",
+              "$id": "582",
               "kind": "string",
               "name": "string",
               "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7651,13 +7659,13 @@
             "isExactName": false
           },
           {
-            "$id": "581",
+            "$id": "583",
             "kind": "property",
             "name": "height",
             "serializedName": "height",
             "doc": "The height of the plant in centimeters",
             "type": {
-              "$id": "582",
+              "$id": "584",
               "kind": "int32",
               "name": "int32",
               "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -7685,13 +7693,13 @@
         ],
         "discriminatedSubtypes": {
           "tree": {
-            "$ref": "575"
+            "$ref": "577"
           }
         }
       },
       "properties": [
         {
-          "$id": "583",
+          "$id": "585",
           "kind": "property",
           "name": "species",
           "serializedName": "species",
@@ -7718,13 +7726,13 @@
           "isExactName": false
         },
         {
-          "$id": "584",
+          "$id": "586",
           "kind": "property",
           "name": "age",
           "serializedName": "age",
           "doc": "The age of the tree in years",
           "type": {
-            "$id": "585",
+            "$id": "587",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -7752,10 +7760,10 @@
       ]
     },
     {
-      "$ref": "576"
+      "$ref": "578"
     },
     {
-      "$id": "586",
+      "$id": "588",
       "kind": "model",
       "name": "GetWidgetMetricsResponse",
       "namespace": "SampleTypeSpec",
@@ -7770,12 +7778,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "587",
+          "$id": "589",
           "kind": "property",
           "name": "numSold",
           "serializedName": "numSold",
           "type": {
-            "$id": "588",
+            "$id": "590",
             "kind": "int32",
             "name": "int32",
             "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -7796,12 +7804,12 @@
           "isExactName": false
         },
         {
-          "$id": "589",
+          "$id": "591",
           "kind": "property",
           "name": "averagePrice",
           "serializedName": "averagePrice",
           "type": {
-            "$id": "590",
+            "$id": "592",
             "kind": "float32",
             "name": "float32",
             "crossLanguageDefinitionId": "TypeSpec.float32",
@@ -7824,7 +7832,7 @@
       ]
     },
     {
-      "$id": "591",
+      "$id": "593",
       "kind": "model",
       "name": "GetNotebookResponse",
       "namespace": "SampleTypeSpec",
@@ -7839,12 +7847,12 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "592",
+          "$id": "594",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
           "type": {
-            "$id": "593",
+            "$id": "595",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7865,12 +7873,12 @@
           "isExactName": false
         },
         {
-          "$id": "594",
+          "$id": "596",
           "kind": "property",
           "name": "content",
           "serializedName": "content",
           "type": {
-            "$id": "595",
+            "$id": "597",
             "kind": "string",
             "name": "string",
             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7893,7 +7901,7 @@
       ]
     },
     {
-      "$id": "596",
+      "$id": "598",
       "kind": "model",
       "name": "JsonlStreamStreamingItem",
       "namespace": "TypeSpec.Http.Streams",
@@ -7905,7 +7913,7 @@
       "isExactName": false,
       "properties": [
         {
-          "$id": "597",
+          "$id": "599",
           "kind": "property",
           "name": "contentType",
           "type": {
@@ -7922,11 +7930,11 @@
           "isExactName": false
         },
         {
-          "$id": "598",
+          "$id": "600",
           "kind": "property",
           "name": "body",
           "type": {
-            "$id": "599",
+            "$id": "601",
             "kind": "bytes",
             "name": "bytes",
             "crossLanguageDefinitionId": "",
@@ -7947,7 +7955,7 @@
   ],
   "clients": [
     {
-      "$id": "600",
+      "$id": "602",
       "kind": "client",
       "name": "SampleTypeSpecClient",
       "isExactName": false,
@@ -7955,7 +7963,7 @@
       "doc": "This is a sample typespec project.",
       "methods": [
         {
-          "$id": "601",
+          "$id": "603",
           "kind": "basic",
           "name": "sayHi",
           "isExactName": false,
@@ -7966,7 +7974,7 @@
           ],
           "doc": "Return hi",
           "operation": {
-            "$id": "602",
+            "$id": "604",
             "name": "sayHi",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -7974,12 +7982,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "603",
+                "$id": "605",
                 "kind": "header",
                 "name": "headParameter",
                 "serializedName": "head-parameter",
                 "type": {
-                  "$id": "604",
+                  "$id": "606",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7994,12 +8002,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.sayHi.headParameter",
                 "methodParameterSegments": [
                   {
-                    "$id": "605",
+                    "$id": "607",
                     "kind": "method",
                     "name": "headParameter",
                     "serializedName": "head-parameter",
                     "type": {
-                      "$id": "606",
+                      "$id": "608",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8019,12 +8027,12 @@
                 "isExactName": false
               },
               {
-                "$id": "607",
+                "$id": "609",
                 "kind": "query",
                 "name": "queryParameter",
                 "serializedName": "queryParameter",
                 "type": {
-                  "$id": "608",
+                  "$id": "610",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8039,12 +8047,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "609",
+                    "$id": "611",
                     "kind": "method",
                     "name": "queryParameter",
                     "serializedName": "queryParameter",
                     "type": {
-                      "$id": "610",
+                      "$id": "612",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8064,12 +8072,12 @@
                 "isExactName": false
               },
               {
-                "$id": "611",
+                "$id": "613",
                 "kind": "query",
                 "name": "optionalQuery",
                 "serializedName": "optionalQuery",
                 "type": {
-                  "$id": "612",
+                  "$id": "614",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8084,12 +8092,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "613",
+                    "$id": "615",
                     "kind": "method",
                     "name": "optionalQuery",
                     "serializedName": "optionalQuery",
                     "type": {
-                      "$id": "614",
+                      "$id": "616",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8109,7 +8117,7 @@
                 "isExactName": false
               },
               {
-                "$id": "615",
+                "$id": "617",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8125,7 +8133,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.sayHi.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "616",
+                    "$id": "618",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8152,7 +8160,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8178,21 +8186,21 @@
           },
           "parameters": [
             {
-              "$ref": "605"
+              "$ref": "607"
             },
             {
-              "$ref": "609"
+              "$ref": "611"
             },
             {
-              "$ref": "613"
+              "$ref": "615"
             },
             {
-              "$ref": "616"
+              "$ref": "618"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -8201,7 +8209,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.sayHi"
         },
         {
-          "$id": "617",
+          "$id": "619",
           "kind": "basic",
           "name": "helloAgain",
           "isExactName": false,
@@ -8212,7 +8220,7 @@
           ],
           "doc": "Return hi again",
           "operation": {
-            "$id": "618",
+            "$id": "620",
             "name": "helloAgain",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -8220,12 +8228,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "619",
+                "$id": "621",
                 "kind": "header",
                 "name": "p1",
                 "serializedName": "p1",
                 "type": {
-                  "$id": "620",
+                  "$id": "622",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8240,12 +8248,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloAgain.p1",
                 "methodParameterSegments": [
                   {
-                    "$id": "621",
+                    "$id": "623",
                     "kind": "method",
                     "name": "p1",
                     "serializedName": "p1",
                     "type": {
-                      "$id": "622",
+                      "$id": "624",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8265,7 +8273,7 @@
                 "isExactName": false
               },
               {
-                "$id": "623",
+                "$id": "625",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -8281,7 +8289,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloAgain.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "624",
+                    "$id": "626",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -8302,12 +8310,12 @@
                 "isExactName": false
               },
               {
-                "$id": "625",
+                "$id": "627",
                 "kind": "path",
                 "name": "p2",
                 "serializedName": "p2",
                 "type": {
-                  "$id": "626",
+                  "$id": "628",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8325,12 +8333,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloAgain.p2",
                 "methodParameterSegments": [
                   {
-                    "$id": "627",
+                    "$id": "629",
                     "kind": "method",
                     "name": "p2",
                     "serializedName": "p2",
                     "type": {
-                      "$id": "628",
+                      "$id": "630",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8350,7 +8358,7 @@
                 "isExactName": false
               },
               {
-                "$id": "629",
+                "$id": "631",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8366,7 +8374,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloAgain.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "630",
+                    "$id": "632",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8387,12 +8395,12 @@
                 "isExactName": false
               },
               {
-                "$id": "631",
+                "$id": "633",
                 "kind": "body",
                 "name": "action",
                 "serializedName": "action",
                 "type": {
-                  "$ref": "291"
+                  "$ref": "293"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -8406,12 +8414,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloAgain.action",
                 "methodParameterSegments": [
                   {
-                    "$id": "632",
+                    "$id": "634",
                     "kind": "method",
                     "name": "action",
                     "serializedName": "action",
                     "type": {
-                      "$ref": "291"
+                      "$ref": "293"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -8434,7 +8442,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "291"
+                  "$ref": "293"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8463,24 +8471,24 @@
           },
           "parameters": [
             {
-              "$ref": "621"
+              "$ref": "623"
+            },
+            {
+              "$ref": "634"
+            },
+            {
+              "$ref": "626"
+            },
+            {
+              "$ref": "629"
             },
             {
               "$ref": "632"
-            },
-            {
-              "$ref": "624"
-            },
-            {
-              "$ref": "627"
-            },
-            {
-              "$ref": "630"
             }
           ],
           "response": {
             "type": {
-              "$ref": "291"
+              "$ref": "293"
             }
           },
           "isOverride": false,
@@ -8489,7 +8497,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.helloAgain"
         },
         {
-          "$id": "633",
+          "$id": "635",
           "kind": "basic",
           "name": "noContentType",
           "isExactName": false,
@@ -8500,7 +8508,7 @@
           ],
           "doc": "Return hi again",
           "operation": {
-            "$id": "634",
+            "$id": "636",
             "name": "noContentType",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -8508,12 +8516,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "635",
+                "$id": "637",
                 "kind": "header",
                 "name": "p1",
                 "serializedName": "p1",
                 "type": {
-                  "$id": "636",
+                  "$id": "638",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8528,12 +8536,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.noContentType.p1",
                 "methodParameterSegments": [
                   {
-                    "$id": "637",
+                    "$id": "639",
                     "kind": "method",
                     "name": "info",
                     "serializedName": "info",
                     "type": {
-                      "$ref": "339"
+                      "$ref": "341"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -8546,13 +8554,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "638",
+                    "$id": "640",
                     "kind": "method",
                     "name": "p1",
                     "serializedName": "p1",
                     "doc": "header parameter",
                     "type": {
-                      "$ref": "341"
+                      "$ref": "343"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -8568,12 +8576,12 @@
                 "isExactName": false
               },
               {
-                "$id": "639",
+                "$id": "641",
                 "kind": "path",
                 "name": "p2",
                 "serializedName": "p2",
                 "type": {
-                  "$id": "640",
+                  "$id": "642",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8591,16 +8599,16 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.noContentType.p2",
                 "methodParameterSegments": [
                   {
-                    "$ref": "637"
+                    "$ref": "639"
                   },
                   {
-                    "$id": "641",
+                    "$id": "643",
                     "kind": "method",
                     "name": "p2",
                     "serializedName": "p2",
                     "doc": "path parameter",
                     "type": {
-                      "$ref": "344"
+                      "$ref": "346"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -8616,7 +8624,7 @@
                 "isExactName": false
               },
               {
-                "$id": "642",
+                "$id": "644",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -8633,7 +8641,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.noContentType.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "643",
+                    "$id": "645",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -8655,7 +8663,7 @@
                 "isExactName": false
               },
               {
-                "$id": "644",
+                "$id": "646",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8671,7 +8679,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.noContentType.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "645",
+                    "$id": "647",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8692,12 +8700,12 @@
                 "isExactName": false
               },
               {
-                "$id": "646",
+                "$id": "648",
                 "kind": "body",
                 "name": "action",
                 "serializedName": "action",
                 "type": {
-                  "$ref": "291"
+                  "$ref": "293"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -8711,16 +8719,16 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.noContentType.action",
                 "methodParameterSegments": [
                   {
-                    "$ref": "637"
+                    "$ref": "639"
                   },
                   {
-                    "$id": "647",
+                    "$id": "649",
                     "kind": "method",
                     "name": "action",
                     "serializedName": "action",
                     "doc": "body parameter",
                     "type": {
-                      "$ref": "291"
+                      "$ref": "293"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -8747,7 +8755,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "291"
+                  "$ref": "293"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8776,18 +8784,18 @@
           },
           "parameters": [
             {
-              "$ref": "637"
-            },
-            {
-              "$ref": "643"
+              "$ref": "639"
             },
             {
               "$ref": "645"
+            },
+            {
+              "$ref": "647"
             }
           ],
           "response": {
             "type": {
-              "$ref": "291"
+              "$ref": "293"
             }
           },
           "isOverride": true,
@@ -8796,7 +8804,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.noContentType"
         },
         {
-          "$id": "648",
+          "$id": "650",
           "kind": "basic",
           "name": "helloDemo2",
           "isExactName": false,
@@ -8807,7 +8815,7 @@
           ],
           "doc": "Return hi in demo2",
           "operation": {
-            "$id": "649",
+            "$id": "651",
             "name": "helloDemo2",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -8815,7 +8823,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "650",
+                "$id": "652",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8831,7 +8839,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloDemo2.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "651",
+                    "$id": "653",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8858,7 +8866,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -8884,12 +8892,12 @@
           },
           "parameters": [
             {
-              "$ref": "651"
+              "$ref": "653"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -8898,7 +8906,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.helloDemo2"
         },
         {
-          "$id": "652",
+          "$id": "654",
           "kind": "basic",
           "name": "createLiteral",
           "isExactName": false,
@@ -8909,7 +8917,7 @@
           ],
           "doc": "Create with literal value",
           "operation": {
-            "$id": "653",
+            "$id": "655",
             "name": "createLiteral",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -8917,7 +8925,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "654",
+                "$id": "656",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -8934,7 +8942,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.createLiteral.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "655",
+                    "$id": "657",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -8956,7 +8964,7 @@
                 "isExactName": false
               },
               {
-                "$id": "656",
+                "$id": "658",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -8972,7 +8980,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.createLiteral.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "657",
+                    "$id": "659",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8993,12 +9001,12 @@
                 "isExactName": false
               },
               {
-                "$id": "658",
+                "$id": "660",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -9012,12 +9020,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.createLiteral.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "659",
+                    "$id": "661",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "256"
+                      "$ref": "258"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -9044,7 +9052,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9073,18 +9081,18 @@
           },
           "parameters": [
             {
-              "$ref": "659"
-            },
-            {
-              "$ref": "655"
+              "$ref": "661"
             },
             {
               "$ref": "657"
+            },
+            {
+              "$ref": "659"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -9093,7 +9101,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.createLiteral"
         },
         {
-          "$id": "660",
+          "$id": "662",
           "kind": "basic",
           "name": "helloLiteral",
           "isExactName": false,
@@ -9104,7 +9112,7 @@
           ],
           "doc": "Send literal parameters",
           "operation": {
-            "$id": "661",
+            "$id": "663",
             "name": "helloLiteral",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -9112,7 +9120,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "662",
+                "$id": "664",
                 "kind": "header",
                 "name": "p1",
                 "serializedName": "p1",
@@ -9128,7 +9136,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloLiteral.p1",
                 "methodParameterSegments": [
                   {
-                    "$id": "663",
+                    "$id": "665",
                     "kind": "method",
                     "name": "p1",
                     "serializedName": "p1",
@@ -9149,7 +9157,7 @@
                 "isExactName": false
               },
               {
-                "$id": "664",
+                "$id": "666",
                 "kind": "path",
                 "name": "p2",
                 "serializedName": "p2",
@@ -9168,7 +9176,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloLiteral.p2",
                 "methodParameterSegments": [
                   {
-                    "$id": "665",
+                    "$id": "667",
                     "kind": "method",
                     "name": "p2",
                     "serializedName": "p2",
@@ -9189,7 +9197,7 @@
                 "isExactName": false
               },
               {
-                "$id": "666",
+                "$id": "668",
                 "kind": "query",
                 "name": "p3",
                 "serializedName": "p3",
@@ -9205,7 +9213,7 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "667",
+                    "$id": "669",
                     "kind": "method",
                     "name": "p3",
                     "serializedName": "p3",
@@ -9226,7 +9234,7 @@
                 "isExactName": false
               },
               {
-                "$id": "668",
+                "$id": "670",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9242,7 +9250,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.helloLiteral.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "669",
+                    "$id": "671",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9269,7 +9277,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9295,9 +9303,6 @@
           },
           "parameters": [
             {
-              "$ref": "663"
-            },
-            {
               "$ref": "665"
             },
             {
@@ -9305,11 +9310,14 @@
             },
             {
               "$ref": "669"
+            },
+            {
+              "$ref": "671"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -9318,7 +9326,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.helloLiteral"
         },
         {
-          "$id": "670",
+          "$id": "672",
           "kind": "basic",
           "name": "topAction",
           "isExactName": false,
@@ -9329,7 +9337,7 @@
           ],
           "doc": "top level method",
           "operation": {
-            "$id": "671",
+            "$id": "673",
             "name": "topAction",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -9337,17 +9345,17 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "672",
+                "$id": "674",
                 "kind": "path",
                 "name": "action",
                 "serializedName": "action",
                 "type": {
-                  "$id": "673",
+                  "$id": "675",
                   "kind": "utcDateTime",
                   "name": "utcDateTime",
                   "encode": "rfc3339",
                   "wireType": {
-                    "$id": "674",
+                    "$id": "676",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9368,17 +9376,17 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.topAction.action",
                 "methodParameterSegments": [
                   {
-                    "$id": "675",
+                    "$id": "677",
                     "kind": "method",
                     "name": "action",
                     "serializedName": "action",
                     "type": {
-                      "$id": "676",
+                      "$id": "678",
                       "kind": "utcDateTime",
                       "name": "utcDateTime",
                       "encode": "rfc3339",
                       "wireType": {
-                        "$id": "677",
+                        "$id": "679",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9401,7 +9409,7 @@
                 "isExactName": false
               },
               {
-                "$id": "678",
+                "$id": "680",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9417,7 +9425,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.topAction.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "679",
+                    "$id": "681",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9444,7 +9452,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9470,15 +9478,15 @@
           },
           "parameters": [
             {
-              "$ref": "675"
+              "$ref": "677"
             },
             {
-              "$ref": "679"
+              "$ref": "681"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -9487,7 +9495,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.topAction"
         },
         {
-          "$id": "680",
+          "$id": "682",
           "kind": "basic",
           "name": "topAction2",
           "isExactName": false,
@@ -9498,7 +9506,7 @@
           ],
           "doc": "top level method2",
           "operation": {
-            "$id": "681",
+            "$id": "683",
             "name": "topAction2",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -9506,7 +9514,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "682",
+                "$id": "684",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9522,7 +9530,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.topAction2.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "683",
+                    "$id": "685",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9549,7 +9557,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9575,12 +9583,12 @@
           },
           "parameters": [
             {
-              "$ref": "683"
+              "$ref": "685"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -9589,7 +9597,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.topAction2"
         },
         {
-          "$id": "684",
+          "$id": "686",
           "kind": "basic",
           "name": "patchAction",
           "isExactName": false,
@@ -9600,7 +9608,7 @@
           ],
           "doc": "top level patch",
           "operation": {
-            "$id": "685",
+            "$id": "687",
             "name": "patchAction",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -9608,7 +9616,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "686",
+                "$id": "688",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -9625,7 +9633,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.patchAction.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "687",
+                    "$id": "689",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -9647,7 +9655,7 @@
                 "isExactName": false
               },
               {
-                "$id": "688",
+                "$id": "690",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9663,7 +9671,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.patchAction.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "689",
+                    "$id": "691",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9684,12 +9692,12 @@
                 "isExactName": false
               },
               {
-                "$id": "690",
+                "$id": "692",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -9703,12 +9711,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.patchAction.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "691",
+                    "$id": "693",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "256"
+                      "$ref": "258"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -9735,7 +9743,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -9764,18 +9772,18 @@
           },
           "parameters": [
             {
-              "$ref": "691"
-            },
-            {
-              "$ref": "687"
+              "$ref": "693"
             },
             {
               "$ref": "689"
+            },
+            {
+              "$ref": "691"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -9784,7 +9792,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.patchAction"
         },
         {
-          "$id": "692",
+          "$id": "694",
           "kind": "basic",
           "name": "anonymousBody",
           "isExactName": false,
@@ -9795,7 +9803,7 @@
           ],
           "doc": "body parameter without body decorator",
           "operation": {
-            "$id": "693",
+            "$id": "695",
             "name": "anonymousBody",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -9803,7 +9811,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "694",
+                "$id": "696",
                 "kind": "query",
                 "name": "requiredQueryParam",
                 "serializedName": "requiredQueryParam",
@@ -9819,7 +9827,7 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "695",
+                    "$id": "697",
                     "kind": "method",
                     "name": "requiredQueryParam",
                     "serializedName": "requiredQueryParam",
@@ -9840,7 +9848,7 @@
                 "isExactName": false
               },
               {
-                "$id": "696",
+                "$id": "698",
                 "kind": "header",
                 "name": "requiredHeader",
                 "serializedName": "required-header",
@@ -9856,7 +9864,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.anonymousBody.requiredHeader",
                 "methodParameterSegments": [
                   {
-                    "$id": "697",
+                    "$id": "699",
                     "kind": "method",
                     "name": "requiredHeader",
                     "serializedName": "required-header",
@@ -9877,7 +9885,7 @@
                 "isExactName": false
               },
               {
-                "$id": "698",
+                "$id": "700",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -9894,7 +9902,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.anonymousBody.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "699",
+                    "$id": "701",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -9916,7 +9924,7 @@
                 "isExactName": false
               },
               {
-                "$id": "700",
+                "$id": "702",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -9932,7 +9940,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.anonymousBody.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "701",
+                    "$id": "703",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9953,12 +9961,12 @@
                 "isExactName": false
               },
               {
-                "$id": "702",
+                "$id": "704",
                 "kind": "body",
                 "name": "thing",
                 "serializedName": "thing",
                 "type": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -9972,13 +9980,13 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.anonymousBody.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "703",
+                    "$id": "705",
                     "kind": "method",
                     "name": "name",
                     "serializedName": "name",
                     "doc": "name of the Thing",
                     "type": {
-                      "$id": "704",
+                      "$id": "706",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10009,7 +10017,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -10038,16 +10046,16 @@
           },
           "parameters": [
             {
-              "$ref": "703"
+              "$ref": "705"
             },
             {
-              "$id": "705",
+              "$id": "707",
               "kind": "method",
               "name": "requiredUnion",
               "serializedName": "requiredUnion",
               "doc": "required Union",
               "type": {
-                "$ref": "260"
+                "$ref": "262"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -10060,7 +10068,7 @@
               "isExactName": false
             },
             {
-              "$id": "706",
+              "$id": "708",
               "kind": "method",
               "name": "requiredLiteralString",
               "serializedName": "requiredLiteralString",
@@ -10079,13 +10087,13 @@
               "isExactName": false
             },
             {
-              "$id": "707",
+              "$id": "709",
               "kind": "method",
               "name": "requiredNullableString",
               "serializedName": "requiredNullableString",
               "doc": "required nullable string",
               "type": {
-                "$ref": "267"
+                "$ref": "269"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -10098,13 +10106,13 @@
               "isExactName": false
             },
             {
-              "$id": "708",
+              "$id": "710",
               "kind": "method",
               "name": "optionalNullableString",
               "serializedName": "optionalNullableString",
               "doc": "required optional string",
               "type": {
-                "$ref": "270"
+                "$ref": "272"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -10117,7 +10125,7 @@
               "isExactName": false
             },
             {
-              "$id": "709",
+              "$id": "711",
               "kind": "method",
               "name": "requiredLiteralInt",
               "serializedName": "requiredLiteralInt",
@@ -10136,7 +10144,7 @@
               "isExactName": false
             },
             {
-              "$id": "710",
+              "$id": "712",
               "kind": "method",
               "name": "requiredLiteralFloat",
               "serializedName": "requiredLiteralFloat",
@@ -10155,7 +10163,7 @@
               "isExactName": false
             },
             {
-              "$id": "711",
+              "$id": "713",
               "kind": "method",
               "name": "requiredLiteralBool",
               "serializedName": "requiredLiteralBool",
@@ -10174,18 +10182,18 @@
               "isExactName": false
             },
             {
-              "$id": "712",
+              "$id": "714",
               "kind": "method",
               "name": "optionalLiteralString",
               "serializedName": "optionalLiteralString",
               "doc": "optional literal string",
               "type": {
-                "$id": "713",
+                "$id": "715",
                 "kind": "enum",
                 "name": "ThingOptionalLiteralString",
                 "crossLanguageDefinitionId": "",
                 "valueType": {
-                  "$id": "714",
+                  "$id": "716",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10193,12 +10201,12 @@
                 },
                 "values": [
                   {
-                    "$id": "715",
+                    "$id": "717",
                     "kind": "enumvalue",
                     "name": "reject",
                     "value": "reject",
                     "valueType": {
-                      "$id": "716",
+                      "$id": "718",
                       "kind": "string",
                       "decorators": [],
                       "doc": "A sequence of textual characters.",
@@ -10206,7 +10214,7 @@
                       "crossLanguageDefinitionId": "TypeSpec.string"
                     },
                     "enumType": {
-                      "$ref": "713"
+                      "$ref": "715"
                     },
                     "decorators": [],
                     "isExactName": false
@@ -10230,13 +10238,13 @@
               "isExactName": false
             },
             {
-              "$id": "717",
+              "$id": "719",
               "kind": "method",
               "name": "requiredNullableLiteralString",
               "serializedName": "requiredNullableLiteralString",
               "doc": "required nullable literal string",
               "type": {
-                "$ref": "277"
+                "$ref": "279"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -10249,18 +10257,18 @@
               "isExactName": false
             },
             {
-              "$id": "718",
+              "$id": "720",
               "kind": "method",
               "name": "optionalLiteralInt",
               "serializedName": "optionalLiteralInt",
               "doc": "optional literal int",
               "type": {
-                "$id": "719",
+                "$id": "721",
                 "kind": "enum",
                 "name": "ThingOptionalLiteralInt",
                 "crossLanguageDefinitionId": "",
                 "valueType": {
-                  "$id": "720",
+                  "$id": "722",
                   "kind": "int32",
                   "name": "int32",
                   "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -10268,12 +10276,12 @@
                 },
                 "values": [
                   {
-                    "$id": "721",
+                    "$id": "723",
                     "kind": "enumvalue",
                     "name": "456",
                     "value": 456,
                     "valueType": {
-                      "$id": "722",
+                      "$id": "724",
                       "kind": "int32",
                       "decorators": [],
                       "doc": "A 32-bit integer. (`-2,147,483,648` to `2,147,483,647`)",
@@ -10281,7 +10289,7 @@
                       "crossLanguageDefinitionId": "TypeSpec.int32"
                     },
                     "enumType": {
-                      "$ref": "719"
+                      "$ref": "721"
                     },
                     "decorators": [],
                     "isExactName": false
@@ -10305,18 +10313,18 @@
               "isExactName": false
             },
             {
-              "$id": "723",
+              "$id": "725",
               "kind": "method",
               "name": "optionalLiteralFloat",
               "serializedName": "optionalLiteralFloat",
               "doc": "optional literal float",
               "type": {
-                "$id": "724",
+                "$id": "726",
                 "kind": "enum",
                 "name": "ThingOptionalLiteralFloat",
                 "crossLanguageDefinitionId": "",
                 "valueType": {
-                  "$id": "725",
+                  "$id": "727",
                   "kind": "float32",
                   "name": "float32",
                   "crossLanguageDefinitionId": "TypeSpec.float32",
@@ -10324,12 +10332,12 @@
                 },
                 "values": [
                   {
-                    "$id": "726",
+                    "$id": "728",
                     "kind": "enumvalue",
                     "name": "4.56",
                     "value": 4.56,
                     "valueType": {
-                      "$id": "727",
+                      "$id": "729",
                       "kind": "float32",
                       "decorators": [],
                       "doc": "A 32 bit floating point number. (`±1.5 x 10^−45` to `±3.4 x 10^38`)",
@@ -10337,7 +10345,7 @@
                       "crossLanguageDefinitionId": "TypeSpec.float32"
                     },
                     "enumType": {
-                      "$ref": "724"
+                      "$ref": "726"
                     },
                     "decorators": [],
                     "isExactName": false
@@ -10361,7 +10369,7 @@
               "isExactName": false
             },
             {
-              "$id": "728",
+              "$id": "730",
               "kind": "method",
               "name": "optionalLiteralBool",
               "serializedName": "optionalLiteralBool",
@@ -10380,13 +10388,13 @@
               "isExactName": false
             },
             {
-              "$id": "729",
+              "$id": "731",
               "kind": "method",
               "name": "requiredBadDescription",
               "serializedName": "requiredBadDescription",
               "doc": "description with xml <|endoftext|>",
               "type": {
-                "$id": "730",
+                "$id": "732",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10403,13 +10411,13 @@
               "isExactName": false
             },
             {
-              "$id": "731",
+              "$id": "733",
               "kind": "method",
               "name": "optionalNullableList",
               "serializedName": "optionalNullableList",
               "doc": "optional nullable collection",
               "type": {
-                "$ref": "284"
+                "$ref": "286"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -10422,13 +10430,13 @@
               "isExactName": false
             },
             {
-              "$id": "732",
+              "$id": "734",
               "kind": "method",
               "name": "requiredNullableList",
               "serializedName": "requiredNullableList",
               "doc": "required nullable collection",
               "type": {
-                "$ref": "288"
+                "$ref": "290"
               },
               "location": "Body",
               "isApiVersion": false,
@@ -10441,13 +10449,13 @@
               "isExactName": false
             },
             {
-              "$id": "733",
+              "$id": "735",
               "kind": "method",
               "name": "propertyWithSpecialDocs",
               "serializedName": "propertyWithSpecialDocs",
               "doc": "This tests:\n- Simple bullet point. This bullet point is going to be very long to test how text wrapping is handled in bullet points within documentation comments. It should properly indent the wrapped lines.\n- Another bullet point with **bold text**. This bullet point is also intentionally long to see how the formatting is preserved when the text wraps onto multiple lines in the generated documentation.\n- Third bullet point with *italic text*. Similar to the previous points, this one is extended to ensure that the wrapping and formatting are correctly applied in the output.\n- Complex bullet point with **bold** and *italic* combined. This bullet point combines both bold and italic formatting and is long enough to test the wrapping behavior in such cases.\n- **Bold bullet point**: A bullet point that is entirely bolded. This point is also made lengthy to observe how the bold formatting is maintained across wrapped lines.\n- *Italic bullet point*: A bullet point that is entirely italicized. This final point is extended to verify that italic formatting is correctly applied even when the text spans multiple lines.",
               "type": {
-                "$id": "734",
+                "$id": "736",
                 "kind": "string",
                 "name": "string",
                 "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10464,9 +10472,6 @@
               "isExactName": false
             },
             {
-              "$ref": "695"
-            },
-            {
               "$ref": "697"
             },
             {
@@ -10474,11 +10479,14 @@
             },
             {
               "$ref": "701"
+            },
+            {
+              "$ref": "703"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -10487,7 +10495,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.anonymousBody"
         },
         {
-          "$id": "735",
+          "$id": "737",
           "kind": "basic",
           "name": "friendlyModel",
           "isExactName": false,
@@ -10498,7 +10506,7 @@
           ],
           "doc": "Model can have its friendly name",
           "operation": {
-            "$id": "736",
+            "$id": "738",
             "name": "friendlyModel",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -10506,7 +10514,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "737",
+                "$id": "739",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -10523,7 +10531,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.friendlyModel.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "738",
+                    "$id": "740",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -10545,7 +10553,7 @@
                 "isExactName": false
               },
               {
-                "$id": "739",
+                "$id": "741",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -10561,7 +10569,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.friendlyModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "740",
+                    "$id": "742",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10582,12 +10590,12 @@
                 "isExactName": false
               },
               {
-                "$id": "741",
+                "$id": "743",
                 "kind": "body",
                 "name": "friend",
                 "serializedName": "friend",
                 "type": {
-                  "$ref": "345"
+                  "$ref": "347"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -10601,13 +10609,13 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.friendlyModel.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "742",
+                    "$id": "744",
                     "kind": "method",
                     "name": "name",
                     "serializedName": "name",
                     "doc": "name of the NotFriend",
                     "type": {
-                      "$id": "743",
+                      "$id": "745",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10638,7 +10646,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "345"
+                  "$ref": "347"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -10667,18 +10675,18 @@
           },
           "parameters": [
             {
-              "$ref": "742"
-            },
-            {
-              "$ref": "738"
+              "$ref": "744"
             },
             {
               "$ref": "740"
+            },
+            {
+              "$ref": "742"
             }
           ],
           "response": {
             "type": {
-              "$ref": "345"
+              "$ref": "347"
             }
           },
           "isOverride": false,
@@ -10687,7 +10695,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.friendlyModel"
         },
         {
-          "$id": "744",
+          "$id": "746",
           "kind": "basic",
           "name": "addTimeHeader",
           "isExactName": false,
@@ -10697,24 +10705,24 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "745",
+            "$id": "747",
             "name": "addTimeHeader",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "746",
+                "$id": "748",
                 "kind": "header",
                 "name": "repeatabilityFirstSent",
                 "serializedName": "Repeatability-First-Sent",
                 "type": {
-                  "$id": "747",
+                  "$id": "749",
                   "kind": "utcDateTime",
                   "name": "utcDateTime",
                   "encode": "rfc7231",
                   "wireType": {
-                    "$id": "748",
+                    "$id": "750",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10732,17 +10740,17 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.addTimeHeader.repeatabilityFirstSent",
                 "methodParameterSegments": [
                   {
-                    "$id": "749",
+                    "$id": "751",
                     "kind": "method",
                     "name": "repeatabilityFirstSent",
                     "serializedName": "Repeatability-First-Sent",
                     "type": {
-                      "$id": "750",
+                      "$id": "752",
                       "kind": "utcDateTime",
                       "name": "utcDateTime",
                       "encode": "rfc7231",
                       "wireType": {
-                        "$id": "751",
+                        "$id": "753",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10787,7 +10795,7 @@
           },
           "parameters": [
             {
-              "$ref": "749"
+              "$ref": "751"
             }
           ],
           "response": {},
@@ -10797,7 +10805,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.addTimeHeader"
         },
         {
-          "$id": "752",
+          "$id": "754",
           "kind": "basic",
           "name": "projectedNameModel",
           "isExactName": false,
@@ -10808,7 +10816,7 @@
           ],
           "doc": "Model can have its projected name",
           "operation": {
-            "$id": "753",
+            "$id": "755",
             "name": "projectedNameModel",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -10816,7 +10824,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "754",
+                "$id": "756",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -10833,7 +10841,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.projectedNameModel.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "755",
+                    "$id": "757",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -10855,7 +10863,7 @@
                 "isExactName": false
               },
               {
-                "$id": "756",
+                "$id": "758",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -10871,7 +10879,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.projectedNameModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "757",
+                    "$id": "759",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -10892,12 +10900,12 @@
                 "isExactName": false
               },
               {
-                "$id": "758",
+                "$id": "760",
                 "kind": "body",
                 "name": "renamedModel",
                 "serializedName": "renamedModel",
                 "type": {
-                  "$ref": "348"
+                  "$ref": "350"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -10911,13 +10919,13 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.projectedNameModel.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "759",
+                    "$id": "761",
                     "kind": "method",
                     "name": "otherName",
                     "serializedName": "otherName",
                     "doc": "name of the ModelWithClientName",
                     "type": {
-                      "$id": "760",
+                      "$id": "762",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -10948,7 +10956,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "348"
+                  "$ref": "350"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -10977,18 +10985,18 @@
           },
           "parameters": [
             {
-              "$ref": "759"
-            },
-            {
-              "$ref": "755"
+              "$ref": "761"
             },
             {
               "$ref": "757"
+            },
+            {
+              "$ref": "759"
             }
           ],
           "response": {
             "type": {
-              "$ref": "348"
+              "$ref": "350"
             }
           },
           "isOverride": false,
@@ -10997,7 +11005,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.projectedNameModel"
         },
         {
-          "$id": "761",
+          "$id": "763",
           "kind": "basic",
           "name": "returnsAnonymousModel",
           "isExactName": false,
@@ -11008,7 +11016,7 @@
           ],
           "doc": "return anonymous model",
           "operation": {
-            "$id": "762",
+            "$id": "764",
             "name": "returnsAnonymousModel",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11016,7 +11024,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "763",
+                "$id": "765",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11032,7 +11040,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.returnsAnonymousModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "764",
+                    "$id": "766",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11059,7 +11067,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "351"
+                  "$ref": "353"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -11085,12 +11093,12 @@
           },
           "parameters": [
             {
-              "$ref": "764"
+              "$ref": "766"
             }
           ],
           "response": {
             "type": {
-              "$ref": "351"
+              "$ref": "353"
             }
           },
           "isOverride": false,
@@ -11099,7 +11107,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.returnsAnonymousModel"
         },
         {
-          "$id": "765",
+          "$id": "767",
           "kind": "basic",
           "name": "getUnknownValue",
           "isExactName": false,
@@ -11110,7 +11118,7 @@
           ],
           "doc": "get extensible enum",
           "operation": {
-            "$id": "766",
+            "$id": "768",
             "name": "getUnknownValue",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11118,7 +11126,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "767",
+                "$id": "769",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11134,7 +11142,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.getUnknownValue.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "768",
+                    "$id": "770",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11183,7 +11191,7 @@
           },
           "parameters": [
             {
-              "$ref": "768"
+              "$ref": "770"
             }
           ],
           "response": {
@@ -11197,7 +11205,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.getUnknownValue"
         },
         {
-          "$id": "769",
+          "$id": "771",
           "kind": "basic",
           "name": "internalProtocol",
           "isExactName": false,
@@ -11208,7 +11216,7 @@
           ],
           "doc": "When set protocol false and convenient true, then the protocol method should be internal",
           "operation": {
-            "$id": "770",
+            "$id": "772",
             "name": "internalProtocol",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11216,7 +11224,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "771",
+                "$id": "773",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -11233,7 +11241,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.internalProtocol.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "772",
+                    "$id": "774",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -11255,7 +11263,7 @@
                 "isExactName": false
               },
               {
-                "$id": "773",
+                "$id": "775",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11271,7 +11279,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.internalProtocol.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "774",
+                    "$id": "776",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11292,12 +11300,12 @@
                 "isExactName": false
               },
               {
-                "$id": "775",
+                "$id": "777",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -11311,12 +11319,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.internalProtocol.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "776",
+                    "$id": "778",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "256"
+                      "$ref": "258"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -11343,7 +11351,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "256"
+                  "$ref": "258"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -11372,18 +11380,18 @@
           },
           "parameters": [
             {
-              "$ref": "776"
-            },
-            {
-              "$ref": "772"
+              "$ref": "778"
             },
             {
               "$ref": "774"
+            },
+            {
+              "$ref": "776"
             }
           ],
           "response": {
             "type": {
-              "$ref": "256"
+              "$ref": "258"
             }
           },
           "isOverride": false,
@@ -11392,7 +11400,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.internalProtocol"
         },
         {
-          "$id": "777",
+          "$id": "779",
           "kind": "basic",
           "name": "stillConvenient",
           "isExactName": false,
@@ -11403,7 +11411,7 @@
           ],
           "doc": "When set protocol false and convenient true, the convenient method should be generated even it has the same signature as protocol one",
           "operation": {
-            "$id": "778",
+            "$id": "780",
             "name": "stillConvenient",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11438,7 +11446,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.stillConvenient"
         },
         {
-          "$id": "779",
+          "$id": "781",
           "kind": "basic",
           "name": "headAsBoolean",
           "isExactName": false,
@@ -11449,7 +11457,7 @@
           ],
           "doc": "head as boolean.",
           "operation": {
-            "$id": "780",
+            "$id": "782",
             "name": "headAsBoolean",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11457,12 +11465,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "781",
+                "$id": "783",
                 "kind": "path",
                 "name": "id",
                 "serializedName": "id",
                 "type": {
-                  "$id": "782",
+                  "$id": "784",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11480,12 +11488,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.headAsBoolean.id",
                 "methodParameterSegments": [
                   {
-                    "$id": "783",
+                    "$id": "785",
                     "kind": "method",
                     "name": "id",
                     "serializedName": "id",
                     "type": {
-                      "$id": "784",
+                      "$id": "786",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11527,7 +11535,7 @@
           },
           "parameters": [
             {
-              "$ref": "783"
+              "$ref": "785"
             }
           ],
           "response": {},
@@ -11537,7 +11545,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.headAsBoolean"
         },
         {
-          "$id": "785",
+          "$id": "787",
           "kind": "basic",
           "name": "WithApiVersion",
           "isExactName": false,
@@ -11548,7 +11556,7 @@
           ],
           "doc": "Return hi again",
           "operation": {
-            "$id": "786",
+            "$id": "788",
             "name": "WithApiVersion",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11556,12 +11564,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "787",
+                "$id": "789",
                 "kind": "header",
                 "name": "p1",
                 "serializedName": "p1",
                 "type": {
-                  "$id": "788",
+                  "$id": "790",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11576,12 +11584,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.WithApiVersion.p1",
                 "methodParameterSegments": [
                   {
-                    "$id": "789",
+                    "$id": "791",
                     "kind": "method",
                     "name": "p1",
                     "serializedName": "p1",
                     "type": {
-                      "$id": "790",
+                      "$id": "792",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11601,12 +11609,12 @@
                 "isExactName": false
               },
               {
-                "$id": "791",
+                "$id": "793",
                 "kind": "query",
                 "name": "apiVersion",
                 "serializedName": "apiVersion",
                 "type": {
-                  "$id": "792",
+                  "$id": "794",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11616,7 +11624,7 @@
                 "explode": false,
                 "defaultValue": {
                   "type": {
-                    "$id": "793",
+                    "$id": "795",
                     "kind": "string",
                     "name": "string",
                     "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11630,12 +11638,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "794",
+                    "$id": "796",
                     "kind": "method",
                     "name": "apiVersion",
                     "serializedName": "apiVersion",
                     "type": {
-                      "$id": "795",
+                      "$id": "797",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11645,7 +11653,7 @@
                     "isApiVersion": true,
                     "defaultValue": {
                       "type": {
-                        "$id": "796",
+                        "$id": "798",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -11686,7 +11694,7 @@
           },
           "parameters": [
             {
-              "$ref": "789"
+              "$ref": "791"
             }
           ],
           "response": {},
@@ -11696,7 +11704,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.WithApiVersion"
         },
         {
-          "$id": "797",
+          "$id": "799",
           "kind": "paging",
           "name": "ListWithNextLink",
           "isExactName": false,
@@ -11707,7 +11715,7 @@
           ],
           "doc": "List things with nextlink",
           "operation": {
-            "$id": "798",
+            "$id": "800",
             "name": "ListWithNextLink",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11715,7 +11723,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "799",
+                "$id": "801",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11731,7 +11739,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.ListWithNextLink.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "800",
+                    "$id": "802",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11758,7 +11766,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "352"
+                  "$ref": "354"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -11784,12 +11792,12 @@
           },
           "parameters": [
             {
-              "$ref": "800"
+              "$ref": "802"
             }
           ],
           "response": {
             "type": {
-              "$ref": "354"
+              "$ref": "356"
             },
             "resultSegments": [
               "things"
@@ -11813,7 +11821,7 @@
           }
         },
         {
-          "$id": "801",
+          "$id": "803",
           "kind": "paging",
           "name": "ListWithStringNextLink",
           "isExactName": false,
@@ -11824,7 +11832,7 @@
           ],
           "doc": "List things with nextlink",
           "operation": {
-            "$id": "802",
+            "$id": "804",
             "name": "ListWithStringNextLink",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11832,7 +11840,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "803",
+                "$id": "805",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -11848,7 +11856,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.ListWithStringNextLink.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "804",
+                    "$id": "806",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -11875,7 +11883,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "357"
+                  "$ref": "359"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -11901,12 +11909,12 @@
           },
           "parameters": [
             {
-              "$ref": "804"
+              "$ref": "806"
             }
           ],
           "response": {
             "type": {
-              "$ref": "354"
+              "$ref": "356"
             },
             "resultSegments": [
               "things"
@@ -11930,7 +11938,7 @@
           }
         },
         {
-          "$id": "805",
+          "$id": "807",
           "kind": "paging",
           "name": "ListWithContinuationToken",
           "isExactName": false,
@@ -11941,7 +11949,7 @@
           ],
           "doc": "List things with continuation token",
           "operation": {
-            "$id": "806",
+            "$id": "808",
             "name": "ListWithContinuationToken",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -11949,12 +11957,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "807",
+                "$id": "809",
                 "kind": "query",
                 "name": "token",
                 "serializedName": "token",
                 "type": {
-                  "$id": "808",
+                  "$id": "810",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11969,12 +11977,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "809",
+                    "$id": "811",
                     "kind": "method",
                     "name": "token",
                     "serializedName": "token",
                     "type": {
-                      "$id": "810",
+                      "$id": "812",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -11994,7 +12002,7 @@
                 "isExactName": false
               },
               {
-                "$id": "811",
+                "$id": "813",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12010,7 +12018,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.ListWithContinuationToken.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "812",
+                    "$id": "814",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12037,7 +12045,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "361"
+                  "$ref": "363"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -12063,15 +12071,15 @@
           },
           "parameters": [
             {
-              "$ref": "809"
+              "$ref": "811"
             },
             {
-              "$ref": "812"
+              "$ref": "814"
             }
           ],
           "response": {
             "type": {
-              "$ref": "354"
+              "$ref": "356"
             },
             "resultSegments": [
               "things"
@@ -12087,7 +12095,7 @@
             ],
             "continuationToken": {
               "parameter": {
-                "$ref": "807"
+                "$ref": "809"
               },
               "responseSegments": [
                 "nextToken"
@@ -12098,7 +12106,7 @@
           }
         },
         {
-          "$id": "813",
+          "$id": "815",
           "kind": "paging",
           "name": "ListWithContinuationTokenHeaderResponse",
           "isExactName": false,
@@ -12109,7 +12117,7 @@
           ],
           "doc": "List things with continuation token header response",
           "operation": {
-            "$id": "814",
+            "$id": "816",
             "name": "ListWithContinuationTokenHeaderResponse",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -12117,12 +12125,12 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "815",
+                "$id": "817",
                 "kind": "query",
                 "name": "token",
                 "serializedName": "token",
                 "type": {
-                  "$id": "816",
+                  "$id": "818",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12137,12 +12145,12 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$id": "817",
+                    "$id": "819",
                     "kind": "method",
                     "name": "token",
                     "serializedName": "token",
                     "type": {
-                      "$id": "818",
+                      "$id": "820",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12162,7 +12170,7 @@
                 "isExactName": false
               },
               {
-                "$id": "819",
+                "$id": "821",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12178,7 +12186,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.ListWithContinuationTokenHeaderResponse.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "820",
+                    "$id": "822",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12205,14 +12213,14 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "365"
+                  "$ref": "367"
                 },
                 "headers": [
                   {
                     "name": "nextToken",
                     "nameInResponse": "next-token",
                     "type": {
-                      "$id": "821",
+                      "$id": "823",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12243,15 +12251,15 @@
           },
           "parameters": [
             {
-              "$ref": "817"
+              "$ref": "819"
             },
             {
-              "$ref": "820"
+              "$ref": "822"
             }
           ],
           "response": {
             "type": {
-              "$ref": "354"
+              "$ref": "356"
             },
             "resultSegments": [
               "things"
@@ -12267,7 +12275,7 @@
             ],
             "continuationToken": {
               "parameter": {
-                "$ref": "815"
+                "$ref": "817"
               },
               "responseSegments": [
                 "next-token"
@@ -12278,7 +12286,7 @@
           }
         },
         {
-          "$id": "822",
+          "$id": "824",
           "kind": "paging",
           "name": "ListWithPaging",
           "isExactName": false,
@@ -12289,7 +12297,7 @@
           ],
           "doc": "List things with paging",
           "operation": {
-            "$id": "823",
+            "$id": "825",
             "name": "ListWithPaging",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -12297,7 +12305,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "824",
+                "$id": "826",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12313,7 +12321,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.ListWithPaging.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "825",
+                    "$id": "827",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12340,7 +12348,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "367"
+                  "$ref": "369"
                 },
                 "headers": [],
                 "isErrorResponse": false,
@@ -12366,12 +12374,12 @@
           },
           "parameters": [
             {
-              "$ref": "825"
+              "$ref": "827"
             }
           ],
           "response": {
             "type": {
-              "$ref": "354"
+              "$ref": "356"
             },
             "resultSegments": [
               "items"
@@ -12389,7 +12397,7 @@
           }
         },
         {
-          "$id": "826",
+          "$id": "828",
           "kind": "basic",
           "name": "EmbeddedParameters",
           "isExactName": false,
@@ -12400,7 +12408,7 @@
           ],
           "doc": "An operation with embedded parameters within the body",
           "operation": {
-            "$id": "827",
+            "$id": "829",
             "name": "EmbeddedParameters",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -12408,13 +12416,13 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "828",
+                "$id": "830",
                 "kind": "header",
                 "name": "requiredHeader",
                 "serializedName": "required-header",
                 "doc": "required header parameter",
                 "type": {
-                  "$id": "829",
+                  "$id": "831",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12429,12 +12437,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.ModelWithEmbeddedNonBodyParameters.requiredHeader",
                 "methodParameterSegments": [
                   {
-                    "$id": "830",
+                    "$id": "832",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "369"
+                      "$ref": "371"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -12447,13 +12455,13 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "831",
+                    "$id": "833",
                     "kind": "method",
                     "name": "requiredHeader",
                     "serializedName": "requiredHeader",
                     "doc": "required header parameter",
                     "type": {
-                      "$ref": "373"
+                      "$ref": "375"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -12469,13 +12477,13 @@
                 "isExactName": false
               },
               {
-                "$id": "832",
+                "$id": "834",
                 "kind": "header",
                 "name": "optionalHeader",
                 "serializedName": "optional-header",
                 "doc": "optional header parameter",
                 "type": {
-                  "$id": "833",
+                  "$id": "835",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12490,16 +12498,16 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.ModelWithEmbeddedNonBodyParameters.optionalHeader",
                 "methodParameterSegments": [
                   {
-                    "$ref": "830"
+                    "$ref": "832"
                   },
                   {
-                    "$id": "834",
+                    "$id": "836",
                     "kind": "method",
                     "name": "optionalHeader",
                     "serializedName": "optionalHeader",
                     "doc": "optional header parameter",
                     "type": {
-                      "$ref": "375"
+                      "$ref": "377"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -12515,13 +12523,13 @@
                 "isExactName": false
               },
               {
-                "$id": "835",
+                "$id": "837",
                 "kind": "query",
                 "name": "requiredQuery",
                 "serializedName": "requiredQuery",
                 "doc": "required query parameter",
                 "type": {
-                  "$id": "836",
+                  "$id": "838",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12536,16 +12544,16 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$ref": "830"
+                    "$ref": "832"
                   },
                   {
-                    "$id": "837",
+                    "$id": "839",
                     "kind": "method",
                     "name": "requiredQuery",
                     "serializedName": "requiredQuery",
                     "doc": "required query parameter",
                     "type": {
-                      "$ref": "377"
+                      "$ref": "379"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -12561,13 +12569,13 @@
                 "isExactName": false
               },
               {
-                "$id": "838",
+                "$id": "840",
                 "kind": "query",
                 "name": "optionalQuery",
                 "serializedName": "optionalQuery",
                 "doc": "optional query parameter",
                 "type": {
-                  "$id": "839",
+                  "$id": "841",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string",
@@ -12582,16 +12590,16 @@
                 "readOnly": false,
                 "methodParameterSegments": [
                   {
-                    "$ref": "830"
+                    "$ref": "832"
                   },
                   {
-                    "$id": "840",
+                    "$id": "842",
                     "kind": "method",
                     "name": "optionalQuery",
                     "serializedName": "optionalQuery",
                     "doc": "optional query parameter",
                     "type": {
-                      "$ref": "379"
+                      "$ref": "381"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -12607,7 +12615,7 @@
                 "isExactName": false
               },
               {
-                "$id": "841",
+                "$id": "843",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -12624,7 +12632,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.EmbeddedParameters.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "842",
+                    "$id": "844",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -12646,12 +12654,12 @@
                 "isExactName": false
               },
               {
-                "$id": "843",
+                "$id": "845",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "369"
+                  "$ref": "371"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -12665,7 +12673,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.EmbeddedParameters.body",
                 "methodParameterSegments": [
                   {
-                    "$ref": "830"
+                    "$ref": "832"
                   }
                 ],
                 "isExactName": false,
@@ -12701,10 +12709,10 @@
           },
           "parameters": [
             {
-              "$ref": "830"
+              "$ref": "832"
             },
             {
-              "$ref": "842"
+              "$ref": "844"
             }
           ],
           "response": {},
@@ -12714,7 +12722,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.EmbeddedParameters"
         },
         {
-          "$id": "844",
+          "$id": "846",
           "kind": "basic",
           "name": "DynamicModelOperation",
           "isExactName": false,
@@ -12725,7 +12733,7 @@
           ],
           "doc": "An operation with a dynamic model",
           "operation": {
-            "$id": "845",
+            "$id": "847",
             "name": "DynamicModelOperation",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -12733,7 +12741,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "846",
+                "$id": "848",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -12750,7 +12758,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.DynamicModelOperation.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "847",
+                    "$id": "849",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -12772,12 +12780,12 @@
                 "isExactName": false
               },
               {
-                "$id": "848",
+                "$id": "850",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "380"
+                  "$ref": "382"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -12791,12 +12799,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.DynamicModelOperation.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "849",
+                    "$id": "851",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "380"
+                      "$ref": "382"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -12842,10 +12850,10 @@
           },
           "parameters": [
             {
-              "$ref": "849"
+              "$ref": "851"
             },
             {
-              "$ref": "847"
+              "$ref": "849"
             }
           ],
           "response": {},
@@ -12855,7 +12863,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.DynamicModelOperation"
         },
         {
-          "$id": "850",
+          "$id": "852",
           "kind": "basic",
           "name": "GetXmlAdvancedModel",
           "isExactName": false,
@@ -12866,7 +12874,7 @@
           ],
           "doc": "Get an advanced XML model with various property types",
           "operation": {
-            "$id": "851",
+            "$id": "853",
             "name": "GetXmlAdvancedModel",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -12874,7 +12882,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "852",
+                "$id": "854",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -12890,7 +12898,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.GetXmlAdvancedModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "853",
+                    "$id": "855",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -12917,7 +12925,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "418"
+                  "$ref": "420"
                 },
                 "headers": [
                   {
@@ -12951,12 +12959,12 @@
           },
           "parameters": [
             {
-              "$ref": "853"
+              "$ref": "855"
             }
           ],
           "response": {
             "type": {
-              "$ref": "418"
+              "$ref": "420"
             }
           },
           "isOverride": false,
@@ -12965,7 +12973,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.GetXmlAdvancedModel"
         },
         {
-          "$id": "854",
+          "$id": "856",
           "kind": "basic",
           "name": "UpdateXmlAdvancedModel",
           "isExactName": false,
@@ -12976,7 +12984,7 @@
           ],
           "doc": "Update an advanced XML model with various property types",
           "operation": {
-            "$id": "855",
+            "$id": "857",
             "name": "UpdateXmlAdvancedModel",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
@@ -12984,7 +12992,7 @@
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "856",
+                "$id": "858",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -13000,7 +13008,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.UpdateXmlAdvancedModel.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "857",
+                    "$id": "859",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -13021,7 +13029,7 @@
                 "isExactName": false
               },
               {
-                "$id": "858",
+                "$id": "860",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -13037,7 +13045,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.UpdateXmlAdvancedModel.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "859",
+                    "$id": "861",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -13058,12 +13066,12 @@
                 "isExactName": false
               },
               {
-                "$id": "860",
+                "$id": "862",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "418"
+                  "$ref": "420"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -13077,12 +13085,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.UpdateXmlAdvancedModel.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "861",
+                    "$id": "863",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "418"
+                      "$ref": "420"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -13109,7 +13117,7 @@
                   200
                 ],
                 "bodyType": {
-                  "$ref": "418"
+                  "$ref": "420"
                 },
                 "headers": [
                   {
@@ -13146,18 +13154,18 @@
           },
           "parameters": [
             {
-              "$ref": "861"
-            },
-            {
-              "$ref": "857"
+              "$ref": "863"
             },
             {
               "$ref": "859"
+            },
+            {
+              "$ref": "861"
             }
           ],
           "response": {
             "type": {
-              "$ref": "418"
+              "$ref": "420"
             }
           },
           "isOverride": false,
@@ -13166,7 +13174,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.UpdateXmlAdvancedModel"
         },
         {
-          "$id": "862",
+          "$id": "864",
           "kind": "basic",
           "name": "uploadCat",
           "isExactName": false,
@@ -13176,14 +13184,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "863",
+            "$id": "865",
             "name": "uploadCat",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "864",
+                "$id": "866",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -13199,7 +13207,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.uploadCat.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "865",
+                    "$id": "867",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -13220,12 +13228,12 @@
                 "isExactName": false
               },
               {
-                "$id": "866",
+                "$id": "868",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$ref": "514"
+                  "$ref": "516"
                 },
                 "isApiVersion": false,
                 "contentTypes": [
@@ -13239,12 +13247,12 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.uploadCat.body",
                 "methodParameterSegments": [
                   {
-                    "$id": "867",
+                    "$id": "869",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "514"
+                      "$ref": "516"
                     },
                     "location": "Body",
                     "isApiVersion": false,
@@ -13286,10 +13294,10 @@
           },
           "parameters": [
             {
-              "$ref": "865"
+              "$ref": "867"
             },
             {
-              "$ref": "867"
+              "$ref": "869"
             }
           ],
           "response": {},
@@ -13299,7 +13307,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.uploadCat"
         },
         {
-          "$id": "868",
+          "$id": "870",
           "kind": "basic",
           "name": "sendJsonLines",
           "isExactName": false,
@@ -13309,14 +13317,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "869",
+            "$id": "871",
             "name": "sendJsonLines",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "870",
+                "$id": "872",
                 "kind": "header",
                 "name": "contentType",
                 "serializedName": "Content-Type",
@@ -13332,16 +13340,16 @@
                 "crossLanguageDefinitionId": "TypeSpec.Http.Streams.JsonlStream.contentType",
                 "methodParameterSegments": [
                   {
-                    "$id": "871",
+                    "$id": "873",
                     "kind": "method",
                     "name": "stream",
                     "serializedName": "stream",
                     "type": {
-                      "$id": "872",
+                      "$id": "874",
                       "kind": "streaming",
                       "name": "JsonlStreamStreamingItem",
                       "valueType": {
-                        "$ref": "559"
+                        "$ref": "561"
                       },
                       "streamKind": "jsonl",
                       "contentTypes": [
@@ -13360,7 +13368,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "873",
+                    "$id": "875",
                     "kind": "method",
                     "name": "contentType",
                     "serializedName": "contentType",
@@ -13381,16 +13389,16 @@
                 "isExactName": false
               },
               {
-                "$id": "874",
+                "$id": "876",
                 "kind": "body",
                 "name": "body",
                 "serializedName": "body",
                 "type": {
-                  "$id": "875",
+                  "$id": "877",
                   "kind": "streaming",
                   "name": "JsonlStreamStreamingItem",
                   "valueType": {
-                    "$ref": "559"
+                    "$ref": "561"
                   },
                   "streamKind": "jsonl",
                   "contentTypes": [
@@ -13410,15 +13418,15 @@
                 "crossLanguageDefinitionId": "TypeSpec.Http.Streams.JsonlStream.body",
                 "methodParameterSegments": [
                   {
-                    "$ref": "871"
+                    "$ref": "873"
                   },
                   {
-                    "$id": "876",
+                    "$id": "878",
                     "kind": "method",
                     "name": "body",
                     "serializedName": "body",
                     "type": {
-                      "$ref": "599"
+                      "$ref": "601"
                     },
                     "location": "",
                     "isApiVersion": false,
@@ -13464,7 +13472,7 @@
           },
           "parameters": [
             {
-              "$ref": "871"
+              "$ref": "873"
             }
           ],
           "response": {},
@@ -13474,7 +13482,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.sendJsonLines"
         },
         {
-          "$id": "877",
+          "$id": "879",
           "kind": "basic",
           "name": "receiveJsonLines",
           "isExactName": false,
@@ -13484,14 +13492,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "878",
+            "$id": "880",
             "name": "receiveJsonLines",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "879",
+                "$id": "881",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -13507,7 +13515,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.receiveJsonLines.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "880",
+                    "$id": "882",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -13534,11 +13542,11 @@
                   200
                 ],
                 "bodyType": {
-                  "$id": "881",
+                  "$id": "883",
                   "kind": "streaming",
                   "name": "JsonlStreamStreamingItem",
                   "valueType": {
-                    "$ref": "559"
+                    "$ref": "561"
                   },
                   "streamKind": "jsonl",
                   "contentTypes": [
@@ -13578,16 +13586,16 @@
           },
           "parameters": [
             {
-              "$ref": "880"
+              "$ref": "882"
             }
           ],
           "response": {
             "type": {
-              "$id": "882",
+              "$id": "884",
               "kind": "streaming",
               "name": "JsonlStreamStreamingItem",
               "valueType": {
-                "$ref": "559"
+                "$ref": "561"
               },
               "streamKind": "jsonl",
               "contentTypes": [
@@ -13602,7 +13610,7 @@
           "crossLanguageDefinitionId": "SampleTypeSpec.receiveJsonLines"
         },
         {
-          "$id": "883",
+          "$id": "885",
           "kind": "basic",
           "name": "receiveSse",
           "isExactName": false,
@@ -13612,14 +13620,14 @@
             "2024-08-16-preview"
           ],
           "operation": {
-            "$id": "884",
+            "$id": "886",
             "name": "receiveSse",
             "isExactName": false,
             "resourceName": "SampleTypeSpec",
             "accessibility": "public",
             "parameters": [
               {
-                "$id": "885",
+                "$id": "887",
                 "kind": "header",
                 "name": "accept",
                 "serializedName": "Accept",
@@ -13635,7 +13643,7 @@
                 "crossLanguageDefinitionId": "SampleTypeSpec.receiveSse.accept",
                 "methodParameterSegments": [
                   {
-                    "$id": "886",
+                    "$id": "888",
                     "kind": "method",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -13662,16 +13670,16 @@
                   200
                 ],
                 "bodyType": {
-                  "$id": "887",
+                  "$id": "889",
                   "kind": "streaming",
                   "name": "SSEStreamSampleEvents",
                   "valueType": {
-                    "$id": "888",
+                    "$id": "890",
                     "kind": "union",
                     "name": "SampleEvents",
                     "variantTypes": [
                       {
-                        "$ref": "559"
+                        "$ref": "561"
                       },
                       {
                         "$ref": "204"
@@ -13716,16 +13724,16 @@
           },
           "parameters": [
             {
-              "$ref": "886"
+              "$ref": "888"
             }
           ],
           "response": {
             "type": {
-              "$id": "889",
+              "$id": "891",
               "kind": "streaming",
               "name": "SSEStreamSampleEvents",
               "valueType": {
-                "$ref": "888"
+                "$ref": "890"
               },
               "streamKind": "sse",
               "contentTypes": [
@@ -13739,16 +13747,124 @@
           "generateConvenient": true,
           "generateProtocol": true,
           "crossLanguageDefinitionId": "SampleTypeSpec.receiveSse"
+        },
+        {
+          "$id": "892",
+          "kind": "basic",
+          "name": "getOptionalResponse",
+          "isExactName": false,
+          "accessibility": "public",
+          "apiVersions": [
+            "2024-07-16-preview",
+            "2024-08-16-preview"
+          ],
+          "operation": {
+            "$id": "893",
+            "name": "getOptionalResponse",
+            "isExactName": false,
+            "resourceName": "SampleTypeSpec",
+            "accessibility": "public",
+            "parameters": [
+              {
+                "$id": "894",
+                "kind": "header",
+                "name": "accept",
+                "serializedName": "Accept",
+                "type": {
+                  "$ref": "208"
+                },
+                "isApiVersion": false,
+                "optional": false,
+                "isContentType": false,
+                "scope": "Constant",
+                "readOnly": false,
+                "decorators": [],
+                "crossLanguageDefinitionId": "SampleTypeSpec.getOptionalResponse.accept",
+                "methodParameterSegments": [
+                  {
+                    "$id": "895",
+                    "kind": "method",
+                    "name": "accept",
+                    "serializedName": "Accept",
+                    "type": {
+                      "$ref": "208"
+                    },
+                    "location": "Header",
+                    "isApiVersion": false,
+                    "optional": false,
+                    "scope": "Constant",
+                    "crossLanguageDefinitionId": "SampleTypeSpec.getOptionalResponse.accept",
+                    "readOnly": false,
+                    "access": "public",
+                    "decorators": [],
+                    "isExactName": false
+                  }
+                ],
+                "isExactName": false
+              }
+            ],
+            "responses": [
+              {
+                "statusCodes": [
+                  200
+                ],
+                "bodyType": {
+                  "$ref": "258"
+                },
+                "headers": [],
+                "isErrorResponse": false,
+                "contentTypes": [
+                  "application/json"
+                ],
+                "serializationOptions": {
+                  "json": {
+                    "name": ""
+                  }
+                }
+              },
+              {
+                "statusCodes": [
+                  204
+                ],
+                "headers": [],
+                "isErrorResponse": false,
+                "serializationOptions": {}
+              }
+            ],
+            "httpMethod": "GET",
+            "uri": "{sampleTypeSpecUrl}",
+            "path": "/optional-response",
+            "bufferResponse": true,
+            "generateProtocolMethod": true,
+            "generateConvenienceMethod": true,
+            "crossLanguageDefinitionId": "SampleTypeSpec.getOptionalResponse",
+            "decorators": [],
+            "namespace": "SampleTypeSpec"
+          },
+          "parameters": [
+            {
+              "$ref": "895"
+            }
+          ],
+          "response": {
+            "type": {
+              "$ref": "258"
+            }
+          },
+          "isOverride": false,
+          "generateConvenient": true,
+          "generateProtocol": true,
+          "crossLanguageDefinitionId": "SampleTypeSpec.getOptionalResponse"
         }
       ],
       "parameters": [
         {
-          "$id": "890",
+          "$id": "896",
           "kind": "endpoint",
           "name": "sampleTypeSpecUrl",
           "serializedName": "sampleTypeSpecUrl",
           "type": {
-            "$id": "891",
+            "$id": "897",
             "kind": "url",
             "name": "endpoint",
             "crossLanguageDefinitionId": "TypeSpec.url"
@@ -13764,7 +13880,7 @@
           "isExactName": false
         },
         {
-          "$ref": "794"
+          "$ref": "796"
         }
       ],
       "initializedBy": 1,
@@ -13776,14 +13892,14 @@
       ],
       "children": [
         {
-          "$id": "892",
+          "$id": "898",
           "kind": "client",
           "name": "AnimalOperations",
           "isExactName": false,
           "namespace": "SampleTypeSpec",
           "methods": [
             {
-              "$id": "893",
+              "$id": "899",
               "kind": "basic",
               "name": "updatePetAsAnimal",
               "isExactName": false,
@@ -13794,7 +13910,7 @@
               ],
               "doc": "Update a pet as an animal",
               "operation": {
-                "$id": "894",
+                "$id": "900",
                 "name": "updatePetAsAnimal",
                 "isExactName": false,
                 "resourceName": "AnimalOperations",
@@ -13802,13 +13918,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "895",
+                    "$id": "901",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "208"
+                      "$ref": "210"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13819,13 +13935,13 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.AnimalOperations.updatePetAsAnimal.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "896",
+                        "$id": "902",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "208"
+                          "$ref": "210"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13841,12 +13957,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "897",
+                    "$id": "903",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "210"
+                      "$ref": "212"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -13857,12 +13973,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.AnimalOperations.updatePetAsAnimal.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "898",
+                        "$id": "904",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "210"
+                          "$ref": "212"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -13878,12 +13994,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "899",
+                    "$id": "905",
                     "kind": "body",
                     "name": "animal",
                     "serializedName": "animal",
                     "type": {
-                      "$ref": "562"
+                      "$ref": "564"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -13897,12 +14013,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.AnimalOperations.updatePetAsAnimal.animal",
                     "methodParameterSegments": [
                       {
-                        "$id": "900",
+                        "$id": "906",
                         "kind": "method",
                         "name": "animal",
                         "serializedName": "animal",
                         "type": {
-                          "$ref": "562"
+                          "$ref": "564"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -13929,7 +14045,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "562"
+                      "$ref": "564"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -13958,18 +14074,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "900"
+                  "$ref": "906"
                 },
                 {
-                  "$ref": "896"
+                  "$ref": "902"
                 },
                 {
-                  "$ref": "898"
+                  "$ref": "904"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "562"
+                  "$ref": "564"
                 }
               },
               "isOverride": false,
@@ -13978,7 +14094,7 @@
               "crossLanguageDefinitionId": "SampleTypeSpec.AnimalOperations.updatePetAsAnimal"
             },
             {
-              "$id": "901",
+              "$id": "907",
               "kind": "basic",
               "name": "updateDogAsAnimal",
               "isExactName": false,
@@ -13989,7 +14105,7 @@
               ],
               "doc": "Update a dog as an animal",
               "operation": {
-                "$id": "902",
+                "$id": "908",
                 "name": "updateDogAsAnimal",
                 "isExactName": false,
                 "resourceName": "AnimalOperations",
@@ -13997,13 +14113,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "903",
+                    "$id": "909",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "212"
+                      "$ref": "214"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14014,13 +14130,13 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.AnimalOperations.updateDogAsAnimal.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "904",
+                        "$id": "910",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "212"
+                          "$ref": "214"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14036,12 +14152,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "905",
+                    "$id": "911",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "214"
+                      "$ref": "216"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14052,12 +14168,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.AnimalOperations.updateDogAsAnimal.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "906",
+                        "$id": "912",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "214"
+                          "$ref": "216"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14073,12 +14189,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "907",
+                    "$id": "913",
                     "kind": "body",
                     "name": "animal",
                     "serializedName": "animal",
                     "type": {
-                      "$ref": "562"
+                      "$ref": "564"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -14092,12 +14208,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.AnimalOperations.updateDogAsAnimal.animal",
                     "methodParameterSegments": [
                       {
-                        "$id": "908",
+                        "$id": "914",
                         "kind": "method",
                         "name": "animal",
                         "serializedName": "animal",
                         "type": {
-                          "$ref": "562"
+                          "$ref": "564"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -14124,7 +14240,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "562"
+                      "$ref": "564"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14153,18 +14269,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "908"
+                  "$ref": "914"
                 },
                 {
-                  "$ref": "904"
+                  "$ref": "910"
                 },
                 {
-                  "$ref": "906"
+                  "$ref": "912"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "562"
+                  "$ref": "564"
                 }
               },
               "isOverride": false,
@@ -14175,12 +14291,12 @@
           ],
           "parameters": [
             {
-              "$id": "909",
+              "$id": "915",
               "kind": "endpoint",
               "name": "sampleTypeSpecUrl",
               "serializedName": "sampleTypeSpecUrl",
               "type": {
-                "$id": "910",
+                "$id": "916",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -14204,19 +14320,19 @@
             "2024-08-16-preview"
           ],
           "parent": {
-            "$ref": "600"
+            "$ref": "602"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "911",
+          "$id": "917",
           "kind": "client",
           "name": "PetOperations",
           "isExactName": false,
           "namespace": "SampleTypeSpec",
           "methods": [
             {
-              "$id": "912",
+              "$id": "918",
               "kind": "basic",
               "name": "updatePetAsPet",
               "isExactName": false,
@@ -14227,7 +14343,7 @@
               ],
               "doc": "Update a pet as a pet",
               "operation": {
-                "$id": "913",
+                "$id": "919",
                 "name": "updatePetAsPet",
                 "isExactName": false,
                 "resourceName": "PetOperations",
@@ -14235,13 +14351,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "914",
+                    "$id": "920",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "216"
+                      "$ref": "218"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14252,13 +14368,13 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PetOperations.updatePetAsPet.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "915",
+                        "$id": "921",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "216"
+                          "$ref": "218"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14274,12 +14390,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "916",
+                    "$id": "922",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "218"
+                      "$ref": "220"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14290,12 +14406,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PetOperations.updatePetAsPet.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "917",
+                        "$id": "923",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "218"
+                          "$ref": "220"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14311,12 +14427,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "918",
+                    "$id": "924",
                     "kind": "body",
                     "name": "pet",
                     "serializedName": "pet",
                     "type": {
-                      "$ref": "567"
+                      "$ref": "569"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -14330,12 +14446,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PetOperations.updatePetAsPet.pet",
                     "methodParameterSegments": [
                       {
-                        "$id": "919",
+                        "$id": "925",
                         "kind": "method",
                         "name": "pet",
                         "serializedName": "pet",
                         "type": {
-                          "$ref": "567"
+                          "$ref": "569"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -14362,7 +14478,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "567"
+                      "$ref": "569"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14391,18 +14507,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "919"
+                  "$ref": "925"
                 },
                 {
-                  "$ref": "915"
+                  "$ref": "921"
                 },
                 {
-                  "$ref": "917"
+                  "$ref": "923"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "567"
+                  "$ref": "569"
                 }
               },
               "isOverride": false,
@@ -14411,7 +14527,7 @@
               "crossLanguageDefinitionId": "SampleTypeSpec.PetOperations.updatePetAsPet"
             },
             {
-              "$id": "920",
+              "$id": "926",
               "kind": "basic",
               "name": "updateDogAsPet",
               "isExactName": false,
@@ -14422,7 +14538,7 @@
               ],
               "doc": "Update a dog as a pet",
               "operation": {
-                "$id": "921",
+                "$id": "927",
                 "name": "updateDogAsPet",
                 "isExactName": false,
                 "resourceName": "PetOperations",
@@ -14430,13 +14546,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "922",
+                    "$id": "928",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "220"
+                      "$ref": "222"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14447,13 +14563,13 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PetOperations.updateDogAsPet.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "923",
+                        "$id": "929",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "220"
+                          "$ref": "222"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14469,12 +14585,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "924",
+                    "$id": "930",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "222"
+                      "$ref": "224"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14485,12 +14601,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PetOperations.updateDogAsPet.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "925",
+                        "$id": "931",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "222"
+                          "$ref": "224"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14506,12 +14622,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "926",
+                    "$id": "932",
                     "kind": "body",
                     "name": "pet",
                     "serializedName": "pet",
                     "type": {
-                      "$ref": "567"
+                      "$ref": "569"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -14525,12 +14641,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PetOperations.updateDogAsPet.pet",
                     "methodParameterSegments": [
                       {
-                        "$id": "927",
+                        "$id": "933",
                         "kind": "method",
                         "name": "pet",
                         "serializedName": "pet",
                         "type": {
-                          "$ref": "567"
+                          "$ref": "569"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -14557,7 +14673,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "567"
+                      "$ref": "569"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14586,18 +14702,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "927"
+                  "$ref": "933"
                 },
                 {
-                  "$ref": "923"
+                  "$ref": "929"
                 },
                 {
-                  "$ref": "925"
+                  "$ref": "931"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "567"
+                  "$ref": "569"
                 }
               },
               "isOverride": false,
@@ -14608,12 +14724,12 @@
           ],
           "parameters": [
             {
-              "$id": "928",
+              "$id": "934",
               "kind": "endpoint",
               "name": "sampleTypeSpecUrl",
               "serializedName": "sampleTypeSpecUrl",
               "type": {
-                "$id": "929",
+                "$id": "935",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -14637,19 +14753,19 @@
             "2024-08-16-preview"
           ],
           "parent": {
-            "$ref": "600"
+            "$ref": "602"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "930",
+          "$id": "936",
           "kind": "client",
           "name": "DogOperations",
           "isExactName": false,
           "namespace": "SampleTypeSpec",
           "methods": [
             {
-              "$id": "931",
+              "$id": "937",
               "kind": "basic",
               "name": "updateDogAsDog",
               "isExactName": false,
@@ -14660,7 +14776,7 @@
               ],
               "doc": "Update a dog as a dog",
               "operation": {
-                "$id": "932",
+                "$id": "938",
                 "name": "updateDogAsDog",
                 "isExactName": false,
                 "resourceName": "DogOperations",
@@ -14668,13 +14784,13 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "933",
+                    "$id": "939",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "doc": "Body parameter's content type. Known values are application/json",
                     "type": {
-                      "$ref": "224"
+                      "$ref": "226"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14685,13 +14801,13 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.DogOperations.updateDogAsDog.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "934",
+                        "$id": "940",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "doc": "Body parameter's content type. Known values are application/json",
                         "type": {
-                          "$ref": "224"
+                          "$ref": "226"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14707,12 +14823,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "935",
+                    "$id": "941",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "226"
+                      "$ref": "228"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14723,12 +14839,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.DogOperations.updateDogAsDog.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "936",
+                        "$id": "942",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "226"
+                          "$ref": "228"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14744,12 +14860,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "937",
+                    "$id": "943",
                     "kind": "body",
                     "name": "dog",
                     "serializedName": "dog",
                     "type": {
-                      "$ref": "571"
+                      "$ref": "573"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -14763,12 +14879,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.DogOperations.updateDogAsDog.dog",
                     "methodParameterSegments": [
                       {
-                        "$id": "938",
+                        "$id": "944",
                         "kind": "method",
                         "name": "dog",
                         "serializedName": "dog",
                         "type": {
-                          "$ref": "571"
+                          "$ref": "573"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -14795,7 +14911,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "571"
+                      "$ref": "573"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -14824,18 +14940,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "938"
+                  "$ref": "944"
                 },
                 {
-                  "$ref": "934"
+                  "$ref": "940"
                 },
                 {
-                  "$ref": "936"
+                  "$ref": "942"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "571"
+                  "$ref": "573"
                 }
               },
               "isOverride": false,
@@ -14846,12 +14962,12 @@
           ],
           "parameters": [
             {
-              "$id": "939",
+              "$id": "945",
               "kind": "endpoint",
               "name": "sampleTypeSpecUrl",
               "serializedName": "sampleTypeSpecUrl",
               "type": {
-                "$id": "940",
+                "$id": "946",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -14875,19 +14991,19 @@
             "2024-08-16-preview"
           ],
           "parent": {
-            "$ref": "600"
+            "$ref": "602"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "941",
+          "$id": "947",
           "kind": "client",
           "name": "PlantOperations",
           "isExactName": false,
           "namespace": "SampleTypeSpec",
           "methods": [
             {
-              "$id": "942",
+              "$id": "948",
               "kind": "basic",
               "name": "getTree",
               "isExactName": false,
@@ -14898,7 +15014,7 @@
               ],
               "doc": "Get a tree as a plant",
               "operation": {
-                "$id": "943",
+                "$id": "949",
                 "name": "getTree",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -14906,12 +15022,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "944",
+                    "$id": "950",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "228"
+                      "$ref": "230"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -14922,12 +15038,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.getTree.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "945",
+                        "$id": "951",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "228"
+                          "$ref": "230"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -14949,14 +15065,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "575"
+                      "$ref": "577"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "230"
+                          "$ref": "232"
                         }
                       }
                     ],
@@ -14983,12 +15099,12 @@
               },
               "parameters": [
                 {
-                  "$ref": "945"
+                  "$ref": "951"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "575"
+                  "$ref": "577"
                 }
               },
               "isOverride": false,
@@ -14997,7 +15113,7 @@
               "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.getTree"
             },
             {
-              "$id": "946",
+              "$id": "952",
               "kind": "basic",
               "name": "getTreeAsJson",
               "isExactName": false,
@@ -15008,7 +15124,7 @@
               ],
               "doc": "Get a tree as a plant",
               "operation": {
-                "$id": "947",
+                "$id": "953",
                 "name": "getTreeAsJson",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -15016,12 +15132,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "948",
+                    "$id": "954",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "232"
+                      "$ref": "234"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15032,12 +15148,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.getTreeAsJson.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "949",
+                        "$id": "955",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "232"
+                          "$ref": "234"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15059,14 +15175,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "575"
+                      "$ref": "577"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "234"
+                          "$ref": "236"
                         }
                       }
                     ],
@@ -15093,12 +15209,12 @@
               },
               "parameters": [
                 {
-                  "$ref": "949"
+                  "$ref": "955"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "575"
+                  "$ref": "577"
                 }
               },
               "isOverride": false,
@@ -15107,7 +15223,7 @@
               "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.getTreeAsJson"
             },
             {
-              "$id": "950",
+              "$id": "956",
               "kind": "basic",
               "name": "updateTree",
               "isExactName": false,
@@ -15118,7 +15234,7 @@
               ],
               "doc": "Update a tree as a plant",
               "operation": {
-                "$id": "951",
+                "$id": "957",
                 "name": "updateTree",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -15126,12 +15242,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "952",
+                    "$id": "958",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "type": {
-                      "$ref": "236"
+                      "$ref": "238"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15142,12 +15258,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.updateTree.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "953",
+                        "$id": "959",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "type": {
-                          "$ref": "236"
+                          "$ref": "238"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15163,12 +15279,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "954",
+                    "$id": "960",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "240"
+                      "$ref": "242"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15179,12 +15295,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.updateTree.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "955",
+                        "$id": "961",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "240"
+                          "$ref": "242"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15200,12 +15316,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "956",
+                    "$id": "962",
                     "kind": "body",
                     "name": "tree",
                     "serializedName": "tree",
                     "type": {
-                      "$ref": "575"
+                      "$ref": "577"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -15219,12 +15335,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.updateTree.tree",
                     "methodParameterSegments": [
                       {
-                        "$id": "957",
+                        "$id": "963",
                         "kind": "method",
                         "name": "tree",
                         "serializedName": "tree",
                         "type": {
-                          "$ref": "575"
+                          "$ref": "577"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -15251,14 +15367,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "575"
+                      "$ref": "577"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "242"
+                          "$ref": "244"
                         }
                       }
                     ],
@@ -15288,18 +15404,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "957"
+                  "$ref": "963"
                 },
                 {
-                  "$ref": "953"
+                  "$ref": "959"
                 },
                 {
-                  "$ref": "955"
+                  "$ref": "961"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "575"
+                  "$ref": "577"
                 }
               },
               "isOverride": false,
@@ -15308,7 +15424,7 @@
               "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.updateTree"
             },
             {
-              "$id": "958",
+              "$id": "964",
               "kind": "basic",
               "name": "updateTreeAsJson",
               "isExactName": false,
@@ -15319,7 +15435,7 @@
               ],
               "doc": "Update a tree as a plant",
               "operation": {
-                "$id": "959",
+                "$id": "965",
                 "name": "updateTreeAsJson",
                 "isExactName": false,
                 "resourceName": "PlantOperations",
@@ -15327,12 +15443,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "960",
+                    "$id": "966",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
                     "type": {
-                      "$ref": "244"
+                      "$ref": "246"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15343,12 +15459,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.updateTreeAsJson.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "961",
+                        "$id": "967",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
                         "type": {
-                          "$ref": "244"
+                          "$ref": "246"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15364,12 +15480,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "962",
+                    "$id": "968",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "248"
+                      "$ref": "250"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15380,12 +15496,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.updateTreeAsJson.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "963",
+                        "$id": "969",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "248"
+                          "$ref": "250"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15401,12 +15517,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "964",
+                    "$id": "970",
                     "kind": "body",
                     "name": "tree",
                     "serializedName": "tree",
                     "type": {
-                      "$ref": "575"
+                      "$ref": "577"
                     },
                     "isApiVersion": false,
                     "contentTypes": [
@@ -15420,12 +15536,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.PlantOperations.updateTreeAsJson.tree",
                     "methodParameterSegments": [
                       {
-                        "$id": "965",
+                        "$id": "971",
                         "kind": "method",
                         "name": "tree",
                         "serializedName": "tree",
                         "type": {
-                          "$ref": "575"
+                          "$ref": "577"
                         },
                         "location": "Body",
                         "isApiVersion": false,
@@ -15452,14 +15568,14 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "575"
+                      "$ref": "577"
                     },
                     "headers": [
                       {
                         "name": "contentType",
                         "nameInResponse": "content-type",
                         "type": {
-                          "$ref": "250"
+                          "$ref": "252"
                         }
                       }
                     ],
@@ -15489,18 +15605,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "965"
+                  "$ref": "971"
                 },
                 {
-                  "$ref": "961"
+                  "$ref": "967"
                 },
                 {
-                  "$ref": "963"
+                  "$ref": "969"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "575"
+                  "$ref": "577"
                 }
               },
               "isOverride": false,
@@ -15511,12 +15627,12 @@
           ],
           "parameters": [
             {
-              "$id": "966",
+              "$id": "972",
               "kind": "endpoint",
               "name": "sampleTypeSpecUrl",
               "serializedName": "sampleTypeSpecUrl",
               "type": {
-                "$id": "967",
+                "$id": "973",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -15540,19 +15656,19 @@
             "2024-08-16-preview"
           ],
           "parent": {
-            "$ref": "600"
+            "$ref": "602"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "968",
+          "$id": "974",
           "kind": "client",
           "name": "Metrics",
           "isExactName": false,
           "namespace": "SampleTypeSpec",
           "methods": [
             {
-              "$id": "969",
+              "$id": "975",
               "kind": "basic",
               "name": "getWidgetMetrics",
               "isExactName": false,
@@ -15563,7 +15679,7 @@
               ],
               "doc": "Get Widget metrics for given day of week",
               "operation": {
-                "$id": "970",
+                "$id": "976",
                 "name": "getWidgetMetrics",
                 "isExactName": false,
                 "resourceName": "Metrics",
@@ -15571,12 +15687,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "971",
+                    "$id": "977",
                     "kind": "path",
                     "name": "metricsNamespace",
                     "serializedName": "metricsNamespace",
                     "type": {
-                      "$id": "972",
+                      "$id": "978",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15594,12 +15710,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.Metrics.getWidgetMetrics.metricsNamespace",
                     "methodParameterSegments": [
                       {
-                        "$id": "973",
+                        "$id": "979",
                         "kind": "method",
                         "name": "metricsNamespace",
                         "serializedName": "metricsNamespace",
                         "type": {
-                          "$id": "974",
+                          "$id": "980",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15619,7 +15735,7 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "975",
+                    "$id": "981",
                     "kind": "path",
                     "name": "day",
                     "serializedName": "day",
@@ -15638,7 +15754,7 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.Metrics.getWidgetMetrics.day",
                     "methodParameterSegments": [
                       {
-                        "$id": "976",
+                        "$id": "982",
                         "kind": "method",
                         "name": "day",
                         "serializedName": "day",
@@ -15659,12 +15775,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "977",
+                    "$id": "983",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "252"
+                      "$ref": "254"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15675,12 +15791,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.Metrics.getWidgetMetrics.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "978",
+                        "$id": "984",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "252"
+                          "$ref": "254"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15702,7 +15818,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "586"
+                      "$ref": "588"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -15728,15 +15844,15 @@
               },
               "parameters": [
                 {
-                  "$ref": "976"
+                  "$ref": "982"
                 },
                 {
-                  "$ref": "978"
+                  "$ref": "984"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "586"
+                  "$ref": "588"
                 }
               },
               "isOverride": false,
@@ -15747,12 +15863,12 @@
           ],
           "parameters": [
             {
-              "$id": "979",
+              "$id": "985",
               "kind": "endpoint",
               "name": "sampleTypeSpecUrl",
               "serializedName": "sampleTypeSpecUrl",
               "type": {
-                "$id": "980",
+                "$id": "986",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -15768,7 +15884,7 @@
               "isExactName": false
             },
             {
-              "$ref": "973"
+              "$ref": "979"
             }
           ],
           "initializedBy": 3,
@@ -15779,19 +15895,19 @@
             "2024-08-16-preview"
           ],
           "parent": {
-            "$ref": "600"
+            "$ref": "602"
           },
           "isMultiServiceClient": false
         },
         {
-          "$id": "981",
+          "$id": "987",
           "kind": "client",
           "name": "Notebooks",
           "isExactName": false,
           "namespace": "SampleTypeSpec",
           "methods": [
             {
-              "$id": "982",
+              "$id": "988",
               "kind": "basic",
               "name": "getNotebook",
               "isExactName": false,
@@ -15802,7 +15918,7 @@
               ],
               "doc": "Get a notebook by name",
               "operation": {
-                "$id": "983",
+                "$id": "989",
                 "name": "getNotebook",
                 "isExactName": false,
                 "resourceName": "Notebooks",
@@ -15810,12 +15926,12 @@
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "984",
+                    "$id": "990",
                     "kind": "path",
                     "name": "notebookName",
                     "serializedName": "notebookName",
                     "type": {
-                      "$id": "985",
+                      "$id": "991",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15833,12 +15949,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.Notebooks.getNotebook.notebookName",
                     "methodParameterSegments": [
                       {
-                        "$id": "986",
+                        "$id": "992",
                         "kind": "method",
                         "name": "notebook",
                         "serializedName": "notebook",
                         "type": {
-                          "$id": "987",
+                          "$id": "993",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -15859,12 +15975,12 @@
                     "isExactName": false
                   },
                   {
-                    "$id": "988",
+                    "$id": "994",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
                     "type": {
-                      "$ref": "254"
+                      "$ref": "256"
                     },
                     "isApiVersion": false,
                     "optional": false,
@@ -15875,12 +15991,12 @@
                     "crossLanguageDefinitionId": "SampleTypeSpec.Notebooks.getNotebook.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "989",
+                        "$id": "995",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
                         "type": {
-                          "$ref": "254"
+                          "$ref": "256"
                         },
                         "location": "Header",
                         "isApiVersion": false,
@@ -15902,7 +16018,7 @@
                       200
                     ],
                     "bodyType": {
-                      "$ref": "591"
+                      "$ref": "593"
                     },
                     "headers": [],
                     "isErrorResponse": false,
@@ -15928,12 +16044,12 @@
               },
               "parameters": [
                 {
-                  "$ref": "989"
+                  "$ref": "995"
                 }
               ],
               "response": {
                 "type": {
-                  "$ref": "591"
+                  "$ref": "593"
                 }
               },
               "isOverride": false,
@@ -15944,12 +16060,12 @@
           ],
           "parameters": [
             {
-              "$id": "990",
+              "$id": "996",
               "kind": "endpoint",
               "name": "sampleTypeSpecUrl",
               "serializedName": "sampleTypeSpecUrl",
               "type": {
-                "$id": "991",
+                "$id": "997",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -15965,7 +16081,7 @@
               "isExactName": false
             },
             {
-              "$ref": "986"
+              "$ref": "992"
             }
           ],
           "initializedBy": 3,
@@ -15976,7 +16092,7 @@
             "2024-08-16-preview"
           ],
           "parent": {
-            "$ref": "600"
+            "$ref": "602"
           },
           "isMultiServiceClient": false
         }


### PR DESCRIPTION
## Summary

- support convenience operations with both body and no-body successful responses
- return `ClientResult<T>` using `ClientResult.FromOptionalValue`
- skip response deserialization for declared no-body success status codes
- select the body-bearing success response regardless of response ordering
- add generated sample and unit coverage

## Testing

- targeted `ScmMethodProviderCollectionTests`
- `Generate.ps1` and generated Sample-TypeSpec build

Fixes #11651
Related to #11650