### PR TITLE
Mark Publish job as release

### DIFF
--- a/eng/emitters/pipelines/templates/stages/emitter-stages.yml
+++ b/eng/emitters/pipelines/templates/stages/emitter-stages.yml
@@ -325,40 +325,6 @@ stages:
                 artifact: build_artifacts_${{ parameters.LanguageShortName }}
                 displayName: Download build artifacts
 
-              # Always publish to internal feed
-              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-
-              # publish to devops feed
-              - pwsh: |
-                  $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
-                  foreach ($file in $packageFiles.Name) {
-                    Write-Host "npm publish $file --verbose --access public"
-                    npm publish $file --verbose --access public
-                  }
-                displayName: Publish to DevOps feed
-                workingDirectory: $(buildArtifactsPath)/packages
-
-              # If publishing publicly, also publish to npmjs.org
-              - ${{ if eq(parameters.Publish, 'public') }}:
-                  # publish to npmjs.org using ESRP
-                  - task: EsrpRelease@11
-                    inputs:
-                      displayName: Publish to npmjs.org
-                      ConnectedServiceName: Azure SDK PME Managed Identity
-                      ClientId: 5f81938c-2544-4f1f-9251-dd9de5b8a81b
-                      DomainTenantId: 975f013f-7f24-47e8-a7d3-abc4752bf346
-                      UseManagedIdentity: true
-                      KeyVaultName: kv-azuresdk-codesign
-                      SignCertName: azure-sdk-esrp-release-certificate
-                      Intent: PackageDistribution
-                      ContentType: npm
-                      FolderLocation: $(buildArtifactsPath)/packages
-                      Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
-                      Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
-                      ServiceEndpointUrl: https://api.esrp.microsoft.com
-                      # cspell:ignore ESRPRELPACMANTEST
-                      MainPublisher: ESRPRELPACMANTEST
-
               - ${{ if parameters.HasNugetPackages }}:
                   - task: 1ES.PublishNuget@1
                     displayName: Publish Nuget packages
@@ -488,12 +454,50 @@ stages:
                         echo "Deployed to https://$APP_NAME.azurewebsites.net"
                       workingDirectory: $(Build.SourcesDirectory)
 
-              - task: 1ES.PublishPipelineArtifact@1
-                displayName: Publish artifacts
-                inputs:
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
                   path: $(Build.ArtifactStagingDirectory)
                   artifact: publish_artifacts
 
+          - job: PublishNpm
+            displayName: Publish npm packages
+            dependsOn: Publish
             templateContext:
               type: releaseJob
               isProduction: true
+              inputs:
+                - input: pipelineArtifact
+                  artifactName: build_artifacts_${{ parameters.LanguageShortName }}
+                  itemPattern: "**"
+                  targetPath: $(buildArtifactsPath)/
+            steps:
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
+              - pwsh: |
+                  $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
+                  foreach ($file in $packageFiles.Name) {
+                    Write-Host "npm publish $file --verbose --access public"
+                    npm publish $file --verbose --access public
+                  }
+                displayName: Publish to DevOps feed
+                workingDirectory: $(buildArtifactsPath)/packages
+
+              - ${{ if eq(parameters.Publish, 'public') }}:
+                  - task: EsrpRelease@11
+                    inputs:
+                      displayName: Publish to npmjs.org
+                      ConnectedServiceName: Azure SDK PME Managed Identity
+                      ClientId: 5f81938c-2544-4f1f-9251-dd9de5b8a81b
+                      DomainTenantId: 975f013f-7f24-47e8-a7d3-abc4752bf346
+                      UseManagedIdentity: true
+                      KeyVaultName: kv-azuresdk-codesign
+                      SignCertName: azure-sdk-esrp-release-certificate
+                      Intent: PackageDistribution
+                      ContentType: npm
+                      FolderLocation: $(buildArtifactsPath)/packages
+                      Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+                      Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+                      ServiceEndpointUrl: https://api.esrp.microsoft.com
+                      # cspell:ignore ESRPRELPACMANTEST
+                      MainPublisher: ESRPRELPACMANTEST

--- a/eng/emitters/pipelines/templates/stages/emitter-stages.yml
+++ b/eng/emitters/pipelines/templates/stages/emitter-stages.yml
@@ -488,8 +488,12 @@ stages:
                         echo "Deployed to https://$APP_NAME.azurewebsites.net"
                       workingDirectory: $(Build.SourcesDirectory)
 
-            templateContext:
-              outputs:
-                - output: pipelineArtifact
+              - task: 1ES.PublishPipelineArtifact@1
+                displayName: Publish artifacts
+                inputs:
                   path: $(Build.ArtifactStagingDirectory)
                   artifact: publish_artifacts
+
+            templateContext:
+              type: releaseJob
+              isProduction: true


### PR DESCRIPTION
This pull request makes a small change to the `emitter-stages.yml` pipeline template. The change sets the `type` to `releaseJob` and marks the job as production by adding `isProduction: true` in the `templateContext`.