### PR TITLE
[http-client-csharp] Fix IPv4 and IPv6 parameter casing

### DIFF
--- a/.chronus/changes/josh-fix-ipv-parameter-casing-2026-08-14-11-10-00.md
+++ b/.chronus/changes/josh-fix-ipv-parameter-casing-2026-08-14-11-10-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Generate `IPv4` and `IPv6` parameter names with conventional camel casing.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -37,7 +37,13 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
             }
 
             bool upperCase = false;
-            int firstWordLength = 1;
+            // Treat the "IPv" prefix as one word so IPv4Address becomes ipv4Address.
+            int firstWordLength =
+                useCamelCase &&
+                (name.AsSpan(i).StartsWith("IPv4", StringComparison.Ordinal) ||
+                 name.AsSpan(i).StartsWith("IPv6", StringComparison.Ordinal))
+                    ? 3
+                    : 1;
             for (; i < name.Length; i++)
             {
                 var c = name[i];

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/StringExtensionsTests.cs
@@ -38,6 +38,10 @@ namespace Microsoft.TypeSpec.Generator.Input.Tests
         [TestCase("HelloWorld", false, "helloWorld")]
         [TestCase("Tls_1_0", false, "tls10")]
         [TestCase("UPPER_CASE", false, "upperCASE")]
+        [TestCase("IPv4", false, "ipv4")]
+        [TestCase("IPv4Address", false, "ipv4Address")]
+        [TestCase("IPv6Address", false, "ipv6Address")]
+        [TestCase("PrimaryIPv4Address", false, "primaryIPv4Address")]
         // New behavior with preserveUnderscores = true
         [TestCase("HelloWorld", true, "helloWorld")]
         [TestCase("Tls_1_0", true, "tls_1_0")]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -129,6 +129,30 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.AreEqual(expectedName, property.Name);
         }
 
+        [TestCase("IpAddress", "IPAddress", "ipAddress")]
+        [TestCase("CosmosDbAccount", "CosmosDBAccount", "cosmosDBAccount")]
+        [TestCase("OsProfile", "OSProfile", "osProfile")]
+        [TestCase("Ipv4Address", "IPv4Address", "ipv4Address")]
+        [TestCase("IpV4Address", "IPv4Address", "ipv4Address")]
+        [TestCase("Ipv6Address", "IPv6Address", "ipv6Address")]
+        [TestCase("IpV6Address", "IPv6Address", "ipv6Address")]
+        public void TestPropertyAcronymNormalizationUsesCamelCaseParameterName(
+            string inputName,
+            string expectedPropertyName,
+            string expectedParameterName)
+        {
+            var inputProperty = InputFactory.Property(
+                inputName,
+                InputPrimitiveType.String,
+                isRequired: true);
+            InputFactory.Model("TestModel", properties: [inputProperty]);
+
+            var property = new PropertyProvider(inputProperty, new TestTypeProvider());
+
+            Assert.AreEqual(expectedPropertyName, property.Name);
+            Assert.AreEqual(expectedParameterName, property.AsParameter.Name);
+        }
+
         [TestCaseSource(nameof(CollectionPropertyTestCases))]
         public void CollectionProperty(CSharpType coreType, InputModelProperty collectionProperty, CSharpType expectedType)
         {


### PR DESCRIPTION
## Summary

- treat leading `IPv4` and `IPv6` as a single word during camel-case conversion
- generate parameter names such as `ipv4Address` instead of `iPv4Address`
- preserve embedded acronym casing such as `primaryIPv4Address`

## Validation

- `npm run build`
- `Microsoft.TypeSpec.Generator.Input.Tests`: 172 passed
- `Microsoft.TypeSpec.Generator.Tests`: 1,902 passed
- `npm run cop`