### PR TITLE
Disable e2e tests

### DIFF
--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -31,7 +31,7 @@ extends:
           - template: /eng/tsp-core/pipelines/jobs/build-packages.yml@self
           - template: /eng/tsp-core/pipelines/jobs/build-vs.yml@self
           - template: /eng/tsp-core/pipelines/jobs/cli/build-tsp-cli-all.yml@self
-          - template: /eng/tsp-core/pipelines/jobs/e2e.yml@self
+            # - template: /eng/tsp-core/pipelines/jobs/e2e.yml@self
             parameters:
               azLogin: true
 


### PR DESCRIPTION
Temporarily disable e2e tests from publish pipeline until there is a fix for: https://github.com/microsoft/typespec/issues/11665 and https://github.com/microsoft/typespec/issues/11688

Tracking issue to re-enable e2e tests: https://github.com/microsoft/typespec/issues/11686
