### PR TITLE
Add C# Spector scenario coverage

### DIFF
--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/BodyRoot/BodyRootTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/BodyRoot/BodyRootTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Parameters.BodyRoot;
+
+namespace TestProjects.Spector.Tests.Http.Parameters.BodyRoot
+{
+    public class BodyRootTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task Nested() => Test(async (host) =>
+        {
+            var bodyRoot = new BodyRootModel
+            {
+                Category = "widget",
+                LinkType = "hard",
+                WasSuccessful = true
+            };
+            var response = await new BodyRootClient(host, null).NestedAsync(new NestedParameterBody(bodyRoot));
+            Assert.AreEqual(204, response.GetRawResponse().Status);
+        });
+    }
+}

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/Query/QueryTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Parameters/Query/QueryTests.cs
@@ -16,5 +16,14 @@ namespace TestProjects.Spector.Tests.Http.Parameters.Query
             ClientResult result = await new QueryClient(host, null).GetConstantClient().PostAsync();
             Assert.AreEqual(204, result.GetRawResponse().Status);
         });
+
+        [SpectorTest]
+        public Task DollarSign() => Test(async (host) =>
+        {
+            ClientResult result = await new QueryClient(host, null)
+                .GetSpecialCharClient()
+                .DollarSignAsync("status eq 'active'");
+            Assert.AreEqual(204, result.GetRawResponse().Status);
+        });
     }
 }

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Streaming/Jsonl/JsonlTests.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Streaming/Jsonl/JsonlTests.cs
@@ -12,7 +12,6 @@ namespace TestProjects.Spector.Tests.Http.Streaming.Jsonl
     public class JsonlTests : SpectorTestBase
     {
         [SpectorTest]
-        [Ignore("https://github.com/microsoft/typespec/pull/11575")]
         public Task Send() => Test(async (host) =>
         {
             var client = new JsonlClient(host, null).GetBasicClient();

--- a/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
+++ b/packages/http-client-csharp/generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\encode\duration\src\Encode.Duration.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\encode\numeric\src\Encode.Numeric.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\parameters\basic\src\Parameters.Basic.csproj" />
+    <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\parameters\body-root\src\Parameters.BodyRoot.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\parameters\body-optionality\src\Parameters.BodyOptionality.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\parameters\collection-format\src\Parameters.CollectionFormat.csproj" />
     <ProjectReference Include="$(RepoRoot)\TestProjects\Spector\http\parameters\spread\src\Parameters.Spread.csproj" />


### PR DESCRIPTION
## Summary

- add C# Spector coverage for nested `@bodyRoot` parameters
- add coverage for dollar-sign query parameter names
- re-enable the JSONL send scenario after the Spector gap was fixed
- track unsupported `@encode(string)` boolean serialization in #11691

## Validation

- `npm run build` (with NuGet audit disabled after nuget.org audit endpoint failures)
- `pwsh eng/scripts/Test-Spector.ps1 -filter "http/parameters/body-root"`
- `pwsh eng/scripts/Test-Spector.ps1 -filter "http/parameters/query"`
- `pwsh eng/scripts/Test-Spector.ps1 -filter "http/streaming/jsonl"`
- `dotnet format whitespace generator/TestProjects/Spector.Tests/TestProjects.Spector.Tests.csproj --include generator/TestProjects/Spector.Tests/Http/Parameters/BodyRoot/BodyRootTests.cs generator/TestProjects/Spector.Tests/Http/Parameters/Query/QueryTests.cs generator/TestProjects/Spector.Tests/Http/Streaming/Jsonl/JsonlTests.cs --verify-no-changes --no-restore`
- `npm run cop`