### PR TITLE
Fix TYPESPEC_NPM_REGISTRY forwarding during install

### DIFF
--- a/.chronus/changes/forward-typespec-npm-registry-2026-08-15.md
+++ b/.chronus/changes/forward-typespec-npm-registry-2026-08-15.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Forward `TYPESPEC_NPM_REGISTRY` to the npm process launched by `tsp install`.

--- a/packages/compiler/src/install/install.ts
+++ b/packages/compiler/src/install/install.ts
@@ -7,7 +7,11 @@ import { createDiagnosticCollector } from "../core/diagnostics.js";
 import { getDirectoryPath, joinPaths } from "../core/path-utils.js";
 import { NoTarget, type Diagnostic, type Tracer } from "../core/types.js";
 import { downloadAndExtractPackage } from "../package-manger/npm-package-download.js";
-import { fetchPackageManifest, type NpmManifest } from "../package-manger/npm-registry.js";
+import {
+  fetchPackageManifest,
+  getNpmRegistryEnvironment,
+  type NpmManifest,
+} from "../package-manger/npm-registry.js";
 import { mkTempDir } from "../utils/fs-utils.js";
 import type { SupportedPackageManager } from "./config.js";
 import { getPackageManagerConfig, type PackageManagerConfig } from "./config.js";
@@ -218,7 +222,7 @@ async function runPackageManager(
     stdio,
     cwd: directory,
     env: {
-      ...process.env,
+      ...getNpmRegistryEnvironment(),
       TYPESPEC_CLI_PASSTHROUGH: "1",
     },
   });

--- a/packages/compiler/src/package-manger/npm-registry.ts
+++ b/packages/compiler/src/package-manger/npm-registry.ts
@@ -93,6 +93,24 @@ export function getNpmRegistry(): string {
   return (process.env["TYPESPEC_NPM_REGISTRY"] ?? defaultRegistry).replace(/\/$/, "");
 }
 
+/** Returns the environment used to run npm with the TypeSpec registry override applied. */
+export function getNpmRegistryEnvironment(): Record<string, string | undefined> {
+  const environment = { ...process.env };
+  if (process.env["TYPESPEC_NPM_REGISTRY"] === undefined) {
+    return environment;
+  }
+
+  // Environment variable names are case-insensitive on Windows. Remove any
+  // existing spelling so Node does not choose between duplicate keys.
+  for (const name of Object.keys(environment)) {
+    if (name.toLowerCase() === "npm_config_registry") {
+      delete environment[name];
+    }
+  }
+  environment["npm_config_registry"] = getNpmRegistry();
+  return environment;
+}
+
 export async function fetchPackageManifest(
   packageName: string,
   version: string,

--- a/packages/compiler/src/package-manger/npm-registry.ts
+++ b/packages/compiler/src/package-manger/npm-registry.ts
@@ -90,13 +90,14 @@ const defaultRegistry = `https://registry.npmjs.org`;
  * otherwise falls back to the default npm registry.
  */
 export function getNpmRegistry(): string {
-  return (process.env["TYPESPEC_NPM_REGISTRY"] ?? defaultRegistry).replace(/\/$/, "");
+  const registry = process.env["TYPESPEC_NPM_REGISTRY"]?.trim();
+  return (registry || defaultRegistry).replace(/\/$/, "");
 }
 
 /** Returns the environment used to run npm with the TypeSpec registry override applied. */
-export function getNpmRegistryEnvironment(): Record<string, string | undefined> {
+export function getNpmRegistryEnvironment(): NodeJS.ProcessEnv {
   const environment = { ...process.env };
-  if (process.env["TYPESPEC_NPM_REGISTRY"] === undefined) {
+  if (!process.env["TYPESPEC_NPM_REGISTRY"]?.trim()) {
     return environment;
   }
 

--- a/packages/compiler/test/package-manager/npm-registry.test.ts
+++ b/packages/compiler/test/package-manager/npm-registry.test.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from "net";
 import { afterEach, beforeEach, expect, it } from "vitest";
 import {
   fetchPackageManifest,
+  getNpmRegistry,
   getNpmRegistryEnvironment,
 } from "../../src/package-manger/npm-registry.js";
 
@@ -72,4 +73,15 @@ it("preserves the npm registry environment when no TypeSpec override is set", ()
   const environment = getNpmRegistryEnvironment();
 
   expect(environment["NPM_CONFIG_REGISTRY"]).toBe("https://configured-registry.example.com");
+});
+
+it.each(["", "   "])("does not forward an empty TypeSpec registry override", (registry) => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registry;
+  process.env["NPM_CONFIG_REGISTRY"] = "https://configured-registry.example.com";
+
+  const environment = getNpmRegistryEnvironment();
+
+  expect(getNpmRegistry()).toBe("https://registry.npmjs.org");
+  expect(environment["NPM_CONFIG_REGISTRY"]).toBe("https://configured-registry.example.com");
+  expect(environment).not.toHaveProperty("npm_config_registry");
 });

--- a/packages/compiler/test/package-manager/npm-registry.test.ts
+++ b/packages/compiler/test/package-manager/npm-registry.test.ts
@@ -1,7 +1,10 @@
 import * as http from "http";
 import type { AddressInfo } from "net";
 import { afterEach, beforeEach, expect, it } from "vitest";
-import { fetchPackageManifest } from "../../src/package-manger/npm-registry.js";
+import {
+  fetchPackageManifest,
+  getNpmRegistryEnvironment,
+} from "../../src/package-manger/npm-registry.js";
 
 let server: http.Server;
 let registryUrl: string;
@@ -34,6 +37,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   delete process.env["TYPESPEC_NPM_REGISTRY"];
+  delete process.env["NPM_CONFIG_REGISTRY"];
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
@@ -49,4 +53,23 @@ it("strips trailing slash from TYPESPEC_NPM_REGISTRY", async () => {
   const manifest = await fetchPackageManifest("test-pkg", "1.0.0");
   expect(manifest.name).toBe("test-pkg");
   expect(lastRequestUrl).toBe("/test-pkg/1.0.0");
+});
+
+it("forwards TYPESPEC_NPM_REGISTRY to npm", () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = `${registryUrl}/`;
+  process.env["NPM_CONFIG_REGISTRY"] = "https://old-registry.example.com";
+
+  const environment = getNpmRegistryEnvironment();
+
+  expect(environment["npm_config_registry"]).toBe(registryUrl);
+  expect(environment).not.toHaveProperty("NPM_CONFIG_REGISTRY");
+});
+
+it("preserves the npm registry environment when no TypeSpec override is set", () => {
+  delete process.env["TYPESPEC_NPM_REGISTRY"];
+  process.env["NPM_CONFIG_REGISTRY"] = "https://configured-registry.example.com";
+
+  const environment = getNpmRegistryEnvironment();
+
+  expect(environment["NPM_CONFIG_REGISTRY"]).toBe("https://configured-registry.example.com");
 });


### PR DESCRIPTION
## Summary

- forward `TYPESPEC_NPM_REGISTRY` to the npm process launched by `tsp install`
- preserve an existing npm registry configuration when no TypeSpec override is provided
- normalize case-insensitive npm registry environment keys before applying the override
- treat empty and whitespace-only TypeSpec overrides as unset

Fixes #11688.

## Root cause

TypeSpec already used `TYPESPEC_NPM_REGISTRY` when it fetched package-manager metadata and archives. The later `npm install` subprocess inherited that TypeSpec-specific variable, but npm reads `npm_config_registry` instead, so project dependencies still came from npm's default configuration.

## Testing

- `pnpm setup:min`
- `pnpm --filter @typespec/compiler exec vitest run test/package-manager/npm-registry.test.ts` — 6 tests passed
- `pnpm --filter @typespec/compiler run build`
- `pnpm exec prettier --check packages/compiler/src/install/install.ts packages/compiler/src/package-manger/npm-registry.ts packages/compiler/test/package-manager/npm-registry.test.ts .chronus/changes/forward-typespec-npm-registry-2026-08-15.md`
- `pnpm --filter @typespec/compiler run lint`
- `git diff --check`

Local setup note: I initially invoked the compiler tests before building the generated manifest and internal workspace packages, which produced bootstrap-related missing-module errors. After running the documented `pnpm setup:min` step, the focused tests and all checks above passed.
