### PR TITLE
[http-client-csharp] Preserve ApiCompat acronym names after namespace updates

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/EnumProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             return input.IsExtensible ? extensibleEnumProvider : fixedEnumProvider;
         }
 
-        protected EnumProvider(InputEnumType? input)
+        protected EnumProvider(InputEnumType? input) : base(input)
         {
             _inputType = input;
             _deprecated = input?.Deprecation;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -63,7 +63,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
             }
 
             var originalName = _inputType.Name.ToIdentifierName();
-            if (typeName != originalName.NormalizeCSharpAcronyms())
+            var normalizedOriginalName = originalName.NormalizeCSharpAcronyms();
+            if (normalizedOriginalName == originalName || typeName != normalizedOriginalName)
             {
                 return null;
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.TypeSpec.Generator.EmitterRpc;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Input.Extensions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.SourceInput;
 using Microsoft.TypeSpec.Generator.Statements;
@@ -49,10 +50,29 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 _declaringTypeName.Value);
 
         private protected virtual TypeProvider? BuildLastContractView(string? generatedTypeName = null, string? generatedTypeNamespace = null)
-            => CodeModelGenerator.Instance.SourceInputModel.FindForTypeInLastContract(
-                generatedTypeNamespace ?? CustomCodeView?.Type.Namespace ?? BuildNamespace(),
-                generatedTypeName ?? CustomCodeView?.Name ?? BuildName(),
+        {
+            var typeNamespace = generatedTypeNamespace ?? CustomCodeView?.Type.Namespace ?? BuildNamespace();
+            var typeName = generatedTypeName ?? CustomCodeView?.Name ?? BuildName();
+            var lastContractView = CodeModelGenerator.Instance.SourceInputModel.FindForTypeInLastContract(
+                typeNamespace,
+                typeName,
                 _declaringTypeName.Value);
+            if (lastContractView is not null || _inputType is null || _inputType.IsExactName)
+            {
+                return lastContractView;
+            }
+
+            var originalName = _inputType.Name.ToIdentifierName();
+            if (typeName != originalName.NormalizeCSharpAcronyms())
+            {
+                return null;
+            }
+
+            return CodeModelGenerator.Instance.SourceInputModel.FindForTypeInLastContract(
+                typeNamespace,
+                originalName,
+                _declaringTypeName.Value);
+        }
 
         private static string? GetDeclaringTypeName(TypeProvider? declaringTypeProvider)
         {
@@ -801,9 +821,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _customCodeView = new(BuildCustomCodeView(name ?? Type.Name, @namespace ?? Type.Namespace));
             name = _customCodeView.Value?.Name ?? name ?? Type.Name;
             @namespace = _customCodeView.Value?.Type.Namespace ?? @namespace ?? Type.Namespace;
-            _lastContractView = new(BuildLastContractView(
+            var lastContractView = BuildLastContractView(
                 name,
-                @namespace));
+                @namespace);
+            _lastContractView = new(lastContractView);
+            name = _customCodeView.Value?.Name ?? lastContractView?.Name ?? name;
             // recalculate declaration modifiers and constructors
             _declarationModifiers = null;
             // constructors might change based on declaration modifier changes

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
@@ -133,8 +133,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
         {
             await MockHelpers.LoadMockGeneratorAsync(
                 createCSharpTypeCore: (inputType) => typeof(string),
-                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(
-                    method: nameof(BuildEnumType_BackCompatTakesPrecedenceOverAcronymNormalization)));
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
             var input = InputFactory.StringEnum(
                 "IpKind",
                 [("Value", "value")],

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/EnumProviderTests.cs
@@ -128,6 +128,27 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.AreEqual("IpKind", enumType.Name);
         }
 
+        [Test]
+        public async Task BuildEnumType_BackCompatTakesPrecedenceAfterNamespaceUpdate()
+        {
+            await MockHelpers.LoadMockGeneratorAsync(
+                createCSharpTypeCore: (inputType) => typeof(string),
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(
+                    method: nameof(BuildEnumType_BackCompatTakesPrecedenceOverAcronymNormalization)));
+            var input = InputFactory.StringEnum(
+                "IpKind",
+                [("Value", "value")],
+                clientNamespace: "Sample");
+
+            var enumType = EnumProvider.Create(input);
+            Assert.AreEqual("IPKind", enumType.Name);
+
+            enumType.Update(@namespace: "Sample.Models");
+
+            Assert.AreEqual("IpKind", enumType.Name);
+            Assert.IsNotNull(enumType.LastContractView);
+        }
+
         // Validates the api version enum
         [TestCase]
         public void BuildEnumType_ValidateApiVersionEnum()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/TestData/EnumProviderTests/BuildEnumType_BackCompatTakesPrecedenceAfterNamespaceUpdate/IpKind.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/EnumProviders/TestData/EnumProviderTests/BuildEnumType_BackCompatTakesPrecedenceAfterNamespaceUpdate/IpKind.cs
@@ -1,0 +1,7 @@
+namespace Sample.Models
+{
+    public enum IpKind
+    {
+        Value
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -119,8 +119,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                 ]);
             await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: [inputModel],
-                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(
-                    method: nameof(TestBuildName_BackCompatTakesPrecedenceOverAcronymNormalization)));
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
 
             var modelProvider = CodeModelGenerator.Instance.TypeFactory.CreateModel(inputModel);
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -105,6 +105,37 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "IpAddressProperty"));
         }
 
+        [Test]
+        public async Task TestBuildName_BackCompatTakesPrecedenceAfterNamespaceUpdate()
+        {
+            var inputModel = InputFactory.Model(
+                "IpAddress",
+                @namespace: "Sample",
+                properties:
+                [
+                    InputFactory.Property("dbName", InputPrimitiveType.String),
+                    InputFactory.Property("osProfile", InputPrimitiveType.String),
+                    InputFactory.Property("IpAddress", InputPrimitiveType.String)
+                ]);
+            await MockHelpers.LoadMockGeneratorAsync(
+                inputModelTypes: [inputModel],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(
+                    method: nameof(TestBuildName_BackCompatTakesPrecedenceOverAcronymNormalization)));
+
+            var modelProvider = CodeModelGenerator.Instance.TypeFactory.CreateModel(inputModel);
+
+            Assert.IsNotNull(modelProvider);
+            Assert.AreEqual("IPAddress", modelProvider!.Name);
+
+            modelProvider.Update(@namespace: "Sample.Models");
+
+            Assert.AreEqual("IpAddress", modelProvider.Name);
+            Assert.IsNotNull(modelProvider.LastContractView);
+            Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "DbName"));
+            Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "OSProfile"));
+            Assert.IsNotNull(modelProvider.Properties.SingleOrDefault(p => p.Name == "IpAddressProperty"));
+        }
+
         // Validates that the property body's setter is correctly set based on the property type
         [TestCaseSource(nameof(BuildProperties_ValidatePropertySettersTestCases))]
         public void TestBuildProperties_ValidatePropertySetters(InputModelProperty inputModelProperty, CSharpType type, bool hasSetter)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/TestBuildName_BackCompatTakesPrecedenceAfterNamespaceUpdate/IpAddress.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/TestBuildName_BackCompatTakesPrecedenceAfterNamespaceUpdate/IpAddress.cs
@@ -1,0 +1,8 @@
+namespace Sample.Models
+{
+    public partial class IpAddress
+    {
+        public string DbName { get; }
+        public string IpAddressProperty { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve last-contract model and enum spelling when namespace visitors relocate generated types
- fall back from the normalized generated name to the original input name only when the names differ solely by supported acronym normalization
- retain enum input metadata so the compatibility lookup can use that fallback
- add regression coverage for model properties and enums after namespace updates

## Validation
- dotnet test packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Microsoft.TypeSpec.Generator.Tests.csproj --no-restore --verbosity minimal -p:NuGetAudit=false (1905 passed)

Fixes #11696