### PR TITLE
Add CFSClean2 to network isolation policy

### DIFF
--- a/eng/common/pipelines/templates/1es-redirect.yml
+++ b/eng/common/pipelines/templates/1es-redirect.yml
@@ -27,7 +27,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive, CFSClean
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     sdl:
       codeql:
         compiled:


### PR DESCRIPTION
## typespec-ci
### Attempted Fix
https://dev.azure.com/azure-sdk/public/_build/results?buildId=6712272&view=results

### Failure
https://dev.azure.com/azure-sdk/public/_build/results?buildId=6697171&view=logs&j=9d31dd02-2a28-5dd7-34f1-13f1e0dc8127&t=6736b1e6-eed2-52e1-7e67-33afcfdb97e6&l=154
 
 ```
Policy: CFSClean2 - Policy required for SFI compliance. Status = [ NOT COMPLIANT ] (1 violations)
oss.sonatype.org
  Domain name: oss.sonatype.org
  Service tags: Amazon,Amazon.CLOUDFRONT
  IP address: 108.138.246.129
  Process path: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\21.0.12-8.0\x64\bin\java.exe
  Task name: PowerShell
```

## typespec - Publish
https://dev.azure.com/azure-sdk/internal/_build?definitionId=3226&_a=summary

- powershellgallery.com
- should be fine to block

## typespec - http-client-java - publish
https://dev.azure.com/azure-sdk/internal/_build?definitionId=7294&_a=summary

- oss.sonatype.org
- likely same as typespec - ci