### PR TITLE
Fix C# synthesized acronym parameter compatibility

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DeserializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DeserializationTests.cs
@@ -114,6 +114,25 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
                 $"Uri property should specify UriKind.RelativeOrAbsolute. Actual:\n{methodBody}");
         }
 
+        [Test]
+        public void AcronymPropertyUsesSynthesizedParameterName()
+        {
+            var inputModel = InputFactory.Model(
+                "TestModel",
+                properties: [InputFactory.Property("ipv4Address", InputPrimitiveType.String)]);
+
+            var mrwProvider = new ModelProvider(inputModel).SerializationProviders.FirstOrDefault();
+            Assert.IsNotNull(mrwProvider);
+
+            var deserializationMethod = mrwProvider!.Methods
+                .FirstOrDefault(m => m.Signature.Name.StartsWith("Deserialize"));
+            Assert.IsNotNull(deserializationMethod);
+
+            var methodBody = deserializationMethod!.BodyStatements!.ToDisplayString();
+            Assert.That(methodBody, Does.Contain("iPv4Address"));
+            Assert.That(methodBody, Does.Not.Contain("ipv4Address ="));
+        }
+
         // Validates that duration properties encoded as integer milliseconds are deserialized
         // from an integer JSON value (GetInt32 for Int32 wire type, GetInt64 for larger integer kinds).
         [TestCase(nameof(InputPrimitiveType.Int32))]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -83,10 +83,11 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
         }
 
         [return: NotNullIfNotNull(nameof(name))]
-        public static string ToVariableName(
-            this string name,
-            bool preserveUnderscores = false,
-            bool normalizeAcronyms = true)
+        public static string ToVariableName(this string name, bool preserveUnderscores = false)
+            => name.ToVariableName(preserveUnderscores, normalizeAcronyms: true);
+
+        [return: NotNullIfNotNull(nameof(name))]
+        public static string ToVariableName(this string name, bool preserveUnderscores, bool normalizeAcronyms)
         {
             var variableName = name.ToIdentifierName(useCamelCase: true, preserveUnderscores: preserveUnderscores);
             if (normalizeAcronyms &&

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -83,11 +83,10 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
         }
 
         [return: NotNullIfNotNull(nameof(name))]
-        public static string ToVariableName(this string name, bool preserveUnderscores = false)
-            => name.ToVariableName(preserveUnderscores, normalizeAcronyms: true);
-
-        [return: NotNullIfNotNull(nameof(name))]
-        public static string ToVariableName(this string name, bool preserveUnderscores, bool normalizeAcronyms)
+        public static string ToVariableName(
+            this string name,
+            bool preserveUnderscores = false,
+            bool normalizeAcronyms = true)
         {
             var variableName = name.ToIdentifierName(useCamelCase: true, preserveUnderscores: preserveUnderscores);
             if (normalizeAcronyms &&

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/src/Extensions/StringExtensions.cs
@@ -83,10 +83,14 @@ namespace Microsoft.TypeSpec.Generator.Input.Extensions
         }
 
         [return: NotNullIfNotNull(nameof(name))]
-        public static string ToVariableName(this string name, bool preserveUnderscores = false)
+        public static string ToVariableName(
+            this string name,
+            bool preserveUnderscores = false,
+            bool normalizeAcronyms = true)
         {
             var variableName = name.ToIdentifierName(useCamelCase: true, preserveUnderscores: preserveUnderscores);
-            if (variableName is { Length: >= 4 } &&
+            if (normalizeAcronyms &&
+                variableName is { Length: >= 4 } &&
                 variableName[0] == 'i' &&
                 variableName[1] == 'P' &&
                 variableName[2] == 'v' &&

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/StringExtensionsTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.TypeSpec.Generator.Input.Tests
         [TestCase("IPAddress", "ipAddress")]
         public void TestToVariableNameWithoutAcronymNormalization(string name, string expected)
         {
-            Assert.AreEqual(expected, name.ToVariableName(normalizeAcronyms: false));
+            Assert.AreEqual(expected, name.ToVariableName(preserveUnderscores: false, normalizeAcronyms: false));
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/StringExtensionsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.Input/test/StringExtensionsTests.cs
@@ -58,5 +58,13 @@ namespace Microsoft.TypeSpec.Generator.Input.Tests
         {
             Assert.AreEqual(expected, name.ToVariableName());
         }
+
+        [TestCase("IPv4", "iPv4")]
+        [TestCase("IPv6Address", "iPv6Address")]
+        [TestCase("IPAddress", "ipAddress")]
+        public void TestToVariableNameWithoutAcronymNormalization(string name, string expected)
+        {
+            Assert.AreEqual(expected, name.ToVariableName(normalizeAcronyms: false));
+        }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -199,7 +199,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 var variableName = parameter.InputParameter?.IsExactName == true
                     ? parameter.Name
-                    : parameter.Property is not null
+                    : parameter.Name.Length > 0 && char.IsLower(parameter.Name[0])
                         ? parameter.Name.ToVariableName(preserveUnderscores: false, normalizeAcronyms: false)
                         : parameter.Name.ToVariableName();
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -199,7 +199,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 var variableName = parameter.InputParameter?.IsExactName == true
                     ? parameter.Name
-                    : parameter.Name.ToVariableName();
+                    : parameter.Property is not null
+                        ? parameter.Name
+                        : parameter.Name.ToVariableName();
 
                 parameter._asVariable = new VariableExpression(
                     parameter.Type,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -200,7 +200,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 var variableName = parameter.InputParameter?.IsExactName == true
                     ? parameter.Name
                     : parameter.Property is not null
-                        ? parameter.Name
+                        ? parameter.Name.ToVariableName(normalizeAcronyms: false)
                         : parameter.Name.ToVariableName();
 
                 parameter._asVariable = new VariableExpression(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -200,7 +200,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 var variableName = parameter.InputParameter?.IsExactName == true
                     ? parameter.Name
                     : parameter.Property is not null
-                        ? parameter.Name.ToVariableName(normalizeAcronyms: false)
+                        ? parameter.Name.ToVariableName(preserveUnderscores: false, normalizeAcronyms: false)
                         : parameter.Name.ToVariableName();
 
                 parameter._asVariable = new VariableExpression(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -188,7 +188,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
         [MemberNotNull(nameof(_parameter))]
         private void InitializeParameter(FormattableString description)
         {
-            _parameter = new(() => new ParameterProvider(Name.ToVariableName(), description, Type, property: this));
+            _parameter = new(() => new ParameterProvider(
+                Name.ToIdentifierName(useCamelCase: true),
+                description,
+                Type,
+                property: this));
         }
 
         public VariableExpression AsVariableExpression => _variable ??= new(Type, Name.ToVariableName());

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -195,7 +195,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 property: this));
         }
 
-        public VariableExpression AsVariableExpression => _variable ??= new(Type, Name.ToVariableName());
+        public VariableExpression AsVariableExpression => _variable ??= AsParameter;
 
         private static bool IsDiscriminatorProperty(InputProperty inputProperty)
         {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -189,7 +189,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private void InitializeParameter(FormattableString description)
         {
             _parameter = new(() => new ParameterProvider(
-                Name.ToIdentifierName(useCamelCase: true),
+                Name.ToVariableName(normalizeAcronyms: false),
                 description,
                 Type,
                 property: this));

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -189,7 +189,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private void InitializeParameter(FormattableString description)
         {
             _parameter = new(() => new ParameterProvider(
-                Name.ToVariableName(normalizeAcronyms: false),
+                Name.ToVariableName(preserveUnderscores: false, normalizeAcronyms: false),
                 description,
                 Type,
                 property: this));

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/BackCompatHelper.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Utilities/BackCompatHelper.cs
@@ -676,7 +676,8 @@ namespace Microsoft.TypeSpec.Generator.Utilities
             }
             else
             {
-                arguments.Add(PositionalReference(currentParam.Name.ToVariableName(), value));
+                var argumentName = currentParam.AsVariable().Declaration.RequestedName;
+                arguments.Add(PositionalReference(argumentName, value));
             }
         }
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -685,6 +685,29 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         }
 
         [Test]
+        public void AcronymParameterNameIsNotNormalized()
+        {
+            var model = InputFactory.Model(
+                "AggregateRouteConfiguration",
+                properties:
+                [
+                    InputFactory.Property("Ipv4Routes", InputFactory.Array(InputPrimitiveType.String)),
+                ]);
+
+            _instance = MockHelpers.LoadMockGenerator(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: [model]).Object;
+
+            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            var method = modelFactory.Methods.Single(m =>
+                m.Signature.Name == "AggregateRouteConfiguration");
+
+            Assert.That(
+                method.Signature.Parameters.Select(p => p.Name),
+                Is.EqualTo(new[] { "iPv4Routes" }));
+        }
+
+        [Test]
         public async Task BackCompatibility_SkipsMethodWithUnavailableParameterType()
         {
             var externalTool = InputFactory.Model(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -708,6 +708,35 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         }
 
         [Test]
+        public async Task BackCompatibility_AcronymParameterNameIsPreservedInForwardingCall()
+        {
+            var model = InputFactory.Model(
+                "AggregateRouteConfiguration",
+                properties:
+                [
+                    InputFactory.Property("Ipv4Routes", InputFactory.Array(InputPrimitiveType.String)),
+                    InputFactory.Property("NewProperty", InputPrimitiveType.String),
+                ]);
+
+            _instance = (await MockHelpers.LoadMockGeneratorAsync(
+                inputNamespaceName: "Sample.Namespace",
+                inputModelTypes: [model],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
+
+            var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
+            modelFactory.ProcessTypeForBackCompatibility();
+
+            var backCompatMethod = modelFactory.Methods.Single(m =>
+                m.Signature.Name == "AggregateRouteConfiguration"
+                && m.Signature.Parameters.Count == 1);
+
+            Assert.AreEqual("iPv4Routes", backCompatMethod.Signature.Parameters[0].Name);
+            Assert.AreEqual(
+                "return AggregateRouteConfiguration(iPv4Routes: iPv4Routes, newProperty: default);\n",
+                backCompatMethod.BodyStatements!.ToDisplayString());
+        }
+
+        [Test]
         public async Task BackCompatibility_SkipsMethodWithUnavailableParameterType()
         {
             var externalTool = InputFactory.Model(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_AcronymParameterNameIsPreservedInForwardingCall/SampleNamespaceModelFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/TestData/ModelFactoryProviderTests/BackCompatibility_AcronymParameterNameIsPreservedInForwardingCall/SampleNamespaceModelFactory.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Sample.Models;
+
+namespace Sample.Namespace
+{
+    public static partial class SampleNamespaceModelFactory
+    {
+        public static AggregateRouteConfiguration AggregateRouteConfiguration(
+            IEnumerable<string> iPv4Routes = default)
+        {
+            return null;
+        }
+    }
+
+}
+
+namespace Sample.Models
+{
+    public partial class AggregateRouteConfiguration
+    {
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -2486,6 +2486,32 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         }
 
         [Test]
+        public async Task BackCompat_ConstructorAcronymParameterNameIsPreserved()
+        {
+            var inputModel = InputFactory.Model(
+                "MockInputModel",
+                usage: InputModelTypeUsage.Input,
+                properties:
+                [
+                    InputFactory.Property("ipv4Address", InputPrimitiveType.String, isRequired: true),
+                ]);
+
+            await MockHelpers.LoadMockGeneratorAsync(
+                inputModelTypes: [inputModel],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var modelProvider = CodeModelGenerator.Instance.OutputLibrary.TypeProviders
+                .OfType<ModelProvider>()
+                .Single(t => t.Name == "MockInputModel");
+
+            modelProvider.ProcessTypeForBackCompatibility();
+
+            var constructor = modelProvider.Constructors.Single(c =>
+                c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.That(constructor.Signature.Parameters.Select(p => p.Name), Is.EqualTo(new[] { "iPv4Address" }));
+        }
+
+        [Test]
         public async Task BackCompat_ConstructorParameterCasingAndRotationRestoredBySignatureMatch()
         {
             var casingModel = InputFactory.Model(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_ConstructorAcronymParameterNameIsPreserved/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_ConstructorAcronymParameterNameIsPreserved/MockInputModel.cs
@@ -1,0 +1,9 @@
+namespace Sample.Models
+{
+    public partial class MockInputModel
+    {
+        public MockInputModel(string iPv4Address)
+        {
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ParameterProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ParameterProviderTests.cs
@@ -67,6 +67,16 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.IsTrue(parameter.ToPublicInputParameter().Type.Equals(typeof(IEnumerable<string>)));
         }
 
+        [TestCase("IPv4Routes", "ipv4Routes")]
+        [TestCase("iPv4Routes", "iPv4Routes")]
+        [TestCase("regularName", "regularName")]
+        public void VariableNamePreservesExistingCamelCase(string name, string expected)
+        {
+            var parameter = new ParameterProvider(name, $"Description", typeof(string));
+
+            Assert.AreEqual(expected, parameter.AsVariable().Declaration.RequestedName);
+        }
+
         private static IEnumerable<InputType> ValueInputTypes()
         {
             yield return InputPrimitiveType.Int32;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -129,15 +129,15 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.AreEqual(expectedName, property.Name);
         }
 
-        [TestCase("Ipv4", false, "ipv4")]
-        [TestCase("Ipv6", false, "ipv6")]
+        [TestCase("Ipv4", false, "iPv4")]
+        [TestCase("Ipv6", false, "iPv6")]
         [TestCase("IpAddress", false, "ipAddress")]
         [TestCase("DbAccount", false, "dbAccount")]
         [TestCase("OsProfile", false, "osProfile")]
         [TestCase("RegularName", false, "regularName")]
         [TestCase("MiniPv4", false, "miniPv4")]
         [TestCase("Ipv4", true, "ipv4")]
-        public void TestPropertyParameterDeclarationNormalizesAcronymCasing(string inputName, bool isExactName, string expectedName)
+        public void TestPropertyParameterDeclarationPreservesAcronymCasing(string inputName, bool isExactName, string expectedName)
         {
             var inputProperty = InputFactory.Property(
                 inputName,

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -149,6 +149,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             var property = new PropertyProvider(inputProperty, new TestTypeProvider());
 
             Assert.AreEqual(expectedName, property.AsParameter.AsVariable().Declaration.RequestedName);
+            Assert.AreEqual(expectedName, property.AsVariableExpression.Declaration.RequestedName);
         }
 
         [TestCaseSource(nameof(CollectionPropertyTestCases))]


### PR DESCRIPTION
## Summary
- preserve legacy casing for parameters synthesized from normalized model properties
- keep direct operation-parameter behavior unchanged
- add property and model-factory regression coverage

## Validation
- 1,906 Microsoft.TypeSpec.Generator tests pass
- reproduced and fixed the Managed Network Fabric \\AggregateRouteConfiguration\\ factory parameters

Fixes #11707