### PR TITLE
Preserve URL operation names from wrapper contracts

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -224,7 +224,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 return serviceMethod.Operation.Name;
             }
 
-            var operationName = serviceMethod.Operation.Name.ToIdentifierName();
+            var operationName = (serviceMethod.Operation.OriginalName ?? serviceMethod.Operation.Name).ToIdentifierName();
             // Replace List with Get as .NET convention is to use Get for list operations.
             if (operationName == "List")
             {
@@ -243,7 +243,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 return operationName;
             }
 
-            var lastContractMethods = LastContractView?.Methods;
+            var lastContractMethods = BackCompatProvider.LastContractView?.Methods;
             if (lastContractMethods?.Any(m =>
                 m.Signature.Name == operationName ||
                 m.Signature.Name == $"{operationName}Async") == true)
@@ -1173,6 +1173,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 if (_backCompatProvider != backCompatProvider)
                 {
                     _backCompatProvider = backCompatProvider;
+                    CleanOperationNames(_inputClient);
                     // Only reset the cached methods (and the underlying RestClient methods)
                     // so they are rebuilt with the new backcompat provider. Do NOT call full
                     // Reset() — that would discard properties/constructors/fields applied by
@@ -1186,6 +1187,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
             else if (_backCompatProvider != null)
             {
                 _backCompatProvider = null;
+                CleanOperationNames(_inputClient);
                 ResetMethods();
                 _restClient?.ResetMethods();
                 _methodCache = null;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/ClientProvider.cs
@@ -243,7 +243,7 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
                 return operationName;
             }
 
-            var lastContractMethods = BackCompatProvider.LastContractView?.Methods;
+            var lastContractMethods = BackCompatProvider.LastContractView?.Methods ?? LastContractView?.Methods;
             if (lastContractMethods?.Any(m =>
                 m.Signature.Name == operationName ||
                 m.Signature.Name == $"{operationName}Async") == true)

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
@@ -4719,6 +4719,28 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         }
 
         [Test]
+        public async Task TestOperationNameFallsBackToClientLastContractWhenBackCompatProviderHasNoLastContract()
+        {
+            var inputOperation = InputFactory.Operation("GetUrl");
+            var inputServiceMethod = InputFactory.BasicServiceMethod("GetUrl", inputOperation);
+            var client = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+            var generator = await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [client],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var clientProvider = generator.Object.OutputLibrary.TypeProviders.OfType<ClientProvider>().Single();
+
+            Assert.AreEqual("GetUrl", inputServiceMethod.Name);
+
+            var backCompatProvider = new BackCompatTypeProvider("MissingWrapper", "Sample");
+            var methods = clientProvider.GetMethodCollectionByOperation(inputOperation, backCompatProvider);
+
+            Assert.IsNull(backCompatProvider.LastContractView);
+            Assert.AreEqual("GetUrl", inputServiceMethod.Name);
+            Assert.AreEqual("GetUrl", inputServiceMethod.Operation.Name);
+            Assert.IsTrue(methods.Any(m => m.Signature.Name == "GetUrl"));
+        }
+
+        [Test]
         public void TestIsExactNameServiceMethodSkipsListToGetRename()
         {
             // The normal CleanOperationNames behavior renames "List" -> "GetAll" and "ListFoo" -> "GetFoo".

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/ClientProviderTests.cs
@@ -4698,6 +4698,27 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
         }
 
         [Test]
+        public async Task TestOperationNamePreservesUrlSuffixFromBackCompatProvider()
+        {
+            var inputOperation = InputFactory.Operation("GetUrl");
+            var inputServiceMethod = InputFactory.BasicServiceMethod("GetUrl", inputOperation);
+            var client = InputFactory.Client("TestClient", methods: [inputServiceMethod]);
+            var generator = await MockHelpers.LoadMockGeneratorAsync(
+                clients: () => [client],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+            var clientProvider = generator.Object.OutputLibrary.TypeProviders.OfType<ClientProvider>().Single();
+
+            Assert.AreEqual("GetUri", inputServiceMethod.Name);
+
+            var backCompatProvider = new BackCompatTypeProvider("MockableTestResource", "Sample");
+            var methods = clientProvider.GetMethodCollectionByOperation(inputOperation, backCompatProvider);
+
+            Assert.AreEqual("GetUrl", inputServiceMethod.Name);
+            Assert.AreEqual("GetUrl", inputServiceMethod.Operation.Name);
+            Assert.IsTrue(methods.Any(m => m.Signature.Name == "GetUrl"));
+        }
+
+        [Test]
         public void TestIsExactNameServiceMethodSkipsListToGetRename()
         {
             // The normal CleanOperationNames behavior renames "List" -> "GetAll" and "ListFoo" -> "GetFoo".
@@ -4723,6 +4744,23 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ClientProvide
             Assert.AreEqual("GetAll", inputServiceMethod.Name);
             Assert.AreEqual("GetAll", inputServiceMethod.Operation.Name);
         }
+
+        private sealed class BackCompatTypeProvider : TypeProvider
+        {
+            private readonly string _name;
+            private readonly string _namespace;
+
+            public BackCompatTypeProvider(string name, string ns)
+            {
+                _name = name;
+                _namespace = ns;
+            }
+
+            protected override string BuildRelativeFilePath() => $"{_name}.cs";
+            protected override string BuildName() => _name;
+            protected override string BuildNamespace() => _namespace;
+        }
+
         private static ClientProvider BuildMultipartClient(InputModelType bodyModel, bool bodyIsRequired = true)
         {
             var body = InputFactory.MethodParameter(

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/TestOperationNameFallsBackToClientLastContractWhenBackCompatProviderHasNoLastContract/TestClient.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/TestOperationNameFallsBackToClientLastContractWhenBackCompatProviderHasNoLastContract/TestClient.cs
@@ -1,0 +1,12 @@
+using System.ClientModel;
+using System.Threading.Tasks;
+
+namespace Sample
+{
+    public partial class TestClient
+    {
+        public virtual ClientResult GetUrl() => default!;
+
+        public virtual Task<ClientResult> GetUrlAsync() => default!;
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/TestOperationNamePreservesUrlSuffixFromBackCompatProvider/MockableTestResource.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ClientProviders/TestData/ClientProviderTests/TestOperationNamePreservesUrlSuffixFromBackCompatProvider/MockableTestResource.cs
@@ -1,0 +1,12 @@
+using System.ClientModel;
+using System.Threading.Tasks;
+
+namespace Sample
+{
+    public partial class MockableTestResource
+    {
+        public virtual ClientResult GetUrl() => default!;
+
+        public virtual Task<ClientResult> GetUrlAsync() => default!;
+    }
+}


### PR DESCRIPTION
## Summary
- re-evaluate operation names when a wrapper back-compat provider is supplied
- preserve shipped `Url`-suffixed methods from the wrapper's last contract
- add a regression proving an initially normalized `GetUri` operation is restored to `GetUrl`

## Validation
- `Microsoft.TypeSpec.Generator.ClientModel.Tests`: 1,572 passed

## Follow-up
This is the unbranded generator prerequisite and only partially addresses #11708. The Azure management emitter must still pass each final resource/mockable-resource/extension provider into this path and separately provide the final management contract for enum values such as `NextPageUrl` and `Url`.