### PR TITLE
Normalize new IPv4 parameter names

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DeserializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DeserializationTests.cs
@@ -129,8 +129,8 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             Assert.IsNotNull(deserializationMethod);
 
             var methodBody = deserializationMethod!.BodyStatements!.ToDisplayString();
-            Assert.That(methodBody, Does.Contain("iPv4Address"));
-            Assert.That(methodBody, Does.Not.Contain("ipv4Address ="));
+            Assert.That(methodBody, Does.Contain("ipv4Address ="));
+            Assert.That(methodBody, Does.Not.Contain("iPv4Address"));
         }
 
         // Validates that duration properties encoded as integer milliseconds are deserialized

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/PropertyProvider.cs
@@ -189,7 +189,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private void InitializeParameter(FormattableString description)
         {
             _parameter = new(() => new ParameterProvider(
-                Name.ToVariableName(preserveUnderscores: false, normalizeAcronyms: false),
+                Name.ToVariableName(),
                 description,
                 Type,
                 property: this));

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelFactories/ModelFactoryProviderTests.cs
@@ -685,7 +685,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
         }
 
         [Test]
-        public void AcronymParameterNameIsNotNormalized()
+        public void NewAcronymParameterNameIsNormalized()
         {
             var model = InputFactory.Model(
                 "AggregateRouteConfiguration",
@@ -704,11 +704,11 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
 
             Assert.That(
                 method.Signature.Parameters.Select(p => p.Name),
-                Is.EqualTo(new[] { "iPv4Routes" }));
+                Is.EqualTo(new[] { "ipv4Routes" }));
         }
 
         [Test]
-        public async Task BackCompatibility_AcronymParameterNameIsPreservedInForwardingCall()
+        public async Task BackCompatibility_AcronymParameterNameIsPreservedAlongsideNormalizedCurrentMethod()
         {
             var model = InputFactory.Model(
                 "AggregateRouteConfiguration",
@@ -721,19 +721,23 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelFactories
             _instance = (await MockHelpers.LoadMockGeneratorAsync(
                 inputNamespaceName: "Sample.Namespace",
                 inputModelTypes: [model],
-                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync())).Object;
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(
+                    method: "BackCompatibility_AcronymParameterNameIsPreservedInForwardingCall"))).Object;
 
             var modelFactory = _instance.OutputLibrary.ModelFactory.Value;
             modelFactory.ProcessTypeForBackCompatibility();
 
+            var currentMethod = modelFactory.Methods.Single(m =>
+                m.Signature.Name == "AggregateRouteConfiguration"
+                && m.Signature.Parameters.Count == 2);
             var backCompatMethod = modelFactory.Methods.Single(m =>
                 m.Signature.Name == "AggregateRouteConfiguration"
                 && m.Signature.Parameters.Count == 1);
 
+            Assert.AreEqual("ipv4Routes", currentMethod.Signature.Parameters[0].Name);
             Assert.AreEqual("iPv4Routes", backCompatMethod.Signature.Parameters[0].Name);
-            Assert.AreEqual(
-                "return AggregateRouteConfiguration(iPv4Routes: iPv4Routes, newProperty: default);\n",
-                backCompatMethod.BodyStatements!.ToDisplayString());
+            Assert.That(backCompatMethod.BodyStatements!.ToDisplayString(), Does.Contain("iPv4Routes"));
+            Assert.That(backCompatMethod.BodyStatements!.ToDisplayString(), Does.Not.Contain("ipv4Routes"));
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/PropertyProviderTests.cs
@@ -129,15 +129,15 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers
             Assert.AreEqual(expectedName, property.Name);
         }
 
-        [TestCase("Ipv4", false, "iPv4")]
-        [TestCase("Ipv6", false, "iPv6")]
+        [TestCase("Ipv4", false, "ipv4")]
+        [TestCase("Ipv6", false, "ipv6")]
         [TestCase("IpAddress", false, "ipAddress")]
         [TestCase("DbAccount", false, "dbAccount")]
         [TestCase("OsProfile", false, "osProfile")]
         [TestCase("RegularName", false, "regularName")]
         [TestCase("MiniPv4", false, "miniPv4")]
         [TestCase("Ipv4", true, "ipv4")]
-        public void TestPropertyParameterDeclarationPreservesAcronymCasing(string inputName, bool isExactName, string expectedName)
+        public void TestPropertyParameterDeclarationNormalizesAcronymCasing(string inputName, bool isExactName, string expectedName)
         {
             var inputProperty = InputFactory.Property(
                 inputName,


### PR DESCRIPTION
## Summary
- normalize newly generated property-derived IPv4/IPv6 parameter names to `ipv4`/`ipv6`
- preserve shipped `iPv4` names only through last-contract compatibility handling
- update model-factory and deserialization regressions to cover both new and existing contracts

Follow-up to #11714.

## Validation
- targeted core casing tests: 11 passed
- ClientModel tests: 1,574 passed
- Azure.Analytics.Defender.Easm regenerated with the local emitter: no diff
- Azure.Analytics.Defender.Easm build: passed with 0 warnings and 0 errors
- core generator suite: 1,902 passed; 9 unrelated Windows plugin subprocess tests fail locally because the spawned dotnet process exits with `0x8000809B`