### PR TITLE
Fix: [ms] encoded duration default values were being encoded with the wrong format.

### DIFF
--- a/.chronus/changes/fix-duration-milliseconds-example-serialization-2026-8-19-18-30-0.md
+++ b/.chronus/changes/fix-duration-milliseconds-example-serialization-2026-8-19-18-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix `duration` example values being serialized verbatim as an ISO 8601 string instead of a numeric value when encoded with `@encode("milliseconds", ...)`

--- a/packages/compiler/src/lib/examples.ts
+++ b/packages/compiler/src/lib/examples.ts
@@ -310,6 +310,12 @@ const ScalarSerializers = {
         } else {
           return duration.total({ unit: "seconds" });
         }
+      case "milliseconds":
+        if (isInteger(encodeAs.type)) {
+          return Math.floor(duration.total({ unit: "milliseconds" }));
+        } else {
+          return duration.total({ unit: "milliseconds" });
+        }
       default:
         return duration.toString();
     }

--- a/packages/compiler/test/decorators/examples.test.ts
+++ b/packages/compiler/test/decorators/examples.test.ts
@@ -477,6 +477,16 @@ describe("json serialization of examples", () => {
             expect: 0.5,
             encode: `@encode("seconds", float32)`,
           },
+          {
+            value: `duration.fromISO("PT5M")`,
+            expect: 300000,
+            encode: `@encode("milliseconds", int32)`,
+          },
+          {
+            value: `duration.fromISO("PT0.5S")`,
+            expect: 500,
+            encode: `@encode("milliseconds", float32)`,
+          },
         ],
       ],
     ];


### PR DESCRIPTION
This pull request fixes an issue with how `duration` example values are serialized when using the `@encode("milliseconds", ...)` decorator. Previously, these values were being serialized as ISO 8601 strings instead of numeric values. The update ensures that durations are now correctly serialized as numbers representing milliseconds. The most important changes are:

**Bug Fix: Duration Serialization**

* Fixed the serialization logic in `packages/compiler/src/lib/examples.ts` so that when encoding durations as `"milliseconds"`, the output is a numeric value (integer or float, as appropriate), not an ISO 8601 string.

**Testing**

* Added new test cases in `packages/compiler/test/decorators/examples.test.ts` to verify that durations encoded as milliseconds produce the correct numeric values in both integer and float formats.

**Documentation**

* Added a changelog entry in `.chronus/changes/fix-duration-milliseconds-example-serialization-2026-8-19-18-30-0.md` describing the fix and its impact.