### PR TITLE
fix(http-client-csharp): fix constructor and serialization generation for models rebased with hierarchyBuilding

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/Providers/MrwSerializationTypeDefinition.cs
@@ -797,20 +797,22 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Providers
 
         private SwitchCaseStatement[] GetDiscriminatorSwitchCases(ModelProvider unknownVariant)
         {
-            SwitchCaseStatement[] cases = new SwitchCaseStatement[_model.DerivedModels.Count - 1];
-            int index = 0;
-            for (int i = 0; i < cases.Length; i++)
+            // Enumerate every derived model rather than the first (Count - 1) entries. The unknown
+            // variant is not guaranteed to be last - rebasing a hierarchy (for example via
+            // hierarchyBuilding) can append derived models after it - which would otherwise leave
+            // unassigned entries in the array.
+            List<SwitchCaseStatement> cases = new(_model.DerivedModels.Count);
+            foreach (var model in _model.DerivedModels)
             {
-                var model = _model.DerivedModels[i];
-                if (ReferenceEquals(model, unknownVariant))
+                if (ReferenceEquals(model, unknownVariant) || model.DiscriminatorValue is null)
                 {
                     continue;
                 }
-                cases[index++] = new SwitchCaseStatement(
-                    Literal(model.DiscriminatorValue!),
-                    Return(GetDeserializationMethodInvocationForType(model, _jsonElementParameterSnippet, _dataParameter, _serializationOptionsParameter)));
+                cases.Add(new SwitchCaseStatement(
+                    Literal(model.DiscriminatorValue),
+                    Return(GetDeserializationMethodInvocationForType(model, _jsonElementParameterSnippet, _dataParameter, _serializationOptionsParameter))));
             }
-            return cases;
+            return [.. cases];
         }
 
         /// <summary>

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DiscriminatorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DiscriminatorTests.cs
@@ -74,6 +74,49 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
         }
 
         [Test]
+        public void RebasedDerivedModelDoesNotProduceNullSwitchCase()
+        {
+            // A model rebased onto this hierarchy (for example via hierarchyBuilding) is appended to
+            // DerivedModels after the generated unknown variant, so the unknown variant is no longer
+            // last. The discriminator switch cases must still be fully populated.
+            var rebasedModel = InputFactory.Model(
+                "voiceItem",
+                discriminatedKind: "voice",
+                baseModel: _baseModel,
+                properties:
+                [
+                    InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true)
+                ]);
+
+            MockHelpers.LoadMockGenerator(inputModels: () => [_baseModel, _catModel, _dogModel, rebasedModel]);
+            var baseModel = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(_baseModel);
+            Assert.IsNotNull(baseModel);
+
+            var unknownVariantIndex = baseModel!.DerivedModels
+                .Select((m, i) => (m, i))
+                .First(t => t.m.IsUnknownDiscriminatorModel).i;
+            Assert.AreNotEqual(
+                baseModel.DerivedModels.Count - 1,
+                unknownVariantIndex,
+                "The unknown variant should not be last, otherwise this scenario is not covered.");
+
+            var serialization = baseModel.SerializationProviders.First();
+            var deserializeMethod = serialization.Methods.First(m => m.Signature.Name == "DeserializePet");
+            var statements = (MethodBodyStatements)deserializeMethod.BodyStatements!;
+            var ifStatement = (IfStatement)statements.Statements[1];
+            var switchStatement = (SwitchStatement)((MethodBodyStatements)ifStatement.Body).Statements[0];
+
+            Assert.AreEqual(3, switchStatement.Cases.Count);
+            for (int i = 0; i < switchStatement.Cases.Count; i++)
+            {
+                Assert.IsNotNull(switchStatement.Cases[i], $"Switch case at index {i} should not be null.");
+            }
+
+            // Writing the type must not throw - a null case previously caused a NullReferenceException.
+            Assert.DoesNotThrow(() => new TypeProviderWriter(serialization).Write());
+        }
+
+        [Test]
         public void UnknownVariantJsonCreateCoreShouldReturnDeserializeBase()
         {
             MockHelpers.LoadMockGenerator(inputModels: () => [_baseModel, _catModel, _dogModel]);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -760,7 +760,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 : _inputModel.Usage.HasFlag(InputModelTypeUsage.Input)
                     ? MethodSignatureModifiers.Public
                     : MethodSignatureModifiers.Internal;
-            var (constructorParameters, constructorInitializer) = BuildConstructorParameters(true);
+            var includeDiscriminatorParameter = _isDiscriminatedBaseType
+                && BaseModelProvider?._inputModel.DiscriminatorProperty is not null;
+            var (constructorParameters, constructorInitializer) = BuildConstructorParameters(
+                true,
+                includeDiscriminatorParameter);
 
             var constructor = new ConstructorProvider(
                 signature: new ConstructorSignature(
@@ -1310,7 +1314,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 ? baseParameters
                 : baseParameters.Where(p =>
                     p.Property is null
-                    || (!overriddenProperties.Contains(p.Property!) && (!p.Property.IsDiscriminator || !isInitializationConstructor || (includeDiscriminatorParameter && IsMultiLevelDiscriminator)))));
+                    || (!overriddenProperties.Contains(p.Property!) && (!p.Property.IsDiscriminator || !isInitializationConstructor || includeDiscriminatorParameter))));
 
             // construct the initializer using the parameters from base signature
             ConstructorInitializer? constructorInitializer = null;
@@ -1322,9 +1326,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     if (isInitializationConstructor && (IsMultiLevelDiscriminator || BaseModelProvider.IsMultiLevelDiscriminator))
                     {
                         var baseDiscriminatorParam = baseParameters.FirstOrDefault(p => p.Property?.IsDiscriminator == true);
-                        var hasDiscriminatorProperty = BaseModelProvider.CanonicalView.Properties.Any(p => p.IsDiscriminator);
 
-                        ValueExpression discriminatorExpression = (hasDiscriminatorProperty && baseDiscriminatorParam is not null && includeDiscriminatorParameter)
+                        ValueExpression discriminatorExpression = (baseDiscriminatorParam is not null && includeDiscriminatorParameter)
                             ? constructorParameters.FirstOrDefault(p => p.Property?.IsDiscriminator == true) ?? baseDiscriminatorParam
                             : DiscriminatorLiteral;
 

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/DiscriminatorTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/DiscriminatorTests.cs
@@ -177,6 +177,101 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.IsTrue(serializationCtor!.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal));
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void RebasedDiscriminatedBaseConstructorForwardsDeclaredParameter(bool useMultiLevelBase)
+        {
+            var rootModel = InputFactory.Model(
+                "conversationItem",
+                properties:
+                [
+                    InputFactory.Property(
+                        "type",
+                        InputPrimitiveType.String,
+                        isRequired: true,
+                        isDiscriminator: true)
+                ]);
+            var rebasedModel = rootModel;
+
+            if (useMultiLevelBase)
+            {
+                rebasedModel = InputFactory.Model(
+                    "realtimeConversationItem",
+                    properties:
+                    [
+                        InputFactory.Property(
+                            "type",
+                            InputPrimitiveType.String,
+                            isRequired: true,
+                            isDiscriminator: true)
+                    ],
+                    baseModel: rootModel,
+                    discriminatedKind: "realtime");
+            }
+
+            var voiceModel = InputFactory.Model(
+                "voiceConversationItem",
+                properties:
+                [
+                    InputFactory.Property(
+                        "type",
+                        InputPrimitiveType.String,
+                        isRequired: true,
+                        isDiscriminator: true)
+                ],
+                baseModel: rebasedModel);
+
+            MockHelpers.LoadMockGenerator(inputModelTypes: [rootModel, rebasedModel, voiceModel]);
+            var model = CodeModelGenerator.Instance.TypeFactory.CreateModel(voiceModel);
+
+            Assert.IsNotNull(model);
+            var constructor = model!.Constructors.Single(c =>
+                c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Private)
+                && c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Protected));
+            Assert.AreEqual(1, constructor.Signature.Parameters.Count);
+            Assert.AreEqual("type", constructor.Signature.Parameters[0].Name);
+            Assert.IsNotNull(constructor.Signature.Initializer);
+            Assert.AreEqual(1, constructor.Signature.Initializer!.Arguments.Count);
+            Assert.AreEqual("@type", constructor.Signature.Initializer.Arguments[0].ToDisplayString());
+        }
+
+        [Test]
+        public void RebasedDiscriminatedBaseWritesDeclaredConstructorParameter()
+        {
+            var rootModel = InputFactory.Model(
+                "conversationItem",
+                properties:
+                [
+                    InputFactory.Property(
+                        "type",
+                        InputPrimitiveType.String,
+                        isRequired: true,
+                        isDiscriminator: true)
+                ]);
+            var voiceModel = InputFactory.Model(
+                "voiceConversationItem",
+                properties:
+                [
+                    InputFactory.Property(
+                        "type",
+                        InputPrimitiveType.String,
+                        isRequired: true,
+                        isDiscriminator: true)
+                ],
+                baseModel: rootModel);
+
+            MockHelpers.LoadMockGenerator(inputModelTypes: [rootModel, voiceModel]);
+            var model = CodeModelGenerator.Instance.TypeFactory.CreateModel(voiceModel);
+
+            Assert.IsNotNull(model);
+            var content = new TypeProviderWriter(model!).Write().Content;
+
+            // The base call must only forward parameters that the constructor actually declares.
+            StringAssert.Contains(
+                "private protected VoiceConversationItem(string @type) : base(@type)",
+                content);
+        }
+
         [Test]
         public void DerivedPublicCtorShouldSetDiscriminator()
         {


### PR DESCRIPTION
Fixes two `@Legacy.hierarchyBuilding` bugs in the C# emitter that made a rebased discriminated model impossible to generate/compile.

## Bug 1 — uncompilable constructor (`CS0103`)

When a discriminated model is rebased onto another discriminated model, the emitter generated:

```csharp
private protected VoiceConversationItem() : base(@type)
{
}
```

`@type` was forwarded to the base initializer but never declared as a parameter, producing:

```
error CS0103: The name 'type' does not exist in the current context
```

**Cause:** `ModelProvider.BuildConstructorParameters` only kept the inherited discriminator in the *signature* when `includeDiscriminatorParameter && IsMultiLevelDiscriminator`, but it always forwarded it in the `base(...)` initializer. `ComputeIsMultiLevelDiscriminator` returns `false` for abstract types, and a discriminated base type is always abstract — so the rebased base type dropped the parameter while still passing the argument.

**Fix:** in `BuildConstructors`, compute `includeDiscriminatorParameter` from whether the *base model* actually declares a discriminator property, and honor that flag directly in the signature filter.

Generated output is now:

```csharp
private protected VoiceConversationItem(string @type) : base(@type)
{
}
```

## Bug 2 — `NullReferenceException` during generation

Generating the reported spec also crashed the emitter with a `NullReferenceException` in `SwitchStatement.Write`.

**Cause:** `MrwSerializationTypeDefinition.GetDiscriminatorSwitchCases` allocated `new SwitchCaseStatement[DerivedModels.Count - 1]` and iterated only that many entries while `continue`-ing past the unknown variant. That is only correct when the unknown variant is last. `hierarchyBuilding` appends the rebased model *after* the unknown variant, leaving a `null` slot in the array.

**Fix:** iterate all derived models into a list and skip entries with no discriminator value.

## Tests

- `Microsoft.TypeSpec.Generator` / `DiscriminatorTests`: 3 new tests covering the rebased-base constructor signature, the multi-level variant, and the emitted C# text.
- `Microsoft.TypeSpec.Generator.ClientModel` / `MrwSerializationTypeDefinitions.DiscriminatorTests`: 1 new test asserting no null switch cases when the unknown variant is not last, and that writing the provider does not throw.

All new tests were confirmed to fail before the corresponding fix.

## Validation

- `Microsoft.TypeSpec.Generator.Tests`: 1913 passed
- `Microsoft.TypeSpec.Generator.ClientModel.Tests`: 1575 passed
- `eng/scripts/Generate.ps1`: no diff to checked-in generated libraries
- `npm run cop`: passed

End-to-end against the reported spec shape (a `VoiceConversationItem` rebased onto `OpenAI.RealtimeConversationItem` via `hierarchyBuilding`):

- **Before:** generation emitted `private protected VoiceConversationItem() : base(@type)` and the build failed with `CS0103: The name 'type' does not exist in the current context` at `VoiceConversationItem.cs(21,58)`.
- **After:** generation emits `private protected VoiceConversationItem(string @type) : base(@type)` and the generated library builds with 0 errors and 0 warnings on `net8.0`.
