### PR TITLE
Improve the error message

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -69,14 +69,14 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(inputParameter.Type);
             if (type is null)
             {
-                StringBuilder sbError = new($"Failed to create CSharpType for {inputParameter.Type}, named in a TypeSpec as \"{inputParameter.Name}\".");
+                StringBuilder sbError = new($"Failed to create CSharpType for {inputParameter.Type}, named in TypeSpec as \"{inputParameter.Name}\".");
                 if (inputParameter.EnclosingType is not null)
                 {
-                    sbError.Append($"Enclosing type: {inputParameter.EnclosingType.Name}");
+                    sbError.Append($"\nEnclosing type: {inputParameter.EnclosingType.Name}");
                 }
                 if (Description is not null)
                 {
-                    sbError.Append($"Description: {Description}");
+                    sbError.Append($"\nDescription: {Description}");
                 }
                 throw new InvalidOperationException(sbError.ToString());
             }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             InputParameter = inputParameter;
             Name = inputParameter.Name;
             Description = DocHelpers.GetFormattableDescription(inputParameter.Summary, inputParameter.Doc) ?? FormattableStringHelpers.Empty;
-            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(inputParameter.Type) ?? throw new InvalidOperationException($"Failed to create CSharpType for {inputParameter.Type}");
+            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(inputParameter.Type) ?? throw new InvalidOperationException($"Failed to create CSharpType for {inputParameter.Type}, named in a typespec as \"{inputParameter.Name}\"; Description: {Description}");
             if (!inputParameter.IsRequired)
             {
                 type = !type.IsCollection ? type.WithNullable(true) : type;

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ParameterProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
@@ -65,7 +66,20 @@ namespace Microsoft.TypeSpec.Generator.Providers
             InputParameter = inputParameter;
             Name = inputParameter.Name;
             Description = DocHelpers.GetFormattableDescription(inputParameter.Summary, inputParameter.Doc) ?? FormattableStringHelpers.Empty;
-            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(inputParameter.Type) ?? throw new InvalidOperationException($"Failed to create CSharpType for {inputParameter.Type}, named in a typespec as \"{inputParameter.Name}\"; Description: {Description}");
+            var type = CodeModelGenerator.Instance.TypeFactory.CreateCSharpType(inputParameter.Type);
+            if (type is null)
+            {
+                StringBuilder sbError = new($"Failed to create CSharpType for {inputParameter.Type}, named in a TypeSpec as \"{inputParameter.Name}\".");
+                if (inputParameter.EnclosingType is not null)
+                {
+                    sbError.Append($"Enclosing type: {inputParameter.EnclosingType.Name}");
+                }
+                if (Description is not null)
+                {
+                    sbError.Append($"Description: {Description}");
+                }
+                throw new InvalidOperationException(sbError.ToString());
+            }
             if (!inputParameter.IsRequired)
             {
                 type = !type.IsCollection ? type.WithNullable(true) : type;


### PR DESCRIPTION
If we have a construct like 
```
@@alternateType(
 Our.Assembly.ClassName,
  {
    identity: "Some.External.Assembly.WrongClassName",
    package: "Some.External.Assembly",
    minVersion: "3.0.0-alpha.20260819.1",
  },
  "csharp"
);
```
We are getting stack trace with non-informative message: "Failed to create CSharpType for Microsoft.TypeSpec.Generator.Input.InputModelType". After the fix we will have more information.
But in the Ideal world the best message will be "The assembly Some.External.Assembly does not have class WrongClassName".