### PR TITLE
Invalidate the full constructor with the constructor cache

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -67,7 +67,6 @@ namespace Microsoft.TypeSpec.Generator.Providers
         private List<PropertyProvider>? _additionalPropertyProperties;
         private ModelProvider? _baseModelProvider;
         private ConstructorProvider? _fullConstructor;
-        private (string Name, string Namespace)? _fullConstructorIdentity;
         internal PropertyProvider? DiscriminatorProperty { get; private set; }
 
         private readonly bool _isDiscriminatedBaseType;
@@ -189,9 +188,13 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _rawDataField = null;
             _additionalPropertyFields = null;
             _additionalPropertyProperties = null;
-            _fullConstructor = null;
-            _fullConstructorIdentity = null;
             _isMultiLevelDiscriminator = null;
+        }
+
+        private protected override void ResetConstructors()
+        {
+            base.ResetConstructors();
+            _fullConstructor = null;
         }
 
         protected FieldProvider? RawDataField
@@ -235,26 +238,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         /// <summary>
         /// The constructor that takes every serializable property.
         /// </summary>
-        /// <remarks>
-        /// This instance is also returned as part of <see cref="TypeProvider.Constructors"/>, and callers are free to
-        /// mutate the constructors they receive. An identity change invalidates the constructor list, so the cached
-        /// instance is rebuilt alongside it; otherwise a rebuild would reuse the same instance and re-apply any
-        /// mutation, producing duplicated members.
-        /// </remarks>
-        public ConstructorProvider FullConstructor
-        {
-            get
-            {
-                var identity = (Type.Name, Type.Namespace);
-                if (_fullConstructor is null || _fullConstructorIdentity != identity)
-                {
-                    _fullConstructor = BuildFullConstructor();
-                    _fullConstructorIdentity = identity;
-                }
-
-                return _fullConstructor;
-            }
-        }
+        public ConstructorProvider FullConstructor => _fullConstructor ??= BuildFullConstructor();
 
         protected override string BuildNamespace() => string.IsNullOrEmpty(_inputModel.Namespace) ?
             // TODO remove null check once https://github.com/Azure/typespec-azure/issues/2209 is fixed.

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/TypeProvider.cs
@@ -690,7 +690,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _methods = null;
             _properties = null;
             _fields = null;
-            _constructors = null;
+            ResetConstructors();
             _implements = null;
             _serializationProviders = null;
             _nestedTypes = null;
@@ -710,6 +710,11 @@ namespace Microsoft.TypeSpec.Generator.Providers
             _description = null;
             _type = null;
             _arguments = null;
+        }
+
+        private protected virtual void ResetConstructors()
+        {
+            _constructors = null;
         }
 
         /// <summary>
@@ -830,7 +835,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             // recalculate declaration modifiers and constructors
             _declarationModifiers = null;
             // constructors might change based on declaration modifier changes
-            _constructors = null;
+            ResetConstructors();
             // serialization providers need to reflect the new type name/namespace
             _serializationProviders = null;
             Type.Update(name: name, @namespace: @namespace);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -2385,6 +2385,13 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             var newerFullConstructor = modelProvider.FullConstructor;
             Assert.AreNotSame(newFullConstructor, newerFullConstructor);
             Assert.IsTrue(modelProvider.Constructors.Contains(newerFullConstructor));
+
+            // Re-applying the current identity also invalidates the constructor list because
+            // customization metadata and declaration modifiers may have changed.
+            modelProvider.Update(name: modelProvider.Name);
+            var sameIdentityFullConstructor = modelProvider.FullConstructor;
+            Assert.AreNotSame(newerFullConstructor, sameIdentityFullConstructor);
+            Assert.IsTrue(modelProvider.Constructors.Contains(sameIdentityFullConstructor));
         }
 
         // Regression coverage for the duplication that the stale FullConstructor caused: a generator that
@@ -2401,6 +2408,11 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
             Assert.AreEqual(1, modelProvider.FullConstructor.Suppressions.Count);
 
             modelProvider.Update(name: "NewName");
+            _ = modelProvider.Constructors;
+
+            Assert.AreEqual(1, modelProvider.FullConstructor.Suppressions.Count);
+
+            modelProvider.Update(name: modelProvider.Name);
             _ = modelProvider.Constructors;
 
             Assert.AreEqual(1, modelProvider.FullConstructor.Suppressions.Count);


### PR DESCRIPTION
## Summary

- centralize constructor-cache invalidation in a private protected hook
- clear ModelProvider.FullConstructor whenever the constructor list is invalidated
- cover same-value identity updates that still rebuild customization and declaration metadata

## Context

Follow-up to #11737. That fix keys FullConstructor only on name and namespace, but Update(name: provider.Name) still invalidates Constructors while preserving that identity. Derived providers that mutate FullConstructor during BuildConstructors then apply those mutations repeatedly. This is exercised downstream by Azure/azure-sdk-for-net#61958 while fixing Azure/azure-sdk-for-net#61851.

## Validation

- Microsoft.TypeSpec.Generator ModelProviderTests (166 passed)
- targeted constructor cache tests (2 passed)