### PR TITLE
Update C# client emitter TCGC dependency to 0.71.2

### DIFF
--- a/.chronus/changes/deps-csharp-tcgc-0.71.2-2026-08-24.md
+++ b/.chronus/changes/deps-csharp-tcgc-0.71.2-2026-08-24.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@typespec/http-client-csharp"
----
-
-Update the TCGC dependency to 0.71.2.

--- a/.chronus/changes/deps-csharp-tcgc-0.71.2-2026-08-24.md
+++ b/.chronus/changes/deps-csharp-tcgc-0.71.2-2026-08-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: dependencies
+packages:
+  - "@typespec/http-client-csharp"
+---
+
+Update the TCGC dependency to 0.71.2.

--- a/packages/http-client-csharp/emitter/test/Unit/operation-paging.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/operation-paging.test.ts
@@ -234,7 +234,7 @@ describe("Next link operations", () => {
   it("includes protocol-only response model in code model (issue #9391)", async () => {
     const program = await typeSpecCompile(
       `
-        @convenientAPI(false)
+        @convenientAPI(false, "csharp")
         @list
         op link(): {
           @pageItems
@@ -267,7 +267,7 @@ describe("Next link operations", () => {
   it("includes nested enum from protocol-only response model in code model", async () => {
     const program = await typeSpecCompile(
       `
-        @convenientAPI(false)
+        @convenientAPI(false, "csharp")
         @list
         op link(): {
           @pageItems
@@ -309,7 +309,7 @@ describe("Next link operations", () => {
   it("includes deeply nested enum from protocol-only response model in code model", async () => {
     const program = await typeSpecCompile(
       `
-        @convenientAPI(false)
+        @convenientAPI(false, "csharp")
         @list
         op link(): {
           @pageItems
@@ -359,7 +359,7 @@ describe("Next link operations", () => {
   it("does not deduplicate enums with the same name but different namespaces", async () => {
     const program = await typeSpecCompile(
       `
-        @convenientAPI(false)
+        @convenientAPI(false, "csharp")
         @list
         op link(): {
           @pageItems
@@ -413,7 +413,7 @@ describe("Next link operations", () => {
           };
         }
 
-        @convenientAPI(false)
+        @convenientAPI(false, "csharp")
         @list
         @route("/a")
         op listA(): {
@@ -423,7 +423,7 @@ describe("Next link operations", () => {
           next?: url;
         };
 
-        @convenientAPI(false)
+        @convenientAPI(false, "csharp")
         @list
         @route("/b")
         op listB(): {

--- a/packages/http-client-csharp/emitter/test/Unit/usage.test.ts
+++ b/packages/http-client-csharp/emitter/test/Unit/usage.test.ts
@@ -633,7 +633,7 @@ interface LegacyLro {
     @doc("Gets the status and details of the Radiology Insights job.")
     @get
     @route("/radiology-insights/jobs/{id}")
-    @convenientAPI(false)
+    @convenientAPI(false, "csharp")
     getJob is HealthInsightsLongRunningPollOperation<RadiologyInsightsResult>;
   
     #suppress "@azure-tools/typespec-azure-core/long-running-polling-operation-required" "Polling through operation-location"
@@ -643,7 +643,7 @@ interface LegacyLro {
     @doc("Creates a Radiology Insights job with the given request body.")
     @pollingOperation(LegacyLro.getJob)
     @route("/radiology-insights/jobs")
-    @convenientAPI(true)
+    @convenientAPI(true, "csharp")
     createJob is HealthInsightsLongRunningRpcOperation<
       RadiologyInsightsData,
       RadiologyInsightsResult

--- a/packages/http-client-csharp/package-lock.json
+++ b/packages/http-client-csharp/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.44",
         "@azure-tools/typespec-azure-core": "0.71.0",
-        "@azure-tools/typespec-client-generator-core": "0.71.1",
+        "@azure-tools/typespec-client-generator-core": "0.71.2",
         "@microsoft/api-extractor": "^7.52.2",
         "@types/node": "~22.12.0",
         "@typespec/compiler": "1.15.0",
@@ -41,7 +41,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.71.0 <0.72.0 || ~0.72.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.71.1 <0.72.0 || ~0.72.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.71.2 <0.72.0 || ~0.72.0-0",
         "@typespec/compiler": "^1.15.0",
         "@typespec/events": ">=0.85.0 <0.86.0 || ~0.86.0-0",
         "@typespec/http": "^1.15.0",
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.71.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.71.1.tgz",
-      "integrity": "sha512-OQsNmNID1OTRqO2EUfHNO0cTRn44tMKVfNrNfVcdBGJv5scsin8U+KiR90M/5nbTqOsGPXSxxExVl7yMuuGk2g==",
+      "version": "0.71.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.71.2.tgz",
+      "integrity": "sha512-/HOH9tPXczcue6t1FHVFRXjTU1/S27dZQd85akgs+KlK1jkA8blgPndB51jSYwn8V+D+9XmHRSRtcQLAW582UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/http-client-csharp/package.json
+++ b/packages/http-client-csharp/package.json
@@ -59,7 +59,7 @@
   ],
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": ">=0.71.0 <0.72.0 || ~0.72.0-0",
-    "@azure-tools/typespec-client-generator-core": ">=0.71.1 <0.72.0 || ~0.72.0-0",
+    "@azure-tools/typespec-client-generator-core": ">=0.71.2 <0.72.0 || ~0.72.0-0",
     "@typespec/compiler": "^1.15.0",
     "@typespec/events": ">=0.85.0 <0.86.0 || ~0.86.0-0",
     "@typespec/http": "^1.15.0",
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.44",
     "@azure-tools/typespec-azure-core": "0.71.0",
-    "@azure-tools/typespec-client-generator-core": "0.71.1",
+    "@azure-tools/typespec-client-generator-core": "0.71.2",
     "@microsoft/api-extractor": "^7.52.2",
     "@types/node": "~22.12.0",
     "@typespec/compiler": "1.15.0",

--- a/packages/http-client-csharp/readme.md
+++ b/packages/http-client-csharp/readme.md
@@ -57,7 +57,7 @@ See [Configuring output directory for more info](https://typespec.io/docs/handbo
 
 **Type:** `string | object`
 
-Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace to its desired version. Nested namespaces must be represented as nested objects in `tspconfig.yaml`; services not listed default to their latest version.
 
 **Options:**
 

--- a/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/http-client-csharp/reference/emitter.md
@@ -40,7 +40,7 @@ See [Configuring output directory for more info](https://typespec.io/docs/handbo
 
 **Type:** `string | object`
 
-Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace to its desired version. Nested namespaces must be represented as nested objects in `tspconfig.yaml`; services not listed default to their latest version.
 
 **Options:**
 


### PR DESCRIPTION
## Summary
- update the C# client emitter TCGC dev dependency and peer lower bound to 0.71.2
- scope affected `@convenientAPI` test fixtures to C# for the new TCGC validation
- regenerate emitter documentation for TCGC 0.71.2's nested service namespace configuration

## Validation
- `npm install`
- `npm run gen-extern-signature`
- `npm run regen-docs`
- `eng/scripts/Generate.ps1`
- `npm run build`
- `npm run test:emitter` (239 passed, 2 skipped)
- `npm run test:generator`
- `npm run cop`
- `pnpm chronus verify`
- changed files pass Prettier