### PR TITLE
fix(http-server-csharp): emitter type errors

### DIFF
--- a/.chronus/changes/sramsey-csharp-emitter-fixes-2026-7-24-10-50-13.md
+++ b/.chronus/changes/sramsey-csharp-emitter-fixes-2026-7-24-10-50-13.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+fix optional error properties, output-type:models, and incorrect namespace issue

--- a/.chronus/changes/sramsey-csharp-server-nullable-2026-7-12-14-45-16.md
+++ b/.chronus/changes/sramsey-csharp-server-nullable-2026-7-12-14-45-16.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+fix errors in emitter including duplicate nullable suffixes, unresolved symbols for multipart content, incompatible types, parameter ordering, and void as a success type

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
@@ -97,6 +97,80 @@ it("renders a DELETE action with path param", async () => {
   `);
 });
 
+it("does not assign a result for void success unions with error responses", async () => {
+  const { deletePet } = await runner.compile(t.code`
+    @error
+    model ErrorResponse {
+      code: string;
+    }
+
+    op ServiceOperation<Response>(): Response | ErrorResponse;
+
+    interface PetStore {
+      @route("/pets") @delete ${t.op("deletePet")} is ServiceOperation<void>;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(deletePet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpDelete]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
+        public virtual async Task<IActionResult> DeletePet()
+        {
+            await PetStoreImpl.DeletePetAsync();
+            return NoContent();
+        }
+    }
+  `);
+});
+
+it("preserves result handling for value success unions with error responses", async () => {
+  const { getPet } = await runner.compile(t.code`
+    @error
+    model ErrorResponse {
+      code: string;
+    }
+
+    op ServiceOperation<Response>(): Response | ErrorResponse;
+
+    interface PetStore {
+      @route("/pets") @get ${t.op("getPet")} is ServiceOperation<string>;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(getPet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpGet]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string))]
+        public virtual async Task<IActionResult> GetPet()
+        {
+            var result = await PetStoreImpl.GetPetAsync();
+            return Ok(result);
+        }
+    }
+  `);
+});
+
 it("orders request model call arguments to match the business interface", async () => {
   const { updatePet } = await runner.compile(t.code`
     model UpdatePetRequest {

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
@@ -96,3 +96,101 @@ it("renders a DELETE action with path param", async () => {
     }
   `);
 });
+
+it("orders request model call arguments to match the business interface", async () => {
+  const { updatePet } = await runner.compile(t.code`
+    model UpdatePetRequest {
+      optionalTag?: string;
+      age: int32;
+    }
+
+    interface PetStore {
+      @route("/pets/{petId}") @post ${t.op("updatePet")}(
+        @path petId: string,
+        ...UpdatePetRequest,
+        @query apiVersion: string,
+      ): void;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(updatePet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction
+        operation={canonOp}
+        implFieldName="PetStoreImpl"
+        requestModel={{ name: "PetStoreUpdatePetRequest", op: canonOp, ifaceName: "PetStore" }}
+      />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpPost]
+        [Route("/pets/{petId}")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
+        public virtual async Task<IActionResult> UpdatePet(
+            string petId,
+            PetStoreUpdatePetRequest body,
+            [FromQuery(Name="apiVersion")]
+            string apiVersion
+        )
+        {
+            await PetStoreImpl.UpdatePetAsync(petId, body.Age, apiVersion, body.OptionalTag);
+            return NoContent();
+        }
+    }
+  `);
+});
+
+it("orders protocol parameter call arguments to match the business interface", async () => {
+  const { getPet, businessGetPet } = await runner.compile(t.code`
+    interface PetStore {
+      @route("/pets/{petId}") @get ${t.op("getPet")}(
+        @path petId: string,
+        @header feature: string,
+        @query apiVersion: string,
+      ): string;
+
+      ${t.op("businessGetPet")}(
+        feature: string,
+        petId: string,
+        apiVersion: string,
+      ): string;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(getPet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction
+        operation={canonOp}
+        businessOperation={businessGetPet}
+        implFieldName="PetStoreImpl"
+      />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpGet]
+        [Route("/pets/{petId}")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string))]
+        public virtual async Task<IActionResult> GetPet(
+            string petId,
+            [FromHeader(Name="feature")]
+            string feature,
+            [FromQuery(Name="apiVersion")]
+            string apiVersion
+        )
+        {
+            var result = await PetStoreImpl.GetPetAsync(feature, petId, apiVersion);
+            return Ok(result);
+        }
+    }
+  `);
+});

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
@@ -165,7 +165,7 @@ export function ControllerAction(props: ControllerActionProps): Children {
   }
 
   // Determine the success status code from the response
-  const { statusCode, hasBody } = getSuccessStatusCode(props.operation);
+  const { statusCode, hasBody } = getSuccessStatusCode($.program, props.operation);
 
   // Determine response type for ProducesResponseType attribute
   const returnType = props.operation.sourceType.returnType;

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
@@ -1,7 +1,7 @@
 import { code, type Children } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
 import { Attribute } from "@alloy-js/csharp";
-import { isErrorModel, isVoidType } from "@typespec/compiler";
+import { isErrorModel, isVoidType, type Operation } from "@typespec/compiler";
 import { useTsp } from "@typespec/emitter-framework";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { AspNetMvc } from "../../utils/csharp-libs.jsx";
@@ -15,6 +15,8 @@ import { getSuccessStatusCode } from "./response-analysis.js";
 export interface ControllerActionProps {
   /** The canonicalized HTTP operation to generate an action method for. */
   operation: OperationHttpCanonicalization;
+  /** The operation used to generate the matching business interface method. */
+  businessOperation?: Operation;
   /** The name of the business logic implementation field (e.g., "petStoreImpl"). */
   implFieldName: string;
   /** Request model info if this operation uses a synthetic request model. */
@@ -45,6 +47,7 @@ export function ControllerAction(props: ControllerActionProps): Children {
   // Map all HTTP parameters (path, query, header) to C# method parameters
   const pathParams: ParamInfo[] = [];
   const queryHeaderParams: ParamInfo[] = [];
+  const callArgBySourceName = new Map<string, string>();
   for (const p of props.operation.requestParameters.properties) {
     if (p.property.isContentTypeProperty) continue;
     const isOptional = p.property.sourceType.optional;
@@ -52,6 +55,7 @@ export function ControllerAction(props: ControllerActionProps): Children {
     if (p.kind === "path") {
       const paramName = namePolicy.getName(p.property.sourceType.name, "parameter");
       const attr = getBindingAttribute(p, paramName);
+      callArgBySourceName.set(p.property.sourceType.name, paramName);
       pathParams.push({
         name: paramName,
         type: <TypeExpression type={p.property.sourceType.type} />,
@@ -61,8 +65,10 @@ export function ControllerAction(props: ControllerActionProps): Children {
       });
     } else if (p.kind === "query" || p.kind === "header") {
       const attr = getBindingAttribute(p);
+      const paramName = namePolicy.getName(p.property.sourceType.name, "parameter");
+      callArgBySourceName.set(p.property.sourceType.name, paramName);
       queryHeaderParams.push({
-        name: namePolicy.getName(p.property.sourceType.name, "parameter"),
+        name: paramName,
         type: <TypeExpression type={p.property.sourceType.type} />,
         attributes: attr ? [attr] : undefined,
         optional: isOptional,
@@ -79,6 +85,15 @@ export function ControllerAction(props: ControllerActionProps): Children {
   };
   // Default: path params, then query/header params (sorted by default presence)
   let parameters: ParamInfo[] = [...pathParams, ...queryHeaderParams.sort(sortByDefault)];
+  const getOrderedCallArgs = () =>
+    Array.from(
+      (props.businessOperation ?? props.operation.sourceType).parameters.properties.entries(),
+    )
+      .filter(([_, prop]) => !isVoidType(prop.type))
+      .map(([name, prop]) => ({ arg: callArgBySourceName.get(name), optional: prop.optional }))
+      .filter((item): item is { arg: string; optional: boolean } => item.arg !== undefined)
+      .sort((a, b) => (a.optional === b.optional ? 0 : a.optional ? 1 : -1))
+      .map((item) => item.arg);
 
   // Add body parameter if present (but NOT for GET requests)
   const body = props.operation.requestParameters.body;
@@ -98,10 +113,10 @@ export function ControllerAction(props: ControllerActionProps): Children {
 
   if (isGet) {
     // GET requests suppress body parameters entirely
-    callArgs = parameters.map((p) => p.name).join(", ");
+    callArgs = getOrderedCallArgs().join(", ");
   } else if (isMultipart) {
     // Multipart body: don't add body as parameter — we'll create a MultipartReader in the method body
-    callArgs = [...parameters.map((p) => p.name), "reader"].join(", ");
+    callArgs = [...getOrderedCallArgs(), "reader"].join(", ");
   } else if (isBodyRoot) {
     // @bodyRoot — the whole model is the body, no other HTTP params extracted
     parameters = [
@@ -115,15 +130,13 @@ export function ControllerAction(props: ControllerActionProps): Children {
     // Call args: path params, then body property accesses, then query/header params
     const bodyType = body.bodies[0].type.sourceType;
     if (bodyType.kind === "Model") {
-      const bodyArgs = Array.from(bodyType.properties.values()).map((p) => {
+      for (const p of bodyType.properties.values()) {
         const propName = namePolicy.getName(p.name, "class-property");
-        return `body.${propName}`;
-      });
-      const pathArgNames = pathParams.map((p) => p.name);
-      const queryArgNames = queryHeaderParams.map((p) => p.name);
-      callArgs = [...pathArgNames, ...bodyArgs, ...queryArgNames].join(", ");
+        callArgBySourceName.set(p.name, `body.${propName}`);
+      }
+      callArgs = getOrderedCallArgs().join(", ");
     } else {
-      callArgs = parameters.map((p) => p.name).join(", ");
+      callArgs = getOrderedCallArgs().join(", ");
     }
   } else if (hasExplicitBody) {
     parameters.push({
@@ -131,16 +144,24 @@ export function ControllerAction(props: ControllerActionProps): Children {
       type: <TypeExpression type={body!.bodies[0].type.sourceType} />,
       attributes: [{ name: AspNetMvc.FromBodyAttribute }],
     });
-    callArgs = parameters.map((p) => p.name).join(", ");
+    const sourceProperty = body.bodies[0].property?.sourceType;
+    if (sourceProperty) callArgBySourceName.set(sourceProperty.name, "body");
+    callArgs = sourceProperty
+      ? getOrderedCallArgs().join(", ")
+      : parameters.map((p) => p.name).join(", ");
   } else if (body?.bodyKind === "single" && body.bodies.length > 0) {
     parameters.push({
       name: "body",
       type: <TypeExpression type={body.bodies[0].type.sourceType} />,
       attributes: [{ name: AspNetMvc.FromBodyAttribute }],
     });
-    callArgs = parameters.map((p) => p.name).join(", ");
+    const sourceProperty = body.bodies[0].property?.sourceType;
+    if (sourceProperty) callArgBySourceName.set(sourceProperty.name, "body");
+    callArgs = sourceProperty
+      ? getOrderedCallArgs().join(", ")
+      : parameters.map((p) => p.name).join(", ");
   } else {
-    callArgs = parameters.map((p) => p.name).join(", ");
+    callArgs = getOrderedCallArgs().join(", ");
   }
 
   // Determine the success status code from the response

--- a/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
+++ b/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
@@ -1,11 +1,14 @@
-import { isVoidType } from "@typespec/compiler";
+import { isErrorModel, isVoidType, type Program } from "@typespec/compiler";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 
 /**
  * Determines the success HTTP status code and whether the response has a body.
  * Checks the original return type for @statusCode properties.
  */
-export function getSuccessStatusCode(operation: OperationHttpCanonicalization): {
+export function getSuccessStatusCode(
+  program: Program,
+  operation: OperationHttpCanonicalization,
+): {
   statusCode: number | undefined;
   hasBody: boolean;
 } {
@@ -18,15 +21,24 @@ export function getSuccessStatusCode(operation: OperationHttpCanonicalization): 
 
   // Check union responses - find the first non-error success response
   if (returnType.kind === "Union") {
+    let hasVoidSuccess = false;
     for (const variant of returnType.variants.values()) {
       const vt = variant.type;
-      if (isVoidType(vt)) continue;
+      if (isVoidType(vt)) {
+        hasVoidSuccess = true;
+        continue;
+      }
       if (vt.kind === "Model") {
+        if (isErrorModel(program, vt)) continue;
         // Skip models with @error decorator or error-range status codes
         const result = analyzeResponseModel(vt);
         if (result.statusCode !== undefined && result.statusCode >= 400) continue;
         return result;
       }
+      return { statusCode: 200, hasBody: true };
+    }
+    if (hasVoidSuccess) {
+      return { statusCode: 204, hasBody: false };
     }
   }
 

--- a/packages/http-server-csharp/src/components/controllers/controllers.test.tsx
+++ b/packages/http-server-csharp/src/components/controllers/controllers.test.tsx
@@ -9,6 +9,7 @@ import {
   type OperationHttpCanonicalization,
 } from "@typespec/http-canonicalization";
 import { beforeEach, describe, expect, it } from "vitest";
+import { OperationSources } from "../../context/operation-source-context.js";
 import { BusinessLogicInterface } from "../interfaces/interfaces.jsx";
 import { Controller } from "./controllers.jsx";
 
@@ -77,6 +78,68 @@ it("renders a controller class with an action method", async () => {
         public virtual async Task<IActionResult> ListPets()
         {
             var result = await PetStoreImpl.ListPetsAsync();
+            return Ok(result);
+        }
+    }
+  `);
+});
+
+it("uses the exact source operation to preserve positional argument order", async () => {
+  const { PetStore, getPet, businessGetPet } = await runner.compile(t.code`
+    interface ${t.interface("PetStore")} {
+      @route("/pets/{petId}") @get ${t.op("getPet")}(
+        @path petId: string,
+        @header feature: string,
+        @query apiVersion: string,
+      ): string;
+
+      ${t.op("businessGetPet")}(
+        feature: string,
+        petId: string,
+        apiVersion: string,
+      ): string;
+    }
+  `);
+  const canonOp = canonicalizeOp(getPet);
+
+  expect(
+    <Wrapper>
+      <OperationSources.Provider value={new Map([[canonOp, businessGetPet]])}>
+        <BusinessLogicInterface type={PetStore} canonicalOps={[canonOp]} />
+        {"\n"}
+        <Controller type={PetStore} operations={[canonOp]} />
+      </OperationSources.Provider>
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    public interface IPetStore
+    {
+        Task<string> GetPetAsync(string petId, string feature, string apiVersion);
+
+        Task<string> BusinessGetPetAsync(string feature, string petId, string apiVersion);
+    }
+    [ApiController]
+    public partial class PetStoreController : ControllerBase
+    {
+        internal virtual IPetStore PetStoreImpl { get; }
+        public PetStoreController(IPetStore operations)
+        {
+            PetStoreImpl = operations;
+        }
+
+        [HttpGet]
+        [Route("/pets/{petId}")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string))]
+        public virtual async Task<IActionResult> GetPet(
+            string petId,
+            [FromHeader(Name="feature")]
+            string feature,
+            [FromQuery(Name="apiVersion")]
+            string apiVersion
+        )
+        {
+            var result = await PetStoreImpl.GetPetAsync(feature, petId, apiVersion);
             return Ok(result);
         }
     }

--- a/packages/http-server-csharp/src/components/controllers/controllers.tsx
+++ b/packages/http-server-csharp/src/components/controllers/controllers.tsx
@@ -3,6 +3,7 @@ import * as cs from "@alloy-js/csharp";
 import { Attribute, Reference } from "@alloy-js/csharp";
 import type { Interface } from "@typespec/compiler";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
+import { useOperationSources } from "../../context/operation-source-context.js";
 import { AspNetMvc } from "../../utils/csharp-libs.jsx";
 import { ControllerAction } from "../controller-action/controller-action.jsx";
 import { businessLogicInterfaceRefkey } from "../interfaces/interfaces.jsx";
@@ -26,6 +27,7 @@ export function Controller(props: ControllerProps): Children {
   const baseName = namePolicy.getName(props.type.name, "class");
   const controllerName = `${baseName}Controller`;
   const implPropName = `${baseName}Impl`;
+  const operationSources = useOperationSources();
 
   const interfaceRef = <Reference refkey={businessLogicInterfaceRefkey(props.type)} />;
 
@@ -49,7 +51,14 @@ export function Controller(props: ControllerProps): Children {
       <For each={props.operations} doubleHardline>
         {(op) => {
           const rm = props.requestModels?.find((r) => r.op === op);
-          return <ControllerAction operation={op} implFieldName={implPropName} requestModel={rm} />;
+          return (
+            <ControllerAction
+              operation={op}
+              businessOperation={operationSources.get(op)}
+              implFieldName={implPropName}
+              requestModel={rm}
+            />
+          );
         }}
       </For>
     </cs.ClassDeclaration>

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
@@ -93,3 +93,35 @@ it("renders one nullable suffix for optional nullable value parameters", async (
     }
   `);
 });
+
+it("falls back to multipart decorators when canonicalization is unavailable", async () => {
+  const { PetStore } = await runner.compile(t.code`
+    model MultipartParts {
+      metadata: HttpPart<string>;
+      code: HttpPart<bytes>;
+    }
+
+    model DerivedMultipartParts {
+      ...MultipartParts;
+    }
+
+    interface ${t.interface("PetStore")} {
+      @post upload(
+        @header contentType: "multipart/form-data",
+        @header checksum: string,
+        @multipartBody content: DerivedMultipartParts,
+      ): void;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <BusinessLogicInterface type={PetStore} />
+    </Wrapper>,
+  ).toRenderTo(`
+    public interface IPetStore
+    {
+        Task UploadAsync(string checksum, MultipartReader reader);
+    }
+  `);
+});

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
@@ -1,9 +1,10 @@
 import { Tester } from "#test/tester.js";
 import { type Children } from "@alloy-js/core";
-import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
+import { createCSharpNamePolicy, EnumDeclaration, SourceFile } from "@alloy-js/csharp";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { Output } from "@typespec/emitter-framework";
 import { beforeEach, expect, it } from "vitest";
+import { efRefkey } from "../type-expression/type-expression.jsx";
 import { BusinessLogicInterface } from "./interfaces.jsx";
 
 let runner: TesterInstance;
@@ -58,6 +59,37 @@ it("renders an interface with void return type", async () => {
     public interface IPetStore
     {
         Task DeletePetAsync(string petId);
+    }
+  `);
+});
+
+it("renders one nullable suffix for optional nullable value parameters", async () => {
+  const { Choice, PetStore } = await runner.compile(t.code`
+    enum ${t.enum("Choice")} {
+      one,
+    }
+
+    interface ${t.interface("PetStore")} {
+      update(value?: int32 | null, choice?: Choice | null): void;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <EnumDeclaration name="Choice" refkey={efRefkey(Choice)}>
+        One
+      </EnumDeclaration>
+      <hbr />
+      <BusinessLogicInterface type={PetStore} />
+    </Wrapper>,
+  ).toRenderTo(`
+    enum Choice
+    {
+        One
+    }
+    public interface IPetStore
+    {
+        Task UpdateAsync(int? value, Choice? choice);
     }
   `);
 });

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.tsx
@@ -7,7 +7,10 @@ import type { OperationHttpCanonicalization } from "@typespec/http-canonicalizat
 import { getUniqueItems } from "@typespec/json-schema";
 import { getDocComments } from "../../utils/doc-comments.jsx";
 import { getSuccessReturnType } from "../../utils/return-type-helpers.js";
-import { TypeExpression } from "../type-expression/type-expression.jsx";
+import {
+  getNullableValueTypeUnionInnerType,
+  TypeExpression,
+} from "../type-expression/type-expression.jsx";
 
 const interfaceRefKeyPrefix = Symbol.for("http-server-csharp:interface");
 
@@ -129,6 +132,9 @@ function BusinessLogicMethod(props: BusinessLogicMethodProps): Children {
     .map(([pName, prop]) => {
       const isUnique = getUniqueItems($.program, prop);
       const isArrayType = prop.type.kind === "Model" && $.array.is(prop.type);
+      const nullableValueType = prop.optional
+        ? getNullableValueTypeUnionInnerType($, prop.type)
+        : undefined;
       let typeExpr: Children;
       if (isUnique && isArrayType && prop.type.kind === "Model" && prop.type.indexer?.value) {
         typeExpr = (
@@ -139,7 +145,7 @@ function BusinessLogicMethod(props: BusinessLogicMethodProps): Children {
           </>
         );
       } else {
-        typeExpr = <TypeExpression type={prop.type} />;
+        typeExpr = <TypeExpression type={nullableValueType ?? prop.type} />;
       }
       return {
         name: namePolicy.getName(pName, "parameter"),

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.tsx
@@ -1,8 +1,9 @@
 import { refkey as ayRefkey, code, For, type Children, type Refkey } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
-import type { Interface, Operation } from "@typespec/compiler";
+import type { Interface, ModelProperty, Operation, Program } from "@typespec/compiler";
 import { isTemplateDeclaration, isVoidType } from "@typespec/compiler";
 import { useTsp } from "@typespec/emitter-framework";
+import { getHeaderFieldName, isMultipartBodyProperty } from "@typespec/http";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { getUniqueItems } from "@typespec/json-schema";
 import { getDocComments } from "../../utils/doc-comments.jsx";
@@ -13,6 +14,33 @@ import {
 } from "../type-expression/type-expression.jsx";
 
 const interfaceRefKeyPrefix = Symbol.for("http-server-csharp:interface");
+
+/** Detects multipart operations without requiring HTTP canonicalization to succeed. */
+export function operationHasMultipartBody(program: Program, operation: Operation): boolean {
+  return Array.from(operation.parameters.properties.values()).some((prop) =>
+    isMultipartBodyProperty(program, prop),
+  );
+}
+
+function isContentTypeHeader(program: Program, property: ModelProperty) {
+  return getHeaderFieldName(program, property)?.toLowerCase() === "content-type";
+}
+
+/** Gets raw multipart protocol parameters when canonical HTTP metadata is unavailable. */
+export function getMultipartProtocolParameterNames(
+  program: Program,
+  operation: Operation,
+): Set<string> {
+  if (!operationHasMultipartBody(program, operation)) return new Set();
+
+  const names = new Set<string>();
+  for (const [name, prop] of operation.parameters.properties) {
+    if (isMultipartBodyProperty(program, prop) || isContentTypeHeader(program, prop)) {
+      names.add(name);
+    }
+  }
+  return names;
+}
 
 /** Creates a stable refkey for a business logic interface from its TypeSpec Interface type. */
 export function businessLogicInterfaceRefkey(type: Interface): Refkey {
@@ -83,7 +111,9 @@ function BusinessLogicMethod(props: BusinessLogicMethodProps): Children {
     : code`Task`;
 
   // Check if this is a multipart request
-  const isMultipart = props.canonicalOp?.requestParameters.body?.bodyKind === "multipart";
+  const isMultipart =
+    props.canonicalOp?.requestParameters.body?.bodyKind === "multipart" ||
+    operationHasMultipartBody($.program, props.operation);
 
   // For GET operations, suppress body parameters entirely
   const isGet = props.canonicalOp?.method === "get";
@@ -107,7 +137,7 @@ function BusinessLogicMethod(props: BusinessLogicMethodProps): Children {
 
   // For multipart requests, suppress all body-related params
   // For all requests, suppress content-type params
-  const filteredPropNames = new Set<string>();
+  const filteredPropNames = getMultipartProtocolParameterNames($.program, props.operation);
   if (props.canonicalOp) {
     for (const p of props.canonicalOp.requestParameters.properties) {
       if (

--- a/packages/http-server-csharp/src/components/models/error-models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.test.tsx
@@ -45,7 +45,7 @@ function findFileContent(output: any, pathSuffix: string): string | undefined {
   return search(output);
 }
 
-it("maps record error constructor parameters without changing other parameter types", async () => {
+it("maps structured error constructor parameters to their property types", async () => {
   const { ApiError } = await runner.compile(t.code`
     @error
     model ${t.model("ApiError")} {
@@ -54,6 +54,7 @@ it("maps record error constructor parameters without changing other parameter ty
       details?: ApiError[];
       additionalInfo?: Record<unknown>;
       counts?: Record<int32>;
+      pair?: [string, string];
       retryAfter?: int32 | null;
     }
   `);
@@ -70,13 +71,14 @@ it("maps record error constructor parameters without changing other parameter ty
         public ApiError(
             string message,
             string param = default,
-            Array details = default,
+            ApiError[] details = default,
             JsonObject additionalInfo = default,
             IDictionary<string, int> counts = default,
-            object retryAfter = default
+            string[] pair = default,
+            int? retryAfter = default
         ) : base(
             400,
-            value: new { message = message, param = param, details = details, additionalInfo = additionalInfo, counts = counts, retryAfter = retryAfter }
+            value: new { message = message, param = param, details = details, additionalInfo = additionalInfo, counts = counts, pair = pair, retryAfter = retryAfter }
         )
         {
             MessageProp = message;
@@ -84,6 +86,7 @@ it("maps record error constructor parameters without changing other parameter ty
             Details = details;
             AdditionalInfo = additionalInfo;
             Counts = counts;
+            Pair = pair;
             RetryAfter = retryAfter;
         }
     }
@@ -93,7 +96,8 @@ it("maps record error constructor parameters without changing other parameter ty
 it("adds the JsonObject using for inherited record error constructor parameters", async () => {
   const { Base, ApiError } = await runner.compile(t.code`
     model ${t.model("Base")} {
-      data?: Record<unknown>;
+      data?: Record<unknown>[];
+      nestedData?: Record<Record<unknown>>;
     }
 
     @error
@@ -113,4 +117,5 @@ it("adds the JsonObject using for inherited record error constructor parameters"
 
   expect(apiErrorFile).toBeDefined();
   expect(apiErrorFile).toContain("using System.Text.Json.Nodes;");
+  expect(apiErrorFile).toContain("IDictionary<string, JsonObject> nestedData = default");
 });

--- a/packages/http-server-csharp/src/components/models/error-models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.test.tsx
@@ -1,0 +1,116 @@
+import { Tester } from "#test/tester.js";
+import { render, type Children } from "@alloy-js/core";
+import * as cs from "@alloy-js/csharp";
+import { t, type TesterInstance } from "@typespec/compiler/testing";
+import { Output } from "@typespec/emitter-framework";
+import { beforeEach, expect, it } from "vitest";
+import { EmitterOptions } from "../../context/emitter-options-context.js";
+import { efRefkey } from "../type-expression/type-expression.jsx";
+import { getErrorConstructor } from "./error-models.jsx";
+import { Models } from "./models.jsx";
+
+let runner: TesterInstance;
+
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
+
+function Wrapper(props: { children: Children }) {
+  return (
+    <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+      <EmitterOptions.Provider value={{ collectionType: "array", serviceNamespace: "Test" }}>
+        <cs.SourceFile path="test.cs">{props.children}</cs.SourceFile>
+      </EmitterOptions.Provider>
+    </Output>
+  );
+}
+
+function findFileContent(output: any, pathSuffix: string): string | undefined {
+  function search(dir: any): string | undefined {
+    for (const item of dir.contents) {
+      if (
+        "contents" in item &&
+        typeof item.contents === "string" &&
+        (item.path === pathSuffix || item.path.endsWith("/" + pathSuffix))
+      ) {
+        return item.contents;
+      }
+      if ("contents" in item && Array.isArray(item.contents)) {
+        const found = search(item);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  }
+  return search(output);
+}
+
+it("maps record error constructor parameters without changing other parameter types", async () => {
+  const { ApiError } = await runner.compile(t.code`
+    @error
+    model ${t.model("ApiError")} {
+      message: string;
+      param?: string;
+      details?: ApiError[];
+      additionalInfo?: Record<unknown>;
+      counts?: Record<int32>;
+      retryAfter?: int32 | null;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <cs.ClassDeclaration name="ApiError" refkey={efRefkey(ApiError)}>
+        {getErrorConstructor(runner.program, ApiError, "ApiError")}
+      </cs.ClassDeclaration>
+    </Wrapper>,
+  ).toRenderTo(`
+    class ApiError
+    {
+        public ApiError(
+            string message,
+            string param = default,
+            Array details = default,
+            JsonObject additionalInfo = default,
+            IDictionary<string, int> counts = default,
+            object retryAfter = default
+        ) : base(
+            400,
+            value: new { message = message, param = param, details = details, additionalInfo = additionalInfo, counts = counts, retryAfter = retryAfter }
+        )
+        {
+            MessageProp = message;
+            Param = param;
+            Details = details;
+            AdditionalInfo = additionalInfo;
+            Counts = counts;
+            RetryAfter = retryAfter;
+        }
+    }
+  `);
+});
+
+it("adds the JsonObject using for inherited record error constructor parameters", async () => {
+  const { Base, ApiError } = await runner.compile(t.code`
+    model ${t.model("Base")} {
+      data?: Record<unknown>;
+    }
+
+    @error
+    model ${t.model("ApiError")} extends Base {
+      message: string;
+    }
+  `);
+
+  const output = render(
+    <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+      <EmitterOptions.Provider value={{ collectionType: "array", serviceNamespace: "Test" }}>
+        <Models models={[Base, ApiError]} serviceNamespace={undefined} />
+      </EmitterOptions.Provider>
+    </Output>,
+  );
+  const apiErrorFile = findFileContent(output, "ApiError.cs");
+
+  expect(apiErrorFile).toBeDefined();
+  expect(apiErrorFile).toContain("using System.Text.Json.Nodes;");
+});

--- a/packages/http-server-csharp/src/components/models/error-models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.test.tsx
@@ -50,11 +50,13 @@ it("maps structured error constructor parameters to their property types", async
     @error
     model ${t.model("ApiError")} {
       message: string;
+      context: string | null;
       param?: string;
       details?: ApiError[];
       additionalInfo?: Record<unknown>;
       counts?: Record<int32>;
       pair?: [string, string];
+      count?: int32;
       retryAfter?: int32 | null;
     }
   `);
@@ -70,23 +72,27 @@ it("maps structured error constructor parameters to their property types", async
     {
         public ApiError(
             string message,
-            string param = default,
-            ApiError[] details = default,
-            JsonObject additionalInfo = default,
-            IDictionary<string, int> counts = default,
-            string[] pair = default,
+            string? context,
+            string? param = default,
+            ApiError[]? details = default,
+            JsonObject? additionalInfo = default,
+            IDictionary<string, int>? counts = default,
+            string[]? pair = default,
+            int? count = default,
             int? retryAfter = default
         ) : base(
             400,
-            value: new { message = message, param = param, details = details, additionalInfo = additionalInfo, counts = counts, pair = pair, retryAfter = retryAfter }
+            value: new { message = message, context = context, param = param, details = details, additionalInfo = additionalInfo, counts = counts, pair = pair, count = count, retryAfter = retryAfter }
         )
         {
             MessageProp = message;
+            Context = context;
             Param = param;
             Details = details;
             AdditionalInfo = additionalInfo;
             Counts = counts;
             Pair = pair;
+            Count = count;
             RetryAfter = retryAfter;
         }
     }
@@ -117,5 +123,5 @@ it("adds the JsonObject using for inherited record error constructor parameters"
 
   expect(apiErrorFile).toBeDefined();
   expect(apiErrorFile).toContain("using System.Text.Json.Nodes;");
-  expect(apiErrorFile).toContain("IDictionary<string, JsonObject> nestedData = default");
+  expect(apiErrorFile).toContain("IDictionary<string, JsonObject>? nestedData = default");
 });

--- a/packages/http-server-csharp/src/components/models/error-models.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.tsx
@@ -3,8 +3,12 @@ import type { ParameterProps } from "@alloy-js/csharp";
 import * as cs from "@alloy-js/csharp";
 import { isErrorModel, type Model, type Program } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
+import { getNullableUnionInnerType } from "@typespec/emitter-framework/csharp";
 import { getHeaderFieldName, isHeader, isStatusCode } from "@typespec/http";
-import { TypeExpression } from "../type-expression/type-expression.jsx";
+import {
+  getNullableValueTypeUnionInnerType,
+  TypeExpression,
+} from "../type-expression/type-expression.jsx";
 import {
   getAllProperties,
   getCSharpTypeString,
@@ -65,10 +69,23 @@ export function getErrorConstructor(program: Program, model: Model, className: s
     ) : (
       getCSharpTypeString(program, prop.type)
     );
+    const nullableUnionInnerType =
+      prop.type.kind === "Union" ? getNullableUnionInnerType(prop.type) : undefined;
+    const typeExpressionIncludesNullable =
+      getNullableValueTypeUnionInnerType(tk, prop.type) !== undefined;
+    const needsNullable =
+      !typeExpressionIncludesNullable && (prop.optional || nullableUnionInnerType !== undefined);
+    const parameterType = needsNullable ? (
+      <>
+        {csharpType}?
+      </>
+    ) : (
+      csharpType
+    );
     const defaultStr = defaultValue ? defaultValue : prop.optional ? "default" : undefined;
     parameters.push({
       name: prop.name,
-      type: csharpType,
+      type: parameterType,
       default: defaultStr,
     });
     bodyParts.push(`${propName} = ${prop.name};`);

--- a/packages/http-server-csharp/src/components/models/error-models.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.tsx
@@ -2,7 +2,9 @@ import { type Children } from "@alloy-js/core";
 import type { ParameterProps } from "@alloy-js/csharp";
 import * as cs from "@alloy-js/csharp";
 import { isErrorModel, type Model, type Program } from "@typespec/compiler";
+import { $ } from "@typespec/compiler/typekit";
 import { getHeaderFieldName, isHeader, isStatusCode } from "@typespec/http";
+import { TypeExpression } from "../type-expression/type-expression.jsx";
 import {
   getAllProperties,
   getCSharpTypeString,
@@ -14,6 +16,7 @@ import {
 
 /** Generates the constructor for an error model. */
 export function getErrorConstructor(program: Program, model: Model, className: string): Children {
+  const tk = $(program);
   const statusCode = getErrorStatusCode(program, model);
   const isChild = model.baseModel && isErrorModel(program, model.baseModel);
   const namePolicy = cs.createCSharpNamePolicy();
@@ -53,9 +56,18 @@ export function getErrorConstructor(program: Program, model: Model, className: s
       propName = propName === "Value" ? "ValueName" : `${propName}Prop`;
     }
 
-    const csharpType = getCSharpTypeString(program, prop.type);
+    const csharpType =
+      prop.type.kind === "Model" && tk.record.is(prop.type) ? (
+        <TypeExpression type={prop.type} />
+      ) : (
+        getCSharpTypeString(program, prop.type)
+      );
     const defaultStr = defaultValue ? defaultValue : prop.optional ? "default" : undefined;
-    parameters.push({ name: prop.name, type: csharpType, default: defaultStr });
+    parameters.push({
+      name: prop.name,
+      type: csharpType,
+      default: defaultStr,
+    });
     bodyParts.push(`${propName} = ${prop.name};`);
 
     if (isHeader(program, prop)) {

--- a/packages/http-server-csharp/src/components/models/error-models.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.tsx
@@ -56,12 +56,15 @@ export function getErrorConstructor(program: Program, model: Model, className: s
       propName = propName === "Value" ? "ValueName" : `${propName}Prop`;
     }
 
-    const csharpType =
-      prop.type.kind === "Model" && tk.record.is(prop.type) ? (
-        <TypeExpression type={prop.type} />
-      ) : (
-        getCSharpTypeString(program, prop.type)
-      );
+    const usesTypeExpression =
+      prop.type.kind === "Union" ||
+      prop.type.kind === "Tuple" ||
+      (prop.type.kind === "Model" && (tk.record.is(prop.type) || tk.array.is(prop.type)));
+    const csharpType = usesTypeExpression ? (
+      <TypeExpression type={prop.type} />
+    ) : (
+      getCSharpTypeString(program, prop.type)
+    );
     const defaultStr = defaultValue ? defaultValue : prop.optional ? "default" : undefined;
     parameters.push({
       name: prop.name,

--- a/packages/http-server-csharp/src/components/models/error-models.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.tsx
@@ -75,13 +75,7 @@ export function getErrorConstructor(program: Program, model: Model, className: s
       getNullableValueTypeUnionInnerType(tk, prop.type) !== undefined;
     const needsNullable =
       !typeExpressionIncludesNullable && (prop.optional || nullableUnionInnerType !== undefined);
-    const parameterType = needsNullable ? (
-      <>
-        {csharpType}?
-      </>
-    ) : (
-      csharpType
-    );
+    const parameterType = needsNullable ? <>{csharpType}?</> : csharpType;
     const defaultStr = defaultValue ? defaultValue : prop.optional ? "default" : undefined;
     parameters.push({
       name: prop.name,

--- a/packages/http-server-csharp/src/components/models/model-helpers.ts
+++ b/packages/http-server-csharp/src/components/models/model-helpers.ts
@@ -188,13 +188,26 @@ export function modelNeedsJsonNodes(
   model: Model,
   includeInherited = false,
 ): boolean {
+  const typeNeedsJsonNodes = (type: Type): boolean => {
+    if (type.kind === "Tuple") return type.values.some(typeNeedsJsonNodes);
+    if (type.kind !== "Model") return false;
+    if ($.record.is(type)) {
+      const valueType = type.indexer?.value;
+      return (
+        (valueType?.kind === "Intrinsic" && valueType.name === "unknown") ||
+        (valueType !== undefined && typeNeedsJsonNodes(valueType))
+      );
+    }
+    if ($.array.is(type) && type.indexer?.value) {
+      return typeNeedsJsonNodes(type.indexer.value);
+    }
+    return false;
+  };
+
   let current: Model | undefined = model;
   while (current) {
     for (const prop of current.properties.values()) {
-      if (prop.type.kind === "Model" && $.record.is(prop.type)) {
-        const valueType = prop.type.indexer?.value;
-        if (valueType?.kind === "Intrinsic" && valueType.name === "unknown") return true;
-      }
+      if (typeNeedsJsonNodes(prop.type)) return true;
     }
     current = includeInherited ? current.baseModel : undefined;
   }

--- a/packages/http-server-csharp/src/components/models/model-helpers.ts
+++ b/packages/http-server-csharp/src/components/models/model-helpers.ts
@@ -182,14 +182,21 @@ export function isValueType($: ReturnType<typeof useTsp>["$"], type: Type): bool
   return false;
 }
 
-/** Returns true if any property of the model uses Record<T> (mapped to JsonObject). */
-export function modelNeedsJsonNodes($: ReturnType<typeof useTsp>["$"], model: Model): boolean {
-  for (const prop of model.properties.values()) {
-    if (prop.type.kind === "Model" && $.record.is(prop.type)) {
-      // Only need JsonNodes for Record<unknown> (maps to JsonObject)
-      const valueType = prop.type.indexer?.value;
-      if (valueType?.kind === "Intrinsic" && valueType.name === "unknown") return true;
+/** Returns true if a model property uses Record<unknown> (mapped to JsonObject). */
+export function modelNeedsJsonNodes(
+  $: ReturnType<typeof useTsp>["$"],
+  model: Model,
+  includeInherited = false,
+): boolean {
+  let current: Model | undefined = model;
+  while (current) {
+    for (const prop of current.properties.values()) {
+      if (prop.type.kind === "Model" && $.record.is(prop.type)) {
+        const valueType = prop.type.indexer?.value;
+        if (valueType?.kind === "Intrinsic" && valueType.name === "unknown") return true;
+      }
     }
+    current = includeInherited ? current.baseModel : undefined;
   }
   return false;
 }

--- a/packages/http-server-csharp/src/components/models/models.tsx
+++ b/packages/http-server-csharp/src/components/models/models.tsx
@@ -9,6 +9,7 @@ import {
   type Namespace as TspNamespace,
 } from "@typespec/compiler";
 import { useTsp } from "@typespec/emitter-framework";
+import { getNullableUnionInnerType } from "@typespec/emitter-framework/csharp";
 import { isStatusCode } from "@typespec/http";
 import { getUniqueItems } from "@typespec/json-schema";
 import { useEmitterOptions } from "../../context/emitter-options-context.js";
@@ -17,7 +18,11 @@ import { JsonSerialization } from "../../utils/csharp-libs.jsx";
 import { getDocComments } from "../../utils/doc-comments.jsx";
 import { getSubNamespaceParts } from "../../utils/namespace-utils.js";
 import { CSharpFile } from "../csharp-file.jsx";
-import { efRefkey, TypeExpression } from "../type-expression/type-expression.jsx";
+import {
+  efRefkey,
+  getNullableValueTypeUnionInnerType,
+  TypeExpression,
+} from "../type-expression/type-expression.jsx";
 import { getErrorConstructor } from "./error-models.jsx";
 import {
   getDefaultValueString,
@@ -29,7 +34,6 @@ import {
   hasNonIntegerValues,
   hasPropertyInChain,
   isDuplicateExceptionName,
-  isValueType,
   modelNeedsJsonNodes,
 } from "./model-helpers.js";
 
@@ -96,7 +100,6 @@ interface ServerClassDeclarationProps {
  * Server-specific class declaration that matches the old emitter output:
  * - No `required` keyword
  * - No `[JsonPropertyName]` attributes
- * - No nullable `?` suffix on reference types (string, byte[], etc.)
  */
 function ServerClassDeclaration(props: ServerClassDeclarationProps): Children {
   const { $ } = useTsp();
@@ -175,7 +178,7 @@ interface ServerPropertyProps {
 
 /**
  * Server-specific property that matches old emitter output.
- * No `required`, no `[JsonPropertyName]`, no nullable `?` for reference types.
+ * No `required` and no `[JsonPropertyName]` unless the C# name differs.
  */
 function ServerProperty(props: ServerPropertyProps): Children {
   const { $ } = useTsp();
@@ -237,7 +240,13 @@ function ServerProperty(props: ServerPropertyProps): Children {
   // But not for union variant types — those should resolve to the enum type
   const resolveToScalar = (isLiteralOnly && !unionVariantInit) || isErrorProp;
   const resolvedType = resolveToScalar ? getScalarForLiteral(propType) : propType;
-  const needsNullable = props.type.optional && (isFloatEnum || isValueType($, resolvedType));
+  const nullableUnionInnerType =
+    resolvedType.kind === "Union" ? getNullableUnionInnerType(resolvedType) : undefined;
+  const typeExpressionIncludesNullable =
+    getNullableValueTypeUnionInnerType($, resolvedType) !== undefined;
+  const needsNullable =
+    !typeExpressionIncludesNullable &&
+    (props.type.optional || nullableUnionInnerType !== undefined);
 
   // Check if this is a @uniqueItems array → ISet<T>
   const isUniqueItems = getUniqueItems($.program, props.type);

--- a/packages/http-server-csharp/src/components/models/models.tsx
+++ b/packages/http-server-csharp/src/components/models/models.tsx
@@ -61,7 +61,10 @@ export function Models(props: ModelsProps): Children {
   return (
     <For each={props.models}>
       {(model) => {
-        const needsJsonNodes = modelNeedsJsonNodes($, model);
+        const isRootError =
+          isErrorModel($.program, model) &&
+          !(model.baseModel && isErrorModel($.program, model.baseModel));
+        const needsJsonNodes = modelNeedsJsonNodes($, model, isRootError);
         const usings = needsJsonNodes ? [...modelUsings, "System.Text.Json.Nodes"] : modelUsings;
         const modelName = getModelEmitName($.program, model);
         const subNsParts = getSubNamespaceParts(model.namespace, props.serviceNamespace);

--- a/packages/http-server-csharp/src/components/multipart-fallback.test.tsx
+++ b/packages/http-server-csharp/src/components/multipart-fallback.test.tsx
@@ -1,0 +1,82 @@
+import { Tester } from "#test/tester.js";
+import { SourceDirectory, render } from "@alloy-js/core";
+import { Namespace, createCSharpNamePolicy } from "@alloy-js/csharp";
+import { t, type TesterInstance } from "@typespec/compiler/testing";
+import { Output } from "@typespec/emitter-framework";
+import { beforeEach, expect, it } from "vitest";
+import { EmitterOptions } from "../context/emitter-options-context.js";
+import { ControllersAndInterfaces } from "./render-root.jsx";
+import { MockImplementations } from "./scaffolding/mock-implementations.jsx";
+
+let runner: TesterInstance;
+
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
+
+function findFileContent(output: any, pathSuffix: string): string | undefined {
+  function search(dir: any): string | undefined {
+    for (const item of dir.contents) {
+      if (
+        "contents" in item &&
+        typeof item.contents === "string" &&
+        (item.path === pathSuffix || item.path.endsWith("/" + pathSuffix))
+      ) {
+        return item.contents;
+      }
+      if ("contents" in item && Array.isArray(item.contents)) {
+        const found = search(item);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  }
+  return search(output);
+}
+
+it("keeps multipart interfaces and mocks aligned without canonical metadata", async () => {
+  const { PetStore } = await runner.compile(t.code`
+    model MultipartParts {
+      metadata: HttpPart<string>;
+      code: HttpPart<bytes>;
+    }
+
+    model DerivedMultipartParts {
+      ...MultipartParts;
+    }
+
+    interface ${t.interface("PetStore")} {
+      @post upload(
+        @header contentType: "multipart/form-data",
+        @header checksum: string,
+        @multipartBody content: DerivedMultipartParts,
+      ): void;
+    }
+  `);
+
+  const canonicalOpsMap = new Map();
+  const output = render(
+    <Output program={runner.program} namePolicy={createCSharpNamePolicy()}>
+      <EmitterOptions.Provider value={{ collectionType: "array", serviceNamespace: "Test" }}>
+        <SourceDirectory path=".">
+          <Namespace name="Test">
+            <SourceDirectory path="generated">
+              <ControllersAndInterfaces interfaces={[PetStore]} canonicalOpsMap={canonicalOpsMap} />
+            </SourceDirectory>
+            <MockImplementations interfaces={[PetStore]} canonicalOpsMap={canonicalOpsMap} />
+          </Namespace>
+        </SourceDirectory>
+      </EmitterOptions.Provider>
+    </Output>,
+  );
+
+  const interfaceContent = findFileContent(output, "operations/IPetStore.cs");
+  const mockContent = findFileContent(output, "mocks/PetStore.cs");
+
+  expect(interfaceContent).toContain("using Microsoft.AspNetCore.WebUtilities;");
+  expect(interfaceContent).toContain("UploadAsync(string checksum, MultipartReader reader)");
+  expect(mockContent).toContain("using Microsoft.AspNetCore.WebUtilities;");
+  expect(mockContent).toContain("UploadAsync(string checksum, MultipartReader reader)");
+  expect(interfaceContent).not.toContain("Unresolved Symbol");
+  expect(mockContent).not.toContain("Unresolved Symbol");
+});

--- a/packages/http-server-csharp/src/components/render-root.tsx
+++ b/packages/http-server-csharp/src/components/render-root.tsx
@@ -2,11 +2,12 @@ import { For, SourceDirectory, type Children } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
 import { Namespace } from "@alloy-js/csharp";
 import type { Interface } from "@typespec/compiler";
+import { useTsp } from "@typespec/emitter-framework";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { useEmitterOptions } from "../context/emitter-options-context.js";
 import { Controller } from "./controllers/controllers.jsx";
 import { CSharpFile } from "./csharp-file.jsx";
-import { BusinessLogicInterface } from "./interfaces/interfaces.jsx";
+import { BusinessLogicInterface, operationHasMultipartBody } from "./interfaces/interfaces.jsx";
 import { RequestModels, type RequestModelInfo } from "./request-models.jsx";
 
 export interface ControllersAndInterfacesProps {
@@ -21,6 +22,7 @@ export interface ControllersAndInterfacesProps {
  */
 export function ControllersAndInterfaces(props: ControllersAndInterfacesProps): Children {
   const namePolicy = cs.useCSharpNamePolicy();
+  const { $ } = useTsp();
   const { serviceNamespace: parentNamespace } = useEmitterOptions();
 
   const interfaceOps = props.interfaces.map((iface) => ({
@@ -61,9 +63,11 @@ export function ControllersAndInterfaces(props: ControllersAndInterfacesProps): 
       <SourceDirectory path="operations">
         <For each={interfaceOps}>
           {({ iface, ops }) => {
-            const hasMultipart = ops.some(
-              (op) => op.requestParameters.body?.bodyKind === "multipart",
-            );
+            const hasMultipart =
+              ops.some((op) => op.requestParameters.body?.bodyKind === "multipart") ||
+              Array.from(iface.operations.values()).some((op) =>
+                operationHasMultipartBody($.program, op),
+              );
             return (
               <CSharpFile
                 path={`I${iface.name}.cs`}

--- a/packages/http-server-csharp/src/components/scaffolding/mock-implementations.tsx
+++ b/packages/http-server-csharp/src/components/scaffolding/mock-implementations.tsx
@@ -4,7 +4,10 @@ import type { Interface, Operation, Program } from "@typespec/compiler";
 import { useTsp } from "@typespec/emitter-framework";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { CSharpFile } from "../csharp-file.jsx";
-import { TypeExpression } from "../type-expression/type-expression.jsx";
+import {
+  getNullableValueTypeUnionInnerType,
+  TypeExpression,
+} from "../type-expression/type-expression.jsx";
 import {
   getGetBodyPropNames,
   getMockReturnStatement,
@@ -112,6 +115,7 @@ interface MockMethodsProps {
 
 function MockMethods(props: MockMethodsProps): Children {
   const namePolicy = cs.useCSharpNamePolicy();
+  const { $ } = useTsp();
   return (
     <For each={props.operations} doubleHardline>
       {([name, op]) => {
@@ -147,11 +151,16 @@ function MockMethods(props: MockMethodsProps): Children {
         const parameters = Array.from(op.parameters.properties.entries())
           .filter(([pName]) => !bodyPropNames.has(pName))
           .filter(([pName]) => !multipartBodyPropNames.has(pName))
-          .map(([pName, prop]) => ({
-            name: namePolicy.getName(pName, "parameter"),
-            type: <TypeExpression type={prop.type} />,
-            optional: prop.optional,
-          }))
+          .map(([pName, prop]) => {
+            const nullableValueType = prop.optional
+              ? getNullableValueTypeUnionInnerType($, prop.type)
+              : undefined;
+            return {
+              name: namePolicy.getName(pName, "parameter"),
+              type: <TypeExpression type={nullableValueType ?? prop.type} />,
+              optional: prop.optional,
+            };
+          })
           // Required parameters must come before optional ones in C#
           .sort((a, b) => (a.optional === b.optional ? 0 : a.optional ? 1 : -1));
 

--- a/packages/http-server-csharp/src/components/scaffolding/mock-implementations.tsx
+++ b/packages/http-server-csharp/src/components/scaffolding/mock-implementations.tsx
@@ -5,6 +5,10 @@ import { useTsp } from "@typespec/emitter-framework";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { CSharpFile } from "../csharp-file.jsx";
 import {
+  getMultipartProtocolParameterNames,
+  operationHasMultipartBody,
+} from "../interfaces/interfaces.jsx";
+import {
   getNullableValueTypeUnionInnerType,
   TypeExpression,
 } from "../type-expression/type-expression.jsx";
@@ -58,6 +62,9 @@ function MockImplementation(props: MockImplementationProps): Children {
       canonicalMap.set(cop.name, cop);
     }
   }
+  const hasMultipart =
+    props.canonicalOps?.some((op) => op.requestParameters.body?.bodyKind === "multipart") ||
+    operations.some(([, op]) => operationHasMultipartBody($.program, op));
 
   return (
     <CSharpFile
@@ -69,6 +76,7 @@ function MockImplementation(props: MockImplementationProps): Children {
         "System.Text.Json.Serialization",
         "System.Threading.Tasks",
         "Microsoft.AspNetCore.Mvc",
+        ...(hasMultipart ? ["Microsoft.AspNetCore.WebUtilities"] : []),
       ]}
     >
       {code`
@@ -130,8 +138,10 @@ function MockMethods(props: MockMethodsProps): Children {
 
         // Check if this is a multipart operation
         const canonicalOp = props.canonicalMap?.get(name);
-        const isMultipart = canonicalOp?.requestParameters.body?.bodyKind === "multipart";
-        const multipartBodyPropNames = new Set<string>();
+        const isMultipart =
+          canonicalOp?.requestParameters.body?.bodyKind === "multipart" ||
+          operationHasMultipartBody(props.program, op);
+        const multipartBodyPropNames = getMultipartProtocolParameterNames(props.program, op);
         if (isMultipart && canonicalOp) {
           for (const p of canonicalOp.requestParameters.properties) {
             if (

--- a/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
+++ b/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
@@ -20,6 +20,12 @@ export interface TypeExpressionProps {
 // Re-export efRefkey for consumers that were using serverRefkey
 export { efRefkey } from "@typespec/emitter-framework/csharp";
 
+export function getNullableValueTypeUnionInnerType($: Typekit, type: Type): Type | undefined {
+  if (type.kind !== "Union" || isUnionEnum(type)) return undefined;
+  const innerType = getNullableUnionInnerType(type);
+  return innerType !== undefined && isValueType($, innerType) ? innerType : undefined;
+}
+
 /**
  * Wrapper around emitter-framework's TypeExpression that handles
  * additional type kinds the server emitter encounters.
@@ -199,10 +205,11 @@ function resolveUnionType($: Typekit, union: import("@typespec/compiler").Union)
       return code`object`;
     }
     // Nullable value type → T?
-    if (isValueType($, innerType)) {
+    const nullableValueType = getNullableValueTypeUnionInnerType($, union);
+    if (nullableValueType) {
       return (
         <>
-          <TypeExpression type={innerType} />?
+          <TypeExpression type={nullableValueType} />?
         </>
       );
     }

--- a/packages/http-server-csharp/src/context/operation-source-context.ts
+++ b/packages/http-server-csharp/src/context/operation-source-context.ts
@@ -1,0 +1,11 @@
+import { createNamedContext, useContext } from "@alloy-js/core";
+import type { Operation } from "@typespec/compiler";
+import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
+
+export type OperationSourceMap = Map<OperationHttpCanonicalization, Operation>;
+
+export const OperationSources = createNamedContext<OperationSourceMap>("OperationSources");
+
+export function useOperationSources(): OperationSourceMap {
+  return useContext(OperationSources) ?? new Map();
+}

--- a/packages/http-server-csharp/src/context/operation-source-context.ts
+++ b/packages/http-server-csharp/src/context/operation-source-context.ts
@@ -6,6 +6,8 @@ export type OperationSourceMap = Map<OperationHttpCanonicalization, Operation>;
 
 export const OperationSources = createNamedContext<OperationSourceMap>("OperationSources");
 
+const emptyOperationSources: OperationSourceMap = new Map();
+
 export function useOperationSources(): OperationSourceMap {
-  return useContext(OperationSources) ?? new Map();
+  return useContext(OperationSources) ?? emptyOperationSources;
 }

--- a/packages/http-server-csharp/src/emitter.tsx
+++ b/packages/http-server-csharp/src/emitter.tsx
@@ -31,13 +31,18 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
   const scalarOverrides = createServerScalarOverrides(tk);
   const options = context.options;
   const collectionType = options["collection-type"] ?? "array";
+  const modelsOnly = options["output-type"] === "models";
   const emitMocks =
-    options["emit-mocks"] === "mocks-only" || options["emit-mocks"] === "mocks-and-project-files";
-  const emitProjectFiles = options["emit-mocks"] === "mocks-and-project-files";
-  const useSwaggerUI = options["use-swaggerui"] ?? false;
+    !modelsOnly &&
+    (options["emit-mocks"] === "mocks-only" ||
+      options["emit-mocks"] === "mocks-and-project-files");
+  const emitProjectFiles = !modelsOnly && options["emit-mocks"] === "mocks-and-project-files";
+  const useSwaggerUI = !modelsOnly && (options["use-swaggerui"] ?? false);
 
   // Resolve all service types in a single pass
-  const resolution = resolveServiceTypes(context.program, tk, canonicalizer);
+  const resolution = resolveServiceTypes(context.program, tk, canonicalizer, {
+    canonicalizeOperations: !modelsOnly,
+  });
   const serviceName = resolution.serviceNamespaceName ?? "ServiceProject";
   const projectName = options["project-name"] ?? "ServiceProject";
 
@@ -84,16 +89,20 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
                       serviceNamespace={resolution.serviceNamespace}
                     />
                   </SourceDirectory>
-                  <ControllersAndInterfaces
-                    interfaces={resolution.interfaces}
-                    canonicalOpsMap={resolution.canonicalOpsMap}
-                  />
+                  <Show when={!modelsOnly}>
+                    <ControllersAndInterfaces
+                      interfaces={resolution.interfaces}
+                      canonicalOpsMap={resolution.canonicalOpsMap}
+                    />
+                  </Show>
                 </SourceDirectory>
-                <ProgramCs
-                  hasMocks={emitMocks}
-                  useSwaggerUI={effectiveUseSwaggerUI}
-                  openApiPath={openApiPath}
-                />
+                <Show when={!modelsOnly}>
+                  <ProgramCs
+                    hasMocks={emitMocks}
+                    useSwaggerUI={effectiveUseSwaggerUI}
+                    openApiPath={openApiPath}
+                  />
+                </Show>
                 <Show when={emitMocks}>
                   <MockImplementations
                     interfaces={resolution.interfaces}
@@ -105,10 +114,12 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
                   <LaunchSettings httpPort={httpPort} httpsPort={httpsPort} />
                   <AppSettings />
                 </Show>
-                <Documentation
-                  interfaceNames={emitMocks ? interfaceNames : []}
-                  useSwaggerUI={useSwaggerUI}
-                />
+                <Show when={!modelsOnly}>
+                  <Documentation
+                    interfaceNames={emitMocks ? interfaceNames : []}
+                    useSwaggerUI={useSwaggerUI}
+                  />
+                </Show>
               </Namespace>
               <SourceDirectory path="generated">
                 <JsonConverters />

--- a/packages/http-server-csharp/src/emitter.tsx
+++ b/packages/http-server-csharp/src/emitter.tsx
@@ -15,6 +15,7 @@ import { MockHelpers, MockImplementations } from "./components/scaffolding/mock-
 import { JsonConverters } from "./components/serialization/json-converters.jsx";
 import { createServerScalarOverrides } from "./components/type-expression/type-expression.jsx";
 import { EmitterOptions } from "./context/emitter-options-context.js";
+import { OperationSources } from "./context/operation-source-context.js";
 import { reportEmitterDiagnostics } from "./diagnostics.js";
 import type { CSharpServiceEmitterOptions } from "./lib.js";
 import { resolveOpenApiPath, writeOutputWithOverwrite } from "./output-writer.js";
@@ -68,53 +69,55 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
     <Output program={context.program} namePolicy={createCSharpNamePolicy()}>
       <Experimental_ComponentOverrides overrides={scalarOverrides}>
         <EmitterOptions.Provider value={{ collectionType, serviceNamespace: serviceName }}>
-          <SourceDirectory path=".">
-            <Namespace name={serviceName}>
-              <SourceDirectory path="generated">
-                <SourceDirectory path="models">
-                  <Models
-                    models={resolution.models}
-                    serviceNamespace={resolution.serviceNamespace}
-                  />
-                  <Enums
-                    enums={resolution.enums}
-                    unionEnums={resolution.unionEnums}
-                    serviceNamespace={resolution.serviceNamespace}
+          <OperationSources.Provider value={resolution.canonicalOperationSourceMap}>
+            <SourceDirectory path=".">
+              <Namespace name={serviceName}>
+                <SourceDirectory path="generated">
+                  <SourceDirectory path="models">
+                    <Models
+                      models={resolution.models}
+                      serviceNamespace={resolution.serviceNamespace}
+                    />
+                    <Enums
+                      enums={resolution.enums}
+                      unionEnums={resolution.unionEnums}
+                      serviceNamespace={resolution.serviceNamespace}
+                    />
+                  </SourceDirectory>
+                  <ControllersAndInterfaces
+                    interfaces={resolution.interfaces}
+                    canonicalOpsMap={resolution.canonicalOpsMap}
                   />
                 </SourceDirectory>
-                <ControllersAndInterfaces
-                  interfaces={resolution.interfaces}
-                  canonicalOpsMap={resolution.canonicalOpsMap}
+                <ProgramCs
+                  hasMocks={emitMocks}
+                  useSwaggerUI={effectiveUseSwaggerUI}
+                  openApiPath={openApiPath}
                 />
+                <Show when={emitMocks}>
+                  <MockImplementations
+                    interfaces={resolution.interfaces}
+                    canonicalOpsMap={resolution.canonicalOpsMap}
+                  />
+                </Show>
+                <Show when={emitProjectFiles}>
+                  <Csproj projectName={projectName} useSwaggerUI={useSwaggerUI} />
+                  <LaunchSettings httpPort={httpPort} httpsPort={httpsPort} />
+                  <AppSettings />
+                </Show>
+                <Documentation
+                  interfaceNames={emitMocks ? interfaceNames : []}
+                  useSwaggerUI={useSwaggerUI}
+                />
+              </Namespace>
+              <SourceDirectory path="generated">
+                <JsonConverters />
               </SourceDirectory>
-              <ProgramCs
-                hasMocks={emitMocks}
-                useSwaggerUI={effectiveUseSwaggerUI}
-                openApiPath={openApiPath}
-              />
               <Show when={emitMocks}>
-                <MockImplementations
-                  interfaces={resolution.interfaces}
-                  canonicalOpsMap={resolution.canonicalOpsMap}
-                />
+                <MockHelpers interfaceRegistrations={interfaceRegistrations} />
               </Show>
-              <Show when={emitProjectFiles}>
-                <Csproj projectName={projectName} useSwaggerUI={useSwaggerUI} />
-                <LaunchSettings httpPort={httpPort} httpsPort={httpsPort} />
-                <AppSettings />
-              </Show>
-              <Documentation
-                interfaceNames={emitMocks ? interfaceNames : []}
-                useSwaggerUI={useSwaggerUI}
-              />
-            </Namespace>
-            <SourceDirectory path="generated">
-              <JsonConverters />
             </SourceDirectory>
-            <Show when={emitMocks}>
-              <MockHelpers interfaceRegistrations={interfaceRegistrations} />
-            </Show>
-          </SourceDirectory>
+          </OperationSources.Provider>
         </EmitterOptions.Provider>
       </Experimental_ComponentOverrides>
     </Output>

--- a/packages/http-server-csharp/src/emitter.tsx
+++ b/packages/http-server-csharp/src/emitter.tsx
@@ -34,8 +34,7 @@ export async function $onEmit(context: EmitContext<CSharpServiceEmitterOptions>)
   const modelsOnly = options["output-type"] === "models";
   const emitMocks =
     !modelsOnly &&
-    (options["emit-mocks"] === "mocks-only" ||
-      options["emit-mocks"] === "mocks-and-project-files");
+    (options["emit-mocks"] === "mocks-only" || options["emit-mocks"] === "mocks-and-project-files");
   const emitProjectFiles = !modelsOnly && options["emit-mocks"] === "mocks-and-project-files";
   const useSwaggerUI = !modelsOnly && (options["use-swaggerui"] ?? false);
 

--- a/packages/http-server-csharp/src/service-discovery.ts
+++ b/packages/http-server-csharp/src/service-discovery.ts
@@ -1,5 +1,6 @@
 import type { Interface } from "@typespec/compiler";
 import {
+  getNamespaceFullName,
   isStdNamespace,
   isTemplateDeclaration,
   listServices,
@@ -104,29 +105,22 @@ export function getServiceInterfaces(
 }
 
 /**
- * Gets the full service namespace name from the program (e.g., "Microsoft.Contoso").
+ * Gets the service namespace declared with `@service`.
+ *
+ * For programs without an explicit service, falls back to the first non-standard
+ * namespace with content to preserve standalone model-emission behavior.
  */
-export function getServiceNamespaceName(
+export function getServiceNamespace(
   program: ReturnType<typeof useTsp>["$"]["program"],
-): string | undefined {
+): TspNamespace | undefined {
+  const service = listServices(program)[0];
+  if (service) return service.type;
+
   const globalNs = program.getGlobalNamespaceType();
 
-  function getFullName(ns: TspNamespace): string {
-    const parts: string[] = [];
-    let current: TspNamespace | undefined = ns;
-    while (current && current !== globalNs) {
-      parts.unshift(current.name);
-      current = current.namespace;
-    }
-    return parts.join(".");
-  }
-
-  // Find the service namespace (deepest non-std namespace in the first branch)
   function findServiceNs(ns: TspNamespace): TspNamespace | undefined {
     for (const child of ns.namespaces.values()) {
       if (isStdNamespace(child)) continue;
-      // If this namespace has content (models, interfaces, operations, enums), use it
-      // Otherwise, recurse deeper
       const hasContent =
         child.models.size > 0 ||
         child.interfaces.size > 0 ||
@@ -140,8 +134,17 @@ export function getServiceNamespaceName(
     return undefined;
   }
 
-  const serviceNs = findServiceNs(globalNs);
+  return findServiceNs(globalNs);
+}
+
+/**
+ * Gets the full service namespace name from the program (e.g., "Microsoft.Contoso").
+ */
+export function getServiceNamespaceName(
+  program: ReturnType<typeof useTsp>["$"]["program"],
+): string | undefined {
+  const serviceNs = getServiceNamespace(program);
   if (!serviceNs) return undefined;
-  const fullName = getFullName(serviceNs);
+  const fullName = getNamespaceFullName(serviceNs);
   return getCSharpIdentifier(fullName, NameCasingType.Namespace);
 }

--- a/packages/http-server-csharp/src/service-resolution.test.ts
+++ b/packages/http-server-csharp/src/service-resolution.test.ts
@@ -1,5 +1,5 @@
 import { Tester } from "#test/tester.js";
-import type { TesterInstance } from "@typespec/compiler/testing";
+import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { $ } from "@typespec/compiler/typekit";
 import { HttpCanonicalizer } from "@typespec/http-canonicalization";
 import { beforeEach, expect, it } from "vitest";
@@ -108,6 +108,29 @@ it("does not emit template arguments that the instantiation never exposes", asyn
   `);
 
   expect(resolution.models.map((m) => m.name).sort()).toEqual(["Envelope", "Widget"]);
+});
+
+it("tracks the exact source operation for each canonical operation", async () => {
+  const { read } = await runner.compile(t.code`
+    @service
+    namespace Contoso {
+      interface ${t.interface("PetStore")} {
+        @route("/pets/{id}") @get ${t.op("read")}(
+          @path id: string,
+          @query apiVersion?: string,
+        ): string;
+      }
+    }
+  `);
+  const tk = $(runner.program);
+  const resolution = resolveServiceTypes(runner.program, tk, new HttpCanonicalizer(tk));
+  const canonicalOperation = [...resolution.canonicalOperationSourceMap].find(
+    ([, sourceOperation]) => sourceOperation === read,
+  )?.[0];
+
+  expect(canonicalOperation).toBeDefined();
+  expect(resolution.canonicalOperationSourceMap.get(canonicalOperation!)).toBe(read);
+  expect([...resolution.canonicalOpsMap.values()].flat()).toContain(canonicalOperation);
 });
 
 it("discovers the payload type of an HttpPart", async () => {

--- a/packages/http-server-csharp/src/service-resolution.test.ts
+++ b/packages/http-server-csharp/src/service-resolution.test.ts
@@ -2,7 +2,7 @@ import { Tester } from "#test/tester.js";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { $ } from "@typespec/compiler/typekit";
 import { HttpCanonicalizer } from "@typespec/http-canonicalization";
-import { beforeEach, expect, it } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
 import { resolveServiceTypes, type ServiceTypeResolution } from "./service-resolution.js";
 
 let runner: TesterInstance;
@@ -131,6 +131,29 @@ it("tracks the exact source operation for each canonical operation", async () =>
   expect(canonicalOperation).toBeDefined();
   expect(resolution.canonicalOperationSourceMap.get(canonicalOperation!)).toBe(read);
   expect([...resolution.canonicalOpsMap.values()].flat()).toContain(canonicalOperation);
+});
+
+it("skips operation canonicalization when it is disabled", async () => {
+  await runner.compile(`
+    @service
+    namespace Contoso {
+      model Widget { id: string; }
+      op read(): Widget;
+    }
+  `);
+  const tk = $(runner.program);
+  const canonicalizer = new HttpCanonicalizer(tk);
+  const canonicalize = vi.spyOn(canonicalizer, "canonicalize");
+
+  const resolution = resolveServiceTypes(runner.program, tk, canonicalizer, {
+    canonicalizeOperations: false,
+  });
+
+  expect(resolution.models.map((m) => m.name)).toContain("Widget");
+  expect(resolution.interfaces).toHaveLength(1);
+  expect(resolution.canonicalOpsMap).toEqual(new Map());
+  expect(resolution.canonicalOperationSourceMap).toEqual(new Map());
+  expect(canonicalize).not.toHaveBeenCalled();
 });
 
 it("discovers the payload type of an HttpPart", async () => {

--- a/packages/http-server-csharp/src/service-resolution.test.ts
+++ b/packages/http-server-csharp/src/service-resolution.test.ts
@@ -34,6 +34,25 @@ it("excludes models declared outside the service namespace that are not referenc
   expect(resolution.models.map((m) => m.name).sort()).toEqual(["Used", "Widget"]);
 });
 
+it("uses the declared service namespace instead of imported namespaces with content", async () => {
+  const resolution = await resolve(`
+    namespace Azure.ClientGenerator.Core {
+      model ClientOptions {}
+      enum Usage { input, output }
+    }
+
+    @service
+    namespace Azure.AI.Projects {
+      model Widget { id: string; }
+      op read(): Widget;
+    }
+  `);
+
+  expect(resolution.serviceNamespace?.name).toBe("Projects");
+  expect(resolution.serviceNamespaceName).toBe("Azure.Ai.Projects");
+  expect(resolution.models.map((m) => m.name)).toEqual(["Widget"]);
+});
+
 it("excludes enums and union enums declared outside the service namespace that are not referenced", async () => {
   const resolution = await resolve(`
     namespace Other {

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -5,6 +5,7 @@ import {
   type Enum,
   type Interface,
   type Model,
+  type Operation,
   type Program,
   type Namespace as TspNamespace,
   type Type,
@@ -44,6 +45,8 @@ export interface ServiceTypeResolution {
   unionEnums: Union[];
   /** Canonicalized HTTP operations per interface. */
   canonicalOpsMap: Map<string, OperationHttpCanonicalization[]>;
+  /** Original business operation for each canonicalized HTTP operation. */
+  canonicalOperationSourceMap: Map<OperationHttpCanonicalization, Operation>;
   /** Namespaces whose declarations are emitted without being referenced. */
   declarationNamespaces: Set<TspNamespace>;
 }
@@ -96,7 +99,10 @@ export function resolveServiceTypes(
   );
 
   // Phase 5: Canonicalize all HTTP operations
-  const canonicalOpsMap = canonicalizeAllInterfaces(canonicalizer, interfaces);
+  const { canonicalOpsMap, canonicalOperationSourceMap } = canonicalizeAllInterfaces(
+    canonicalizer,
+    interfaces,
+  );
 
   return {
     serviceNamespace,
@@ -106,6 +112,7 @@ export function resolveServiceTypes(
     enums,
     unionEnums,
     canonicalOpsMap,
+    canonicalOperationSourceMap,
     declarationNamespaces,
   };
 }
@@ -116,20 +123,26 @@ export function resolveServiceTypes(
 function canonicalizeAllInterfaces(
   canonicalizer: HttpCanonicalizer,
   interfaces: Interface[],
-): Map<string, OperationHttpCanonicalization[]> {
-  const result = new Map<string, OperationHttpCanonicalization[]>();
+): {
+  canonicalOpsMap: Map<string, OperationHttpCanonicalization[]>;
+  canonicalOperationSourceMap: Map<OperationHttpCanonicalization, Operation>;
+} {
+  const canonicalOpsMap = new Map<string, OperationHttpCanonicalization[]>();
+  const canonicalOperationSourceMap = new Map<OperationHttpCanonicalization, Operation>();
   for (const iface of interfaces) {
     const ops: OperationHttpCanonicalization[] = [];
     for (const [, op] of iface.operations) {
       try {
-        ops.push(canonicalizer.canonicalize(op) as OperationHttpCanonicalization);
+        const canonicalOp = canonicalizer.canonicalize(op) as OperationHttpCanonicalization;
+        ops.push(canonicalOp);
+        canonicalOperationSourceMap.set(canonicalOp, op);
       } catch {
         // Skip operations that can't be canonicalized
       }
     }
-    result.set(iface.name, ops);
+    canonicalOpsMap.set(iface.name, ops);
   }
-  return result;
+  return { canonicalOpsMap, canonicalOperationSourceMap };
 }
 
 // ── Type discovery ──────────────────────────────────────────────────────

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -51,6 +51,11 @@ export interface ServiceTypeResolution {
   declarationNamespaces: Set<TspNamespace>;
 }
 
+export interface ServiceTypeResolutionOptions {
+  /** Whether to canonicalize HTTP operations for controller and interface generation. */
+  canonicalizeOperations?: boolean;
+}
+
 /**
  * Resolves all service types in a single pass, eliminating redundant
  * namespace traversals that previously occurred in individual components.
@@ -70,6 +75,7 @@ export function resolveServiceTypes(
   program: Program,
   $: Typekit,
   canonicalizer: HttpCanonicalizer,
+  options: ServiceTypeResolutionOptions = {},
 ): ServiceTypeResolution {
   resetAnonymousModels();
 
@@ -98,11 +104,14 @@ export function resolveServiceTypes(
     authModels,
   );
 
-  // Phase 5: Canonicalize all HTTP operations
-  const { canonicalOpsMap, canonicalOperationSourceMap } = canonicalizeAllInterfaces(
-    canonicalizer,
-    interfaces,
-  );
+  // Phase 5: Canonicalize HTTP operations only when operation artifacts are emitted.
+  const { canonicalOpsMap, canonicalOperationSourceMap } =
+    options.canonicalizeOperations === false
+      ? {
+          canonicalOpsMap: new Map<string, OperationHttpCanonicalization[]>(),
+          canonicalOperationSourceMap: new Map<OperationHttpCanonicalization, Operation>(),
+        }
+      : canonicalizeAllInterfaces(canonicalizer, interfaces);
 
   return {
     serviceNamespace,

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -25,13 +25,13 @@ import {
 import {
   getDeclarationNamespaces,
   getServiceInterfaces,
+  getServiceNamespace,
   getServiceNamespaceName,
 } from "./service-discovery.js";
-import { findServiceNamespace } from "./utils/namespace-utils.js";
 
 /** All resolved service types, computed once before rendering. */
 export interface ServiceTypeResolution {
-  /** The service namespace (first non-std namespace with content). */
+  /** The namespace declared with `@service`, or the standalone namespace fallback. */
   serviceNamespace: TspNamespace | undefined;
   /** The C#-normalized service namespace name. */
   serviceNamespaceName: string | undefined;
@@ -79,10 +79,8 @@ export function resolveServiceTypes(
 ): ServiceTypeResolution {
   resetAnonymousModels();
 
-  const globalNs = program.getGlobalNamespaceType();
-
   // Phase 1: Service namespace
-  const serviceNamespace = findServiceNamespace(globalNs);
+  const serviceNamespace = getServiceNamespace(program);
   const serviceNamespaceName = getServiceNamespaceName(program);
   const declarationNamespaces = getDeclarationNamespaces(program);
 

--- a/packages/http-server-csharp/src/utils/namespace-utils.ts
+++ b/packages/http-server-csharp/src/utils/namespace-utils.ts
@@ -1,4 +1,4 @@
-import { isStdNamespace, type Namespace as TspNamespace } from "@typespec/compiler";
+import type { Namespace as TspNamespace } from "@typespec/compiler";
 
 /**
  * Gets the sub-namespace path of a type's namespace relative to the service namespace.
@@ -37,26 +37,4 @@ export function getSubNamespaceParts(
   }
 
   return typeParts.slice(serviceParts.length).map((ns) => ns.name);
-}
-
-/**
- * Finds the service namespace (the first namespace with content).
- */
-export function findServiceNamespace(globalNs: TspNamespace): TspNamespace | undefined {
-  function findServiceNs(ns: TspNamespace): TspNamespace | undefined {
-    for (const child of ns.namespaces.values()) {
-      if (isStdNamespace(child)) continue;
-      const hasContent =
-        child.models.size > 0 ||
-        child.interfaces.size > 0 ||
-        child.operations.size > 0 ||
-        child.enums.size > 0;
-      if (hasContent) return child;
-      const deeper = findServiceNs(child);
-      if (deeper) return deeper;
-      return child;
-    }
-    return undefined;
-  }
-  return findServiceNs(globalNs);
 }

--- a/packages/http-server-csharp/test/emitter.test.ts
+++ b/packages/http-server-csharp/test/emitter.test.ts
@@ -37,16 +37,12 @@ it("emits only models and their support files when output-type is models", async
     @post
     op create(name: string): Pet;
   `);
-  const [result] = await compileAndDiagnose(
-    tester,
-    service,
-    {
-      "emit-mocks": "mocks-and-project-files",
-      "output-type": "models",
-      "skip-format": true,
-      "use-swaggerui": true,
-    },
-  );
+  const [result] = await compileAndDiagnose(tester, service, {
+    "emit-mocks": "mocks-and-project-files",
+    "output-type": "models",
+    "skip-format": true,
+    "use-swaggerui": true,
+  });
 
   const paths = [...result.fs.fs.keys()];
   const hasPathEndingWith = (suffix: string) => paths.some((path) => path.endsWith(suffix));

--- a/packages/http-server-csharp/test/emitter.test.ts
+++ b/packages/http-server-csharp/test/emitter.test.ts
@@ -21,3 +21,60 @@ it("uses deterministic default ports for project files", async () => {
   expect(launchSettings).toContain("https://localhost:7000;http://localhost:5000");
   expect(launchSettings).toContain("http://localhost:5000");
 });
+
+it("emits only models and their support files when output-type is models", async () => {
+  const service = getStandardService(`
+    enum PetKind {
+      dog,
+    }
+
+    model Pet {
+      name: string;
+      kind: PetKind;
+    }
+
+    @route("/pets")
+    @post
+    op create(name: string): Pet;
+  `);
+  const [result] = await compileAndDiagnose(
+    tester,
+    service,
+    {
+      "emit-mocks": "mocks-and-project-files",
+      "output-type": "models",
+      "skip-format": true,
+      "use-swaggerui": true,
+    },
+  );
+
+  const paths = [...result.fs.fs.keys()];
+  const hasPathEndingWith = (suffix: string) => paths.some((path) => path.endsWith(suffix));
+
+  expect(hasPathEndingWith("/generated/models/Pet.cs")).toBe(true);
+  expect(hasPathEndingWith("/generated/models/PetKind.cs")).toBe(true);
+  expect(hasPathEndingWith("/generated/lib/JsonSerializationProvider.cs")).toBe(true);
+
+  expect(paths.some((path) => path.includes("/generated/controllers/"))).toBe(false);
+  expect(paths.some((path) => path.includes("/generated/operations/"))).toBe(false);
+  expect(hasPathEndingWith("/generated/models/ContosoOperationsCreateRequest.cs")).toBe(false);
+  expect(paths.some((path) => path.includes("/mocks/"))).toBe(false);
+  expect(hasPathEndingWith("/Program.cs")).toBe(false);
+  expect(hasPathEndingWith("/ServiceProject.csproj")).toBe(false);
+  expect(hasPathEndingWith("/Properties/launchSettings.json")).toBe(false);
+  expect(hasPathEndingWith("/docs/emitter.md")).toBe(false);
+
+  const [allResult] = await compileAndDiagnose(tester, service, {
+    "output-type": "all",
+    "skip-format": true,
+  });
+  const allPaths = [...allResult.fs.fs.keys()];
+
+  expect(
+    allPaths.some((path) => path.endsWith("/generated/models/ContosoOperationsCreateRequest.cs")),
+  ).toBe(true);
+  expect(allPaths.some((path) => path.includes("/generated/controllers/"))).toBe(true);
+  expect(allPaths.some((path) => path.includes("/generated/operations/"))).toBe(true);
+  expect(allPaths.some((path) => path.endsWith("/Program.cs"))).toBe(true);
+  expect(allPaths.some((path) => path.endsWith("/docs/emitter.md"))).toBe(true);
+});

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -3113,7 +3113,7 @@ describe("emit correct code for `@error` models", () => {
         `public Error(`,
         `string code,`,
         `string message,`,
-        `string optionalMessage = default,`,
+        `string? optionalMessage = default,`,
         `string defined = "default message"`,
         `) : base(200, value: new { code = code, message = message, optionalMessage = optionalMessage, defined = defined })`,
       ],

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -1451,13 +1451,13 @@ it("Handles user-defined model templates", async () => {
     [
       [
         "IMyServiceOperations.cs",
-        ["interface IMyServiceOperations", "Task<ResponsePageToy> FooAsync();"],
+        ["interface IMyServiceOperations", "Task<MyService.ResponsePageToy> FooAsync();"],
       ],
       [
         "MyServiceOperationsController.cs",
         [
           "public partial class MyServiceOperationsController : ControllerBase",
-          "[ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(ResponsePageToy))]",
+          "[ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(MyService.ResponsePageToy))]",
           "public virtual async Task<IActionResult> Foo()",
         ],
       ],

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -157,7 +157,7 @@ it("generates standard scalar properties", async () => {
     "Foo.cs",
     [
       "public partial class Foo",
-      "public byte[] BytesProp { get; set; }",
+      "public byte[]? BytesProp { get; set; }",
       "public SByte? SignedByteProp { get; set; }",
       "public Byte? ByteProp { get; set; }",
       "public Int16? Int16Prop { get; set; }",
@@ -175,10 +175,10 @@ it("generates standard scalar properties", async () => {
       "public TimeSpan? DurationProp { get; set; }",
       "public DateTimeOffset? UtcDateTimeProp { get; set; }",
       "public DateTimeOffset? OffsetDateTimeProp { get; set; }",
-      "public string StringProp { get; set; }",
+      "public string? StringProp { get; set; }",
       "[JsonConverter(typeof(UnixEpochDateTimeOffsetConverter))]",
       "public DateTimeOffset? TimestampProp { get; set; }",
-      "public string UrlProp { get; set; }",
+      "public string? UrlProp { get; set; }",
       "public long? SafeIntProp { get; set; }",
       "public decimal? DecimalProp { get; set; }",
       "public decimal? Decimal128Prop { get; set; }",
@@ -236,7 +236,7 @@ it("generates string constraints", async () => {
     [
       "public partial class Foo",
       "[StringConstraint(MinLength = 3, MaxLength = 72)]",
-      "public string StringProp { get; set; }",
+      "public string? StringProp { get; set; }",
     ],
   );
 });
@@ -342,7 +342,7 @@ it("generates literal properties", async () => {
     "Foo.cs",
     [
       "public partial class Foo",
-      `public string StringLiteralProp { get; } = "This is a string literal";`,
+      `public string? StringLiteralProp { get; } = "This is a string literal";`,
       "public bool? BoolLiteralProp { get; } = true;",
       "public int? NumericLiteralProp { get; } = 17",
     ],
@@ -366,7 +366,7 @@ it("generates default values in properties", async () => {
     "Foo.cs",
     [
       "public partial class Foo",
-      `public string StringLiteralProp { get; set; } = "This is a string literal";`,
+      `public string? StringLiteralProp { get; set; } = "This is a string literal";`,
       "public bool? BoolLiteralProp { get; set; } = true;",
       "public int? NumericLiteralProp { get; set; } = 17;",
     ],
@@ -630,7 +630,7 @@ it("handles enum, complex type properties, and circular references", async () =>
         [
           "public partial class Foo",
           `public SimpleBar? BarProp { get; set; }`,
-          `public Baz BazProp { get; set; }`,
+          `public Baz? BazProp { get; set; }`,
         ],
       ],
       [
@@ -670,8 +670,8 @@ it("handles enum, complex type properties, and circular references", async () =>
         "Baz.cs",
         [
           "public partial class Baz",
-          `public Foo FooProp { get; set; }`,
-          `public Baz NextBazProp { get; set; }`,
+          `public Foo? FooProp { get; set; }`,
+          `public Baz? NextBazProp { get; set; }`,
         ],
       ],
     ],
@@ -896,7 +896,7 @@ it("processes sub-namespaces of a service", async () => {
     "Foo.cs",
     [
       "public partial class Foo",
-      `public string InvalidName { get; set; } = "This is a string literal";`,
+      `public string? InvalidName { get; set; } = "This is a string literal";`,
     ],
   );
 });
@@ -917,7 +917,7 @@ it("creates Valid Identifiers", async () => {
     [
       "public partial class Foo",
       `[JsonPropertyName("**()invalid~~Name")]`,
-      `public string InvalidName { get; set; } = "This is a string literal";`,
+      `public string? InvalidName { get; set; } = "This is a string literal";`,
     ],
   );
 });
@@ -1133,9 +1133,9 @@ interface Widgets {
         "WidgetMergePatchUpdate.cs",
         [
           "namespace Contoso;",
-          "public string Id { get; set; }",
+          "public string? Id { get; set; }",
           "public int? Weight { get; set; }",
-          "public string Color { get; set; }",
+          "public string? Color { get; set; }",
         ],
       ],
     ],
@@ -1170,7 +1170,7 @@ interface Widgets {
         "WidgetMergePatchUpdate.cs",
         [
           "namespace Contoso;",
-          "public string Id { get; set; }",
+          "public string? Id { get; set; }",
           "public int? Weight { get; set; }",
           "public WidgetColor? Color { get; set; }",
         ],
@@ -1212,7 +1212,7 @@ interface Widgets {
         "WidgetMergePatchUpdate.cs",
         [
           "namespace Contoso;",
-          "public string Id { get; set; }",
+          "public string? Id { get; set; }",
           "WidgetColor? Color { get; set; }",
           "WidgetSize? Size { get; set; }",
         ],
@@ -1280,7 +1280,7 @@ interface Widgets {
         "WidgetMergePatchUpdate.cs",
         [
           "namespace Contoso;",
-          "public string Id { get; set; }",
+          "public string? Id { get; set; }",
           "public WidgetColor? Color { get; set; }",
         ],
       ],
@@ -1316,7 +1316,7 @@ interface Widgets {
     [
       [
         "WidgetMergePatchUpdate.cs",
-        ["namespace Contoso;", "public string Id { get; set; }", "Color { get; set; }"],
+        ["namespace Contoso;", "public string? Id { get; set; }", "Color { get; set; }"],
       ],
     ],
   );
@@ -1350,8 +1350,8 @@ interface Widgets {
         "WidgetMergePatchUpdate.cs",
         [
           "namespace Contoso;",
-          "public string Id { get; set; }",
-          "TagMergePatchUpdateReplaceOnly[] Tags { get; set; }",
+          "public string? Id { get; set; }",
+          "TagMergePatchUpdateReplaceOnly[]? Tags { get; set; }",
         ],
       ],
     ],
@@ -1796,7 +1796,7 @@ it("generates appropriate types for arrays", async () => {
           "namespace TypeName.Array",
           "public partial class InnerModel",
           "public string Property { get; set; }",
-          "public InnerModel[] Children { get; set; }",
+          "public InnerModel[]? Children { get; set; }",
         ],
       ],
       [
@@ -2003,10 +2003,10 @@ it("handles nullable types correctly", async () => {
         [
           "public partial class Foo",
           "public int? IntProp { get; set; }",
-          "public string StringProp { get; set; }",
-          "public Model0 ModelProp { get; set; }",
+          "public string? StringProp { get; set; }",
+          "public Model0? ModelProp { get; set; }",
           "public Model1 AnotherModelProp { get; set; }",
-          "public Model0 YetAnother { get; set; }",
+          "public Model0? YetAnother { get; set; }",
         ],
       ],
       ["ContosoOperationsController.cs", [`public virtual async Task<IActionResult> Foo()`]],
@@ -2679,7 +2679,7 @@ it("generates one line `@doc` decorator comments", async () => {
       "/// <summary>",
       "/// Pet name in the format of a string",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2705,7 +2705,7 @@ it("generates multiline jsdoc comments", async () => {
       "/// The name will be the main identifier for the dog. It is suggested to keep it short and simple.",
       "/// Pets have a difficult time understanding and learning complex names.",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2729,7 +2729,7 @@ it("generates multiline jsdoc comments with long non-space words", async () => {
       "/// Pet name in the format of a string.",
       "/// Visit example.funnamesforpets.com/bestowners/popularnames/let-your-best-friend-have-the-best-name where you can find many unique names.",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2771,7 +2771,7 @@ it("generates correct (awkward) multiline jsdoc comments without multiline aster
       "///         The name will be the main identifier for the dog. It is suggested to keep it short and simple.",
       "///         Pets have a difficult time understanding and learning complex names.",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2870,7 +2870,7 @@ it("generates correct (awkward) multiline jsdoc comments with long non-space wor
       "/// Pet name in the format of a string.",
       "///         Visit example.funnamesforpets.com/bestowners/popularnames/let-your-best-friend-have-the-best-name where you can find many unique names.",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2896,7 +2896,7 @@ it("generates multiline `@doc` decorator comments", async () => {
       "/// The name will be the main identifier for the dog. It is suggested to keep it short and simple.",
       "/// Pets have a difficult time understanding and learning complex names.",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2920,7 +2920,7 @@ it("generates multiline `@doc` decorator comments with long non-space words", as
       "/// Pet name in the format of a string.",
       "/// Visit example.funnamesforpets.com/bestowners/popularnames/let-your-best-friend-have-the-best-name where you can find many unique names.",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2940,7 +2940,7 @@ it("generates single line `@doc` decorator comments", async () => {
       "/// <summary>",
       "/// Pet name in the format of a string",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });
@@ -2962,7 +2962,7 @@ it("generates jsdoc comments", async () => {
       "/// <summary>",
       "/// Pet name in the format of a string",
       "/// </summary>",
-      "public string Name { get; set; }",
+      "public string? Name { get; set; }",
     ],
   );
 });

--- a/packages/http-server-csharp/test/nullable-parameters.test.ts
+++ b/packages/http-server-csharp/test/nullable-parameters.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, expect, it } from "vitest";
+import { ApiTester, compileAndDiagnose, getStandardService } from "./test-host.js";
+
+let tester: Awaited<ReturnType<typeof ApiTester.createInstance>>;
+
+beforeEach(async () => {
+  tester = await ApiTester.createInstance();
+});
+
+it("emits one nullable suffix for optional nullable value parameters", async () => {
+  const [result] = await compileAndDiagnose(
+    tester,
+    getStandardService(`
+      enum Choice {
+        one,
+      }
+
+      @route("/nullable")
+      interface NullableParameters {
+        @get test(
+          @query value?: int32 | null,
+          @query choice?: Choice | null,
+        ): void;
+      }
+    `),
+    {
+      "emit-mocks": "mocks-only",
+      "skip-format": true,
+    },
+  );
+
+  const interfaceContent = [...result.fs.fs.entries()].find(([path]) =>
+    path.endsWith("/INullableParameters.cs"),
+  )?.[1];
+  const mockContent = [...result.fs.fs.entries()].find(([path]) =>
+    path.endsWith("/NullableParameters.cs"),
+  )?.[1];
+
+  expect(interfaceContent).toContain("TestAsync(int? value, Choice? choice)");
+  expect(mockContent).toContain("TestAsync(int? value, Choice? choice)");
+  expect(interfaceContent).not.toMatch(/\w+\?\?\s+\w+/);
+  expect(mockContent).not.toMatch(/\w+\?\?\s+\w+/);
+});

--- a/packages/http-server-csharp/test/snapshots/sample-service/generated/controllers/PetsController.cs
+++ b/packages/http-server-csharp/test/snapshots/sample-service/generated/controllers/PetsController.cs
@@ -87,10 +87,10 @@ public partial class PetsController : ControllerBase
     /// </summary>
     [HttpDelete]
     [Route("/pets/{id}")]
-    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(void))]
+    [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
     public virtual async Task<IActionResult> Delete(long id)
     {
-        var result = await PetsImpl.DeleteAsync(id);
-        return Ok(result);
+        await PetsImpl.DeleteAsync(id);
+        return NoContent();
     }
 }

--- a/packages/http-server-csharp/test/snapshots/sample-service/generated/models/Pet.cs
+++ b/packages/http-server-csharp/test/snapshots/sample-service/generated/models/Pet.cs
@@ -23,11 +23,11 @@ public partial class Pet
     public string Name { get; set; }
 
     [JsonPropertyName("tag")]
-    public string Tag { get; set; }
+    public string? Tag { get; set; }
 
     [JsonPropertyName("age")]
     public int? Age { get; set; }
 
     [JsonPropertyName("address")]
-    public Address Address { get; set; }
+    public Address? Address { get; set; }
 }

--- a/packages/http-server-csharp/test/snapshots/sample-service/generated/models/PetListResult.cs
+++ b/packages/http-server-csharp/test/snapshots/sample-service/generated/models/PetListResult.cs
@@ -20,5 +20,5 @@ public partial class PetListResult
     public Pet[] Items { get; set; }
 
     [JsonPropertyName("nextLink")]
-    public string NextLink { get; set; }
+    public string? NextLink { get; set; }
 }


### PR DESCRIPTION
Addresses errors I encountered while using the C# server emitter to emit code from [the ai foundry spec](https://github.com/Azure/azure-rest-api-specs/tree/feature/foundry-release/specification/ai-foundry/data-plane/Foundry/src) for the [agent contracts api service package](https://dev.azure.com/msdata/Vienna/_git/agent-api-service-contracts?version=GBmain). Includes tests

Issues addressed:
* duplicate nullable suffixes: fixed optional nullable value parameters emitting invalid C# types by ensuring nullable suffixes are applied only once (`int??` to `int?`)
* multipart content: fixed multipart operations emitting `<Unresolved Symbol ...>` by falling back to the original `@multipartBody` metadata when canonicalization data is unavailable
* record parameter fixes: fixed error-model constructors emitting incompatible types such as `Record`, `Array`, or `object` instead of the same concrete structured types used by their properties
* parameter ordering fix: fixed controller calls passing positional arguments in a different order than their business-interface signatures while preserving positional syntax for existing generated code
* void as a success type: fixed `void | @error` responses generating invalid result assignments by excluding error branches from success-response analysis and emitting direct awaits with `NoContent()`
* optional nullables for errors: errors with optional properties would emit with those properties non-optional and only show as optional if the spec specified ` | null`
* fix model only emitter option: `output-type:models` was emitting controllers and responses, and it now emits models only
* namespace issue: the emitter was generating code with the wrong namespace, using whichever namespace was the first to appear in the typespec (ex. using the namespace of a package that was imported) instead of the intended namespace

