### PR TITLE
Support registry mirrors in tsp install

### DIFF
--- a/.chronus/changes/fix-tsp-install-registry-bootstrap-2026-7-27-13-23-35.md
+++ b/.chronus/changes/fix-tsp-install-registry-bootstrap-2026-7-27-13-23-35.md
@@ -4,4 +4,4 @@ packages:
   - "@typespec/compiler"
 ---
 
-Resolve package manager versions through registry packuments so `TYPESPEC_NPM_REGISTRY` works with registries that do not support abbreviated manifest endpoints.
+Allow `tsp install` to download package managers from npm-compatible registry mirrors by resolving versions from package metadata instead of version-specific manifest endpoints.

--- a/.chronus/changes/fix-tsp-install-registry-bootstrap-2026-7-27-13-23-35.md
+++ b/.chronus/changes/fix-tsp-install-registry-bootstrap-2026-7-27-13-23-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Resolve package manager versions through registry packuments so `TYPESPEC_NPM_REGISTRY` works with registries that do not support abbreviated manifest endpoints.

--- a/eng/tsp-core/pipelines/jobs/e2e.yml
+++ b/eng/tsp-core/pipelines/jobs/e2e.yml
@@ -9,6 +9,7 @@ jobs:
     variables:
       TYPESPEC_VS_CI_BUILD: false # Enable official Visual Studio extension build
       TYPESPEC_SKIP_WEBSITE_BUILD: true # Disable docusaurus build
+      TYPESPEC_NPM_REGISTRY: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
       DISPLAY: ":99" # Set DISPLAY for Linux GUI applications
 
     pool:

--- a/eng/tsp-core/pipelines/publish.yml
+++ b/eng/tsp-core/pipelines/publish.yml
@@ -31,7 +31,7 @@ extends:
           - template: /eng/tsp-core/pipelines/jobs/build-packages.yml@self
           - template: /eng/tsp-core/pipelines/jobs/build-vs.yml@self
           - template: /eng/tsp-core/pipelines/jobs/cli/build-tsp-cli-all.yml@self
-            # - template: /eng/tsp-core/pipelines/jobs/e2e.yml@self
+          - template: /eng/tsp-core/pipelines/jobs/e2e.yml@self
             parameters:
               azLogin: true
 

--- a/packages/compiler/src/install/install.ts
+++ b/packages/compiler/src/install/install.ts
@@ -7,7 +7,11 @@ import { createDiagnosticCollector } from "../core/diagnostics.js";
 import { getDirectoryPath, joinPaths } from "../core/path-utils.js";
 import { NoTarget, type Diagnostic, type Tracer } from "../core/types.js";
 import { downloadAndExtractPackage } from "../package-manger/npm-package-download.js";
-import { fetchPackageManifest, type NpmManifest } from "../package-manger/npm-registry.js";
+import {
+  fetchPackageManifest,
+  NpmRegistryError,
+  type NpmManifest,
+} from "../package-manger/npm-registry.js";
 import { mkTempDir } from "../utils/fs-utils.js";
 import type { SupportedPackageManager } from "./config.js";
 import { getPackageManagerConfig, type PackageManagerConfig } from "./config.js";
@@ -99,7 +103,17 @@ async function installPackageManager(
     "downloading-extracting",
     `Downloading and extracting ${packageManager} at version ${manifest.version} in ${tempDir}`,
   );
-  const extractResult = await downloadAndExtractPackage(manifest, tempDir, spec.hash?.algorithm);
+  let extractResult;
+  try {
+    extractResult = await downloadAndExtractPackage(manifest, tempDir, spec.hash?.algorithm);
+  } catch (error) {
+    if (error instanceof NpmRegistryError) {
+      throw new InstallDependenciesError(
+        `Failed to download package manager ${packageManager}: ${error.message}`,
+      );
+    }
+    throw error;
+  }
   if (spec.hash) {
     if (spec.hash.value !== extractResult.hash.value) {
       throw new InstallDependenciesError(
@@ -165,7 +179,17 @@ export async function installTypeSpecDependencies(
     );
     const packageManager = spec.name;
     const packageManagerConfig = getPackageManagerConfig(packageManager);
-    const manifest = await fetchPackageManifest(packageManager, spec.range);
+    let manifest: NpmManifest;
+    try {
+      manifest = await fetchPackageManifest(packageManager, spec.range);
+    } catch (error) {
+      if (error instanceof NpmRegistryError) {
+        throw new InstallDependenciesError(
+          `Failed to resolve package manager ${packageManager}: ${error.message}`,
+        );
+      }
+      throw error;
+    }
     tracer.trace(
       "fetched-manifest",
       `Resolved manifest for ${packageManager} at version ${manifest.version}`,

--- a/packages/compiler/src/install/install.ts
+++ b/packages/compiler/src/install/install.ts
@@ -6,11 +6,14 @@ import { DiagnosticError } from "../core/diagnostic-error.js";
 import { createDiagnosticCollector } from "../core/diagnostics.js";
 import { getDirectoryPath, joinPaths } from "../core/path-utils.js";
 import { NoTarget, type Diagnostic, type Tracer } from "../core/types.js";
-import { downloadAndExtractPackage } from "../package-manger/npm-package-download.js";
+import {
+  downloadAndExtractPackage,
+  type ExtractedTarballResult,
+} from "../package-manger/npm-package-download.js";
 import {
   fetchPackageManifest,
   NpmRegistryError,
-  type NpmManifest,
+  type NpmPackageVersion,
 } from "../package-manger/npm-registry.js";
 import { mkTempDir } from "../utils/fs-utils.js";
 import type { SupportedPackageManager } from "./config.js";
@@ -94,7 +97,7 @@ async function installPackageManager(
   packageManager: SupportedPackageManager,
   spec: Descriptor,
   installDir: string,
-  manifest: NpmManifest,
+  manifest: NpmPackageVersion,
 ) {
   await rm(installDir, { recursive: true, force: true });
   const tempDir = await mkTempDir(host, pmDir, `tsp-pm-${packageManager}-${manifest.version}`);
@@ -103,7 +106,7 @@ async function installPackageManager(
     "downloading-extracting",
     `Downloading and extracting ${packageManager} at version ${manifest.version} in ${tempDir}`,
   );
-  let extractResult;
+  let extractResult: ExtractedTarballResult;
   try {
     extractResult = await downloadAndExtractPackage(manifest, tempDir, spec.hash?.algorithm);
   } catch (error) {
@@ -179,7 +182,7 @@ export async function installTypeSpecDependencies(
     );
     const packageManager = spec.name;
     const packageManagerConfig = getPackageManagerConfig(packageManager);
-    let manifest: NpmManifest;
+    let manifest: NpmPackageVersion;
     try {
       manifest = await fetchPackageManifest(packageManager, spec.range);
     } catch (error) {
@@ -194,6 +197,12 @@ export async function installTypeSpecDependencies(
       "fetched-manifest",
       `Resolved manifest for ${packageManager} at version ${manifest.version}`,
     );
+    const bin = manifest.bin?.[packageManager];
+    if (bin === undefined) {
+      throw new InstallDependenciesError(
+        `Package manager ${packageManager} does not define a "${packageManager}" executable.`,
+      );
+    }
 
     const installDir = joinPaths(pmDir, packageManager, manifest.version);
     if ((await isDirectory(host, installDir)) && !savePackageManager) {
@@ -216,7 +225,6 @@ export async function installTypeSpecDependencies(
       }
     }
 
-    const bin = manifest.bin![packageManager];
     const binPath = joinPaths(installDir, bin);
     tracer.trace("running-binary", `Running binary ${binPath}`);
 

--- a/packages/compiler/src/package-manger/npm-package-download.ts
+++ b/packages/compiler/src/package-manger/npm-package-download.ts
@@ -66,7 +66,12 @@ async function downloadAndExtractTarball(
   });
 
   tarballStream.pipe(extractor);
-  await p;
+  try {
+    await p;
+  } catch (error) {
+    const message = error instanceof Error ? `: ${error.message}` : "";
+    throw new NpmRegistryError(`Failed to extract package from ${url}${message}`);
+  }
 
   return { dest, hash: { algorithm: hashAlgorithm, value: hash.digest("hex") } };
 }

--- a/packages/compiler/src/package-manger/npm-package-download.ts
+++ b/packages/compiler/src/package-manger/npm-package-download.ts
@@ -4,7 +4,7 @@ import { createHash } from "crypto";
 import { Readable } from "stream";
 import { extract as tarX } from "tar/extract";
 import type { Hash } from "../install/spec.js";
-import { fetchPackageManifest, type NpmManifest } from "./npm-registry.js";
+import { fetchPackageManifest, NpmRegistryError, type NpmManifest } from "./npm-registry.js";
 
 export async function downloadPackageVersion(
   packageName: string,
@@ -32,7 +32,20 @@ async function downloadAndExtractTarball(
   dest: string,
   hashAlgorithm: string = "sha512",
 ): Promise<ExtractedTarballResult> {
-  const res = await fetch(url);
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (error) {
+    const message = error instanceof Error ? `: ${error.message}` : "";
+    throw new NpmRegistryError(`Request to ${url} failed${message}`);
+  }
+  if (!res.ok) {
+    throw new NpmRegistryError(`Request to ${url} failed with status ${res.status}.`);
+  }
+  if (res.body === null) {
+    throw new NpmRegistryError(`Request to ${url} returned an empty response.`);
+  }
+
   const tarballStream = Readable.fromWeb(res.body as any);
   const hash = tarballStream.pipe(createHash(hashAlgorithm));
   const extractor = tarX({

--- a/packages/compiler/src/package-manger/npm-package-download.ts
+++ b/packages/compiler/src/package-manger/npm-package-download.ts
@@ -4,7 +4,7 @@ import { createHash } from "crypto";
 import { Readable } from "stream";
 import { extract as tarX } from "tar/extract";
 import type { Hash } from "../install/spec.js";
-import { fetchPackageManifest, NpmRegistryError, type NpmManifest } from "./npm-registry.js";
+import { fetchPackageManifest, NpmRegistryError, type NpmPackageVersion } from "./npm-registry.js";
 
 export async function downloadPackageVersion(
   packageName: string,
@@ -16,7 +16,7 @@ export async function downloadPackageVersion(
 }
 
 export async function downloadAndExtractPackage(
-  manifest: NpmManifest,
+  manifest: NpmPackageVersion,
   dest: string,
   hashAlgorithm: string = "sha512",
 ): Promise<ExtractedTarballResult> {

--- a/packages/compiler/src/package-manger/npm-registry.ts
+++ b/packages/compiler/src/package-manger/npm-registry.ts
@@ -1,5 +1,6 @@
 // Browser-safe helpers to access the npm registry api
 // https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md#package-endpoints
+import semverMaxSatisfying from "semver/ranges/max-satisfying.js";
 
 /** Manifest of a single package version. */
 export interface NpmManifest {
@@ -26,7 +27,7 @@ export interface NpmManifest {
 export interface NpmPackument {
   readonly name: string;
   readonly "dist-tags": { latest: string } & Record<string, string>;
-  readonly versions: Record<string, NpmPackageVersion>;
+  readonly versions: Record<string, NpmManifest>;
 
   readonly [key: string]: unknown;
 }
@@ -82,6 +83,8 @@ export interface NpmHuman {
   readonly url?: string | undefined;
 }
 
+export class NpmRegistryError extends Error {}
+
 const defaultRegistry = `https://registry.npmjs.org`;
 
 /**
@@ -95,11 +98,36 @@ export function getNpmRegistry(): string {
 
 export async function fetchPackageManifest(
   packageName: string,
-  version: string,
+  versionOrRange: string,
 ): Promise<NpmManifest> {
-  const url = `${getNpmRegistry()}/${packageName}/${version}`;
-  const res = await fetch(url);
-  return await res.json();
+  const encodedPackageName = packageName.startsWith("@")
+    ? packageName.replace("/", "%2F")
+    : packageName;
+  const url = `${getNpmRegistry()}/${encodedPackageName}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { Accept: "application/vnd.npm.install-v1+json" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? `: ${error.message}` : "";
+    throw new NpmRegistryError(`Request to ${url} failed${message}`);
+  }
+  if (!res.ok) {
+    throw new NpmRegistryError(`Request to ${url} failed with status ${res.status}.`);
+  }
+
+  const packument = (await res.json()) as NpmPackument;
+  const version =
+    packument["dist-tags"][versionOrRange] ??
+    semverMaxSatisfying(Object.keys(packument.versions), versionOrRange);
+  const manifest = version === null ? undefined : packument.versions[version];
+  if (manifest === undefined) {
+    throw new NpmRegistryError(
+      `Package "${packageName}" does not have a version or tag matching "${versionOrRange}".`,
+    );
+  }
+  return manifest;
 }
 
 export function fetchLatestPackageManifest(packageName: string): Promise<NpmManifest> {

--- a/packages/compiler/src/package-manger/npm-registry.ts
+++ b/packages/compiler/src/package-manger/npm-registry.ts
@@ -2,36 +2,6 @@
 // https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md#package-endpoints
 import semverMaxSatisfying from "semver/ranges/max-satisfying.js";
 
-/** Manifest of a single package version. */
-export interface NpmManifest {
-  readonly name: string;
-  readonly version: string;
-  readonly dependencies: Record<string, string>;
-  readonly optionalDependencies: Record<string, string>;
-  readonly devDependencies: Record<string, string>;
-  readonly peerDependencies: Record<string, string>;
-  readonly bundleDependencies: false | string[];
-  readonly dist: NpmPackageDist;
-  readonly bin: Record<string, string> | null;
-  readonly _shrinkwrap: Record<string, unknown> | null;
-
-  readonly engines?: Record<string, string> | undefined;
-  readonly cpu?: string[] | undefined;
-  readonly os?: string[] | undefined;
-  readonly _id?: string | undefined;
-
-  readonly [key: string]: unknown;
-}
-
-/** Document listing a package information and all its versions. */
-export interface NpmPackument {
-  readonly name: string;
-  readonly "dist-tags": { latest: string } & Record<string, string>;
-  readonly versions: Record<string, NpmManifest>;
-
-  readonly [key: string]: unknown;
-}
-
 export interface NpmPackageVersion {
   readonly name: string;
   readonly version: string;
@@ -39,9 +9,12 @@ export interface NpmPackageVersion {
   readonly optionalDependencies?: Record<string, string> | undefined;
   readonly devDependencies?: Record<string, string> | undefined;
   readonly peerDependencies?: Record<string, string> | undefined;
-  readonly directories: {};
+  readonly bundleDependencies?: false | string[] | undefined;
   readonly dist: NpmPackageDist;
-  readonly _hasShrinkwrap: boolean;
+  readonly bin?: Record<string, string> | null | undefined;
+  readonly _shrinkwrap?: Record<string, unknown> | null | undefined;
+  readonly directories?: {} | undefined;
+  readonly _hasShrinkwrap?: boolean | undefined;
 
   // Extra metadata which may be added by the registry:
   readonly description?: string | undefined;
@@ -62,10 +35,32 @@ export interface NpmPackageVersion {
   readonly license?: string | undefined;
   readonly homepage?: string | undefined;
   readonly bugs?: { url: string } | undefined;
+  readonly cpu?: string[] | undefined;
+  readonly os?: string[] | undefined;
   readonly _id?: string | undefined;
   readonly _nodeVersion?: string | undefined;
   readonly _npmVersion?: string | undefined;
   readonly _npmUser?: NpmHuman | undefined;
+  readonly [key: string]: unknown;
+}
+
+/** Manifest of a single package version. */
+export interface NpmManifest extends NpmPackageVersion {
+  readonly dependencies: Record<string, string>;
+  readonly optionalDependencies: Record<string, string>;
+  readonly devDependencies: Record<string, string>;
+  readonly peerDependencies: Record<string, string>;
+  readonly bundleDependencies: false | string[];
+  readonly bin: Record<string, string> | null;
+  readonly _shrinkwrap: Record<string, unknown> | null;
+}
+
+/** Document listing a package information and all its versions. */
+export interface NpmPackument {
+  readonly name: string;
+  readonly "dist-tags": { latest: string } & Record<string, string>;
+  readonly versions: Record<string, NpmPackageVersion>;
+
   readonly [key: string]: unknown;
 }
 
@@ -99,7 +94,7 @@ export function getNpmRegistry(): string {
 export async function fetchPackageManifest(
   packageName: string,
   versionOrRange: string,
-): Promise<NpmManifest> {
+): Promise<NpmPackageVersion> {
   const encodedPackageName = packageName.startsWith("@")
     ? packageName.replace("/", "%2F")
     : packageName;
@@ -117,12 +112,18 @@ export async function fetchPackageManifest(
     throw new NpmRegistryError(`Request to ${url} failed with status ${res.status}.`);
   }
 
-  const packument = (await res.json()) as NpmPackument;
+  let response: unknown;
+  try {
+    response = await res.json();
+  } catch {
+    throw new NpmRegistryError(`Request to ${url} returned invalid JSON.`);
+  }
+  const packument = parsePackument(url, response);
   const version =
     packument["dist-tags"][versionOrRange] ??
     semverMaxSatisfying(Object.keys(packument.versions), versionOrRange);
   const manifest = version === null ? undefined : packument.versions[version];
-  if (manifest === undefined) {
+  if (manifest === undefined || !isNpmPackageVersion(manifest)) {
     throw new NpmRegistryError(
       `Package "${packageName}" does not have a version or tag matching "${versionOrRange}".`,
     );
@@ -130,6 +131,36 @@ export async function fetchPackageManifest(
   return manifest;
 }
 
-export function fetchLatestPackageManifest(packageName: string): Promise<NpmManifest> {
+export function fetchLatestPackageManifest(packageName: string): Promise<NpmPackageVersion> {
   return fetchPackageManifest(packageName, "latest");
+}
+
+function parsePackument(url: string, value: unknown): NpmPackument {
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    !isStringRecord(value["dist-tags"]) ||
+    !isRecord(value.versions)
+  ) {
+    throw new NpmRegistryError(`Request to ${url} returned an invalid package document.`);
+  }
+  return value as NpmPackument;
+}
+
+function isNpmPackageVersion(value: unknown): value is NpmPackageVersion {
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    typeof value.version === "string" &&
+    isRecord(value.dist) &&
+    typeof value.dist.tarball === "string"
+  );
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/compiler/test/cli/init.test.ts
+++ b/packages/compiler/test/cli/init.test.ts
@@ -10,9 +10,7 @@ import { createTestFileSystem } from "../../src/testing/fs.js";
 import type { TestFileSystem } from "../../src/testing/types.js";
 import { parseYaml as coreParseYaml } from "../../src/yaml/parser.js";
 
-const fetchMock = vi.fn().mockResolvedValue({
-  json: () => Promise.resolve({ name: "mock-pkg", version: "1.0.0" }),
-});
+const fetchMock = vi.fn().mockResolvedValue(createFetchResponse());
 
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
@@ -20,10 +18,21 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  fetchMock.mockResolvedValue({
-    json: () => Promise.resolve({ name: "mock-pkg", version: "1.0.0" }),
-  });
+  fetchMock.mockResolvedValue(createFetchResponse());
 });
+
+function createFetchResponse() {
+  const manifest = { name: "mock-pkg", version: "1.0.0" };
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        name: manifest.name,
+        "dist-tags": { latest: manifest.version },
+        versions: { [manifest.version]: manifest },
+      }),
+  };
+}
 
 const TEST_SCAFFOLDING = {
   foo: {

--- a/packages/compiler/test/cli/init.test.ts
+++ b/packages/compiler/test/cli/init.test.ts
@@ -22,7 +22,11 @@ afterEach(() => {
 });
 
 function createFetchResponse() {
-  const manifest = { name: "mock-pkg", version: "1.0.0" };
+  const manifest = {
+    name: "mock-pkg",
+    version: "1.0.0",
+    dist: { shasum: "abc", tarball: "https://example.com/mock-pkg.tgz" },
+  };
   return {
     ok: true,
     json: () =>

--- a/packages/compiler/test/e2e/cli/cli.e2e.ts
+++ b/packages/compiler/test/e2e/cli/cli.e2e.ts
@@ -1,6 +1,8 @@
 import type { ChildProcess, SpawnOptions } from "child_process";
 import { spawn } from "child_process";
 import { access, readFile, rm } from "fs/promises";
+import * as http from "http";
+import type { AddressInfo } from "net";
 import { beforeEach, describe, expect, it } from "vitest";
 import { resolvePath } from "../../../src/index.js";
 import { findTestPackageRoot } from "../../../src/testing/test-utils.js";
@@ -13,25 +15,26 @@ function getScenarioDir(name: string) {
 }
 interface ExecCliOptions {
   cwd?: string;
+  env?: NodeJS.ProcessEnv;
 }
 
-async function execCli(args: string[], { cwd }: ExecCliOptions) {
+async function execCli(args: string[], { cwd, env }: ExecCliOptions) {
   const node = process.platform === "win32" ? "node.exe" : "node";
   return execAsync(node, [resolvePath(pkgRoot, "entrypoints/cli.js"), ...args], {
     cwd,
-    env: { ...process.env, NO_COLOR: "1" },
+    env: { ...process.env, ...env, NO_COLOR: "1" },
   });
 }
-async function execCliSuccess(args: string[], { cwd }: ExecCliOptions) {
-  const result = await execCli(args, { cwd });
+async function execCliSuccess(args: string[], options: ExecCliOptions) {
+  const result = await execCli(args, options);
   if (result.exitCode !== 0) {
     throw new Error(`Failed to execute cli: ${result.stdio}`);
   }
 
   return result;
 }
-async function execCliFail(args: string[], { cwd }: ExecCliOptions) {
-  const result = await execCli(args, { cwd });
+async function execCliFail(args: string[], options: ExecCliOptions) {
+  const result = await execCli(args, options);
   if (result.exitCode === 0) {
     throw new Error(`Cli succeeded but expected failure: ${result.stdio}`);
   }
@@ -103,6 +106,32 @@ describe("info", () => {
     });
     expect(stdout).toContain(`User Config:`);
     expect(stdout).toContain(`outputDir: "{project-root}/tsp-output/{custom-dir}"`);
+  });
+});
+
+describe("install", () => {
+  it("reports registry failures without an internal compiler error", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(401);
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      const result = await execCliFail(["install"], {
+        cwd: getScenarioDir("install"),
+        env: { TYPESPEC_NPM_REGISTRY: `http://127.0.0.1:${port}` },
+      });
+
+      expect(result.stdio).toContain("install-package-manager-error");
+      expect(result.stdio).toContain("failed with status 401");
+      expect(result.stdio).not.toContain("Internal compiler error");
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 });
 

--- a/packages/compiler/test/e2e/cli/cli.e2e.ts
+++ b/packages/compiler/test/e2e/cli/cli.e2e.ts
@@ -133,6 +133,50 @@ describe("install", () => {
       );
     }
   });
+
+  it("reports package manager download failures without an internal compiler error", async () => {
+    let registryUrl: string;
+    const server = http.createServer((req, res) => {
+      if (req.url === "/npm") {
+        const manifest = {
+          name: "npm",
+          version: "99.99.99",
+          dist: { tarball: `${registryUrl}/npm.tgz` },
+          bin: { npm: "bin/npm-cli.js" },
+        };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            name: "npm",
+            "dist-tags": { latest: manifest.version },
+            versions: { [manifest.version]: manifest },
+          }),
+        );
+      } else {
+        res.writeHead(503);
+        res.end();
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    registryUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      const result = await execCliFail(["install"], {
+        cwd: getScenarioDir("install"),
+        env: { TYPESPEC_NPM_REGISTRY: registryUrl },
+      });
+
+      expect(result.stdio).toContain("install-package-manager-error");
+      expect(result.stdio).toContain("Failed to download package manager npm");
+      expect(result.stdio).toContain("failed with status 503");
+      expect(result.stdio).not.toContain("Internal compiler error");
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
 });
 
 describe("format", () => {

--- a/packages/compiler/test/e2e/cli/cli.e2e.ts
+++ b/packages/compiler/test/e2e/cli/cli.e2e.ts
@@ -153,7 +153,7 @@ describe("install", () => {
           }),
         );
       } else {
-        res.writeHead(503);
+        res.writeHead(200);
         res.end();
       }
     });
@@ -169,7 +169,7 @@ describe("install", () => {
 
       expect(result.stdio).toContain("install-package-manager-error");
       expect(result.stdio).toContain("Failed to download package manager npm");
-      expect(result.stdio).toContain("failed with status 503");
+      expect(result.stdio).toContain("Failed to extract package from");
       expect(result.stdio).not.toContain("Internal compiler error");
     } finally {
       await new Promise<void>((resolve, reject) =>

--- a/packages/compiler/test/e2e/cli/scenarios/install/package.json
+++ b/packages/compiler/test/e2e/cli/scenarios/install/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "install-test",
+  "private": true
+}

--- a/packages/compiler/test/e2e/init-templates.e2e.ts
+++ b/packages/compiler/test/e2e/init-templates.e2e.ts
@@ -10,8 +10,15 @@ import { getTypeSpecCoreTemplates } from "../../src/init/core-templates.js";
 import { makeScaffoldingConfig, scaffoldNewProject } from "../../src/init/scaffold.js";
 import { defaultInternalTemplateSource } from "../../src/init/template-source/index.js";
 
+const manifest = { name: "mock-pkg", version: "1.0.0" };
 const fetchMock = vi.fn().mockResolvedValue({
-  json: () => Promise.resolve({ name: "mock-pkg", version: "1.0.0" }),
+  ok: true,
+  json: () =>
+    Promise.resolve({
+      name: manifest.name,
+      "dist-tags": { latest: manifest.version },
+      versions: { [manifest.version]: manifest },
+    }),
 });
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/compiler/test/e2e/init-templates.e2e.ts
+++ b/packages/compiler/test/e2e/init-templates.e2e.ts
@@ -10,7 +10,11 @@ import { getTypeSpecCoreTemplates } from "../../src/init/core-templates.js";
 import { makeScaffoldingConfig, scaffoldNewProject } from "../../src/init/scaffold.js";
 import { defaultInternalTemplateSource } from "../../src/init/template-source/index.js";
 
-const manifest = { name: "mock-pkg", version: "1.0.0" };
+const manifest = {
+  name: "mock-pkg",
+  version: "1.0.0",
+  dist: { shasum: "abc", tarball: "https://example.com/mock-pkg.tgz" },
+};
 const fetchMock = vi.fn().mockResolvedValue({
   ok: true,
   json: () =>

--- a/packages/compiler/test/init/init-template.test.ts
+++ b/packages/compiler/test/init/init-template.test.ts
@@ -7,8 +7,15 @@ import { makeScaffoldingConfig, scaffoldNewProject } from "../../src/init/scaffo
 import type { TestHost } from "../../src/testing/index.js";
 import { createTestHost, resolveVirtualPath } from "../../src/testing/index.js";
 
+const manifest = { name: "mock-pkg", version: "1.0.0" };
 const fetchMock = vi.fn().mockResolvedValue({
-  json: () => Promise.resolve({ name: "mock-pkg", version: "1.0.0" }),
+  ok: true,
+  json: () =>
+    Promise.resolve({
+      name: manifest.name,
+      "dist-tags": { latest: manifest.version },
+      versions: { [manifest.version]: manifest },
+    }),
 });
 
 let testHost: TestHost;

--- a/packages/compiler/test/init/init-template.test.ts
+++ b/packages/compiler/test/init/init-template.test.ts
@@ -7,7 +7,11 @@ import { makeScaffoldingConfig, scaffoldNewProject } from "../../src/init/scaffo
 import type { TestHost } from "../../src/testing/index.js";
 import { createTestHost, resolveVirtualPath } from "../../src/testing/index.js";
 
-const manifest = { name: "mock-pkg", version: "1.0.0" };
+const manifest = {
+  name: "mock-pkg",
+  version: "1.0.0",
+  dist: { shasum: "abc", tarball: "https://example.com/mock-pkg.tgz" },
+};
 const fetchMock = vi.fn().mockResolvedValue({
   ok: true,
   json: () =>

--- a/packages/compiler/test/package-manager/npm-package-download.test.ts
+++ b/packages/compiler/test/package-manager/npm-package-download.test.ts
@@ -1,3 +1,5 @@
+import * as http from "http";
+import type { AddressInfo } from "net";
 import { afterEach, expect, it, vi } from "vitest";
 import { downloadAndExtractPackage } from "../../src/package-manger/npm-package-download.js";
 import type { NpmPackageVersion } from "../../src/package-manger/npm-registry.js";
@@ -38,4 +40,28 @@ it("reports empty tarball responses", async () => {
   await expect(downloadAndExtractPackage(manifest, "/tmp/test")).rejects.toThrow(
     `Request to ${tarballUrl} returned an empty response.`,
   );
+});
+
+it("reports invalid tarball streams", async () => {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}/npm.tgz`;
+  const invalidManifest: NpmPackageVersion = {
+    ...manifest,
+    dist: { ...manifest.dist, tarball: url },
+  };
+
+  try {
+    await expect(downloadAndExtractPackage(invalidManifest, "/tmp")).rejects.toThrow(
+      `Failed to extract package from ${url}`,
+    );
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
 });

--- a/packages/compiler/test/package-manager/npm-package-download.test.ts
+++ b/packages/compiler/test/package-manager/npm-package-download.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { downloadAndExtractPackage } from "../../src/package-manger/npm-package-download.js";
+import type { NpmPackageVersion } from "../../src/package-manger/npm-registry.js";
+
+const tarballUrl = "https://registry.example.com/npm.tgz";
+const manifest: NpmPackageVersion = {
+  name: "npm",
+  version: "1.0.0",
+  dist: {
+    shasum: "abc",
+    tarball: tarballUrl,
+  },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+it("reports tarball network failures", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network unavailable")));
+
+  await expect(downloadAndExtractPackage(manifest, "/tmp/test")).rejects.toThrow(
+    `Request to ${tarballUrl} failed: network unavailable`,
+  );
+});
+
+it("reports unsuccessful tarball responses", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+
+  await expect(downloadAndExtractPackage(manifest, "/tmp/test")).rejects.toThrow(
+    `Request to ${tarballUrl} failed with status 503.`,
+  );
+});
+
+it("reports empty tarball responses", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, body: null }));
+
+  await expect(downloadAndExtractPackage(manifest, "/tmp/test")).rejects.toThrow(
+    `Request to ${tarballUrl} returned an empty response.`,
+  );
+});

--- a/packages/compiler/test/package-manager/npm-registry.test.ts
+++ b/packages/compiler/test/package-manager/npm-registry.test.ts
@@ -1,31 +1,27 @@
 import * as http from "http";
 import type { AddressInfo } from "net";
 import { afterEach, beforeEach, expect, it } from "vitest";
-import { fetchPackageManifest } from "../../src/package-manger/npm-registry.js";
+import {
+  fetchPackageManifest,
+  getNpmRegistry,
+  type NpmManifest,
+  type NpmPackument,
+} from "../../src/package-manger/npm-registry.js";
 
 let server: http.Server;
 let registryUrl: string;
 let lastRequestUrl: string | undefined;
+let responseStatus: number;
+const originalTypeSpecNpmRegistry = process.env["TYPESPEC_NPM_REGISTRY"];
+const originalNpmConfigRegistry = process.env["NPM_CONFIG_REGISTRY"];
 
 beforeEach(async () => {
   lastRequestUrl = undefined;
+  responseStatus = 200;
   server = http.createServer((req, res) => {
     lastRequestUrl = req.url ?? "";
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(
-      JSON.stringify({
-        name: "test-pkg",
-        version: "1.0.0",
-        dependencies: {},
-        optionalDependencies: {},
-        devDependencies: {},
-        peerDependencies: {},
-        bundleDependencies: false,
-        dist: { shasum: "abc", tarball: "http://example.com/test.tgz" },
-        bin: null,
-        _shrinkwrap: null,
-      }),
-    );
+    res.writeHead(responseStatus, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(createPackument()));
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address() as AddressInfo;
@@ -33,20 +29,96 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  delete process.env["TYPESPEC_NPM_REGISTRY"];
+  restoreEnvironmentVariable("TYPESPEC_NPM_REGISTRY", originalTypeSpecNpmRegistry);
+  restoreEnvironmentVariable("NPM_CONFIG_REGISTRY", originalNpmConfigRegistry);
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
 it("uses the registry URL from TYPESPEC_NPM_REGISTRY when set", async () => {
   process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
   const manifest = await fetchPackageManifest("test-pkg", "latest");
-  expect(manifest.name).toBe("test-pkg");
-  expect(lastRequestUrl).toBe("/test-pkg/latest");
+  expect(manifest.version).toBe("2.0.0");
+  expect(lastRequestUrl).toBe("/test-pkg");
 });
 
 it("strips trailing slash from TYPESPEC_NPM_REGISTRY", async () => {
   process.env["TYPESPEC_NPM_REGISTRY"] = `${registryUrl}/`;
   const manifest = await fetchPackageManifest("test-pkg", "1.0.0");
-  expect(manifest.name).toBe("test-pkg");
-  expect(lastRequestUrl).toBe("/test-pkg/1.0.0");
+  expect(manifest.version).toBe("1.0.0");
+  expect(lastRequestUrl).toBe("/test-pkg");
 });
+
+it("resolves a package version from a semver range", async () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
+
+  const manifest = await fetchPackageManifest("test-pkg", "^1.0.0");
+
+  expect(manifest.version).toBe("1.2.0");
+});
+
+it("encodes scoped package names", async () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
+
+  await fetchPackageManifest("@scope/test-pkg", "latest");
+
+  expect(lastRequestUrl).toBe("/@scope%2Ftest-pkg");
+});
+
+it("reports a missing package version or tag", async () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
+
+  await expect(fetchPackageManifest("test-pkg", "unknown")).rejects.toThrow(
+    `Package "test-pkg" does not have a version or tag matching "unknown".`,
+  );
+});
+
+it("reports registry request failures", async () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
+  responseStatus = 401;
+
+  await expect(fetchPackageManifest("test-pkg", "latest")).rejects.toThrow(
+    `Request to ${registryUrl}/test-pkg failed with status 401.`,
+  );
+});
+
+it("does not use package-manager-specific registry environment variables", () => {
+  delete process.env["TYPESPEC_NPM_REGISTRY"];
+  process.env["NPM_CONFIG_REGISTRY"] = registryUrl;
+
+  expect(getNpmRegistry()).toBe("https://registry.npmjs.org");
+});
+
+function createPackument(): NpmPackument {
+  const versions = ["1.0.0", "1.2.0", "2.0.0"].map(createManifest);
+  return {
+    name: "test-pkg",
+    "dist-tags": {
+      latest: "2.0.0",
+      next: "1.2.0",
+    },
+    versions: Object.fromEntries(versions.map((manifest) => [manifest.version, manifest])),
+  };
+}
+
+function createManifest(version: string): NpmManifest {
+  return {
+    name: "test-pkg",
+    version,
+    dependencies: {},
+    optionalDependencies: {},
+    devDependencies: {},
+    peerDependencies: {},
+    bundleDependencies: false,
+    dist: { shasum: "abc", tarball: `http://example.com/test-${version}.tgz` },
+    bin: null,
+    _shrinkwrap: null,
+  };
+}
+
+function restoreEnvironmentVariable(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/packages/compiler/test/package-manager/npm-registry.test.ts
+++ b/packages/compiler/test/package-manager/npm-registry.test.ts
@@ -11,17 +11,22 @@ import {
 let server: http.Server;
 let registryUrl: string;
 let lastRequestUrl: string | undefined;
+let lastAcceptHeader: string | undefined;
 let responseStatus: number;
+let responseBody: NpmPackument | string;
 const originalTypeSpecNpmRegistry = process.env["TYPESPEC_NPM_REGISTRY"];
 const originalNpmConfigRegistry = process.env["NPM_CONFIG_REGISTRY"];
 
 beforeEach(async () => {
   lastRequestUrl = undefined;
+  lastAcceptHeader = undefined;
   responseStatus = 200;
+  responseBody = createPackument();
   server = http.createServer((req, res) => {
     lastRequestUrl = req.url ?? "";
+    lastAcceptHeader = req.headers.accept;
     res.writeHead(responseStatus, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(createPackument()));
+    res.end(typeof responseBody === "string" ? responseBody : JSON.stringify(responseBody));
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address() as AddressInfo;
@@ -39,6 +44,7 @@ it("uses the registry URL from TYPESPEC_NPM_REGISTRY when set", async () => {
   const manifest = await fetchPackageManifest("test-pkg", "latest");
   expect(manifest.version).toBe("2.0.0");
   expect(lastRequestUrl).toBe("/test-pkg");
+  expect(lastAcceptHeader).toBe("application/vnd.npm.install-v1+json");
 });
 
 it("strips trailing slash from TYPESPEC_NPM_REGISTRY", async () => {
@@ -52,6 +58,14 @@ it("resolves a package version from a semver range", async () => {
   process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
 
   const manifest = await fetchPackageManifest("test-pkg", "^1.0.0");
+
+  expect(manifest.version).toBe("1.2.0");
+});
+
+it("resolves a non-latest package tag", async () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
+
+  const manifest = await fetchPackageManifest("test-pkg", "next");
 
   expect(manifest.version).toBe("1.2.0");
 });
@@ -78,6 +92,24 @@ it("reports registry request failures", async () => {
 
   await expect(fetchPackageManifest("test-pkg", "latest")).rejects.toThrow(
     `Request to ${registryUrl}/test-pkg failed with status 401.`,
+  );
+});
+
+it("reports invalid JSON responses", async () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
+  responseBody = "not JSON";
+
+  await expect(fetchPackageManifest("test-pkg", "latest")).rejects.toThrow(
+    `Request to ${registryUrl}/test-pkg returned invalid JSON.`,
+  );
+});
+
+it("reports invalid package documents", async () => {
+  process.env["TYPESPEC_NPM_REGISTRY"] = registryUrl;
+  responseBody = JSON.stringify({ name: "test-pkg" });
+
+  await expect(fetchPackageManifest("test-pkg", "latest")).rejects.toThrow(
+    `Request to ${registryUrl}/test-pkg returned an invalid package document.`,
   );
 });
 

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalPassThroughEnv": [
     "TYPESPEC_WEBSITE_BASE_PATH",
+    "TYPESPEC_NPM_REGISTRY",
     "TYPESPEC_SKIP_WEBSITE_BUILD",
     "TYPESPEC_SKIP_VS_BUILD",
     "TYPESPEC_VS_CI_BUILD"

--- a/website/src/content/docs/docs/handbook/cli.md
+++ b/website/src/content/docs/docs/handbook/cli.md
@@ -44,5 +44,7 @@ TYPESPEC_NPM_REGISTRY=https://my-corp-registry.example.com tsp init
 
 If this variable is not set, TypeSpec defaults to `https://registry.npmjs.org`.
 
-This variable does not configure the package manager invoked by `tsp install`. Configure that
-package manager separately using its own registry and authentication settings.
+This variable does not configure the package manager invoked by `tsp init` or `tsp install`.
+Configure that package manager separately using its own registry and authentication settings.
+TypeSpec does not read those authentication settings: its package metadata request and the tarball
+URL returned by the registry must be accessible to the TypeSpec process.

--- a/website/src/content/docs/docs/handbook/cli.md
+++ b/website/src/content/docs/docs/handbook/cli.md
@@ -36,10 +36,13 @@ Options:
 
 ### `TYPESPEC_NPM_REGISTRY`
 
-Set the npm registry URL used by `tsp init` and `tsp install` when downloading the package manager and resolving package manifests. This is useful in corporate environments where a private npm registry is required.
+Set the npm-compatible registry URL used by `tsp init` when resolving package versions and by `tsp install` when downloading the configured package manager. This is useful in corporate environments where a private registry is required.
 
 ```bash
 TYPESPEC_NPM_REGISTRY=https://my-corp-registry.example.com tsp init
 ```
 
 If this variable is not set, TypeSpec defaults to `https://registry.npmjs.org`.
+
+This variable does not configure the package manager invoked by `tsp install`. Configure that
+package manager separately using its own registry and authentication settings.


### PR DESCRIPTION
`tsp install` could not bootstrap its package manager from registries such as Azure Artifacts because it relied on a version-specific manifest endpoint those registries do not provide. This kept the release E2E job disabled even when `TYPESPEC_NPM_REGISTRY` was configured.

Package-manager versions are now resolved from standard registry package metadata, including tags and semver ranges. TypeSpec still reads only `TYPESPEC_NPM_REGISTRY` for its bootstrap; the invoked package manager remains responsible for its own registry and authentication configuration. Registry and tarball failures are also reported as install diagnostics instead of internal compiler errors.

The release E2E job is re-enabled against the Azure SDK registry mirror, with the TypeSpec registry variable passed through Turbo.

Fixes https://github.com/microsoft/typespec/issues/11665
Fixes https://github.com/microsoft/typespec/issues/11688