### PR TITLE
Prevent spec provided names from escaping the emitter output dir

### DIFF
--- a/.chronus/changes/escape-version-2026-8-27.md
+++ b/.chronus/changes/escape-version-2026-8-27.md
@@ -1,0 +1,12 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Add `sanitizePathSegment` helper to make a value coming from a TypeSpec spec safe to use as a single path segment. Path separators, drive letter separators and values only made of `.` are replaced with `_`.
+
+```ts
+sanitizePathSegment("2021-10-01-preview"); // "2021-10-01-preview"
+sanitizePathSegment("../../etc/passwd"); // ".._.._etc_passwd"
+```

--- a/.chronus/changes/escape-version-asset-emitter-2026-8-27.md
+++ b/.chronus/changes/escape-version-asset-emitter-2026-8-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/asset-emitter"
+---
+
+`createSourceFile` now resolves the given path strictly under the emitter output dir. Absolute roots and `..` components are dropped so a file name derived from a TypeSpec spec cannot escape the emitter output dir.

--- a/.chronus/changes/escape-version-json-schema-2026-8-27.md
+++ b/.chronus/changes/escape-version-json-schema-2026-8-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/json-schema"
+---
+
+Sanitize declaration names used as file names so a declaration named with a backticked identifier containing path separators cannot write the schema outside of the emitter output dir.

--- a/.chronus/changes/escape-version-openapi3-2026-8-27.md
+++ b/.chronus/changes/escape-version-openapi3-2026-8-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/openapi3"
+---
+
+Sanitize the spec provided values interpolated in `output-file`(`{version}`, `{service-name}` and `{service-name-if-multiple}`) so a version or namespace name containing path separators cannot write the OpenAPI document outside of the emitter output dir.

--- a/packages/asset-emitter/src/asset-emitter.ts
+++ b/packages/asset-emitter/src/asset-emitter.ts
@@ -8,6 +8,7 @@ import {
   getTypeName,
   isTemplateDeclaration,
   joinPaths,
+  sanitizePathSegment,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import { CustomKeyMap } from "./custom-key-map.js";
@@ -198,7 +199,7 @@ export function createAssetEmitter<T, TOptions extends object>(
       const basePath = options.emitterOutputDir;
       const sourceFile = {
         globalScope: undefined as any,
-        path: joinPaths(basePath, path),
+        path: joinPaths(basePath, resolveContainedPath(path)),
         imports: new Map(),
         meta: {},
       };
@@ -975,4 +976,17 @@ function resolveReferenceCycle(
   throw new Error(
     `Couldn't resolve the circular reference stack for ${getTypeName(entity.emitEntityKey[1])}`,
   );
+}
+
+/**
+ * Resolve the given source file path as a path relative to the emitter output dir.
+ * Any component that could take the file outside of the emitter output dir(absolute root, `..`, drive letter) is dropped or sanitized.
+ * This makes sure a name coming from a TypeSpec spec(e.g. a model name) cannot be used to write outside of the emitter output dir.
+ */
+function resolveContainedPath(path: string): string {
+  return path
+    .split(/[/\\]/)
+    .filter((segment) => segment !== "" && segment !== "." && segment !== "..")
+    .map(sanitizePathSegment)
+    .join("/");
 }

--- a/packages/asset-emitter/test/source-file-path.test.ts
+++ b/packages/asset-emitter/test/source-file-path.test.ts
@@ -1,0 +1,39 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { createAssetEmitter, TypeEmitter } from "../src/index.js";
+import { getHostForTypeSpecFile } from "./host.js";
+
+async function createEmitter() {
+  const host = await getHostForTypeSpecFile("");
+  return createAssetEmitter(host.program, TypeEmitter, {
+    emitterOutputDir: "/out",
+    options: {},
+  } as any);
+}
+
+describe("createSourceFile path", () => {
+  it("resolve the path relative to the emitter output dir", async () => {
+    const emitter = await createEmitter();
+    assert.strictEqual(emitter.createSourceFile("output.ts").path, "/out/output.ts");
+  });
+
+  it("keep sub directories", async () => {
+    const emitter = await createEmitter();
+    assert.strictEqual(emitter.createSourceFile("src/models/a.ts").path, "/out/src/models/a.ts");
+  });
+
+  it("cannot escape the emitter output dir with ..", async () => {
+    const emitter = await createEmitter();
+    assert.strictEqual(emitter.createSourceFile("../../escaped.ts").path, "/out/escaped.ts");
+  });
+
+  it("cannot escape the emitter output dir with an absolute path", async () => {
+    const emitter = await createEmitter();
+    assert.strictEqual(emitter.createSourceFile("/etc/passwd").path, "/out/etc/passwd");
+  });
+
+  it("cannot escape the emitter output dir with windows separators", async () => {
+    const emitter = await createEmitter();
+    assert.strictEqual(emitter.createSourceFile("..\\..\\escaped.ts").path, "/out/escaped.ts");
+  });
+});

--- a/packages/compiler/src/core/helpers/index.ts
+++ b/packages/compiler/src/core/helpers/index.ts
@@ -5,7 +5,7 @@ export {
 export type { DiscriminatedUnion, DiscriminatedUnionLegacy } from "./discriminator-utils.js";
 export { getLocationContext } from "./location-context.js";
 export { listOperationsIn, type ListOperationOptions } from "./operation-utils.js";
-export { interpolatePath } from "./path-interpolation.js";
+export { interpolatePath, sanitizePathSegment } from "./path-interpolation.js";
 
 export { cacheRawText, getCachedRawText, getRawTextWithCache } from "./raw-text-cache.js";
 export { explainStringTemplateNotSerializable } from "./string-template-utils.js";

--- a/packages/compiler/src/core/helpers/path-interpolation.ts
+++ b/packages/compiler/src/core/helpers/path-interpolation.ts
@@ -1,5 +1,27 @@
 const VariableInterpolationRegex = /{([a-zA-Z-_.]+)}(\/|\.?)/g;
 
+const UnsafePathSegmentCharsRegex = /[/\\:\0]/g;
+const OnlyDotsRegex = /^\.+$/;
+
+/**
+ * Sanitize a value so it is safe to use as a single segment of a path.
+ *
+ * Path separators, drive letter separators and NUL are replaced with `_` and values only made of `.`(e.g. `.` or `..`) are replaced with `_`.
+ * This prevents values coming from a TypeSpec spec(e.g. a version or a service name) from escaping the directory the file was meant to be written to.
+ *
+ * @param value Value to sanitize.
+ *
+ * @example
+ * ```ts
+ * sanitizePathSegment("2021-10-01-preview"); // "2021-10-01-preview"
+ * sanitizePathSegment("../../etc/passwd"); // ".._.._etc_passwd"
+ * ```
+ */
+export function sanitizePathSegment(value: string): string {
+  const sanitized = value.replace(UnsafePathSegmentCharsRegex, "_");
+  return OnlyDotsRegex.test(sanitized) ? "_" : sanitized;
+}
+
 /**
  * Interpolate a path template
  * @param pathTemplate Path template

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -62,6 +62,7 @@ export {
   listOperationsIn,
   printIdentifier,
   resolveUsages,
+  sanitizePathSegment,
   UsageFlags,
 } from "./core/helpers/index.js";
 export type {

--- a/packages/compiler/test/helpers/path-interpolation.test.ts
+++ b/packages/compiler/test/helpers/path-interpolation.test.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from "assert";
 import { describe, it } from "vitest";
-import { interpolatePath } from "../../src/core/helpers/path-interpolation.js";
+import { interpolatePath, sanitizePathSegment } from "../../src/core/helpers/path-interpolation.js";
 
 it("noop if there is nothing to interpolate", () => {
   strictEqual(interpolatePath("output.json", {}), "output.json");
@@ -34,5 +34,34 @@ describe("when value to interpolate is undefined", () => {
       interpolatePath("dist/{version}-suffix/output.json", { serviceName: "PetStore" }),
       "dist/-suffix/output.json",
     );
+  });
+});
+
+describe("sanitizePathSegment", () => {
+  it.each([
+    ["", ""],
+    ["v1", "v1"],
+    ["2021-10-01-preview", "2021-10-01-preview"],
+    ["1.0.0", "1.0.0"],
+    ["Pet.Store", "Pet.Store"],
+    ["..dir", "..dir"],
+    ["dir..", "dir.."],
+  ])("keeps %j as is", (value, expected) => {
+    strictEqual(sanitizePathSegment(value), expected);
+  });
+
+  it.each([
+    ["../../etc/passwd", ".._.._etc_passwd"],
+    ["..\\..\\windows\\system32", ".._.._windows_system32"],
+    ["/etc/passwd", "_etc_passwd"],
+    ["C:\\evil", "C__evil"],
+    ["\\\\server\\share", "__server_share"],
+    [".", "_"],
+    ["..", "_"],
+    ["....", "_"],
+    ["v1/../../out", "v1_.._.._out"],
+    ["with\0null", "with_null"],
+  ])("sanitizes %j", (value, expected) => {
+    strictEqual(sanitizePathSegment(value), expected);
   });
 });

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -54,6 +54,7 @@ import {
   isStringType,
   isType,
   joinPaths,
+  sanitizePathSegment,
   serializeValueAsJson,
 } from "@typespec/compiler";
 import { DuplicateTracker } from "@typespec/compiler/utils";
@@ -1131,7 +1132,7 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
 
   #newFileScope(type: JsonSchemaDeclaration) {
     const sourceFile = this.emitter.createSourceFile(
-      `${this.declarationName(type)}.${this.#fileExtension()}`,
+      `${sanitizePathSegment(this.declarationName(type)!)}.${this.#fileExtension()}`,
     );
 
     sourceFile.meta.shouldEmit = true;

--- a/packages/json-schema/test/output-file.test.ts
+++ b/packages/json-schema/test/output-file.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { emitSchema } from "./utils.js";
+
+describe("json-schema: output file", () => {
+  it("emit a file per declaration named after the declaration", async () => {
+    const schemas = await emitSchema(`model Foo {}`);
+    expect(Object.keys(schemas)).toContain("Foo.json");
+  });
+
+  it("sanitize path separators and traversal in declaration names", async () => {
+    const schemas = await emitSchema("model `../../escaped` {}");
+    expect(Object.keys(schemas)).toContain(".._.._escaped.json");
+  });
+
+  it("sanitize declaration names only made of dots", async () => {
+    const schemas = await emitSchema("model `..` {}");
+    expect(Object.keys(schemas)).toContain("_.json");
+  });
+});

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -41,6 +41,7 @@ import {
   navigateTypesInNamespace,
   NoTarget,
   resolvePath,
+  sanitizePathSegment,
 } from "@typespec/compiler";
 import type { unsafe_MutatorWithNamespace } from "@typespec/compiler/experimental";
 import { unsafe_mutateSubgraphWithNamespace } from "@typespec/compiler/experimental";
@@ -634,10 +635,12 @@ function createOAPIEmitter(
   ): string {
     return interpolatePath(options.outputFile, {
       "openapi-version": specVersion,
-      "service-name-if-multiple": multipleService ? getNamespaceFullName(service.type) : undefined,
-      "service-name": getNamespaceFullName(service.type),
+      "service-name-if-multiple": multipleService
+        ? sanitizePathSegment(getNamespaceFullName(service.type))
+        : undefined,
+      "service-name": sanitizePathSegment(getNamespaceFullName(service.type)),
       "file-type": fileType,
-      version,
+      version: version && sanitizePathSegment(version),
     });
   }
 

--- a/packages/openapi3/test/output-file.test.ts
+++ b/packages/openapi3/test/output-file.test.ts
@@ -243,4 +243,65 @@ describe("openapi3: output file", () => {
       for (const outputFile of c.expectedOutputFiles) expectHasOutput(outputFile);
     });
   });
+
+  describe("sanitize spec provided values", () => {
+    it("sanitize path separators and traversal in {version}", async () => {
+      await compileOpenAPI(
+        { "output-file": "openapi.{version}.yaml" },
+        `
+          using Versioning;
+          @versioned(Versions) @service namespace Service1 {
+            enum Versions {v1: "../../../escaped"}
+          }
+        `,
+      );
+      expectHasOutput("openapi..._.._.._escaped.yaml");
+    });
+
+    it("sanitize {version} used as a directory segment", async () => {
+      await compileOpenAPI(
+        { "output-file": "{version}/openapi.yaml" },
+        `
+          using Versioning;
+          @versioned(Versions) @service namespace Service1 {
+            enum Versions {v1: ".."}
+          }
+        `,
+      );
+      expectHasOutput("_/openapi.yaml");
+    });
+
+    it("sanitize path separators in {service-name}", async () => {
+      await compileOpenAPI(
+        { "output-file": "{service-name}.yaml" },
+        "@service namespace `../../escaped` {}",
+      );
+      expectHasOutput(".._.._escaped.yaml");
+    });
+
+    it("sanitize path separators in {service-name-if-multiple}", async () => {
+      await compileOpenAPI(
+        { "output-file": "openapi.{service-name-if-multiple}.yaml" },
+        `
+          @service namespace \`../../escaped\` {}
+          @service namespace Service2 {}
+        `,
+      );
+      expectHasOutput("openapi..._.._escaped.yaml");
+      expectHasOutput("openapi.Service2.yaml");
+    });
+
+    it("keep benign versions and service names untouched", async () => {
+      await compileOpenAPI(
+        { "output-file": "{service-name}.{version}.yaml" },
+        `
+          using Versioning;
+          @versioned(Versions) @service namespace Pet.Store {
+            enum Versions {v1: "2021-10-01-preview"}
+          }
+        `,
+      );
+      expectHasOutput("Pet.Store.2021-10-01-preview.yaml");
+    });
+  });
 });


### PR DESCRIPTION
A value coming from a `.tsp` spec could be interpolated into an emitted file path without any sanitization, letting a spec write files **outside** the emitter output dir.

```tsp
@versioned(Versions) @service namespace Svc;
enum Versions { v1: "../../../../../../tmp/PWNED/pwn" }
```

With `@typespec/openapi3` this wrote `/tmp/PWNED/pwn.yaml` instead of something under `tsp-output/`.

`{version}` was not the only vector. Backticked identifiers accept arbitrary characters, so any name reaching a file path had the same problem:

| Emitter | Vector |
| --- | --- |
| `openapi3` | `{version}`, `{service-name}`, `{service-name-if-multiple}` in `output-file` |
| `json-schema` | ``model `../../x` {}`` → `../../x.json` |
| `asset-emitter` | any `createSourceFile` name, which is the choke point for `emitter-framework`, `http-server-csharp`, `http-client-js`, … |

## What changed

New `sanitizePathSegment` helper in the compiler, applied to every spec-derived value that ends up as a path segment:

```ts
sanitizePathSegment("2021-10-01-preview"); // "2021-10-01-preview" (unchanged)
sanitizePathSegment("../../etc/passwd"); //  ".._.._etc_passwd"
```

- **openapi3**: applied to `{version}`, `{service-name}` and `{service-name-if-multiple}`. The user provided `output-file` option is untouched — that is config, not spec input.
- **json-schema**: applied to the declaration name used as the file name.
- **asset-emitter**: `createSourceFile` now resolves strictly under `emitterOutputDir` — absolute roots and `..` components are dropped, sub-directories keep working.

`emitFile` itself is deliberately left unrestricted: an emitter may legitimately write outside its own output dir, so the fix is at the source of the untrusted data.

## Notes

- Behavior change for anyone relying on a `{version}` value containing `/` to build a nested layout — that is exactly the vulnerable behavior.
- `typespec-autorest` in `Azure/typespec-azure` has the same exposure on `{version}`/`{service-name}` and needs a follow-up once this ships. Sanitizing inside `interpolatePath` itself was ruled out on purpose: that emitter interpolates `{arm-types-dir}`, a genuine multi-segment path.
