### PR TITLE
fix(compiler): fix stack overflow when checking assignability of recursive types

### DIFF
--- a/.chronus/changes/fix-relation-checker-recursion-2026-8-26.md
+++ b/.chronus/changes/fix-relation-checker-recursion-2026-8-26.md
@@ -1,0 +1,14 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Fix a stack overflow when checking assignability of mutually recursive types
+
+Checking whether a type was assignable to another one could recurse forever and crash the compiler with `RangeError: Maximum call stack size exceeded`. Two cases were affected:
+
+- mutually recursive models, such as `model A { b: B }` / `model B { a: A }`
+- any union reaching itself, such as `union Foo { self: Foo }`
+
+The relation cache is now shared for the whole check instead of being recreated at every level, and unions seed it before walking their variants, so a cycle coming back to the same pair of types resolves instead of recursing.

--- a/packages/compiler/src/core/type-relation-checker.ts
+++ b/packages/compiler/src/core/type-relation-checker.ts
@@ -88,6 +88,28 @@ interface TypeRelationError {
 }
 
 /**
+ * Result of a relation check.
+ *
+ * The errors are cached together with the result: returning a cached `Related.false` without its
+ * errors would make callers like {@link areModelsRelated} see a failure with nothing to report and
+ * turn it back into a success.
+ */
+type RelationResult = [Related, readonly TypeRelationError[]];
+
+/**
+ * Cache of the relation between two entities for the duration of a single top level check.
+ *
+ * It doubles as the guard that makes recursive types terminate: a relation is seeded with
+ * {@link Related.maybe} before its members are walked, so a cycle coming back to the same pair
+ * resolves optimistically instead of recursing forever.
+ */
+type RelationCache = MultiKeyMap<[Entity | IndeterminateEntity, Entity], RelationResult>;
+
+function createRelationCache(): RelationCache {
+  return new MultiKeyMap<[Entity | IndeterminateEntity, Entity], RelationResult>();
+}
+
+/**
  * Mapping from the reflection models to Type["kind"] value
  */
 const ReflectionNameToKind = {
@@ -130,7 +152,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
       source,
       target,
       diagnosticTarget,
-      new MultiKeyMap<[Entity, Entity], Related>(),
+      createRelationCache(),
     );
     return [related === Related.true, convertErrorsToDiagnostics(errors, diagnosticTarget)];
   }
@@ -218,7 +240,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
       source,
       target,
       diagnosticTarget,
-      new MultiKeyMap<[Entity, Entity], Related>(),
+      createRelationCache(),
     );
     return [related === Related.true, convertErrorsToDiagnostics(errors, diagnosticTarget)];
   }
@@ -227,27 +249,22 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Entity | IndeterminateEntity,
     target: Entity,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity | IndeterminateEntity, Entity], Related>,
-  ): [Related, readonly TypeRelationError[]] {
+    relationCache: RelationCache,
+  ): RelationResult {
     const cached = relationCache.get([source, target]);
     if (cached !== undefined) {
-      return [cached, []];
+      return cached;
     }
-    const [result, diagnostics] = isTypeAssignableToWorker(
-      source,
-      target,
-      diagnosticTarget,
-      new MultiKeyMap<[Entity, Entity], Related>(),
-    );
+    const result = isTypeAssignableToWorker(source, target, diagnosticTarget, relationCache);
     relationCache.set([source, target], result);
-    return [result, diagnostics];
+    return result;
   }
 
   function isTypeAssignableToWorker(
     source: Entity | IndeterminateEntity,
     target: Entity,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     if (
       "kind" in source &&
@@ -298,6 +315,9 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     }
 
     if (source.kind === "Union") {
+      // Seed the relation before walking the variants: a union can reach itself
+      // (`union Foo { self: Foo }`) and would otherwise recurse forever.
+      relationCache.set([source, target], [Related.maybe, []]);
       for (const variant of source.variants.values()) {
         const [variantAssignable] = isTypeAssignableToInternal(
           variant.type,
@@ -366,7 +386,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     indeterminate: IndeterminateEntity,
     target: Type | MixedParameterConstraint,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     const [typeRelated, typeDiagnostics] = isTypeAssignableToInternal(
       indeterminate.type,
@@ -398,7 +418,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Entity,
     target: Type,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     if (!isValue(source)) {
       return [Related.false, [createUnassignableDiagnostic(source, target, diagnosticTarget)]];
@@ -411,7 +431,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Entity,
     target: MixedParameterConstraint,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     if ("entityKind" in source && source.entityKind === "MixedParameterConstraint") {
       if (source.type && target.type) {
@@ -471,7 +491,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Value,
     target: Type,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     return isTypeAssignableToInternal(source.type, target, diagnosticTarget, relationCache);
   }
@@ -549,7 +569,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Type,
     target: FunctionType,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     if (source.kind !== "FunctionType") {
       return [Related.false, [createUnassignableDiagnostic(source, target, diagnosticTarget)]];
@@ -599,7 +619,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     sourceParameters: readonly MixedFunctionParameter[],
     targetParameters: readonly MixedFunctionParameter[],
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     const queue = sourceParameters.slice();
     const errors: TypeRelationError[] = [];
@@ -836,9 +856,9 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Model,
     target: Model,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
-    relationCache.set([source, target], Related.maybe);
+    relationCache.set([source, target], [Related.maybe, []]);
     const errors: TypeRelationError[] = [];
     const remainingProperties = new Map(source.properties);
 
@@ -952,7 +972,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     properties: Map<string, ModelProperty>,
     indexerConstaint: Type,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Type, Type], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     for (const prop of properties.values()) {
       const [related, diagnostics] = isTypeAssignableToInternal(
@@ -974,7 +994,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Model,
     target: Model & { indexer: ModelIndexer },
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     if (source.indexer === undefined || source.indexer.key !== target.indexer.key) {
       return [
@@ -1003,7 +1023,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Tuple,
     target: ArrayModelType,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     const minItems = getMinItems(program, target);
     const maxItems = getMaxItems(program, target);
@@ -1051,7 +1071,7 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Tuple | ArrayValue,
     target: Tuple,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, readonly TypeRelationError[]] {
     if (source.values.length !== target.values.length) {
       return [
@@ -1085,11 +1105,19 @@ export function createTypeRelationChecker(program: Program, checker: Checker): T
     source: Type,
     target: Union,
     diagnosticTarget: Entity | Node,
-    relationCache: MultiKeyMap<[Entity, Entity], Related>,
+    relationCache: RelationCache,
   ): [Related, TypeRelationError[]] {
     if (source.kind === "UnionVariant" && source.union === target) {
       return [Related.true, []];
     }
+    // Seed the relation before walking the variants: a union can reach itself
+    // (`union Foo { self: Foo }`) and would otherwise recurse forever. Being assignable to a union
+    // means being assignable to at least one of its variants, so coming back to the same pair
+    // brings no new information and is resolved as unrelated.
+    relationCache.set(
+      [source, target],
+      [Related.false, [createUnassignableDiagnostic(source, target, diagnosticTarget)]],
+    );
     for (const option of target.variants.values()) {
       const [related] = isTypeAssignableToInternal(
         source,

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -1713,6 +1713,142 @@ describe("compiler: checker: type relations", () => {
         await expectTypeAssignable({ source, target });
       });
     });
+
+    describe("recursive types", () => {
+      it("model referencing itself", async () => {
+        await expectTypeAssignable({
+          source: "Source",
+          target: "Target",
+          commonCode: `
+            model Source { self: Source }
+            model Target { self: Target }
+          `,
+        });
+      });
+
+      it("mutually recursive models", async () => {
+        await expectTypeAssignable({
+          source: "SourceA",
+          target: "TargetA",
+          commonCode: `
+            model SourceA { b: SourceB }
+            model SourceB { a: SourceA }
+            model TargetA { b: TargetB }
+            model TargetB { a: TargetA }
+          `,
+        });
+      });
+
+      it("mutually recursive models with a mismatch deep in the cycle", async () => {
+        await expectTypeNotAssignable(
+          {
+            source: "SourceA",
+            target: "TargetA",
+            commonCode: `
+              model SourceA { b: SourceB }
+              model SourceB { a: SourceA, extra: string }
+              model TargetA { b: TargetB }
+              model TargetB { a: TargetA, extra: int32 }
+            `,
+          },
+          { code: "unassignable" },
+        );
+      });
+
+      it("union referencing itself", async () => {
+        // A union whose only variant is itself describes an empty set of values, so like `never`
+        // it is vacuously assignable to anything. What matters here is that it terminates.
+        await expectTypeAssignable({
+          source: "Loop",
+          target: "Target",
+          commonCode: `
+            union Loop { self: Loop }
+            model Target { name: string }
+          `,
+        });
+      });
+
+      it("mutually recursive unions", async () => {
+        await expectTypeAssignable({
+          source: "LoopA",
+          target: "Target",
+          commonCode: `
+            union LoopA { b: LoopB }
+            union LoopB { a: LoopA }
+            model Target { name: string }
+          `,
+        });
+      });
+
+      it("union referencing itself alongside an unassignable variant", async () => {
+        await expectTypeNotAssignable(
+          {
+            source: "Loop",
+            target: "Target",
+            commonCode: `
+              union Loop { self: Loop, other: string }
+              model Target { name: string }
+            `,
+          },
+          { code: "unassignable" },
+        );
+      });
+
+      it("model with a recursive union property", async () => {
+        await expectTypeAssignable({
+          source: "Source",
+          target: "Target",
+          commonCode: `
+            union Loop { self: Loop, name: string }
+            model Source { value: Loop }
+            model Target { value: Loop }
+          `,
+        });
+      });
+
+      it("recursive union as the target", async () => {
+        await expectTypeAssignable({
+          source: "string",
+          target: "Loop",
+          commonCode: `union Loop { self: Loop, s: string }`,
+        });
+      });
+
+      it("recursive union as the target without a matching variant", async () => {
+        await expectTypeNotAssignable(
+          {
+            source: "string",
+            target: "Loop",
+            commonCode: `union Loop { self: Loop }`,
+          },
+          { code: "unassignable" },
+        );
+      });
+
+      it("mutually recursive unions on both sides", async () => {
+        await expectTypeAssignable({
+          source: "SourceA",
+          target: "TargetA",
+          commonCode: `
+            union SourceA { b: SourceB }
+            union SourceB { a: SourceA, s: string }
+            union TargetA { b: TargetB }
+            union TargetB { a: TargetA, s: string }
+          `,
+        });
+      });
+
+      it("model with a recursive array property", async () => {
+        await expectTypeAssignable({
+          source: "Source",
+          target: "Target",
+          commonCode: `
+            model Source { items: Source[] }
+            model Target { items: Target[] }
+          `,
+        });
+      });
+    });
   });
 });
 

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -1715,6 +1715,19 @@ describe("compiler: checker: type relations", () => {
     });
 
     describe("recursive types", () => {
+      it("checks mutually recursive models through a template constraint", async () => {
+        const diagnostics = await Tester.diagnose(`
+          model SourceA { b: SourceB }
+          model SourceB { a: SourceA }
+          model TargetA { b: TargetB }
+          model TargetB { a: TargetA }
+
+          model Constrained<T extends TargetA> {}
+          alias Result = Constrained<SourceA>;
+        `);
+        expectDiagnosticEmpty(diagnostics);
+      });
+
       it("model referencing itself", async () => {
         await expectTypeAssignable({
           source: "Source",


### PR DESCRIPTION
`isTypeAssignableToInternal` created a brand new relation cache for every nested call instead of forwarding the one it was given, so the "in progress" entry seeded by `areModelsRelated` only survived a single level. Two mutually recursive models therefore recursed forever. Unions were never seeded at all, so any union reaching itself did the same.

This reproduces on `main` today through a regular template constraint, so it can be pasted directly into the playground:

```typespec
model SourceA {
  b: SourceB;
}
model SourceB {
  a: SourceA;
}
model TargetA {
  b: TargetB;
}
model TargetB {
  a: TargetA;
}

model Constrained<T extends TargetA> {}
alias Result = Constrained<SourceA>;
```

The compiler crashes with `RangeError: Maximum call stack size exceeded`.

## What changed

- `isTypeAssignableToInternal` now forwards the `relationCache` it was given instead of allocating a fresh one.
- The cache stores `[Related, errors]` instead of just `Related`. Forwarding the cache alone was not safe: the old code returned `[cached, []]` and `areModelsRelated` turns a result with no errors back into `Related.true`, so a cached `false` would flip to `true`.
- The source-union branch of `isTypeAssignableToWorker` and `isAssignableToUnion` now seed the cache before walking variants, the same way `areModelsRelated` already did.

## Semantics of a cyclic union

A purely cyclic union such as `union Loop { self: Loop }` has no way to produce a value, so it describes the empty set and is vacuously assignable to anything, exactly like `never`. That is why the source side is seeded with `Related.maybe`.

The target side is the dual: being assignable *to* a union only requires one variant to match, so a cycle brings no new information and is seeded with `Related.false`.

## Validation

- `tsc -p tsconfig.build.json --noEmit` clean
- 4,121 compiler tests pass, including a playground-style regression test verified to fail with the exact stack overflow on the pre-fix checker
- `@typespec/openapi3` 2,578 tests pass, plus http, json-schema, versioning, rest, events, sse, streams, and xml
- `pnpm lint` clean

--generated by Copilot
