### PR TITLE
Fix derived model description when no public derived models

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -32,6 +32,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
             {
                 _derivedModels = BuildDerivedModels();
                 var publicDerivedModels = _derivedModels.Where(m => m.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Public)).ToList();
+                if (publicDerivedModels.Count == 0)
+                {
+                    return description;
+                }
                 var derivedClassesDescription = DeclarationModifiers.HasFlag(TypeSignatureModifiers.Abstract)
                     ? "Please note this is the abstract base class. The derived classes available for instantiation are: "
                     : "Please note this is the base class. The derived classes available for instantiation are: ";

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -29,6 +29,24 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         }
 
         [Test]
+        public void TestBuildDescription_SkipsDerivedClassesTextWhenNoPublicDerivedModels()
+        {
+            var discriminator = InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true);
+            var internalDerived = InputFactory.Model("InternalDerived", access: "internal");
+            var baseModel = InputFactory.Model(
+                "BaseModel",
+                properties: [discriminator],
+                derivedModels: [internalDerived],
+                discriminatorProperty: discriminator);
+            MockHelpers.LoadMockGenerator(inputModelTypes: [baseModel, internalDerived]);
+
+            var provider = CodeModelGenerator.Instance.TypeFactory.CreateModel(baseModel);
+
+            Assert.IsNotNull(provider);
+            Assert.AreEqual("BaseModel description", provider!.Description.ToString());
+        }
+
+        [Test]
         public void TestBuildProperties_ValidateInheritHierarchyWithOverride()
         {
             var baseProp1 = InputFactory.Property("prop1", InputPrimitiveType.String);


### PR DESCRIPTION
## Summary

Fixes the C# generator description for discriminated base models whose derived models are all non-public.

`ModelProvider.BuildDescription` now returns the model description without appending the derived-classes sentence when there are no public derived models. This avoids both the dangling `instantiation are:` text and its trailing whitespace.

A regression test covers the all-internal-derived-model case.

Fixes #11769

## Validation

- Regression test failed before the fix and passes after it.
- `Microsoft.TypeSpec.Generator.Tests`: 2162 passed, 0 failed.
- `npm run build` passed.
- `eng/scripts/Generate.ps1` completed successfully.
- `npm run cop` passed (`cop checks passed.`).
- `git diff --check` passed.
