### PR TITLE
[http-client-csharp] Preserve cref tags in parameter docs

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
         protected override string BuildNamespace() => _namedTypeSymbol.ContainingNamespace.GetFullyQualifiedNameFromDisplayString();
 
         protected override IReadOnlyList<AttributeStatement> BuildAttributes()
-            => [.._namedTypeSymbol.GetAttributes().Select(a => new AttributeStatement(a))];
+            => [.. _namedTypeSymbol.GetAttributes().Select(a => new AttributeStatement(a))];
 
         protected internal override CSharpType[] BuildImplements()
             => [.. _namedTypeSymbol.AllInterfaces.Select(i => i.GetCSharpType())];
@@ -961,7 +961,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
             var paramElement = xmlDoc.Descendants("param")
                                      .FirstOrDefault(e => e.Attribute("name")?.Value == parameterSymbol.Name);
 
-            return paramElement?.Value.Trim();
+            return paramElement is null ? null : ProcessXmlContent(paramElement);
         }
 
         private static MethodSignatureModifiers GetAccessModifier(Accessibility accessibility) => accessibility switch

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/XmlDocsTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/XmlDocsTests.cs
@@ -127,6 +127,19 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
         }
 
         [Test]
+        public void ParameterSeeTagsProcessedCorrectly()
+        {
+            var model = new ParameterSeeTagsModel();
+            var compilation = CompilationHelper.LoadCompilation(new[] { model });
+            var symbol = CompilationHelper.GetSymbol(compilation.Assembly.Modules.First().GlobalNamespace, nameof(ParameterSeeTagsModel));
+
+            var provider = new NamedTypeSymbolProvider(symbol!, compilation);
+            var description = provider.Methods.Single().Signature.Parameters.Single().Description.ToString();
+
+            Assert.AreEqual("Works with <see cref=\"System.String\"/> and <see cref=\"System.Int32\"/> types.", description);
+        }
+
+        [Test]
         public void InvalidParameterDocsThrows()
         {
             var model = new InvalidParameterDocsModel();
@@ -167,8 +180,21 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.NamedTypeSymbolProviders
 
             protected internal override MethodProvider[] BuildMethods()
             {
-                var sig = new MethodSignature("Write", $"", MethodSignatureModifiers.Public, null, $"", [ new ParameterProvider("value", $"This is an invalid description because it is missing closing slash <see cref=\"Y\">", typeof(int)), new ParameterProvider("options", $"", typeof(string)) ]);
+                var sig = new MethodSignature("Write", $"", MethodSignatureModifiers.Public, null, $"", [new ParameterProvider("value", $"This is an invalid description because it is missing closing slash <see cref=\"Y\">", typeof(int)), new ParameterProvider("options", $"", typeof(string))]);
                 return [new MethodProvider(sig, Snippet.ThrowExpression(Snippet.Null), this, null)];
+            }
+        }
+
+        private class ParameterSeeTagsModel : TypeProvider
+        {
+            protected override string BuildRelativeFilePath() => ".";
+
+            protected override string BuildName() => nameof(ParameterSeeTagsModel);
+
+            protected internal override MethodProvider[] BuildMethods()
+            {
+                var signature = new MethodSignature("Write", $"", MethodSignatureModifiers.Public, null, $"", [new ParameterProvider("value", $"Works with <see cref=\"T:System.String\"/> and <see cref=\"T:System.Int32\"/> types", typeof(string))]);
+                return [new MethodProvider(signature, Snippet.ThrowExpression(Snippet.Null), this, null)];
             }
         }
 


### PR DESCRIPTION
Fixes #11768

## Summary

- route parameter XML documentation through the existing structured-content processor instead of flattening it with `XElement.Value`
- preserve `<see cref="..."/>` references while retaining the existing type-prefix cleanup
- add a regression test that fails on `main` with missing type references and passes with the fix

## Testing

- `dotnet test packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Microsoft.TypeSpec.Generator.Tests.csproj --no-restore --filter FullyQualifiedName~NamedTypeSymbolProviders --nologo` (78 passed)
- `dotnet format packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.sln whitespace --verify-no-changes --no-restore --include packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/NamedTypeSymbolProvider.cs packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/NamedTypeSymbolProviders/XmlDocsTests.cs --verbosity minimal`
- `git diff --check`
