### PR TITLE
[http-client-java] Continue after constant response headers

### DIFF
--- a/.chronus/changes/fix-java-response-constant-header-2026-08-31.md
+++ b/.chronus/changes/fix-java-response-constant-header-2026-08-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-java"
+---
+
+Continue generating response headers that follow a constant header.

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -2322,15 +2322,15 @@ export class CodeModelBuilder {
 
         if (schema instanceof ConstantSchema) {
           // skip constant header in response
-          if (isContentTypeHeader(header)) {
-            // we does not warn on content-type as constant, as this is the most common case
+          if (!isContentTypeHeader(header)) {
+            // we do not warn on content-type as constant, as this is the most common case
             reportDiagnostic(this.program, {
               code: "constant-header-in-response-removed",
               format: { headerName: header.serializedName },
               target: header.__raw ?? NoTarget,
             });
           }
-          break;
+          continue;
         }
 
         const httpHeader = new HttpHeader(header.serializedName, schema, {

--- a/packages/http-client-java/generator/http-client-generator-test/tsp/response-headers.tsp
+++ b/packages/http-client-java/generator/http-client-generator-test/tsp/response-headers.tsp
@@ -17,6 +17,9 @@ interface ResponseHeaderOp {
   getResourceMetadata(): {
     @statusCode statusCode: 200;
 
+    // constant headers are omitted from the generated response headers model
+    @header("x-constant-header") constantHeader: "constant-value";
+
     // required header, with mixed-case header name
     @header("ETag") eTag: string;
 


### PR DESCRIPTION
## Summary

- continue processing response headers after omitting a constant header
- suppress the constant-header warning only for `Content-Type`
- add a response-header generation regression case

## Validation

- `npm run build`
- `npm run format`
- `pnpm format`
- `pnpm exec oxlint packages/http-client-java/emitter --type-aware --deny-warnings`
- `npm run test:emitter`
- `mvn test --define "test=tsptest.responseheaders.ResponseHeadersTests" --no-transfer-progress`
