### PR TITLE
[http-server-csharp] Import JsonNodes for record arrays

### DIFF
--- a/.chronus/changes/http-server-csharp-import-json-nodes-2026-09-01.md
+++ b/.chronus/changes/http-server-csharp-import-json-nodes-2026-09-01.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Import `JsonNode` collection types when generating models containing record arrays.

--- a/packages/http-server-csharp/src/components/models/model-helpers.ts
+++ b/packages/http-server-csharp/src/components/models/model-helpers.ts
@@ -185,9 +185,13 @@ export function isValueType($: ReturnType<typeof useTsp>["$"], type: Type): bool
 /** Returns true if any property of the model uses Record<T> (mapped to JsonObject). */
 export function modelNeedsJsonNodes($: ReturnType<typeof useTsp>["$"], model: Model): boolean {
   for (const prop of model.properties.values()) {
-    if (prop.type.kind === "Model" && $.record.is(prop.type)) {
+    let type = prop.type;
+    while (type.kind === "Model" && $.array.is(type) && type.indexer?.value) {
+      type = type.indexer.value;
+    }
+    if (type.kind === "Model" && $.record.is(type)) {
       // Only need JsonNodes for Record<unknown> (maps to JsonObject)
-      const valueType = prop.type.indexer?.value;
+      const valueType = type.indexer?.value;
       if (valueType?.kind === "Intrinsic" && valueType.name === "unknown") return true;
     }
   }

--- a/packages/http-server-csharp/src/components/models/models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/models.test.tsx
@@ -8,6 +8,7 @@ import { ClassDeclaration } from "@typespec/emitter-framework/csharp";
 import { HttpCanonicalizer } from "@typespec/http-canonicalization";
 import { beforeEach, expect, it } from "vitest";
 import { resolveServiceTypes } from "../../service-resolution.js";
+import { modelNeedsJsonNodes } from "./model-helpers.js";
 
 let runner: TesterInstance;
 
@@ -128,6 +129,21 @@ it("renders a model with nullable union property", async () => {
         public required string? Name { get; set; }
     }
   `);
+});
+
+it("detects Record<unknown> nested in array properties", async () => {
+  const { JsonObjectArray, StringMapArray } = await runner.compile(t.code`
+    model ${t.model("JsonObjectArray")} {
+      items: Record<unknown>[][];
+    }
+    model ${t.model("StringMapArray")} {
+      items: Record<string>[];
+    }
+  `);
+  const tk = $(runner.program);
+
+  expect(modelNeedsJsonNodes(tk, JsonObjectArray)).toBe(true);
+  expect(modelNeedsJsonNodes(tk, StringMapArray)).toBe(false);
 });
 
 it("does not emit a model class for an @useAuth scheme model", async () => {


### PR DESCRIPTION
Fixes #11733.

## Summary

- unwrap array element types before checking whether a model property maps to `JsonObject`
- keep the existing `Record<unknown>`-only behavior, including for nested arrays
- add focused coverage for nested `Record<unknown>` arrays and typed record arrays

This ensures generated models using `Record<unknown>[]` import `System.Text.Json.Nodes`, while `Record<string>[]` continues to use dictionary types without that import.

## Verification

- `pnpm --filter @typespec/http-server-csharp exec vitest run src/components/models/models.test.tsx` (6 passed)
- `pnpm --filter @typespec/http-server-csharp lint`
- `pnpm --filter @typespec/http-server-csharp build`
- `pnpm exec prettier --check packages/http-server-csharp/src/components/models/model-helpers.ts packages/http-server-csharp/src/components/models/models.test.tsx`

AI-assisted; I reviewed the change and verified the commands above locally.
