### PR TITLE
Preserve accessible serialization constructors during back compat

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/ScmModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/ScmModelProviderTests.cs
@@ -6,8 +6,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Tests.Common;
 using NUnit.Framework;
 using ScmModel = Microsoft.TypeSpec.Generator.ClientModel.Providers.ScmModelProvider;
@@ -258,6 +260,85 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.ScmModelProvi
             // The serialization partial no longer carries the parameterless mocking constructor (avoids CS0111).
             var serializationContent = new TypeProviderWriter(model.SerializationProviders.Single()).Write().Content;
             Assert.AreEqual(Helpers.GetExpectedFromFile("Serialization"), serializationContent);
+        }
+
+        [Test]
+        public async Task BackCompat_AccessibleParameterlessSerializationConstructorIsPreserved()
+        {
+            var inputModel = InputFactory.Model(
+                "mockInputModel",
+                usage: InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true)
+                ]);
+
+            await MockHelpers.LoadMockGeneratorAsync(
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(),
+                inputModels: () => [inputModel]);
+
+            var model = ScmCodeModelGenerator.Instance.OutputLibrary.TypeProviders
+                .OfType<ScmModel>().Single(t => t.Name == "MockInputModel");
+            var serializationProvider = model.SerializationProviders.Single();
+            var serializationConstructor = serializationProvider.Constructors
+                .Single(c => c.Signature.Parameters.Count == 0);
+            var originalSignature = serializationConstructor.Signature;
+            ValueExpression[] fullConstructorArguments =
+                [.. model.FullConstructor.Signature.Parameters.Select(_ => Snippet.Default)];
+            var fullConstructorInitializer = new ConstructorInitializer(
+                IsBase: false,
+                fullConstructorArguments);
+
+            // Simulate a visitor making the serialization constructor public and routing it through
+            // the full constructor.
+            serializationConstructor.Update(
+                signature: new ConstructorSignature(
+                    originalSignature.Type,
+                    originalSignature.Description,
+                    MethodSignatureModifiers.Public,
+                    originalSignature.Parameters,
+                    originalSignature.Attributes,
+                    fullConstructorInitializer));
+
+            model.ProcessTypeForBackCompatibility();
+
+            Assert.IsFalse(model.Constructors.Any(c => c.Signature.Parameters.Count == 0),
+                "An accessible parameterless constructor already exists on the serialization partial.");
+            var preservedConstructor = serializationProvider.Constructors
+                .Single(c => c.Signature.Parameters.Count == 0);
+            Assert.AreSame(serializationConstructor, preservedConstructor);
+            Assert.AreSame(fullConstructorInitializer, preservedConstructor.Signature.Initializer);
+        }
+
+        [Test]
+        public async Task BackCompat_InaccessibleParameterlessSerializationConstructorIsReplaced()
+        {
+            var inputModel = InputFactory.Model(
+                "mockInputModel",
+                usage: InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true)
+                ]);
+
+            await MockHelpers.LoadMockGeneratorAsync(
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync(
+                    method: nameof(BackCompat_AccessibleParameterlessSerializationConstructorIsPreserved)),
+                inputModels: () => [inputModel]);
+
+            var model = ScmCodeModelGenerator.Instance.OutputLibrary.TypeProviders
+                .OfType<ScmModel>().Single(t => t.Name == "MockInputModel");
+            var serializationProvider = model.SerializationProviders.Single();
+            Assert.IsTrue(serializationProvider.Constructors.Any(c =>
+                c.Signature.Parameters.Count == 0
+                && c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal)));
+
+            model.ProcessTypeForBackCompatibility();
+
+            Assert.IsFalse(serializationProvider.Constructors.Any(c => c.Signature.Parameters.Count == 0));
+            Assert.IsTrue(model.Constructors.Any(c =>
+                c.Signature.Parameters.Count == 0
+                && c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)));
         }
 
         [Test]

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/TestData/ScmModelProviderTests/BackCompat_AccessibleParameterlessSerializationConstructorIsPreserved/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/ScmModelProvider/TestData/ScmModelProviderTests/BackCompat_AccessibleParameterlessSerializationConstructorIsPreserved/MockInputModel.cs
@@ -1,0 +1,9 @@
+namespace Sample.Models
+{
+    public partial class MockInputModel
+    {
+        public MockInputModel()
+        {
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -847,15 +847,20 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
                 // A previously published accessible parameterless constructor is dropped when the current
                 // generation makes a property required. Restore it and drop the generated mocking constructor
-                // so it is not a duplicate. An accessible parameterless constructor (generated or custom code)
-                // counts as already present; an inaccessible generated mocking constructor does not. A struct
-                // always exposes a public parameterless constructor via its serialization (mocking)
-                // constructor, so there is nothing to restore on the model partial.
+                // so it is not a duplicate. An accessible parameterless constructor (generated, customized,
+                // or custom code) counts as already present; an inaccessible generated mocking constructor
+                // does not. A struct always exposes a public parameterless constructor via its serialization
+                // (mocking) constructor, so there is nothing to restore on the model partial.
                 if (previousParameters.Count == 0)
                 {
+                    var hasAccessibleParameterlessSerializationConstructor = SerializationProviders
+                        .SelectMany(p => p.Constructors)
+                        .Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers));
+
                     if (!Type.IsStruct
                         && !constructors.Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers))
-                        && !candidateConstructors.Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers)))
+                        && !candidateConstructors.Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers))
+                        && !hasAccessibleParameterlessSerializationConstructor)
                     {
                         var parameterlessConstructor = BuildBackCompatParameterlessConstructor(previousConstructor, candidateConstructors);
                         RemoveGeneratedMockingConstructor(constructors);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -847,10 +847,9 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
                 // A previously published accessible parameterless constructor is dropped when the current
                 // generation makes a property required. Restore it and drop the generated mocking constructor
-                // so it is not a duplicate. An accessible parameterless constructor (generated, customized,
-                // or custom code) counts as already present; an inaccessible generated mocking constructor
-                // does not. A struct always exposes a public parameterless constructor via its serialization
-                // (mocking) constructor, so there is nothing to restore on the model partial.
+                // so it is not a duplicate. An accessible parameterless constructor on any generated partial
+                // or in custom code counts as already present. A struct always exposes a public parameterless
+                // constructor via its serialization partial, so there is nothing to restore on the model partial.
                 if (previousParameters.Count == 0)
                 {
                     var hasAccessibleParameterlessSerializationConstructor = SerializationProviders

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -852,12 +852,16 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // constructor via its serialization partial, so there is nothing to restore on the model partial.
                 if (previousParameters.Count == 0)
                 {
+                    if (Type.IsStruct)
+                    {
+                        continue;
+                    }
+
                     var hasAccessibleParameterlessSerializationConstructor = SerializationProviders
                         .SelectMany(p => p.Constructors)
                         .Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers));
 
-                    if (!Type.IsStruct
-                        && !constructors.Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers))
+                    if (!constructors.Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers))
                         && !candidateConstructors.Any(c => c.Signature.Parameters.Count == 0 && MethodSignatureHelper.IsPublicApi(c.Signature.Modifiers))
                         && !hasAccessibleParameterlessSerializationConstructor)
                     {

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -738,10 +738,10 @@ protected Widget() : this(default)
 
 **Key Points:**
 
-- The previous parameterless constructor must be accessible and no accessible generated or custom parameterless constructor may already exist.
+- The previous parameterless constructor must be accessible and no accessible parameterless constructor may already exist in generated code (including another partial declaration) or custom code.
 - The restored constructor retains the previous accessibility.
 - The generator prefers an accessible current constructor with the fewest required parameters as the chain target. When necessary, it can chain to a `private protected` initialization constructor.
-- The generated parameterless mocking constructor is removed so it does not duplicate the restored constructor.
+- An inaccessible generated parameterless mocking constructor is removed so it does not duplicate the restored constructor.
 - If the constructor removal is accepted in an ApiCompat baseline, the generator does not restore it.
 
 #### Scenario: Constructor Parameter Name Restored by Signature Match

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -738,10 +738,10 @@ protected Widget() : this(default)
 
 **Key Points:**
 
-- The previous parameterless constructor must be accessible and no accessible parameterless constructor may already exist in generated code (including another partial declaration) or custom code.
+- The previous parameterless constructor must be accessible and no accessible generated or custom parameterless constructor may already exist.
 - The restored constructor retains the previous accessibility.
 - The generator prefers an accessible current constructor with the fewest required parameters as the chain target. When necessary, it can chain to a `private protected` initialization constructor.
-- An inaccessible generated parameterless mocking constructor is removed so it does not duplicate the restored constructor.
+- The generated parameterless mocking constructor is removed so it does not duplicate the restored constructor.
 - If the constructor removal is accepted in an ApiCompat baseline, the generator does not restore it.
 
 #### Scenario: Constructor Parameter Name Restored by Signature Match


### PR DESCRIPTION
## Summary

- Preserve an accessible parameterless constructor that already exists on a generated serialization partial during API compatibility processing.
- Avoid removing a visitor-customized constructor and synthesizing a replacement that delegates to a different overload.
- Cover both the accessible-constructor preservation path and the existing internal-constructor replacement path.

This addresses the constructor churn observed in openai/openai-dotnet#1341 when ApiCompatVersion is enabled.

## Validation

- `npm run build`
- `eng/scripts/Generate.ps1`
- `npm test`
- `npm run cop`
- Focused constructor compatibility tests