### PR TITLE
Fix Python playground publish authentication

### DIFF
--- a/eng/emitters/pipelines/templates/stages/emitter-stages.yml
+++ b/eng/emitters/pipelines/templates/stages/emitter-stages.yml
@@ -353,6 +353,10 @@ stages:
                       versionSpec: "22.x"
                       checkLatest: true
                   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+                  - ${{ if eq(parameters.LanguageShortName, 'python') }}:
+                      - template: /eng/common/pipelines/templates/steps/pypi-auth-dev-feed.yml
+                        parameters:
+                          EnableTwineAuth: false
                   - script: npm ci
                     displayName: Install emitter dependencies for playground bundle
                     workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}


### PR DESCRIPTION
## Summary

- authenticate pip and uv before installing Python emitter dependencies for playground bundling
- disable unused Twine authentication in the playground publish job
- leave non-Python emitter publish behavior unchanged

## Root cause

The playground publish path runs `npm ci`, which invokes the Python emitter lifecycle `install` script and installs the local generator. Unlike the Python build jobs, this publish job did not configure the authenticated Azure Python feed.

Because public PyPI access is blocked in the publish environment, pip could not create its isolated build environment. Its lookup for `setuptools>=40.8.0` failed with `Operation not permitted`; the later `No matching distribution found` message was a consequence of having no reachable package index, not a missing setuptools version.

This change reuses `pypi-auth-dev-feed.yml`, the same feed setup used by Python build jobs, before the playground dependency installation. Twine authentication is disabled because this job only consumes Python packages.

Failed release: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6768189&view=results

## Validation

- `npx prettier --check eng/emitters/pipelines/templates/stages/emitter-stages.yml`
- `git diff --check`
- `npm run build`
- `npm run test:emitter` (21 tests passed)