### PR TITLE
chore: add Java emitter code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,9 +22,9 @@ cspell.yaml
 ######################
 # Java
 ######################
-/packages/http-client-java/                  @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @alzimmermsft @jsquire
-/website/src/content/docs/docs/emitters/clients/http-client-java/ @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @alzimmermsft @jsquire
-/.github/instructions/http-client-java.instructions.md @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @alzimmermsft @jsquire
+/packages/http-client-java/                  @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @alzimmermsft @jsquire @JoshLove-msft
+/website/src/content/docs/docs/emitters/clients/http-client-java/ @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @alzimmermsft @jsquire @JoshLove-msft
+/.github/instructions/http-client-java.instructions.md @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @alzimmermsft @jsquire @JoshLove-msft
 
 ######################
 # Python


### PR DESCRIPTION
## Summary
- add @JoshLove-msft to the Java emitter package, documentation, and instruction CODEOWNERS entries

## Validation
- npm run build
- npm run format
- npm run lint
- pnpm format
- pnpm lint