### PR TITLE
Fix Python playground bundle esbuild failure by isolating browser-safe YAML util

### DIFF
--- a/.chronus/changes/fix-python-playground-bundle-esbuild-2026-9-1-14-15-1.md
+++ b/.chronus/changes/fix-python-playground-bundle-esbuild-2026-9-1-14-15-1.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Fix playground bundle publish failing with esbuild errors ("Could not resolve child_process/crypto/fs/promises/os") by moving the browser-safe YAML serialization helper out of a module that also contains Node-only code

--- a/packages/http-client-python/emitter/src/emitter.ts
+++ b/packages/http-client-python/emitter/src/emitter.ts
@@ -9,13 +9,13 @@ import {
   PYGEN_WHEEL_FILENAME,
   PYODIDE_VERSION,
 } from "./constants.js";
-import { dumpCodeModelToYaml } from "./external-process.js";
 import type { PythonEmitterOptions, PythonSdkContext } from "./lib.js";
 import { reportDiagnostic } from "./lib.js";
 import { runNodeEmit } from "./node-runner.js";
 import type { PyodideInterface } from "./pyodide-loader.js";
 import { loadPyodide } from "./pyodide-loader.js";
 import { getRootNamespace, md2Rst } from "./utils.js";
+import { dumpCodeModelToYaml } from "./yaml-utils.js";
 
 function getBrowserPygenWheelUrl(): string {
   return `${BLOB_STORAGE_BASE_URL}/${PACKAGE_NAME}/${pkgJson.version}/generator/dist/${PYGEN_WHEEL_FILENAME}`;

--- a/packages/http-client-python/emitter/src/external-process.ts
+++ b/packages/http-client-python/emitter/src/external-process.ts
@@ -3,30 +3,13 @@ import type { ChildProcess, SpawnOptions } from "child_process";
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
 import { mkdir, writeFile } from "fs/promises";
-import jsyaml from "js-yaml";
 import os from "os";
+import { dumpCodeModelToYaml } from "./yaml-utils.js";
 
 const tspCodeGenTempDir = joinPaths(os.tmpdir(), "tsp-codegen");
 
 export function createTempPath(extension: string, prefix: string = "") {
   return joinPaths(tspCodeGenTempDir, prefix + randomUUID() + extension);
-}
-
-/**
- * Serialize the given codemodel to a YAML string.
- *
- * The generated YAML is consumed by the Python generator, which parses it with
- * PyYAML (YAML 1.1). js-yaml, on the other hand, dumps using YAML 1.2 rules, so
- * plain scalars such as `2020_01_01` (a snake-cased enum member name) are left
- * unquoted because YAML 1.2 does not treat underscores as integer separators.
- * PyYAML would then read `2020_01_01` back as the integer `20200101`, corrupting
- * string values (e.g. enum member names, descriptions). Forcing every string
- * scalar to be quoted guarantees that PyYAML round-trips them as strings.
- * @param codemodel Codemodel to serialize
- * @return the YAML representation of the codemodel.
- */
-export function dumpCodeModelToYaml(codemodel: unknown): string {
-  return jsyaml.dump(codemodel, { forceQuotes: true, quotingType: '"' });
 }
 
 /**

--- a/packages/http-client-python/emitter/src/yaml-utils.ts
+++ b/packages/http-client-python/emitter/src/yaml-utils.ts
@@ -1,0 +1,22 @@
+import jsyaml from "js-yaml";
+
+/**
+ * Serialize the given codemodel to a YAML string.
+ *
+ * The generated YAML is consumed by the Python generator, which parses it with
+ * PyYAML (YAML 1.1). js-yaml, on the other hand, dumps using YAML 1.2 rules, so
+ * plain scalars such as `2020_01_01` (a snake-cased enum member name) are left
+ * unquoted because YAML 1.2 does not treat underscores as integer separators.
+ * PyYAML would then read `2020_01_01` back as the integer `20200101`, corrupting
+ * string values (e.g. enum member names, descriptions). Forcing every string
+ * scalar to be quoted guarantees that PyYAML round-trips them as strings.
+ *
+ * This module must remain browser-safe (no Node built-ins): `emitter.ts` calls
+ * this function on the browser/Pyodide path, and esbuild bundles it into the
+ * playground bundle with `platform: "browser"`.
+ * @param codemodel Codemodel to serialize
+ * @return the YAML representation of the codemodel.
+ */
+export function dumpCodeModelToYaml(codemodel: unknown): string {
+  return jsyaml.dump(codemodel, { forceQuotes: true, quotingType: '"' });
+}

--- a/packages/http-client-python/emitter/test/yaml-utils.test.ts
+++ b/packages/http-client-python/emitter/test/yaml-utils.test.ts
@@ -1,9 +1,9 @@
 import { ok, strictEqual } from "assert";
 import { load } from "js-yaml";
 import { describe, it } from "vitest";
-import { dumpCodeModelToYaml } from "../src/external-process.js";
+import { dumpCodeModelToYaml } from "../src/yaml-utils.js";
 
-describe("typespec-python: external-process", () => {
+describe("typespec-python: yaml-utils", () => {
   // The Python generator parses the emitted YAML with PyYAML (YAML 1.1), where a plain
   // scalar such as `2020_01_01` is interpreted as the integer `20200101`. js-yaml dumps
   // using YAML 1.2 rules and would otherwise leave such string scalars unquoted, so we


### PR DESCRIPTION
## Summary

PR #11800 fixed the pip/PyPI authentication failure in the Python playground publish job, but a subsequent publish build (6772679) failed later in the same job, at the "Upload playground bundle" step:

```
✘ [ERROR] Could not resolve "child_process"
✘ [ERROR] Could not resolve "crypto"
✘ [ERROR] Could not resolve "fs/promises"
✘ [ERROR] Could not resolve "os"
    packages/http-client-python/dist/emitter/external-process.js
```

## Root cause

`emitter.ts` imports `dumpCodeModelToYaml` from `external-process.ts` for use on the browser/Pyodide code path. However, `external-process.ts` also contains Node-only code (`execAsync`, `saveCodeModelAsYaml`) that uses `child_process`, `crypto`, `fs/promises`, and `os`.

Only `node-runner.js` is swapped out for a browser-safe stub via the `"browser"` field in `package.json`; `emitter.ts` is not. As a result, when esbuild bundles the emitter for the browser playground (`platform: "browser"`), it pulls in all of `external-process.ts`, including the Node-only imports, which can't be resolved for a browser target.

## Fix

Extracted `dumpCodeModelToYaml` (a pure, browser-safe YAML serialization helper) into a new `yaml-utils.ts` module. Both `emitter.ts` (browser path) and `external-process.ts` (Node-only path, still used by `node-runner.ts`) now import it from there, so no Node builtins leak into the browser bundle.

## Validation

- `npx tsc -p ./emitter/tsconfig.build.json` — passes with no errors
- `npx tsx ./eng/scripts/ci/run-tests.ts --emitter` — 21/21 tests pass
- Reproduced the exact esbuild failure against the pre-fix code (via `createTypeSpecBundle` from `@typespec/bundler`) and confirmed it is resolved after this change.