### PR TITLE
Support libraries using auto decorators in tspd

### DIFF
--- a/.chronus/changes/graphql-regen-auto-accessor-docs-2026-9-2.md
+++ b/.chronus/changes/graphql-regen-auto-accessor-docs-2026-9-2.md
@@ -1,0 +1,8 @@
+---
+changeKind: internal
+packages:
+  - "@typespec/graphql"
+---
+
+Regenerate the decorator signatures to pick up the doc comments now emitted for auto decorator
+accessors.

--- a/.chronus/changes/tspd-auto-accessor-docs-2026-9-2.md
+++ b/.chronus/changes/tspd-auto-accessor-docs-2026-9-2.md
@@ -1,0 +1,22 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/tspd"
+---
+
+Document the generated auto decorator accessors, so libraries re-exporting them satisfy
+api-extractor's `ae-undocumented` rule. `get*` and `set*` accessors carry the description of the
+decorator they read or write; `is*` accessors get a generic one, since a decorator description
+does not describe a boolean check.
+
+```ts
+/** Check if the `@TypeSpec.GraphQL.inputType` decorator was applied on the given target. */
+export function isInputType(program: Program, target: Model): boolean {
+  return hasAutoDecorator(program, "TypeSpec.GraphQL.inputType", target);
+}
+
+/** Mark a model as a GraphQL input type in the emitted schema. */
+export function setInputType(program: Program, target: Model): void {
+  setAutoDecorator(program, "TypeSpec.GraphQL.inputType", target);
+}
+```

--- a/.chronus/changes/tspd-honor-library-config-2026-9-2.md
+++ b/.chronus/changes/tspd-honor-library-config-2026-9-2.md
@@ -1,0 +1,9 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/tspd"
+---
+
+Honor the library's own `tspconfig.yaml` when generating signatures and reference documentation, so
+libraries that opt into a compiler feature (such as `auto-decorators`) no longer report errors during
+`gen-extern-signature` and `doc`.

--- a/packages/graphql/generated-defs/TypeSpec.GraphQL.ts
+++ b/packages/graphql/generated-defs/TypeSpec.GraphQL.ts
@@ -184,14 +184,23 @@ export type TypeSpecGraphQLDecorators = {
   specifiedBy: SpecifiedByDecorator;
 };
 
+/** Check if the `@TypeSpec.GraphQL.inputType` decorator was applied on the given target. */
 export function isInputType(program: Program, target: Model): boolean {
   return hasAutoDecorator(program, "TypeSpec.GraphQL.inputType", target);
 }
 
+/**
+ * Mark a model as a GraphQL input type in the emitted schema.
+ *
+ * This decorator is applied automatically by the mutation engine when it produces
+ * a model that is used in input position. The emitter uses this to emit the model
+ * as an `input` type rather than an object `type`.
+ */
 export function setInputType(program: Program, target: Model): void {
   setAutoDecorator(program, "TypeSpec.GraphQL.inputType", target);
 }
 
+/** Check if the `@TypeSpec.GraphQL.nullable` decorator was applied on the given target. */
 export function isNullable(
   program: Program,
   target: ModelProperty | Operation | Union | Model,
@@ -199,6 +208,12 @@ export function isNullable(
   return hasAutoDecorator(program, "TypeSpec.GraphQL.nullable", target);
 }
 
+/**
+ * Mark a field, operation, or type as nullable in the emitted GraphQL schema.
+ *
+ * Applied automatically by the mutation engine when it strips `| null` from
+ * union types, and can also be applied directly in TypeSpec source.
+ */
 export function setNullable(
   program: Program,
   target: ModelProperty | Operation | Union | Model,
@@ -206,18 +221,33 @@ export function setNullable(
   setAutoDecorator(program, "TypeSpec.GraphQL.nullable", target);
 }
 
+/** Check if the `@TypeSpec.GraphQL.nullableElements` decorator was applied on the given target. */
 export function isNullableElements(program: Program, target: ModelProperty | Operation): boolean {
   return hasAutoDecorator(program, "TypeSpec.GraphQL.nullableElements", target);
 }
 
+/**
+ * Mark a field or operation as having nullable array elements in the emitted GraphQL schema.
+ *
+ * Applied automatically by the mutation engine when it detects `Array<T | null>`
+ * patterns. Causes the emitter to emit `[T]` instead of `[T!]`.
+ */
 export function setNullableElements(program: Program, target: ModelProperty | Operation): void {
   setAutoDecorator(program, "TypeSpec.GraphQL.nullableElements", target);
 }
 
+/** Check if the `@TypeSpec.GraphQL.oneOf` decorator was applied on the given target. */
 export function isOneOf(program: Program, target: Model): boolean {
   return hasAutoDecorator(program, "TypeSpec.GraphQL.oneOf", target);
 }
 
+/**
+ * Mark a model as a `@oneOf` input object in the emitted GraphQL schema.
+ *
+ * This decorator is applied automatically by the mutation engine when it converts
+ * a union type in input context to a synthetic input object (since GraphQL unions
+ * are output-only). The emitter uses this to emit the `@oneOf` directive.
+ */
 export function setOneOf(program: Program, target: Model): void {
   setAutoDecorator(program, "TypeSpec.GraphQL.oneOf", target);
 }

--- a/packages/tspd/src/gen-extern-signatures/components/auto-decorator-accessors.tsx
+++ b/packages/tspd/src/gen-extern-signatures/components/auto-decorator-accessors.tsx
@@ -1,5 +1,6 @@
 import { code, For, List } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
+import type { Decorator } from "@typespec/compiler";
 import { typespecCompiler } from "../external-packages/compiler.js";
 import type { DecoratorSignature } from "../types.js";
 import { ParameterTsType, TargetParameterTsType } from "./decorator-signature-type.js";
@@ -51,17 +52,20 @@ function AutoDecoratorReader(props: Readonly<AutoDecoratorAccessorProps>) {
   if (params.length === 0) {
     // No-arg auto decorator — generate `is*` function
     return (
-      <ts.FunctionDeclaration
-        export
-        name={`is${capitalizedName}`}
-        parameters={[
-          { name: "program", type: typespecCompiler.Program },
-          { name: decorator.target.name, type: targetType },
-        ]}
-        returnType="boolean"
-      >
-        {code`return ${typespecCompiler.hasAutoDecorator}(program, "${fqn}", ${decorator.target.name});`}
-      </ts.FunctionDeclaration>
+      <List hardline>
+        <AccessorDoc doc={`Check if the \`@${fqn}\` decorator was applied on the given target.`} />
+        <ts.FunctionDeclaration
+          export
+          name={`is${capitalizedName}`}
+          parameters={[
+            { name: "program", type: typespecCompiler.Program },
+            { name: decorator.target.name, type: targetType },
+          ]}
+          returnType="boolean"
+        >
+          {code`return ${typespecCompiler.hasAutoDecorator}(program, "${fqn}", ${decorator.target.name});`}
+        </ts.FunctionDeclaration>
+      </List>
     );
   }
 
@@ -99,17 +103,20 @@ function AutoDecoratorReader(props: Readonly<AutoDecoratorAccessorProps>) {
   }
 
   return (
-    <ts.FunctionDeclaration
-      export
-      name={`get${capitalizedName}`}
-      parameters={[
-        { name: "program", type: typespecCompiler.Program },
-        { name: decorator.target.name, type: targetType },
-      ]}
-      returnType={returnType}
-    >
-      {body}
-    </ts.FunctionDeclaration>
+    <List hardline>
+      <AccessorDoc doc={getDocDescription(decorator)} />
+      <ts.FunctionDeclaration
+        export
+        name={`get${capitalizedName}`}
+        parameters={[
+          { name: "program", type: typespecCompiler.Program },
+          { name: decorator.target.name, type: targetType },
+        ]}
+        returnType={returnType}
+      >
+        {body}
+      </ts.FunctionDeclaration>
+    </List>
   );
 }
 
@@ -161,13 +168,61 @@ function AutoDecoratorSetter(props: Readonly<AutoDecoratorAccessorProps>) {
   }
 
   return (
-    <ts.FunctionDeclaration
-      export
-      name={`set${capitalizedName}`}
-      parameters={parameters}
-      returnType="void"
-    >
-      {body}
-    </ts.FunctionDeclaration>
+    <List hardline>
+      <AccessorDoc doc={getDocDescription(decorator)} />
+      <ts.FunctionDeclaration
+        export
+        name={`set${capitalizedName}`}
+        parameters={parameters}
+        returnType="void"
+      >
+        {body}
+      </ts.FunctionDeclaration>
+    </List>
   );
+}
+
+/**
+ * Render a doc comment for an accessor.
+ *
+ * The comment is rendered standalone rather than through the `doc` prop of
+ * `ts.FunctionDeclaration`, because that also emits `@param {Type}` tags whose type references count
+ * as value usages and would turn the type-only imports of this file into value imports.
+ */
+function AccessorDoc(props: Readonly<{ doc: string | undefined }>) {
+  if (props.doc === undefined) {
+    return null;
+  }
+  const lines = props.doc.split("\n");
+  const comment =
+    lines.length === 1
+      ? `/** ${lines[0]} */`
+      : [`/**`, ...lines.map((line) => ` * ${line}`.trimEnd()), ` */`].join("\n");
+  return <>{comment}</>;
+}
+
+/**
+ * Get the description of a decorator, excluding any doc tag.
+ *
+ * Only the description is carried over: the `@param` tags of the decorator describe its TypeSpec
+ * parameters, which do not line up with the accessor signatures.
+ */
+function getDocDescription(decorator: Decorator): string | undefined {
+  const docs = decorator.node?.docs;
+  if (docs === undefined || docs.length === 0) {
+    return undefined;
+  }
+
+  const lines: string[] = [];
+  for (const doc of docs) {
+    for (const content of doc.content) {
+      for (const line of content.text.split("\n")) {
+        // Issue to escape @internal and other tsdoc tags https://github.com/microsoft/TypeScript/issues/47679
+        lines.push(line.replaceAll("@internal", "@_internal"));
+      }
+    }
+  }
+
+  const description = lines.join("\n").trim();
+  return description === "" ? undefined : description;
 }

--- a/packages/tspd/src/gen-extern-signatures/gen-extern-signatures.ts
+++ b/packages/tspd/src/gen-extern-signatures/gen-extern-signatures.ts
@@ -25,6 +25,7 @@ import {
 } from "@typespec/compiler";
 import prettier from "prettier";
 import { createDiagnostic } from "../ref-doc/lib.js";
+import { resolveLibraryCompilerOptions } from "../utils/library-config.js";
 import { generateSignatures } from "./components/entity-signatures.js";
 import type { DecoratorSignature, EntitySignature, FunctionSignature } from "./types.js";
 
@@ -155,6 +156,7 @@ export async function generateExternSignatureForExports(
   for (const entry of exports) {
     programs.push(
       await compile(host, entry.typespecEntrypoint, {
+        ...(await resolveLibraryCompilerOptions(host, entry.typespecEntrypoint)),
         parseOptions: { comments: true, docs: true },
       }),
     );

--- a/packages/tspd/src/ref-doc/experimental.ts
+++ b/packages/tspd/src/ref-doc/experimental.ts
@@ -2,6 +2,7 @@ import type { Diagnostic } from "@typespec/compiler";
 import { compile, createDiagnosticCollector, joinPaths, NodeHost } from "@typespec/compiler";
 import { mkdir, writeFile } from "fs/promises";
 import prettier from "prettier";
+import { resolveLibraryCompilerOptions } from "../utils/library-config.js";
 import { generateJsApiDocs } from "./api-docs.js";
 import { renderReadme } from "./emitters/markdown.js";
 import { renderToAstroStarlightMarkdown } from "./emitters/starlight.js";
@@ -74,6 +75,7 @@ export async function resolveLibraryRefDocsBase(
   if (pkgJson.tspMain) {
     const main = joinPaths(libraryPath, pkgJson.tspMain);
     const program = await compile(NodeHost, main, {
+      ...(await resolveLibraryCompilerOptions(NodeHost, main)),
       parseOptions: { comments: true, docs: true },
     });
     const refDoc = diagnostics.pipe(extractRefDocs(program, options));

--- a/packages/tspd/src/ref-doc/extractor.ts
+++ b/packages/tspd/src/ref-doc/extractor.ts
@@ -46,6 +46,7 @@ import {
 import { SyntaxKind, type DocUnknownTagNode } from "@typespec/compiler/ast";
 import { readFile } from "fs/promises";
 import { pathToFileURL } from "url";
+import { resolveLibraryCompilerOptions } from "../utils/library-config.js";
 import { createDiagnostic, reportDiagnostic } from "./lib.js";
 import type {
   DecoratorRefDoc,
@@ -109,6 +110,7 @@ export async function extractLibraryRefDocs(
   if (tspMain) {
     const main = resolvePath(libraryPath, tspMain);
     const program = await compile(NodeHost, main, {
+      ...(await resolveLibraryCompilerOptions(NodeHost, main)),
       parseOptions: { comments: true, docs: true },
     });
     mainSourceFiles = new Set(program.sourceFiles.keys());
@@ -203,6 +205,7 @@ async function extractSubExports(
     const main = resolvePath(libraryPath, tspEntry);
     try {
       const program = await compile(NodeHost, main, {
+        ...(await resolveLibraryCompilerOptions(NodeHost, main)),
         parseOptions: { comments: true, docs: true },
       });
       const subRefDoc = diagnostics.pipe(

--- a/packages/tspd/src/utils/library-config.ts
+++ b/packages/tspd/src/utils/library-config.ts
@@ -1,0 +1,19 @@
+import {
+  resolveCompilerOptions,
+  type CompilerHost,
+  type CompilerOptions,
+} from "@typespec/compiler";
+
+/**
+ * Resolve the compiler options from the library's own `tspconfig.yaml`, so that features it opts
+ * into (such as `auto-decorators`) apply when tspd compiles it.
+ *
+ * tspd only ever inspects a library, so emitting is always disabled.
+ */
+export async function resolveLibraryCompilerOptions(
+  host: CompilerHost,
+  entrypoint: string,
+): Promise<CompilerOptions> {
+  const [options] = await resolveCompilerOptions(host, { cwd: process.cwd(), entrypoint });
+  return { ...options, noEmit: true };
+}

--- a/packages/tspd/test/gen-extern-signature/decorators-signatures.test.ts
+++ b/packages/tspd/test/gen-extern-signature/decorators-signatures.test.ts
@@ -469,6 +469,7 @@ describe("auto decorator accessors", () => {
       expected: `
 import { hasAutoDecorator, type Model, type Program, setAutoDecorator } from "@typespec/compiler";
 
+/** Check if the \`@myFlag\` decorator was applied on the given target. */
 export function isMyFlag(program: Program, target: Model): boolean {
   return hasAutoDecorator(program, "myFlag", target);
 }
@@ -529,6 +530,71 @@ export function setMyMeta(program: Program, target: Model, value: { name: string
 }
   `,
     });
+  });
+
+  it("documents accessors with the decorator description, dropping doc tags", async () => {
+    await expectSignatures({
+      code: `
+        /**
+         * Specify the minimum number of instances the array must contain.
+         *
+         * @param value The minimum number of instances.
+         */
+        auto dec myMin(target: Model, value: valueof int32);
+      `,
+      expected: `
+import { getAutoDecoratorValue, type Model, type Program, setAutoDecorator } from "@typespec/compiler";
+
+/** Specify the minimum number of instances the array must contain. */
+export function getMyMin(program: Program, target: Model): number | undefined {
+  return getAutoDecoratorValue(program, "myMin", target)?.["value"] as any;
+}
+
+/** Specify the minimum number of instances the array must contain. */
+export function setMyMin(program: Program, target: Model, value: number): void {
+  setAutoDecorator(program, "myMin", target, { value: value });
+}
+  `,
+    });
+  });
+
+  it("documents `is*` accessors generically instead of with the decorator description", async () => {
+    await expectSignatures({
+      code: `
+        /** Mark the model as a flag. */
+        auto dec myFlag(target: Model);
+      `,
+      expected: `
+import { hasAutoDecorator, type Model, type Program, setAutoDecorator } from "@typespec/compiler";
+
+/** Check if the \`@myFlag\` decorator was applied on the given target. */
+export function isMyFlag(program: Program, target: Model): boolean {
+  return hasAutoDecorator(program, "myFlag", target);
+}
+
+/** Mark the model as a flag. */
+export function setMyFlag(program: Program, target: Model): void {
+  setAutoDecorator(program, "myFlag", target);
+}
+  `,
+    });
+  });
+
+  it("renders a multi line description as a block comment", async () => {
+    const result = await generateDecoratorSignatures(`
+      /**
+       * First line.
+       *
+       * Second line.
+       */
+      auto dec myLabel(target: Model, label: valueof string);
+    `);
+    expect(result).toContain(`/**
+ * First line.
+ *
+ * Second line.
+ */
+export function getMyLabel`);
   });
 
   it("generates accessor with fully-qualified name for namespaced auto decorator", async () => {

--- a/packages/tspd/test/utils/library-config.test.ts
+++ b/packages/tspd/test/utils/library-config.test.ts
@@ -1,0 +1,53 @@
+import { compile } from "@typespec/compiler";
+import { createTestHost, resolveVirtualPath, type TestHost } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resolveLibraryCompilerOptions } from "../../src/utils/library-config.js";
+
+describe("resolveLibraryCompilerOptions", () => {
+  let host: TestHost;
+  const entrypoint = resolveVirtualPath("main.tsp");
+
+  beforeEach(async () => {
+    host = await createTestHost();
+    host.addTypeSpecFile(
+      "main.tsp",
+      `
+      namespace TestLib;
+      auto dec myFlag(target: unknown);
+    `,
+    );
+  });
+
+  async function compileLibrary() {
+    const options = await resolveLibraryCompilerOptions(host.compilerHost, entrypoint);
+    return await compile(host.compilerHost, entrypoint, options);
+  }
+
+  it("enables the features the library opted into in its own tspconfig.yaml", async () => {
+    host.addTypeSpecFile("tspconfig.yaml", `features:\n  - auto-decorators\n`);
+
+    const program = await compileLibrary();
+
+    expect(program.diagnostics.map((x) => x.code)).toEqual([]);
+  });
+
+  it("reports the feature as disabled when the library did not opt in", async () => {
+    const program = await compileLibrary();
+
+    expect(program.diagnostics.map((x) => x.code)).toContain("auto-decorator-disabled");
+  });
+
+  it("never emits, even if the library configures emitters", async () => {
+    host.addTypeSpecFile("tspconfig.yaml", `emit:\n  - some-emitter\n`);
+
+    const options = await resolveLibraryCompilerOptions(host.compilerHost, entrypoint);
+
+    expect(options.noEmit).toBe(true);
+  });
+
+  it("resolves without a tspconfig.yaml", async () => {
+    const options = await resolveLibraryCompilerOptions(host.compilerHost, entrypoint);
+
+    expect(options.noEmit).toBe(true);
+  });
+});


### PR DESCRIPTION
Two things stand in the way of a library shipping `auto dec` in its public API.

**tspd never loads the library's own `tspconfig.yaml`.** Every `compile()` call site passes only
`parseOptions`, so any compiler feature the library opts into is invisible. `@typespec/graphql` shows
the symptom today — its `regen-docs` prints one error per auto decorator:

```
error auto-decorator-disabled: Auto decorators are experimental. Enable the `auto-decorators` feature...
```

Fixed by running the library's entrypoint through the existing `resolveCompilerOptions` and handing
the result to `compile()`, with `noEmit: true` since tspd only ever inspects a library.

**Generated accessors carried no doc comment,** so a library re-exporting one failed api-extractor's
`ae-undocumented` rule. `get*` and `set*` now inherit the description of the decorator they read or
write, which is already the source of truth in the `.tsp`. `is*` gets a generic one instead — a
decorator description reads as an instruction to apply it, which says nothing about a boolean check:

```ts
/** Check if the `@TypeSpec.GraphQL.nullable` decorator was applied on the given target. */
export function isNullable(program: Program, target: ModelProperty | Operation | Union | Model): boolean

/**
 * Mark a field, operation, or type as nullable in the emitted GraphQL schema.
 *
 * Applied automatically by the mutation engine when it strips `| null` from
 * union types, and can also be applied directly in TypeSpec source.
 */
export function setNullable(program: Program, target: ModelProperty | Operation | Union | Model): void
```

Only the description is carried over; the decorator's `@param` tags describe its TypeSpec parameters,
which do not line up with the accessor signatures. A `get*`/`set*` pair for a decorator with no doc
still generates no doc.

One detail worth knowing for anyone touching this later: the doc is emitted as a standalone comment
rather than through alloy's `doc` prop, because that prop also emits `@param {Type}` tags whose type
references count as *value* usages — which turns this file's type-only imports into value imports and
breaks `verbatimModuleSyntax`.

The only output change is `@typespec/graphql`'s regenerated signatures.

