### PR TITLE
fix(http-client-csharp): preserve nullable reference properties

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -659,7 +659,7 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 // a source-breaking change
                 if (MethodSignatureHelper.IsPublicApi(outputProperty.Modifiers) &&
                     LastContractPropertiesMap.TryGetValue(outputProperty.Name, out var lastContractPropertyType) &&
-                    !lastContractPropertyType.Equals(outputProperty.Type))
+                    ShouldReplacePropertyTypeWithLastContractType(lastContractPropertyType, outputProperty.Type))
                 {
                     // If the previous property type (or a type nested in it) has been intentionally
                     // removed and that removal is accepted in the ApiCompat baseline, preserving it
@@ -672,7 +672,10 @@ namespace Microsoft.TypeSpec.Generator.Providers
                     }
                     else
                     {
-                        outputProperty.Type = lastContractPropertyType.ApplyInputSpecProperty(property);
+                        outputProperty.Type = GetPropertyTypeForBackCompatibility(
+                            lastContractPropertyType,
+                            outputProperty.Type,
+                            property);
                         CodeModelGenerator.Instance.Emitter.Info(
                             $"Changed property '{Name}.{outputProperty.Name}' type to '{lastContractPropertyType}' to match last contract.",
                             BackCompatibilityChangeCategory.PropertyTypePreserved);
@@ -753,6 +756,31 @@ namespace Microsoft.TypeSpec.Generator.Providers
 
             var baseNullable = baseProperty.Type is InputNullableType;
             return baseNullable ? derivedProperty.Type is InputNullableType : derivedProperty.Type is not InputNullableType;
+        }
+
+        private static bool ShouldReplacePropertyTypeWithLastContractType(CSharpType lastContractType, CSharpType currentType)
+        {
+            if (lastContractType.Equals(currentType))
+            {
+                return false;
+            }
+
+            // Roslyn-backed last-contract reference types do not retain nullable-reference metadata.
+            // Keep the current TypeSpec nullability when the reference types otherwise match.
+            return lastContractType.IsValueType
+                || currentType.IsValueType
+                || !lastContractType.Equals(currentType, ignoreNullable: true);
+        }
+
+        private static CSharpType GetPropertyTypeForBackCompatibility(
+            CSharpType lastContractType,
+            CSharpType currentType,
+            InputProperty inputProperty)
+        {
+            var compatibleType = lastContractType.ApplyInputSpecProperty(inputProperty);
+            return !compatibleType.IsValueType && currentType.IsNullable
+                ? compatibleType.WithNullable(true)
+                : compatibleType;
         }
 
         protected internal override ConstructorProvider[] BuildConstructors()

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/src/Providers/ModelProvider.cs
@@ -765,8 +765,8 @@ namespace Microsoft.TypeSpec.Generator.Providers
                 return false;
             }
 
-            // Roslyn-backed last-contract reference types do not retain nullable-reference metadata.
-            // Keep the current TypeSpec nullability when the reference types otherwise match.
+            // Roslyn-backed last-contract reference types do not retain top-level nullable-reference metadata.
+            // Keep the current TypeSpec top-level nullability when the reference types otherwise match.
             return lastContractType.IsValueType
                 || currentType.IsValueType
                 || !lastContractType.Equals(currentType, ignoreNullable: true);

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/ModelProviderTests.cs
@@ -1361,6 +1361,58 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         }
 
         [Test]
+        public async Task BackCompat_NullableReferencePropertiesRetainSpecNullability()
+        {
+            var bytes = new InputPrimitiveType(InputPrimitiveTypeKind.Bytes, "bytes", "TypeSpec.bytes");
+            var inputModel = InputFactory.Model(
+                "MockInputModel",
+                usage: InputModelTypeUsage.Input,
+                properties:
+                [
+                    InputFactory.Property("unknown", new InputNullableType(InputPrimitiveType.Any), isRequired: true),
+                    InputFactory.Property("bytes", new InputNullableType(bytes), isRequired: true),
+                    InputFactory.Property("description", new InputNullableType(InputPrimitiveType.String), isRequired: true),
+                    InputFactory.Property("items", new InputNullableType(InputFactory.Array(InputPrimitiveType.String)), isRequired: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isRequired: true),
+                ]);
+
+            await MockHelpers.LoadMockGeneratorAsync(
+                inputModelTypes: [inputModel],
+                lastContractCompilation: async () => await Helpers.GetCompilationFromDirectoryAsync());
+
+            var modelProvider = CodeModelGenerator.Instance.OutputLibrary.TypeProviders
+                .OfType<ModelProvider>()
+                .Single(t => t.Name == "MockInputModel");
+            var properties = modelProvider.Properties.ToDictionary(p => p.Name);
+
+            Assert.IsTrue(properties["Unknown"].Type.IsNullable);
+            Assert.IsTrue(properties["Bytes"].Type.IsNullable);
+            Assert.IsTrue(properties["Description"].Type.IsNullable);
+            Assert.IsTrue(properties["Description"].Type.Equals(typeof(object)));
+            Assert.IsTrue(properties["Items"].Type.IsNullable);
+            Assert.AreEqual(typeof(IReadOnlyList<>), properties["Items"].Type.FrameworkType);
+            Assert.IsFalse(properties["Name"].Type.IsNullable);
+
+            var constructor = modelProvider.Constructors.Single(c =>
+                c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            var parameters = constructor.Signature.Parameters.ToDictionary(p => p.Name);
+
+            Assert.AreEqual(ParameterValidationType.None, parameters["unknown"].Validation);
+            Assert.AreEqual(ParameterValidationType.None, parameters["bytes"].Validation);
+            Assert.AreEqual(ParameterValidationType.None, parameters["description"].Validation);
+            Assert.AreEqual(ParameterValidationType.None, parameters["items"].Validation);
+            Assert.AreEqual(ParameterValidationType.AssertNotNull, parameters["name"].Validation);
+
+            var generatedCode = new TypeProviderWriter(modelProvider).Write().Content;
+            Assert.IsFalse(generatedCode.Contains("AssertNotNull(unknown"));
+            Assert.IsFalse(generatedCode.Contains("AssertNotNull(bytes"));
+            Assert.IsFalse(generatedCode.Contains("AssertNotNull(description"));
+            Assert.IsFalse(generatedCode.Contains("AssertNotNull(items"));
+            Assert.IsTrue(generatedCode.Contains("AssertNotNull(name"));
+            Assert.IsTrue(generatedCode.Contains("Items = items?.ToList();"));
+        }
+
+        [Test]
         public async Task BackCompat_ScalarPropertyTypeOverriddenWhenTypeNameDiffers()
         {
             var inputModel = InputFactory.Model(
@@ -1542,7 +1594,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                     InputFactory.Property("kind", discriminatorEnum, isRequired: false, isDiscriminator: true),
                     InputFactory.Property("baseProp", InputPrimitiveType.String, isRequired: true)
                 ],
-                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel }});
+                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel } });
 
             await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: [inputModel],
@@ -1574,7 +1626,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                     InputFactory.Property("kind", discriminatorEnum, isRequired: false, isDiscriminator: true),
                     InputFactory.Property("baseProp", InputPrimitiveType.String, isRequired: true)
                 ],
-                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel }});
+                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel } });
 
             await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: [inputModel],
@@ -1607,7 +1659,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                     InputFactory.Property("kind", discriminatorEnum, isRequired: false, isDiscriminator: true),
                     InputFactory.Property("baseProp", InputPrimitiveType.String, isRequired: true)
                 ],
-                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel }});
+                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel } });
 
             await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: [inputModel],
@@ -1773,7 +1825,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
         [TestCase(true, true, InputModelTypeUsage.Output, true, false)]
         [TestCase(true, false, InputModelTypeUsage.Output, true, false)]
         [TestCase(false, true, InputModelTypeUsage.Output, true, false)]
-        [TestCase(false, false,InputModelTypeUsage.Output, true, false)]
+        [TestCase(false, false, InputModelTypeUsage.Output, true, false)]
         [TestCase(true, true, InputModelTypeUsage.Input, true, false)]
         [TestCase(true, true, InputModelTypeUsage.Input | InputModelTypeUsage.Output, true, true)]
         [TestCase(true, false, InputModelTypeUsage.Input, false, false)]
@@ -1992,7 +2044,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                     InputFactory.Property("kind", discriminatorEnum, isRequired: false, isDiscriminator: true),
                     InputFactory.Property("baseProp", InputPrimitiveType.String, isRequired: true)
                 ],
-                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel }});
+                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel } });
 
             MockHelpers.LoadMockGenerator(
                 inputModelTypes: [inputModel, derivedInputModel],
@@ -2478,7 +2530,7 @@ namespace Microsoft.TypeSpec.Generator.Tests.Providers.ModelProviders
                     InputFactory.Property("kind", discriminatorEnum, isRequired: false, isDiscriminator: true),
                     InputFactory.Property("baseProp", InputPrimitiveType.String, isRequired: true)
                 ],
-                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel }});
+                discriminatedModels: new Dictionary<string, InputModelType>() { { "one", derivedInputModel } });
 
             await MockHelpers.LoadMockGeneratorAsync(
                 inputModelTypes: [inputModel],

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_NullableReferencePropertiesRetainSpecNullability/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_NullableReferencePropertiesRetainSpecNullability/MockInputModel.cs
@@ -1,13 +1,16 @@
 #nullable disable
 
+using System;
+using System.Collections.Generic;
+
 namespace Sample.Models
 {
     public partial class MockInputModel
     {
-        public global::System.BinaryData Unknown { get; set; }
-        public global::System.BinaryData Bytes { get; set; }
+        public BinaryData Unknown { get; set; }
+        public BinaryData Bytes { get; set; }
         public object Description { get; set; }
-        public global::System.Collections.Generic.IReadOnlyList<string> Items { get; set; }
+        public IReadOnlyList<string> Items { get; set; }
         public string Name { get; set; }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_NullableReferencePropertiesRetainSpecNullability/MockInputModel.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator/test/Providers/ModelProviders/TestData/ModelProviderTests/BackCompat_NullableReferencePropertiesRetainSpecNullability/MockInputModel.cs
@@ -1,0 +1,13 @@
+#nullable disable
+
+namespace Sample.Models
+{
+    public partial class MockInputModel
+    {
+        public global::System.BinaryData Unknown { get; set; }
+        public global::System.BinaryData Bytes { get; set; }
+        public object Description { get; set; }
+        public global::System.Collections.Generic.IReadOnlyList<string> Items { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -272,7 +272,7 @@ public IReadOnlyList<string> Items { get; }
 
 **Description:** When the type of a scalar, enum, or model property differs between the last contract and the current spec, the generator preserves the last contract's type shape. Nullable value-type differences also preserve the last contract's nullability.
 
-Reference types loaded from the last contract are nullable-oblivious, so their nullability is not used as compatibility evidence. The generator retains the current TypeSpec reference nullability while preserving any other last-contract type differences. This prevents compatibility processing from adding null guards or null-unsafe collection conversions that contradict the current wire contract.
+Reference types loaded from the last contract are nullable-oblivious, so their top-level nullability is not used as compatibility evidence. The generator retains the current TypeSpec top-level reference nullability while preserving any other last-contract type differences, including nested generic argument types. This prevents compatibility processing from adding null guards or null-unsafe collection conversions that contradict the current wire contract.
 
 **Example:**
 

--- a/packages/http-client-csharp/generator/docs/backward-compatibility.md
+++ b/packages/http-client-csharp/generator/docs/backward-compatibility.md
@@ -270,7 +270,9 @@ public IReadOnlyList<string> Items { get; }
 
 #### Scenario: Scalar/Model Property Type Changed
 
-**Description:** When the type of a scalar, enum, or model property differs between the last contract and the current spec — whether the change is in nullability, the underlying type, or anything else — the generator preserves the last contract's type.
+**Description:** When the type of a scalar, enum, or model property differs between the last contract and the current spec, the generator preserves the last contract's type shape. Nullable value-type differences also preserve the last contract's nullability.
+
+Reference types loaded from the last contract are nullable-oblivious, so their nullability is not used as compatibility evidence. The generator retains the current TypeSpec reference nullability while preserving any other last-contract type differences. This prevents compatibility processing from adding null guards or null-unsafe collection conversions that contradict the current wire contract.
 
 **Example:**
 


### PR DESCRIPTION
## Summary

- preserve current TypeSpec reference nullability when API compatibility processing retains a last-contract reference type shape
- prevent nullable reference properties from gaining invalid null guards or null-unsafe collection conversions
- add regression coverage for nullable `unknown`, bytes, changed reference shapes, nullable collections, and a nonnullable control
- document how nullable-oblivious last-contract reference types are handled

Fixes #11814

## Validation

- `npm run build`
- `npm run test:emitter` — 239 passed, 2 skipped
- `dotnet test .\generator\Microsoft.TypeSpec.Generator\test\Microsoft.TypeSpec.Generator.Tests.csproj --no-restore` — 2192 passed
- generator solution suites — ClientModel 1598 passed; Input 177 passed; Local 55 passed; Spector 15 passed, 938 skipped
- `pwsh .\eng\scripts\Generate.ps1`
- `npm run cop`
- C# and Markdown formatting checks