### PR TITLE
Pin execa to 9.x to fix Windows batch file argument escaping

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ catalogs:
       specifier: ^1.8.3
       version: 1.8.3
     execa:
-      specifier: ^10.0.1
-      version: 10.0.1
+      specifier: ^9.6.1
+      version: 9.6.1
     express:
       specifier: ^5.2.1
       version: 5.2.1
@@ -522,7 +522,7 @@ importers:
         version: 10.1.1
       execa:
         specifier: 'catalog:'
-        version: 10.0.1
+        version: 9.6.1
       micromatch:
         specifier: 'catalog:'
         version: 4.0.8
@@ -1223,7 +1223,7 @@ importers:
         version: 10.1.0
       execa:
         specifier: 'catalog:'
-        version: 10.0.1
+        version: 9.6.1
       ora:
         specifier: 'catalog:'
         version: 9.4.1
@@ -2549,7 +2549,7 @@ importers:
         version: 0.28.2
       execa:
         specifier: 'catalog:'
-        version: 10.0.1
+        version: 9.6.1
       ora:
         specifier: 'catalog:'
         version: 9.4.1
@@ -2619,7 +2619,7 @@ importers:
         version: link:../internal-build-utils
       execa:
         specifier: 'catalog:'
-        version: 10.0.1
+        version: 9.6.1
       log-symbols:
         specifier: 'catalog:'
         version: 7.0.1
@@ -7808,9 +7808,9 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  execa@10.0.1:
-    resolution: {integrity: sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==}
-    engines: {node: '>=22'}
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -11033,11 +11033,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  which-command@0.1.0:
-    resolution: {integrity: sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==}
-    engines: {node: '>=22'}
-    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -17029,9 +17024,10 @@ snapshots:
 
   events@3.3.0: {}
 
-  execa@10.0.1:
+  execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
       figures: 6.1.0
       get-stream: 9.0.1
       human-signals: 8.0.1
@@ -17041,7 +17037,6 @@ snapshots:
       pretty-ms: 9.3.0
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
-      which-command: 0.1.0
       yoctocolors: 2.2.0
 
   expand-template@2.0.3:
@@ -20893,8 +20888,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  which-command@0.1.0: {}
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -109,7 +109,11 @@ catalog:
   es-module-shims: ^2.8.4
   esbuild: ^0.28.2
   esbuild-plugins-node-modules-polyfill: ^1.8.3
-  execa: ^10.0.1
+  # Pinned to 9.x: execa 10 caret-escapes arguments twice for every Windows batch file, assuming it
+  # is an npm cmd-shim that re-expands `%*` through a second `cmd.exe` parse. A batch file that
+  # inspects its own arguments instead, like Maven's `mvn.cmd` (`if "%~1" == "-f"`), then fails with
+  # "The syntax of the command is incorrect.". Revert once execa fixes this upstream.
+  execa: ^9.6.1
   express: ^5.2.1
   fast-xml-parser: ^5.11.0
   graphql: ^17.0.2


### PR DESCRIPTION
execa 10 rewrote how it spawns commands on Windows ([#1251](https://github.com/sindresorhus/execa/pull/1251), which replaced `cross-spawn`). It now caret-escapes every argument **twice** for any `.cmd`/`.bat` file, on the assumption that the batch file is an npm cmd-shim which re-expands `%*` through a second `cmd.exe` parse. `cross-spawn` only did that for actual shims under `node_modules/.bin`.

Batch files that inspect their own arguments instead of forwarding them get the extra carets verbatim and break. Maven's `mvn.cmd` is one of them:

```bat
if "%~1" == "-f" (
```

so `mvn clean install` spawned through execa dies immediately on Windows with:

```
The syntax of the command is incorrect.
ExecaError: Command failed with exit code 255: mvn clean install ...
```

This already breaks the `typespec-java` generator build in typespec-azure, which invokes Maven through execa and takes this catalog. What execa 10 produces versus 9:

```
cmd.exe /q /d /s /c "…\mvn.cmd ^^^"clean^^^" ^^^"install^^^" …"   # 10.0.1 — mvn.cmd chokes
cmd.exe    /d /s /c "…\mvn.cmd ^"clean^" ^"install^" …"           # 9.6.1  — works
```

There is no upstream issue or fixed release yet (10.0.1 is latest), so this pins the catalog back to `^9.6.1` with a comment. Nothing in this repo uses the execa 10 API surface (`nodeChildProcess`, `killDescendants`, the new stream methods), so the downgrade is a no-op here beyond the Windows behavior.