### PR TITLE
Fix C# ClientResult conversions for streaming events

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ScmTypeFactory.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/src/ScmTypeFactory.cs
@@ -129,9 +129,6 @@ namespace Microsoft.TypeSpec.Generator.ClientModel
                 case InputNullableType nullableType:
                     PopulateRootOutputModelsFromTypeRecursive(nullableType.Type, targetSet, visited);
                     break;
-                case InputStreamingType streamingType:
-                    PopulateRootOutputModelsFromTypeRecursive(streamingType.ValueType, targetSet, visited);
-                    break;
                 case InputUnionType unionType:
                     foreach (var variantType in unionType.VariantTypes)
                     {

--- a/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DynamicModelSerializationTests.cs
+++ b/packages/http-client-csharp/generator/Microsoft.TypeSpec.Generator.ClientModel/test/Providers/MrwSerializationTypeDefinitions/DynamicModelSerializationTests.cs
@@ -1270,6 +1270,46 @@ namespace Microsoft.TypeSpec.Generator.ClientModel.Tests.Providers.MrwSerializat
             Assert.AreEqual(Helpers.GetExpectedFromFile(isDynamicModel.ToString()), file.Content);
         }
 
+        [TestCase(InputStreamingType.JsonLinesStreamKind, "application/jsonl")]
+        [TestCase(InputStreamingType.SseStreamKind, "text/event-stream")]
+        public void StreamingResponseDoesNotHaveExplicitClientResultOperator(string streamKind, string contentType)
+        {
+            var inputModel = InputFactory.Model(
+               "cat",
+               properties:
+               [
+                    InputFactory.Property("foo", InputPrimitiveType.String, isRequired: true),
+               ]);
+            var streamType = new InputStreamingType(
+                "CatStream",
+                "Sample.CatStream",
+                inputModel,
+                [contentType],
+                streamKind);
+            var operation = InputFactory.Operation(
+                "getCats",
+                responses: [InputFactory.OperationResponse([200], streamType)],
+                bufferResponse: false);
+            var method = InputFactory.BasicServiceMethod(
+                "GetCats",
+                operation,
+                response: InputFactory.ServiceMethodResponse(streamType, null));
+            MockHelpers.LoadMockGenerator(
+                inputModels: () => [inputModel],
+                clients: () => [InputFactory.Client("TestClient", methods: [method])]);
+
+            var model = ScmCodeModelGenerator.Instance.TypeFactory.CreateModel(inputModel) as ClientModel.Providers.ScmModelProvider;
+
+            Assert.IsNotNull(model);
+            var serialization = model!.SerializationProviders.SingleOrDefault();
+            Assert.IsNotNull(serialization);
+            Assert.That(
+                serialization!.Methods.Any(m =>
+                    m.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Explicit) &&
+                    m.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Operator)),
+                Is.False);
+        }
+
         [Test]
         public void PropagateDerivedDynamicPropertiesWithNonDynamicBase()
         {

--- a/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/StreamingItem.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Sample-TypeSpec/src/Generated/Models/StreamingItem.Serialization.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -60,14 +59,6 @@ namespace SampleTypeSpec
 
         /// <param name="options"> The client options for reading and writing models. </param>
         string IPersistableModel<StreamingItem>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
-
-        /// <param name="result"> The <see cref="ClientResult"/> to deserialize the <see cref="StreamingItem"/> from. </param>
-        public static explicit operator StreamingItem(ClientResult result)
-        {
-            PipelineResponse response = result.GetRawResponse();
-            using JsonDocument document = JsonDocument.Parse(response.Content, ModelSerializationExtensions.JsonDocumentOptions);
-            return DeserializeStreamingItem(document.RootElement, ModelSerializationExtensions.WireOptions);
-        }
 
         /// <param name="writer"> The JSON writer. </param>
         /// <param name="options"> The client options for reading and writing models. </param>

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/streaming/jsonl/src/Generated/Models/Info.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/streaming/jsonl/src/Generated/Models/Info.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -22,8 +21,6 @@ namespace Streaming.Jsonl._Basic
         Info IPersistableModel<Info>.Create(BinaryData data, ModelReaderWriterOptions options) => throw null;
 
         string IPersistableModel<Info>.GetFormatFromOptions(ModelReaderWriterOptions options) => throw null;
-
-        public static explicit operator Info(ClientResult result) => throw null;
 
         void IJsonModel<Info>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) => throw null;
 

--- a/packages/http-client-csharp/generator/TestProjects/Spector/http/streaming/sse/src/Generated/Models/Info.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Spector/http/streaming/sse/src/Generated/Models/Info.Serialization.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -22,8 +21,6 @@ namespace Streaming.Sse._Unnamed
         Info IPersistableModel<Info>.Create(BinaryData data, ModelReaderWriterOptions options) => throw null;
 
         string IPersistableModel<Info>.GetFormatFromOptions(ModelReaderWriterOptions options) => throw null;
-
-        public static explicit operator Info(ClientResult result) => throw null;
 
         void IJsonModel<Info>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) => throw null;
 


### PR DESCRIPTION
Streaming event models are never returned as plain `ClientResult` values, so generating explicit conversions for them adds unusable API surface.

## Summary

- Stop treating streaming payload models as root `ClientResult` outputs.
- Preserve conversion operators for models returned by ordinary protocol methods.
- Add SSE and JSON Lines regression coverage and regenerate streaming fixtures.

## Testing

- `npm run build`
- `npm run test:generator`
- `npm run test:emitter`
- `npm run format`
- Targeted `oxlint`
- `npm run cop`

Fixes: #11856