### PR TITLE
[http-client-java] Support collection header prefixes

### DIFF
--- a/.chronus/changes/http-client-java-collection-header-prefix-2026-09-04.md
+++ b/.chronus/changes/http-client-java-collection-header-prefix-2026-09-04.md
@@ -1,0 +1,13 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/http-client-java"
+---
+
+Add the Java `collectionHeaderPrefix` client option for map-valued headers:
+
+```typespec
+@@clientOption(MetadataHeaders.metadata, "collectionHeaderPrefix", "x-ms-meta-", "java");
+```
+
+The generated client deserializes response headers with the configured prefix into the map.

--- a/packages/http-client-java/emitter/src/code-model-builder.ts
+++ b/packages/http-client-java/emitter/src/code-model-builder.ts
@@ -67,6 +67,7 @@ import type {
   SdkPathParameter,
   SdkQueryParameter,
   SdkServiceMethod,
+  SdkServiceResponseHeader,
   SdkType,
   SdkUnionType,
 } from "@azure-tools/typespec-client-generator-core";
@@ -2340,6 +2341,7 @@ export class CodeModelBuilder {
           continue;
         }
 
+        const collectionHeaderPrefix = this.getCollectionHeaderPrefix(header);
         const httpHeader = new HttpHeader(header.serializedName, schema, {
           language: {
             default: {
@@ -2347,6 +2349,9 @@ export class CodeModelBuilder {
               description: header.summary ?? header.doc,
             },
           },
+          extensions: collectionHeaderPrefix
+            ? { "x-ms-header-collection-prefix": collectionHeaderPrefix }
+            : undefined,
         });
         if (header.isExactName) {
           httpHeader.language.java = httpHeader.language.java ?? new Language();
@@ -3769,5 +3774,11 @@ export class CodeModelBuilder {
       });
     }
     return clientRequired ?? !property.optional;
+  }
+
+  private getCollectionHeaderPrefix(header: SdkServiceResponseHeader): string | undefined {
+    const value = getClientOptions(header, "collectionHeaderPrefix");
+    const type = getNonNullSdkType(header.type);
+    return type.kind === "dict" && typeof value === "string" ? value : undefined;
   }
 }

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ModelTemplate.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/ModelTemplate.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -437,6 +438,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             // If the import isn't used it will be removed later on.
             imports.add(Base64.class.getName());
             imports.add(LinkedHashMap.class.getName());
+            imports.add(Locale.class.getName());
             imports.add(UUID.class.getName());
             imports.add(URL.class.getName());
             imports.add(IOException.class.getName());

--- a/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/util/ModelTemplateHeaderHelper.java
+++ b/packages/http-client-java/generator/http-client-generator-core/src/main/java/com/microsoft/typespec/http/client/generator/core/template/util/ModelTemplateHeaderHelper.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -293,11 +294,13 @@ public final class ModelTemplateHeaderHelper {
             } else {
                 body.line("String headerName = header.getName().getValue();");
             }
+            body.line("String headerNameLowerCase = headerName.toLowerCase(Locale.ROOT);");
             int propertiesSize = properties.size();
             for (int i = 0; i < propertiesSize; i++) {
                 ClientModelProperty property = properties.get(i);
                 boolean needsContinue = i < propertiesSize - 1;
-                body.ifBlock("headerName.startsWith(\"" + property.getHeaderCollectionPrefix() + "\")", ifBlock -> {
+                String headerCollectionPrefix = property.getHeaderCollectionPrefix().toLowerCase(Locale.ROOT);
+                body.ifBlock("headerNameLowerCase.startsWith(\"" + headerCollectionPrefix + "\")", ifBlock -> {
                     ifBlock.line("%sHeaderCollection.put(headerName.substring(%d), header.getValue());",
                         property.getName(), property.getHeaderCollectionPrefix().length());
                     if (needsContinue) {

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/ResponseHeadersAsyncClient.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/ResponseHeadersAsyncClient.java
@@ -45,6 +45,7 @@ public final class ResponseHeadersAsyncClient {
      * <tr><td>ETag</td><td>String</td><td>The ETag response header.</td></tr>
      * <tr><td>x-resource-count</td><td>int</td><td>The x-resource-count response header.</td></tr>
      * <tr><td>Last-Modified</td><td>OffsetDateTime</td><td>The Last-Modified response header.</td></tr>
+     * <tr><td>x-ms-meta</td><td>Map&lt;String, String&gt;</td><td>The x-ms-meta response header.</td></tr>
      * </table>
      * 
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/ResponseHeadersClient.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/ResponseHeadersClient.java
@@ -44,6 +44,7 @@ public final class ResponseHeadersClient {
      * <tr><td>ETag</td><td>String</td><td>The ETag response header.</td></tr>
      * <tr><td>x-resource-count</td><td>int</td><td>The x-resource-count response header.</td></tr>
      * <tr><td>Last-Modified</td><td>OffsetDateTime</td><td>The Last-Modified response header.</td></tr>
+     * <tr><td>x-ms-meta</td><td>Map&lt;String, String&gt;</td><td>The x-ms-meta response header.</td></tr>
      * </table>
      * 
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/implementation/ResponseHeaderOpsImpl.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/implementation/ResponseHeaderOpsImpl.java
@@ -83,6 +83,7 @@ public final class ResponseHeaderOpsImpl {
      * <tr><td>ETag</td><td>String</td><td>The ETag response header.</td></tr>
      * <tr><td>x-resource-count</td><td>int</td><td>The x-resource-count response header.</td></tr>
      * <tr><td>Last-Modified</td><td>OffsetDateTime</td><td>The Last-Modified response header.</td></tr>
+     * <tr><td>x-ms-meta</td><td>Map&lt;String, String&gt;</td><td>The x-ms-meta response header.</td></tr>
      * </table>
      * 
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
@@ -107,6 +108,7 @@ public final class ResponseHeaderOpsImpl {
      * <tr><td>ETag</td><td>String</td><td>The ETag response header.</td></tr>
      * <tr><td>x-resource-count</td><td>int</td><td>The x-resource-count response header.</td></tr>
      * <tr><td>Last-Modified</td><td>OffsetDateTime</td><td>The Last-Modified response header.</td></tr>
+     * <tr><td>x-ms-meta</td><td>Map&lt;String, String&gt;</td><td>The x-ms-meta response header.</td></tr>
      * </table>
      * 
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/models/ResponseHeaderOpsGetResourceMetadataHeaders.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/models/ResponseHeaderOpsGetResourceMetadataHeaders.java
@@ -11,6 +11,7 @@ import com.azure.core.http.HttpHeaders;
 import com.azure.core.util.DateTimeRfc1123;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -68,7 +69,8 @@ public final class ResponseHeaderOpsGetResourceMetadataHeaders {
 
         rawHeaders.stream().forEach(header -> {
             String headerName = header.getName();
-            if (headerName.startsWith("x-ms-meta-")) {
+            String headerNameLowerCase = headerName.toLowerCase(Locale.ROOT);
+            if (headerNameLowerCase.startsWith("x-ms-meta-")) {
                 metadataHeaderCollection.put(headerName.substring(10), header.getValue());
             }
         });

--- a/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/models/ResponseHeaderOpsGetResourceMetadataHeaders.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/main/java/tsptest/responseheaders/models/ResponseHeaderOpsGetResourceMetadataHeaders.java
@@ -10,6 +10,8 @@ import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.util.DateTimeRfc1123;
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * The ResponseHeaderOpsGetResourceMetadataHeaders model.
@@ -34,6 +36,12 @@ public final class ResponseHeaderOpsGetResourceMetadataHeaders {
     @Generated
     private final DateTimeRfc1123 lastModified;
 
+    /*
+     * The x-ms-meta- property.
+     */
+    @Generated
+    private final Map<String, String> metadata;
+
     private static final HttpHeaderName X_RESOURCE_COUNT = HttpHeaderName.fromString("x-resource-count");
 
     // HttpHeaders containing the raw property values.
@@ -56,6 +64,15 @@ public final class ResponseHeaderOpsGetResourceMetadataHeaders {
         } else {
             this.lastModified = null;
         }
+        Map<String, String> metadataHeaderCollection = new LinkedHashMap<>();
+
+        rawHeaders.stream().forEach(header -> {
+            String headerName = header.getName();
+            if (headerName.startsWith("x-ms-meta-")) {
+                metadataHeaderCollection.put(headerName.substring(10), header.getValue());
+            }
+        });
+        this.metadata = metadataHeaderCollection;
     }
 
     /**
@@ -89,5 +106,15 @@ public final class ResponseHeaderOpsGetResourceMetadataHeaders {
             return null;
         }
         return this.lastModified.getDateTime();
+    }
+
+    /**
+     * Get the metadata property: The x-ms-meta- property.
+     * 
+     * @return the metadata value.
+     */
+    @Generated
+    public Map<String, String> getMetadata() {
+        return this.metadata;
     }
 }

--- a/packages/http-client-java/generator/http-client-generator-test/src/test/java/tsptest/responseheaders/ResponseHeadersTests.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/test/java/tsptest/responseheaders/ResponseHeadersTests.java
@@ -8,6 +8,7 @@ import com.azure.core.http.HttpHeaders;
 import com.azure.core.test.http.MockHttpResponse;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -25,7 +26,9 @@ public class ResponseHeadersTests {
     public void testResponseHeadersAsModel() {
         HttpHeaders responseHeaders = new HttpHeaders().set(HttpHeaderName.ETAG, "\"0x8D9\"")
             .set(HttpHeaderName.fromString("x-resource-count"), "42")
-            .set(HttpHeaderName.LAST_MODIFIED, "Mon, 26 Aug 2022 14:38:00 GMT");
+            .set(HttpHeaderName.LAST_MODIFIED, "Mon, 26 Aug 2022 14:38:00 GMT")
+            .set(HttpHeaderName.fromString("x-ms-meta-key1"), "value1")
+            .set(HttpHeaderName.fromString("x-ms-meta-key2"), "value2");
 
         ResponseHeaderOpsGetResourceMetadataHeaders headers = createClient(responseHeaders).getResourceMetadata();
 
@@ -35,6 +38,7 @@ public class ResponseHeadersTests {
         Assertions.assertEquals(42, headers.getResourceCount());
         Assertions.assertEquals(OffsetDateTime.of(2022, 8, 26, 14, 38, 0, 0, ZoneOffset.UTC),
             headers.getLastModified());
+        Assertions.assertEquals(Map.of("key1", "value1", "key2", "value2"), headers.getMetadata());
     }
 
     @Test

--- a/packages/http-client-java/generator/http-client-generator-test/src/test/java/tsptest/responseheaders/ResponseHeadersTests.java
+++ b/packages/http-client-java/generator/http-client-generator-test/src/test/java/tsptest/responseheaders/ResponseHeadersTests.java
@@ -27,7 +27,7 @@ public class ResponseHeadersTests {
         HttpHeaders responseHeaders = new HttpHeaders().set(HttpHeaderName.ETAG, "\"0x8D9\"")
             .set(HttpHeaderName.fromString("x-resource-count"), "42")
             .set(HttpHeaderName.LAST_MODIFIED, "Mon, 26 Aug 2022 14:38:00 GMT")
-            .set(HttpHeaderName.fromString("x-ms-meta-key1"), "value1")
+            .set(HttpHeaderName.fromString("X-Ms-Meta-key1"), "value1")
             .set(HttpHeaderName.fromString("x-ms-meta-key2"), "value2");
 
         ResponseHeaderOpsGetResourceMetadataHeaders headers = createClient(responseHeaders).getResourceMetadata();

--- a/packages/http-client-java/generator/http-client-generator-test/tsp/response-headers.tsp
+++ b/packages/http-client-java/generator/http-client-generator-test/tsp/response-headers.tsp
@@ -7,6 +7,10 @@ using Azure.ClientGenerator.Core;
 @service(#{ title: "ResponseHeaders" })
 namespace TspTest.ResponseHeaders;
 
+model MetadataHeaders {
+  @header("x-ms-meta") metadata?: string;
+}
+
 @route("/response-headers")
 interface ResponseHeaderOp {
   // HEAD operation with significant response headers but no response body.
@@ -28,7 +32,11 @@ interface ResponseHeaderOp {
 
     // optional header, with mixed-case header name
     @header("Last-Modified") lastModified?: utcDateTime;
+
+    ...MetadataHeaders;
   };
 }
 
 @@clientOption(ResponseHeaderOp.getResourceMetadata, "responseHeadersAsModel", true, "java");
+@@alternateType(MetadataHeaders.metadata, Record<string>, "java");
+@@clientOption(MetadataHeaders.metadata, "collectionHeaderPrefix", "x-ms-meta-", "java");


### PR DESCRIPTION
## Summary

- map the Java `collectionHeaderPrefix` client option to `x-ms-header-collection-prefix` for response headers
- generate prefix-based deserialization into `Map<String, String>`
- add TypeSpec coverage and an end-to-end mock response test

## Testing

- `npm run build`
- `npm run format`
- `npm run lint`
- `npm run test:emitter`
- `mvn test --define "test=tsptest.responseheaders.ResponseHeadersTests" --no-transfer-progress`

Fixes #11859
