### PR TITLE
Report linter diagnostics on library template members the user gave a type to

### DIFF
--- a/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
+++ b/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
@@ -4,6 +4,8 @@ packages:
   - "@typespec/compiler"
 ---
 
-Report linter diagnostics on library templates that the user project instantiated
+Report linter diagnostics on library template members whose type the user supplied
 
-A rule reporting on a type declared inside a library template — for example the `value` property of `Wrapper<T>` when the project writes `Wrapper<uuid>` — was silently dropped, because the target's source location resolves to the template declaration in the library. Such a type only exists because of the template arguments the user passed, so the diagnostic is now reported with the instantiation trace pointing back at the user's own code, matching how non-linter diagnostics already behave.
+A rule reporting on a member declared inside a library template — for example the `value` property of `Wrapper<T>` when the project writes `Wrapper<uuid>` — was silently dropped, because the member's source location resolves to the template declaration in the library. That member only has the type it has because of the argument the user passed, so it is now reported, on the argument in the user's own file.
+
+Members whose type the library declared itself are still not reported, so a rule never blames the user for code they cannot change.

--- a/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
+++ b/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
@@ -1,0 +1,9 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Report linter diagnostics on library templates that the user project instantiated
+
+A rule reporting on a type declared inside a library template — for example the `value` property of `Wrapper<T>` when the project writes `Wrapper<uuid>` — was silently dropped, because the target's source location resolves to the template declaration in the library. Such a type only exists because of the template arguments the user passed, so the diagnostic is now reported with the instantiation trace pointing back at the user's own code, matching how non-linter diagnostics already behave.

--- a/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
+++ b/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
@@ -4,8 +4,8 @@ packages:
   - "@typespec/compiler"
 ---
 
-Report linter diagnostics on library template members whose type the user supplied
+Report linter diagnostics on library template members the user gave a type to
 
 A rule reporting on a member declared inside a library template — for example the `value` property of `Wrapper<T>` when the project writes `Wrapper<uuid>` — was silently dropped, because the member's source location resolves to the template declaration in the library. That member only has the type it has because of the argument the user passed, so it is now reported, on the argument in the user's own file.
 
-Members whose type the library declared itself are still not reported, so a rule never blames the user for code they cannot change.
+Only a member declared *as* the parameter, such as `value: T`, counts. A member the parameter merely appears inside, such as `value: T[]`, is still left alone: the array is the library's own declaration, so a diagnostic about it is the library's to fix no matter which item type the user passed.

--- a/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
+++ b/.chronus/changes/linter-report-template-instantiation-2026-9-4.md
@@ -9,3 +9,5 @@ Report linter diagnostics on library template members the user gave a type to
 A rule reporting on a member declared inside a library template — for example the `value` property of `Wrapper<T>` when the project writes `Wrapper<uuid>` — was silently dropped, because the member's source location resolves to the template declaration in the library. That member only has the type it has because of the argument the user passed, so it is now reported, on the argument in the user's own file.
 
 Only a member declared *as* the parameter, such as `value: T`, counts. A member the parameter merely appears inside, such as `value: T[]`, is still left alone: the array is the library's own declaration, so a diagnostic about it is the library's to fix no matter which item type the user passed.
+
+The argument must also be a type the user cannot edit, such as a library scalar or `unknown`. When they pass one of their own declarations, anything wrong with it is reportable on that declaration, where they can see it in context, so the instantiated member has nothing to add.

--- a/.chronus/changes/suppress-template-instantiation-2026-9-4.md
+++ b/.chronus/changes/suppress-template-instantiation-2026-9-4.md
@@ -1,0 +1,16 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Suppress a diagnostic reported inside a template where the template was instantiated
+
+```tsp
+model Widget {
+  #suppress "some-rule" "Not applicable here"
+  page: Page<WidgetItem>;
+}
+```
+
+Previously the `#suppress` directive was only looked up on the target and its parents, so a diagnostic coming from a template declaration could not be suppressed from the code that instantiated it.

--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -2,7 +2,11 @@ import { isPromise } from "../utils/misc.js";
 import type { DiagnosticCodeResolver } from "./diagnostic-code.js";
 import { formatShortNameCandidates } from "./diagnostic-code.js";
 import type { DiagnosticCollector } from "./diagnostics.js";
-import { compilerAssert, createDiagnosticCollector } from "./diagnostics.js";
+import {
+  compilerAssert,
+  createDiagnosticCollector,
+  getDiagnosticTemplateInstantitationTrace,
+} from "./diagnostics.js";
 import { getLocationContext } from "./helpers/location-context.js";
 import { defineLinter } from "./library.js";
 import { createUnusedTemplateParameterLinterRule } from "./linter-rules/unused-template-parameter.rule.js";
@@ -15,6 +19,7 @@ import { EventEmitter, mapEventEmitterToNodeListener, navigateProgram } from "./
 import type {
   Diagnostic,
   DiagnosticMessages,
+  DiagnosticTarget,
   LinterDefinition,
   LinterResolvedDefinition,
   LinterRule,
@@ -427,15 +432,29 @@ export function createLinterRuleContext<
 
   function reportDiagnostic<M extends keyof DM>(diag: LinterRuleDiagnosticReport<DM, M>): void {
     const diagnostic = createDiagnostic(diag);
-    if (diagnostic.target !== NoTarget) {
-      const context = getLocationContext(program, diagnostic.target);
-      // Only report diagnostic in the user project.
-      // See for showing diagnostic in library at point of usage https://github.com/microsoft/typespec/issues/1997
-      if (context.type === "project") {
-        diagnosticCollector.add(diagnostic);
-      }
+    if (diagnostic.target !== NoTarget && isUserOwnedTarget(program, diagnostic.target)) {
+      diagnosticCollector.add(diagnostic);
     }
   }
+}
+
+/**
+ * Linter rules should only report on code the user is able to act on.
+ *
+ * A target is user owned if it is declared in the user project, or if it belongs to a
+ * library template that the user project instantiated: in that case the type only exists
+ * because of the template arguments the user passed, and the diagnostic is rendered with
+ * the instantiation trace pointing back at the user's own code.
+ *
+ * See https://github.com/microsoft/typespec/issues/11861
+ */
+function isUserOwnedTarget(program: Program, target: DiagnosticTarget): boolean {
+  if (getLocationContext(program, target).type === "project") {
+    return true;
+  }
+  return getDiagnosticTemplateInstantitationTrace(target).some(
+    (node) => getLocationContext(program, node).type === "project",
+  );
 }
 
 export const builtInLinterLibraryName = `@typespec/compiler`;

--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -27,7 +27,6 @@ import type {
   RuleRef,
   SemanticNodeListener,
   TemplateParameter,
-  Type,
   TypeMapper,
 } from "./types.js";
 import { NoTarget, SyntaxKind } from "./types.js";
@@ -466,9 +465,9 @@ function resolveUserOwnedTarget(
 }
 
 /**
- * Resolve the node of the template argument the given target's type was built from, as
- * written in the user project. Returns `undefined` when the target isn't attributable to
- * an argument the user wrote, which includes arguments left to their default value.
+ * Resolve the node of the template argument the given target was declared as, as written in
+ * the user project. Returns `undefined` when the target isn't attributable to an argument the
+ * user wrote, which includes arguments left to their default value.
  */
 function findUserSuppliedArgumentNode(
   program: Program,
@@ -486,7 +485,7 @@ function findUserSuppliedArgumentNode(
   const mapper = (target as { templateMapper?: TypeMapper }).templateMapper;
   if (mapper === undefined) return undefined;
 
-  const parameter = findTemplateParameterInDeclaredType(program, target.node);
+  const parameter = findDeclaredTemplateParameter(program, target.node);
   if (parameter === undefined) return undefined;
 
   const node = getTemplateArgumentNode(mapper.source.node, parameter);
@@ -494,38 +493,25 @@ function findUserSuppliedArgumentNode(
 }
 
 /**
- * Resolve the member as declared, with its template parameters unsubstituted, and find the
- * parameter its type is built from. Looking at the declaration rather than comparing the
- * instantiated type to the arguments avoids matching a type the library declared itself
- * that merely happens to be the same as an argument, such as `string`.
+ * Resolve the member as declared, with its template parameters unsubstituted, and return the
+ * parameter it was declared as, if any.
+ *
+ * Only a member declared *as* the parameter, such as `body: Request`, is considered. A member
+ * the parameter merely appears inside, such as `value: Item[]` in `Page<Item>`, is left alone:
+ * the array is the library's own declaration, so a diagnostic about it is the library's to fix
+ * no matter which item type the user passed.
+ *
+ * Looking at the declaration rather than comparing the instantiated type to the arguments
+ * avoids matching a type the library declared itself that merely happens to be the same as an
+ * argument, such as `string`.
  */
-function findTemplateParameterInDeclaredType(
+function findDeclaredTemplateParameter(
   program: Program,
   node: Node,
 ): TemplateParameter | undefined {
   const declared = program.checker.getTypeForNode(node);
   if (declared.kind !== "ModelProperty" && declared.kind !== "UnionVariant") return undefined;
-  return findTemplateParameter(declared.type);
-}
-
-/** Find the template parameter a type is built from, looking through instantiations so `T[]` matches `T`. */
-function findTemplateParameter(
-  type: Type,
-  visited = new Set<Type>(),
-): TemplateParameter | undefined {
-  if (visited.has(type)) return undefined;
-  visited.add(type);
-
-  if (type.kind === "TemplateParameter") return type;
-
-  const mapper = (type as { templateMapper?: TypeMapper }).templateMapper;
-  for (const argument of mapper?.args ?? []) {
-    if (typeof argument === "object" && "kind" in argument) {
-      const found = findTemplateParameter(argument as Type, visited);
-      if (found) return found;
-    }
-  }
-  return undefined;
+  return declared.type.kind === "TemplateParameter" ? declared.type : undefined;
 }
 
 /** Resolve the argument passed for `parameter` in a template reference, by name or by position. */

--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -2,11 +2,7 @@ import { isPromise } from "../utils/misc.js";
 import type { DiagnosticCodeResolver } from "./diagnostic-code.js";
 import { formatShortNameCandidates } from "./diagnostic-code.js";
 import type { DiagnosticCollector } from "./diagnostics.js";
-import {
-  compilerAssert,
-  createDiagnosticCollector,
-  getDiagnosticTemplateInstantitationTrace,
-} from "./diagnostics.js";
+import { compilerAssert, createDiagnosticCollector } from "./diagnostics.js";
 import { getLocationContext } from "./helpers/location-context.js";
 import { defineLinter } from "./library.js";
 import { createUnusedTemplateParameterLinterRule } from "./linter-rules/unused-template-parameter.rule.js";
@@ -27,10 +23,14 @@ import type {
   LinterRuleDiagnosticReport,
   LinterRuleEnableValue,
   LinterRuleSet,
+  Node,
   RuleRef,
   SemanticNodeListener,
+  TemplateParameter,
+  Type,
+  TypeMapper,
 } from "./types.js";
-import { NoTarget } from "./types.js";
+import { NoTarget, SyntaxKind } from "./types.js";
 
 type LinterLibraryInstance = { linter: LinterResolvedDefinition };
 
@@ -432,8 +432,11 @@ export function createLinterRuleContext<
 
   function reportDiagnostic<M extends keyof DM>(diag: LinterRuleDiagnosticReport<DM, M>): void {
     const diagnostic = createDiagnostic(diag);
-    if (diagnostic.target !== NoTarget && isUserOwnedTarget(program, diagnostic.target)) {
-      diagnosticCollector.add(diagnostic);
+    if (diagnostic.target === NoTarget) return;
+
+    const target = resolveUserOwnedTarget(program, diagnostic.target);
+    if (target !== undefined) {
+      diagnosticCollector.add({ ...diagnostic, target });
     }
   }
 }
@@ -441,20 +444,103 @@ export function createLinterRuleContext<
 /**
  * Linter rules should only report on code the user is able to act on.
  *
- * A target is user owned if it is declared in the user project, or if it belongs to a
- * library template that the user project instantiated: in that case the type only exists
- * because of the template arguments the user passed, and the diagnostic is rendered with
- * the instantiation trace pointing back at the user's own code.
+ * A target declared in the user project is reported as is. A target declared in a library
+ * is reported only when its type is a template argument the user supplied: given
+ * `model Wrapper<T> { value: T }`, `Wrapper<uuid>.value` exists in that shape only because
+ * the user chose `uuid`, while everything else `Wrapper<T>` declares is authored by the
+ * library and cannot be changed by them.
+ *
+ * The diagnostic is then reported on the argument in the user's own file, which is the
+ * code they can actually change.
  *
  * See https://github.com/microsoft/typespec/issues/11861
  */
-function isUserOwnedTarget(program: Program, target: DiagnosticTarget): boolean {
+function resolveUserOwnedTarget(
+  program: Program,
+  target: DiagnosticTarget,
+): DiagnosticTarget | undefined {
   if (getLocationContext(program, target).type === "project") {
-    return true;
+    return target;
   }
-  return getDiagnosticTemplateInstantitationTrace(target).some(
-    (node) => getLocationContext(program, node).type === "project",
-  );
+  return findUserSuppliedArgumentNode(program, target);
+}
+
+/**
+ * Resolve the node of the template argument the given target's type was built from, as
+ * written in the user project. Returns `undefined` when the target isn't attributable to
+ * an argument the user wrote, which includes arguments left to their default value.
+ */
+function findUserSuppliedArgumentNode(
+  program: Program,
+  target: DiagnosticTarget,
+): Node | undefined {
+  if (typeof target !== "object" || !("kind" in target)) return undefined;
+  // Only members carry a type the user could have supplied. A whole instantiated model or
+  // operation is a library declaration, and reporting on it would duplicate the diagnostic
+  // already reported on the user's own `is`/`extends`/property declaration.
+  if (target.kind !== "ModelProperty" && target.kind !== "UnionVariant") return undefined;
+  if (target.node === undefined) return undefined;
+
+  // Members are linked to the mapper of the template they were instantiated with, even
+  // though `TemplatedTypeBase` is not part of their public type.
+  const mapper = (target as { templateMapper?: TypeMapper }).templateMapper;
+  if (mapper === undefined) return undefined;
+
+  const parameter = findTemplateParameterInDeclaredType(program, target.node);
+  if (parameter === undefined) return undefined;
+
+  const node = getTemplateArgumentNode(mapper.source.node, parameter);
+  return node && getLocationContext(program, node).type === "project" ? node : undefined;
+}
+
+/**
+ * Resolve the member as declared, with its template parameters unsubstituted, and find the
+ * parameter its type is built from. Looking at the declaration rather than comparing the
+ * instantiated type to the arguments avoids matching a type the library declared itself
+ * that merely happens to be the same as an argument, such as `string`.
+ */
+function findTemplateParameterInDeclaredType(
+  program: Program,
+  node: Node,
+): TemplateParameter | undefined {
+  const declared = program.checker.getTypeForNode(node);
+  if (declared.kind !== "ModelProperty" && declared.kind !== "UnionVariant") return undefined;
+  return findTemplateParameter(declared.type);
+}
+
+/** Find the template parameter a type is built from, looking through instantiations so `T[]` matches `T`. */
+function findTemplateParameter(
+  type: Type,
+  visited = new Set<Type>(),
+): TemplateParameter | undefined {
+  if (visited.has(type)) return undefined;
+  visited.add(type);
+
+  if (type.kind === "TemplateParameter") return type;
+
+  const mapper = (type as { templateMapper?: TypeMapper }).templateMapper;
+  for (const argument of mapper?.args ?? []) {
+    if (typeof argument === "object" && "kind" in argument) {
+      const found = findTemplateParameter(argument as Type, visited);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/** Resolve the argument passed for `parameter` in a template reference, by name or by position. */
+function getTemplateArgumentNode(source: Node, parameter: TemplateParameter): Node | undefined {
+  if (source.kind !== SyntaxKind.TypeReference) return undefined;
+  const args = source.arguments;
+
+  const name = parameter.node.id.sv;
+  const named = args.find((arg) => arg.name?.sv === name);
+  if (named) return named.argument;
+
+  const declaration = parameter.node.parent;
+  const index = declaration?.templateParameters?.indexOf(parameter.node) ?? -1;
+  const positional = index === -1 ? undefined : args[index];
+  return positional?.name === undefined ? positional?.argument : undefined;
 }
 
 export const builtInLinterLibraryName = `@typespec/compiler`;

--- a/packages/compiler/src/core/linter.ts
+++ b/packages/compiler/src/core/linter.ts
@@ -444,10 +444,10 @@ export function createLinterRuleContext<
  * Linter rules should only report on code the user is able to act on.
  *
  * A target declared in the user project is reported as is. A target declared in a library
- * is reported only when its type is a template argument the user supplied: given
- * `model Wrapper<T> { value: T }`, `Wrapper<uuid>.value` exists in that shape only because
- * the user chose `uuid`, while everything else `Wrapper<T>` declares is authored by the
- * library and cannot be changed by them.
+ * is reported only when its type is a template argument the user supplied and could not have
+ * been told about anywhere else: given `model Wrapper<T> { value: T }`, `Wrapper<uuid>.value`
+ * exists in that shape only because the user chose `uuid`, while everything else `Wrapper<T>`
+ * declares is authored by the library and cannot be changed by them.
  *
  * The diagnostic is then reported on the argument in the user's own file, which is the
  * code they can actually change.
@@ -479,6 +479,12 @@ function findUserSuppliedArgumentNode(
   // already reported on the user's own `is`/`extends`/property declaration.
   if (target.kind !== "ModelProperty" && target.kind !== "UnionVariant") return undefined;
   if (target.node === undefined) return undefined;
+
+  // When the user passed one of their own declarations the member tells them nothing new:
+  // anything wrong with that type is reportable on the declaration itself, where they can see
+  // it in context. Only a type they cannot edit, such as a library scalar or `unknown`, makes
+  // the instantiation the sole place the problem is visible.
+  if (getLocationContext(program, target.type).type === "project") return undefined;
 
   // Members are linked to the mapper of the template they were instantiated with, even
   // though `TemplatedTypeBase` is not part of their public type.

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -14,7 +14,7 @@ import { createChecker } from "./checker.js";
 import { createSuppressCodeFix } from "./compiler-code-fixes/suppress.codefix.js";
 import type { DiagnosticCodeResolver, LibraryNameInfo } from "./diagnostic-code.js";
 import { createDiagnosticCodeResolver, formatShortNameCandidates } from "./diagnostic-code.js";
-import { compilerAssert } from "./diagnostics.js";
+import { compilerAssert, getDiagnosticTemplateInstantitationTrace } from "./diagnostics.js";
 import { getEmittedFilesForProgram } from "./emitter-utils.js";
 import { resolveTypeSpecEntrypoint } from "./entrypoint-resolution.js";
 import { ExternalError } from "./external-error.js";
@@ -54,6 +54,7 @@ import {
 import type {
   CompilerHost,
   Diagnostic,
+  DiagnosticTarget,
   EmitContext,
   EmitterFunc,
   Entity,
@@ -979,11 +980,7 @@ async function createProgram(
       return false; // Can't find target cannot be suppressed.
     }
 
-    const suppressing = findDirectiveSuppressingOnNode(
-      diagnostic.code,
-      node,
-      diagnosticCodeResolver,
-    );
+    const suppressing = findSuppressingDirective(target, node);
     if (suppressing) {
       if (diagnostic.severity === "error") {
         // Cannot suppress errors.
@@ -1002,6 +999,26 @@ async function createProgram(
       }
     }
     return false;
+
+    /**
+     * Look for a `#suppress` directive on the target itself, then on each template
+     * instantiation that produced it, so a diagnostic reported inside a template can be
+     * suppressed where the template was instantiated.
+     */
+    function findSuppressingDirective(target: DiagnosticTarget, node: Node) {
+      const direct = findDirectiveSuppressingOnNode(diagnostic.code, node, diagnosticCodeResolver);
+      if (direct) return direct;
+
+      for (const instantiation of getDiagnosticTemplateInstantitationTrace(target)) {
+        const suppressing = findDirectiveSuppressingOnNode(
+          diagnostic.code,
+          instantiation,
+          diagnosticCodeResolver,
+        );
+        if (suppressing) return suppressing;
+      }
+      return undefined;
+    }
   }
 
   function getNode(target: Node | Entity | Sym | TemplateInstanceTarget): Node | undefined {

--- a/packages/compiler/test/core/linter.test.ts
+++ b/packages/compiler/test/core/linter.test.ts
@@ -296,7 +296,11 @@ describe("diagnostic location", () => {
   });
 
   describe("library template instantiated from the user project", () => {
-    async function lintPropertyValue(lib: string, main: string) {
+    async function lintLibrary(
+      lib: string,
+      main: string,
+      rules: LinterDefinition["rules"] = [noPropertyValue],
+    ) {
       const linter = await createTestLinterAndEnableRules(
         {
           "main.tsp": `import "my-lib";\n${main}`,
@@ -306,13 +310,13 @@ describe("diagnostic location", () => {
           }),
           "node_modules/my-lib/main.tsp": lib,
         },
-        { rules: [noPropertyValue] },
+        { rules },
       );
       return (await linter.lint()).diagnostics;
     }
 
-    it("emit diagnostic when the user project instantiated the template", async () => {
-      const diagnostics = await lintPropertyValue(
+    it("reports on the argument the user supplied", async () => {
+      const diagnostics = await lintLibrary(
         `model Wrapper<T> { value: T; }`,
         `model Bar { wrapped: Wrapper<string>; }`,
       );
@@ -320,12 +324,35 @@ describe("diagnostic location", () => {
         severity: "warning",
         code: "@typespec/test-linter/no-property-value",
         message: `Cannot call property 'value'`,
+        file: "main.tsp",
+      });
+    });
+
+    it("reports on a named argument", async () => {
+      const diagnostics = await lintLibrary(
+        `model Wrapper<T extends string = string> { value: T; }`,
+        `model Bar { wrapped: Wrapper<T = string>; }`,
+      );
+      expectDiagnostics(diagnostics, {
+        code: "@typespec/test-linter/no-property-value",
+        file: "main.tsp",
+      });
+    });
+
+    it("reports when the argument is nested in the property type", async () => {
+      const diagnostics = await lintLibrary(
+        `model Wrapper<T> { value: T[]; }`,
+        `model Bar { wrapped: Wrapper<string>; }`,
+      );
+      expectDiagnostics(diagnostics, {
+        code: "@typespec/test-linter/no-property-value",
+        file: "main.tsp",
       });
     });
 
     it("doesn't emit diagnostic for a non templated library model", async () => {
       expectDiagnosticEmpty(
-        await lintPropertyValue(
+        await lintLibrary(
           `model NotATemplate { value: string; }`,
           `model Bar { plain: NotATemplate; }`,
         ),
@@ -334,11 +361,37 @@ describe("diagnostic location", () => {
 
     it("doesn't emit diagnostic when the library instantiated the template itself", async () => {
       expectDiagnosticEmpty(
-        await lintPropertyValue(
+        await lintLibrary(
           `model Wrapper<T> { value: T; }
            model LibOwnedUsage { ...Wrapper<string>; }`,
           `model Bar { plain: LibOwnedUsage; }`,
         ),
+      );
+    });
+
+    it("doesn't emit diagnostic for a property the library declared itself", async () => {
+      expectDiagnosticEmpty(
+        await lintLibrary(
+          `model Wrapper<T> { wrapped: T; value: string; }`,
+          `model Bar { wrapped: Wrapper<string>; }`,
+        ),
+      );
+    });
+
+    it("doesn't emit diagnostic when the argument was left to its default", async () => {
+      expectDiagnosticEmpty(
+        await lintLibrary(
+          `model Wrapper<T extends string = string> { value: T; }`,
+          `model Bar { wrapped: Wrapper; }`,
+        ),
+      );
+    });
+
+    it("doesn't emit diagnostic on the instantiated model itself", async () => {
+      expectDiagnosticEmpty(
+        await lintLibrary(`model Foo<T> { value: T; }`, `model Bar { wrapped: Foo<string>; }`, [
+          noModelFoo,
+        ]),
       );
     });
   });

--- a/packages/compiler/test/core/linter.test.ts
+++ b/packages/compiler/test/core/linter.test.ts
@@ -339,15 +339,15 @@ describe("diagnostic location", () => {
       });
     });
 
-    it("reports when the argument is nested in the property type", async () => {
-      const diagnostics = await lintLibrary(
-        `model Wrapper<T> { value: T[]; }`,
-        `model Bar { wrapped: Wrapper<string>; }`,
+    it("doesn't emit diagnostic when the argument is only nested in the property type", async () => {
+      // `value: T[]` is the library's own array declaration, so a diagnostic about it is the
+      // library's to fix no matter which item type the user passed.
+      expectDiagnosticEmpty(
+        await lintLibrary(
+          `model Wrapper<T> { value: T[]; }`,
+          `model Bar { wrapped: Wrapper<string>; }`,
+        ),
       );
-      expectDiagnostics(diagnostics, {
-        code: "@typespec/test-linter/no-property-value",
-        file: "main.tsp",
-      });
     });
 
     it("doesn't emit diagnostic for a non templated library model", async () => {

--- a/packages/compiler/test/core/linter.test.ts
+++ b/packages/compiler/test/core/linter.test.ts
@@ -34,6 +34,26 @@ const noModelFoo = createLinterRule({
   },
 });
 
+const noPropertyValue = createLinterRule({
+  name: "no-property-value",
+  description: "",
+  severity: "warning",
+  messages: {
+    default: "Cannot call property 'value'",
+  },
+  create(context) {
+    return {
+      modelProperty: (target) => {
+        if (target.name === "value") {
+          context.reportDiagnostic({
+            target,
+          });
+        }
+      },
+    };
+  },
+});
+
 const exitLintRuleSync = createLinterRule({
   name: "exit-lint-rule-sync",
   description: "",
@@ -272,6 +292,54 @@ describe("diagnostic location", () => {
       severity: "warning",
       code: "@typespec/test-linter/no-model-foo",
       message: `Cannot call model 'Foo'`,
+    });
+  });
+
+  describe("library template instantiated from the user project", () => {
+    async function lintPropertyValue(lib: string, main: string) {
+      const linter = await createTestLinterAndEnableRules(
+        {
+          "main.tsp": `import "my-lib";\n${main}`,
+          "node_modules/my-lib/package.json": JSON.stringify({
+            name: "my-lib",
+            tspMain: "main.tsp",
+          }),
+          "node_modules/my-lib/main.tsp": lib,
+        },
+        { rules: [noPropertyValue] },
+      );
+      return (await linter.lint()).diagnostics;
+    }
+
+    it("emit diagnostic when the user project instantiated the template", async () => {
+      const diagnostics = await lintPropertyValue(
+        `model Wrapper<T> { value: T; }`,
+        `model Bar { wrapped: Wrapper<string>; }`,
+      );
+      expectDiagnostics(diagnostics, {
+        severity: "warning",
+        code: "@typespec/test-linter/no-property-value",
+        message: `Cannot call property 'value'`,
+      });
+    });
+
+    it("doesn't emit diagnostic for a non templated library model", async () => {
+      expectDiagnosticEmpty(
+        await lintPropertyValue(
+          `model NotATemplate { value: string; }`,
+          `model Bar { plain: NotATemplate; }`,
+        ),
+      );
+    });
+
+    it("doesn't emit diagnostic when the library instantiated the template itself", async () => {
+      expectDiagnosticEmpty(
+        await lintPropertyValue(
+          `model Wrapper<T> { value: T; }
+           model LibOwnedUsage { ...Wrapper<string>; }`,
+          `model Bar { plain: LibOwnedUsage; }`,
+        ),
+      );
     });
   });
 });

--- a/packages/compiler/test/core/linter.test.ts
+++ b/packages/compiler/test/core/linter.test.ts
@@ -339,6 +339,32 @@ describe("diagnostic location", () => {
       });
     });
 
+    it("reports on a library type the user chose", async () => {
+      // The shape ARM's `ResourceNameParameter<..., Type = uuid>` has: the user cannot edit
+      // `uuid`, so the instantiation is the only place the choice is visible.
+      const diagnostics = await lintLibrary(
+        `scalar libScalar extends string;
+         model Wrapper<T> { value: T; }`,
+        `model Bar { wrapped: Wrapper<libScalar>; }`,
+      );
+      expectDiagnostics(diagnostics, {
+        code: "@typespec/test-linter/no-property-value",
+        file: "main.tsp",
+      });
+    });
+
+    it("doesn't emit diagnostic when the user passed one of their own declarations", async () => {
+      // Anything wrong with `Mine` is reportable on `Mine` itself, where the user can see it in
+      // context, so the instantiated member has nothing to add.
+      expectDiagnosticEmpty(
+        await lintLibrary(
+          `model Wrapper<T> { value: T; }`,
+          `model Mine { a: string; }
+           model Bar { wrapped: Wrapper<Mine>; }`,
+        ),
+      );
+    });
+
     it("doesn't emit diagnostic when the argument is only nested in the property type", async () => {
       // `value: T[]` is the library's own array declaration, so a diagnostic about it is the
       // library's to fix no matter which item type the user passed.

--- a/packages/compiler/test/suppression.test.ts
+++ b/packages/compiler/test/suppression.test.ts
@@ -75,6 +75,23 @@ it("suppress warning diagnostic on parent node", async () => {
   expectDiagnosticEmpty(diagnostics);
 });
 
+it("suppress warning diagnostic where the template was instantiated", async () => {
+  const diagnostics = await run(`
+      model Wrapper<T> {
+        wrapped: T;
+        inline: {
+          name: 123;
+        };
+      }
+
+      model Foo {
+        #suppress "no-inline-model" "This is needed"
+        prop: Wrapper<string>;
+      }
+    `);
+  expectDiagnosticEmpty(diagnostics);
+});
+
 it("error diagnostics cannot be suppressed and emit another error", async () => {
   const diagnostics = await run(`
       model Foo {

--- a/website/src/content/docs/docs/language-basics/directives.md
+++ b/website/src/content/docs/docs/language-basics/directives.md
@@ -87,6 +87,15 @@ namespace Lib {
 }
 ```
 
+A diagnostic reported inside a template can also be suppressed where the template was instantiated:
+
+```tsp
+model Widget {
+  #suppress "some-rule" "Not applicable here"
+  page: Page<WidgetItem>;
+}
+```
+
 ### Short diagnostic codes
 
 Diagnostic codes from a library are prefixed with the package name (e.g. `@typespec/http/no-service-found`), which can get verbose. You can also reference a diagnostic using its **short name**, where the package scope is stripped:


### PR DESCRIPTION
A linter rule can never report on a type that exists only because the user instantiated a library template. `reportDiagnostic` keeps a diagnostic only when its target resolves to the project, and an instantiated member's source location is the template declaration inside the library, so the diagnostic is dropped without a trace.

That hides real problems. Given ARM's

```tsp
model ResourceNameParameter<Resource, ..., Type extends string = string> {
  name: Type;
}
```

a rule that objects to `Type` being a `uuid` cannot say so about

```tsp
model Employee is TrackedResource<EmployeeProperties> {
  ...ResourceNameParameter<Employee, Type = Azure.Core.uuid>;
}
```

even though the `uuid` is the user's own choice, written in their own file. This was found on https://github.com/Azure/typespec-azure/pull/5336, where it silenced 9 declarations across 6 projects. A plain (non-linter) diagnostic on the exact same target renders fine, complete with an instantiation trace, so the two kinds of diagnostic disagree about the same code.

Now a library-declared member is reported when both of the following hold, and the diagnostic is moved onto the argument in the user's own file:

- **it was declared *as* a template parameter the user supplied an argument for.** `name: Type` qualifies, so the type really is the one they passed. `value: T[]` in `Page<T>` does not: the array is the library's own declaration, and a complaint about it is the library's to fix whichever item type is passed.
- **the argument is a type they cannot edit**, such as a library scalar or `unknown`. When they pass one of their own declarations, anything wrong with it is reportable on that declaration, where they can see it in context, so the instantiation adds nothing.

Together these keep the diagnostic pointed at a line the reader can act on. Measured against `azure-rest-api-specs`, this reports the cases the rules were written to catch — `ArmResponse<unknown>`, `ArmResponse<NetworkTrace[]>` — without reporting members whose problem lies in a model the author already owns.

`#suppress` now walks the template instantiation trace too, so the diagnostic can be suppressed where the user instantiates the template, which is the only place they can write a directive.

Fixes https://github.com/microsoft/typespec/issues/11861

### Known follow-up

`documentation-required` reports on a type whose documentation was blanked with `@@doc(X, "")`, and points at the type rather than at the augmentation that blanked it. The rule knows it is about `@doc` and can point at the responsible node; the linter cannot guess which decorator a rule cares about. Tracked in https://github.com/Azure/typespec-azure/issues/5445.
