### PR TITLE
Fix cache poisoning code scanning alerts in Python integration workflows

### DIFF
--- a/.github/workflows/external-integration.yml
+++ b/.github/workflows/external-integration.yml
@@ -9,8 +9,6 @@ on:
       - "packages/http-client-python/**"
       - "website/**"
       - "docs/**"
-  # Allow manual triggering
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -73,7 +71,7 @@ jobs:
   azure-rest-api-specs:
     name: Azure REST API Specs
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'int:azure-specs') || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.pull_request.labels.*.name, 'int:azure-specs')
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -6,8 +6,6 @@ on:
     paths:
       - "packages/http-client-python/**"
       - ".github/workflows/python-integration.yml"
-  # Allow manual triggering
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Resolves the 36 open **code scanning** alerts of rule [`actions/cache-poisoning/poisonable-step`](https://github.com/microsoft/typespec/security/code-scanning) (Cache Poisoning via execution of untrusted code):

- 31 alerts in `.github/workflows/python-integration.yml` (the `http-client-python` emitter CI)
- 5 alerts in `.github/workflows/external-integration.yml`

## Root cause

Both workflows check out **untrusted PR code** (they update the `core` submodule / checkout to `github.event.pull_request.head.sha`) and then run steps that use caching. Each also declared a `workflow_dispatch` trigger. Because `workflow_dispatch` runs in the context of the **default branch**, it has **write access to the default-branch cache scope**. CodeQL flags this combination as a cache-poisoning risk: a run could write poisoned entries into a cache that privileged default-branch workflows later restore.

Every flagged instance in the alerts is attributed to the `workflow_dispatch` trigger.

## Fix

Remove the `workflow_dispatch` trigger from both workflows so they run only on `pull_request`. Under `pull_request`, the cache is scoped to the PR branch rather than the default branch, which is exactly the **"Correct Usage"** pattern in the CodeQL rule's guidance.

- `python-integration.yml`: dropped `workflow_dispatch:`.
- `external-integration.yml`: dropped `workflow_dispatch:`, and removed the now-dead `|| github.event_name == 'workflow_dispatch'` disjunct from the `azure-rest-api-specs` job condition. That job remains manually triggerable via the existing `int:azure-specs` PR label.

> Note: CodeQL does not evaluate step/job `if:` gates, so gating the untrusted checkout on `github.event_name == 'pull_request'` (as `python-integration.yml` already did) does not clear the alerts — removing the write-capable trigger is required.

## Impact

- No change to the primary PR-validation behavior of either workflow.
- Loses the ability to *manually* dispatch these integration workflows with no PR context (which was not meaningful, since the jobs depend on PR head SHA). The `azure-rest-api-specs` job retains its label-based manual path.
