### PR TITLE
chore(http-client-java): fix npm audit vulnerabilities

### DIFF
--- a/.chronus/changes/http-client-java-npm-audit-fix-2026-09-07.md
+++ b/.chronus/changes/http-client-java-npm-audit-fix-2026-09-07.md
@@ -1,0 +1,7 @@
+---
+changeKind: dependencies
+packages:
+  - "@typespec/http-client-java"
+---
+
+Update transitive Node.js dependencies to address security vulnerabilities.

--- a/packages/http-client-java/package-lock.json
+++ b/packages/http-client-java/package-lock.json
@@ -3177,9 +3177,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
+      "version": "3.1.6",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha1-v90wjvdj+DX+0Fnzxskl9wjjPjo=",
       "dev": true,
       "funding": [
         {
@@ -4557,9 +4557,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
+      "version": "3.3.18",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=",
       "dev": true,
       "funding": [
         {
@@ -4894,9 +4894,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

- update vulnerable transitive Node.js dependencies in the Java emitter lockfile
- add a dependency changelog entry

## Validation

- `npm audit`
- `npm run build`
- `npm run format`
- `npm run lint`
- `pnpm format`
