### PR TITLE
Emit minItems+maxItems on tuples

### DIFF
--- a/.chronus/changes/tuple-jsonschema-fixed-length-2026-8-9-13-1-9.md
+++ b/.chronus/changes/tuple-jsonschema-fixed-length-2026-8-9-13-1-9.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/json-schema"
+---
+
+Emit `minItems` and `maxItems` for tuple types so generated schemas enforce the tuple's exact length.

--- a/packages/json-schema/src/json-schema-emitter.ts
+++ b/packages/json-schema/src/json-schema-emitter.ts
@@ -378,9 +378,12 @@ export class JsonSchemaEmitter extends TypeEmitter<Record<string, any>, JSONSche
   }
 
   tupleLiteral(tuple: Tuple): EmitterOutput<Record<string, any>> {
+    const size = tuple.values.length;
     return new ObjectBuilder({
       type: "array",
       prefixItems: this.emitter.emitTupleLiteralValues(tuple),
+      minItems: size,
+      maxItems: size,
     });
   }
 

--- a/packages/json-schema/test/extension.test.ts
+++ b/packages/json-schema/test/extension.test.ts
@@ -60,10 +60,14 @@ it("handles types", async () => {
   assert.deepStrictEqual(Foo["x-tuple"], {
     prefixItems: [{ type: "string" }, { type: "string" }],
     type: "array",
+    minItems: 2,
+    maxItems: 2,
   });
   assert.deepStrictEqual(Foo["x-tuple-val"], {
     prefixItems: [{ type: "string", const: "foo" }],
     type: "array",
+    minItems: 1,
+    maxItems: 1,
   });
   assert.deepStrictEqual(Foo["x-array"], {
     items: { type: "string" },

--- a/packages/json-schema/test/tuples.test.ts
+++ b/packages/json-schema/test/tuples.test.ts
@@ -27,6 +27,8 @@ it("emit tuples as items", async () => {
               maximum: 2147483647,
             },
           ],
+          minItems: 2,
+          maxItems: 2,
         },
       },
     },


### PR DESCRIPTION
JSONSchema `prefixItems` doesn't constrain the length of an array. But tuple types do.

```typespec
alias Tuple = #[string, number];
```

This PR changes the JSONSchema generator so generated JSONSchema won't accept 1-element or 3-element arrays.