### PR TITLE
fix(python): escape quotes in enum documentation

### DIFF
--- a/.chronus/changes/escape-python-enum-docstrings.md
+++ b/.chronus/changes/escape-python-enum-docstrings.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-client-python"
+---
+
+Escape quotes in enum and enum member documentation so embedded Python string delimiters remain documentation in generated code.

--- a/packages/http-client-python/generator/pygen/codegen/templates/enum.py.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/enum.py.jinja2
@@ -3,13 +3,13 @@ class {{ enum.name }}({{enum.pylint_disable()}}
   {{ enum.value_type.type_annotation(is_operation_file=False) }}, Enum, metaclass=CaseInsensitiveEnumMeta
 ):
     {% if enum.yaml_data.get("description") %}
-    """{{ op_tools.wrap_string(enum.yaml_data["description"], "\n    ") }}
+    """{{ op_tools.wrap_docstring(enum.yaml_data["description"], "\n    ") }}
     """
     {% endif %}
 
     {% for value in enum.values %}
     {{ value.name }} = {{ enum.value_type.get_declaration(value.value) }}
     {% if value.description(is_operation_file=False) %}
-    """{{ op_tools.wrap_string(value.description(is_operation_file=False), "\n    ") }}"""
+    """{{ op_tools.wrap_docstring(value.description(is_operation_file=False), "\n    ") }}"""
     {% endif %}
     {% endfor %}

--- a/packages/http-client-python/generator/pygen/codegen/templates/operation_tools.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/operation_tools.jinja2
@@ -31,6 +31,11 @@
 {%- endif -%}
 {{ normalized_string | replace("\\", "\\\\") | wordwrap(width=width, break_long_words=False, break_on_hyphens=False, wrapstring=wrapstring)}}{% endmacro %}
 
+{# Escape quotes after wrapping so wrapping cannot split an escape sequence. #}
+{% macro wrap_docstring(string, wrapstring, width=95) -%}
+{{ wrap_string(string, wrapstring, width) | replace('"', '\\"') }}
+{%- endmacro %}
+
 {% macro description(builder, serializer) %}
 {% set example_template = serializer.example_template(builder) %}
 {% set param_description_and_response_docstring = serializer.param_description_and_response_docstring(builder) %}

--- a/packages/http-client-python/generator/pygen/codegen/templates/types.py.jinja2
+++ b/packages/http-client-python/generator/pygen/codegen/templates/types.py.jinja2
@@ -10,7 +10,7 @@
 
 {{ serializer.declare_literal_enum(enum) }}
 {% if enum.yaml_data.get("description") %}
-"""{{ op_tools.wrap_string(enum.yaml_data["description"], "\n") }}"""
+"""{{ op_tools.wrap_docstring(enum.yaml_data["description"], "\n") }}"""
 {% endif %}
 {% endfor %}
 {% for model in models %}

--- a/packages/http-client-python/tests/unit/test_enum_docstrings.py
+++ b/packages/http-client-python/tests/unit/test_enum_docstrings.py
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Enum documentation must remain string literals in generated Python."""
+
+import ast
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import black
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        "Ordinary documentation.",
+        'A"""; print("This should remain documentation"); """B.',
+        'Quotes: " and "" and """.',
+        'Ends with a quote"',
+        r'Quotes """ with a regex \W and a path C:\new\test.',
+        'First paragraph.\n\nSecond paragraph with """ quotes.',
+    ],
+)
+@pytest.mark.parametrize("location", ["enum", "member"])
+def test_enum_docstrings_preserve_documentation(description, location):
+    templates = Path(__file__).parents[2] / "generator/pygen/codegen/templates"
+    env = Environment(loader=FileSystemLoader(templates), trim_blocks=True, lstrip_blocks=True)
+    value = SimpleNamespace(
+        name="FAST",
+        value="fast",
+        description=lambda **kwargs: description if location == "member" else "",
+    )
+    enum = SimpleNamespace(
+        name="WidgetMode",
+        yaml_data={"description": description if location == "enum" else ""},
+        values=[value],
+        pylint_disable=lambda: "",
+        value_type=SimpleNamespace(type_annotation=lambda **kwargs: "str", get_declaration=repr),
+    )
+    source = env.from_string('{% import "operation_tools.jinja2" as op_tools %}{% include "enum.py.jinja2" %}').render(
+        enum=enum
+    )
+    # Formatting success alone does not prove that documentation stayed inside a string.
+    source = black.format_str(source, mode=black.Mode())
+    body = ast.parse(source).body[0].body
+    assert len(body) == 2
+    doc, assignment = body if location == "enum" else reversed(body)
+    assert isinstance(assignment, ast.Assign)
+    assert isinstance(doc, ast.Expr)
+    assert isinstance(doc.value, ast.Constant)
+    assert inspect.cleandoc(doc.value.value).strip() == description

--- a/packages/http-client-python/tests/unit/test_enum_docstrings.py
+++ b/packages/http-client-python/tests/unit/test_enum_docstrings.py
@@ -26,7 +26,7 @@ from jinja2 import Environment, FileSystemLoader
         'First paragraph.\n\nSecond paragraph with """ quotes.',
     ],
 )
-@pytest.mark.parametrize("location", ["enum", "member"])
+@pytest.mark.parametrize("location", ["enum", "member", "literal"])
 def test_enum_docstrings_preserve_documentation(description, location):
     templates = Path(__file__).parents[2] / "generator/pygen/codegen/templates"
     env = Environment(loader=FileSystemLoader(templates), trim_blocks=True, lstrip_blocks=True)
@@ -37,17 +37,28 @@ def test_enum_docstrings_preserve_documentation(description, location):
     )
     enum = SimpleNamespace(
         name="WidgetMode",
-        yaml_data={"description": description if location == "enum" else ""},
+        yaml_data={"description": description if location in ("enum", "literal") else ""},
         values=[value],
         pylint_disable=lambda: "",
         value_type=SimpleNamespace(type_annotation=lambda **kwargs: "str", get_declaration=repr),
     )
-    source = env.from_string('{% import "operation_tools.jinja2" as op_tools %}{% include "enum.py.jinja2" %}').render(
-        enum=enum
-    )
+    if location == "literal":
+        source = env.get_template("types.py.jinja2").render(
+            code_model=SimpleNamespace(license_header=""),
+            imports="",
+            literal_enums=[enum],
+            models=[],
+            discriminated_bases=[],
+            serializer=SimpleNamespace(declare_literal_enum=lambda enum: f'{enum.name} = Literal["fast"]'),
+        )
+    else:
+        source = env.from_string(
+            '{% import "operation_tools.jinja2" as op_tools %}{% include "enum.py.jinja2" %}'
+        ).render(enum=enum)
     # Formatting success alone does not prove that documentation stayed inside a string.
     source = black.format_str(source, mode=black.Mode())
-    body = ast.parse(source).body[0].body
+    module = ast.parse(source)
+    body = module.body if location == "literal" else module.body[0].body
     assert len(body) == 2
     doc, assignment = body if location == "enum" else reversed(body)
     assert isinstance(assignment, ast.Assign)


### PR DESCRIPTION
Enum and enum member documentation containing triple quotes can terminate its generated Python docstring. For syntactically valid input, the formatter accepts the following documentation as class-body statements; trailing single quotes can also make member docstrings invalid Python.

Add a reusable docstring-wrapping macro that escapes quotes after the existing prose wrapping and backslash escaping, and use it for enum classes, members, and `Literal[...]` enum descriptions in TypedDict output. This preserves ordinary documentation.

Fixes #11881. Related to #10784; this change specifically covers quotes at the enum rendering boundary.

Validation:
- 18 template regression cases pass. Nine original cases failed against the base templates; five added Literal-enum cases fail against the previous PR head. Cases cover ordinary prose, embedded delimiters, statement-shaped documentation, trailing quotes, backslashes, and multiple paragraphs. The tests inspect the formatted Python AST and documentation contents, rather than relying only on formatting success.
- Package build and wheel creation pass.
- All 23 emitter tests pass.
- Python generator Pylint, TypeScript Oxlint, test formatting, changeset formatting, and `git diff --check` pass. Linters were invoked directly to work around local optional-dependency and path-with-spaces problems in the wrapper.
- Full SDK regeneration passes for both flavors: 124 Azure specs / 133 generation tasks and 65 unbranded specs / 73 generation tasks. Regeneration leaves the working tree clean.
- Earlier broader unit run (not repeated for this review update): 528 passed, 3 failed. Running the same suite against the base generator gives 516 passed and the same 3 failures (the difference is the 12 added tests). Existing failures are `test_polymorphic_deserialization`, `test_enumeration_results_blobs_unwrapped`, and `test_models_mode_typeddict_does_not_write_empty_models_folder`. The local test run uses `--confcutdir=tests/unit` to avoid starting the unrelated mock API server.
- The full generated-SDK CI matrix was not run locally; upstream CI status is tracked on the PR.

