### PR TITLE
fix(http-server-csharp): avoid duplicate nullable suffixes

### DIFF
--- a/.chronus/changes/sramsey-csharp-duplicate-nullable-suffixes-2026-09-08.md
+++ b/.chronus/changes/sramsey-csharp-duplicate-nullable-suffixes-2026-09-08.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Prevent optional nullable value parameters from emitting duplicate nullable suffixes in generated C# interfaces and mocks.

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
@@ -8,7 +8,10 @@ import type { OperationHttpCanonicalization } from "@typespec/http-canonicalizat
 import { AspNetMvc } from "../../utils/csharp-libs.jsx";
 import { getHttpVerbAttribute, getRouteTemplate } from "../../utils/http-helpers.js";
 import type { RequestModelInfo } from "../request-models.jsx";
-import { TypeExpression } from "../type-expression/type-expression.jsx";
+import {
+  getNullableValueTypeUnionInnerType,
+  TypeExpression,
+} from "../type-expression/type-expression.jsx";
 import { getBindingAttribute, getLiteralDefaultValue } from "./parameter-binding.js";
 import { getSuccessStatusCode } from "./response-analysis.js";
 
@@ -49,12 +52,15 @@ export function ControllerAction(props: ControllerActionProps): Children {
     if (p.property.isContentTypeProperty) continue;
     const isOptional = p.property.sourceType.optional;
     const literalDefault = getLiteralDefaultValue(p.property.sourceType.type);
+    const nullableValueType = isOptional
+      ? getNullableValueTypeUnionInnerType($, p.property.sourceType.type)
+      : undefined;
     if (p.kind === "path") {
       const paramName = namePolicy.getName(p.property.sourceType.name, "parameter");
       const attr = getBindingAttribute(p, paramName);
       pathParams.push({
         name: paramName,
-        type: <TypeExpression type={p.property.sourceType.type} />,
+        type: <TypeExpression type={nullableValueType ?? p.property.sourceType.type} />,
         attributes: attr ? [attr] : undefined,
         optional: isOptional,
         default: literalDefault,
@@ -63,7 +69,7 @@ export function ControllerAction(props: ControllerActionProps): Children {
       const attr = getBindingAttribute(p);
       queryHeaderParams.push({
         name: namePolicy.getName(p.property.sourceType.name, "parameter"),
-        type: <TypeExpression type={p.property.sourceType.type} />,
+        type: <TypeExpression type={nullableValueType ?? p.property.sourceType.type} />,
         attributes: attr ? [attr] : undefined,
         optional: isOptional,
         default: literalDefault,

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
@@ -1,9 +1,10 @@
 import { Tester } from "#test/tester.js";
 import { type Children } from "@alloy-js/core";
-import { createCSharpNamePolicy, SourceFile } from "@alloy-js/csharp";
+import { createCSharpNamePolicy, EnumDeclaration, SourceFile } from "@alloy-js/csharp";
 import { t, type TesterInstance } from "@typespec/compiler/testing";
 import { Output } from "@typespec/emitter-framework";
 import { beforeEach, expect, it } from "vitest";
+import { efRefkey } from "../type-expression/type-expression.jsx";
 import { BusinessLogicInterface } from "./interfaces.jsx";
 
 let runner: TesterInstance;
@@ -58,6 +59,37 @@ it("renders an interface with void return type", async () => {
     public interface IPetStore
     {
         Task DeletePetAsync(string petId);
+    }
+  `);
+});
+
+it("renders one nullable suffix for optional nullable value parameters", async () => {
+  const { Choice, PetStore } = await runner.compile(t.code`
+    enum ${t.enum("Choice")} {
+      one,
+    }
+
+    interface ${t.interface("PetStore")} {
+      update(value?: int32 | null, choice?: Choice | null): void;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <EnumDeclaration name="Choice" refkey={efRefkey(Choice)}>
+        One
+      </EnumDeclaration>
+      <hbr />
+      <BusinessLogicInterface type={PetStore} />
+    </Wrapper>,
+  ).toRenderTo(`
+    enum Choice
+    {
+        One
+    }
+    public interface IPetStore
+    {
+        Task UpdateAsync(int? value, Choice? choice);
     }
   `);
 });

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.tsx
@@ -7,7 +7,10 @@ import { getDocComments } from "@typespec/emitter-framework/csharp";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { getUniqueItems } from "@typespec/json-schema";
 import { getSuccessReturnType } from "../../utils/return-type-helpers.js";
-import { TypeExpression } from "../type-expression/type-expression.jsx";
+import {
+  getNullableValueTypeUnionInnerType,
+  TypeExpression,
+} from "../type-expression/type-expression.jsx";
 
 const interfaceRefKeyPrefix = Symbol.for("http-server-csharp:interface");
 
@@ -129,6 +132,9 @@ function BusinessLogicMethod(props: BusinessLogicMethodProps): Children {
     .map(([pName, prop]) => {
       const isUnique = getUniqueItems($.program, prop);
       const isArrayType = prop.type.kind === "Model" && $.array.is(prop.type);
+      const nullableValueType = prop.optional
+        ? getNullableValueTypeUnionInnerType($, prop.type)
+        : undefined;
       let typeExpr: Children;
       if (isUnique && isArrayType && prop.type.kind === "Model" && prop.type.indexer?.value) {
         typeExpr = (
@@ -139,7 +145,7 @@ function BusinessLogicMethod(props: BusinessLogicMethodProps): Children {
           </>
         );
       } else {
-        typeExpr = <TypeExpression type={prop.type} />;
+        typeExpr = <TypeExpression type={nullableValueType ?? prop.type} />;
       }
       return {
         name: namePolicy.getName(pName, "parameter"),

--- a/packages/http-server-csharp/src/components/scaffolding/mock-implementations.tsx
+++ b/packages/http-server-csharp/src/components/scaffolding/mock-implementations.tsx
@@ -4,7 +4,10 @@ import type { Interface, Operation, Program } from "@typespec/compiler";
 import { useTsp } from "@typespec/emitter-framework";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { CSharpFile } from "../csharp-file.jsx";
-import { TypeExpression } from "../type-expression/type-expression.jsx";
+import {
+  getNullableValueTypeUnionInnerType,
+  TypeExpression,
+} from "../type-expression/type-expression.jsx";
 import {
   getGetBodyPropNames,
   getMockReturnStatement,
@@ -112,6 +115,7 @@ interface MockMethodsProps {
 
 function MockMethods(props: MockMethodsProps): Children {
   const namePolicy = cs.useCSharpNamePolicy();
+  const { $ } = useTsp();
   return (
     <For each={props.operations} doubleHardline>
       {([name, op]) => {
@@ -147,11 +151,16 @@ function MockMethods(props: MockMethodsProps): Children {
         const parameters = Array.from(op.parameters.properties.entries())
           .filter(([pName]) => !bodyPropNames.has(pName))
           .filter(([pName]) => !multipartBodyPropNames.has(pName))
-          .map(([pName, prop]) => ({
-            name: namePolicy.getName(pName, "parameter"),
-            type: <TypeExpression type={prop.type} />,
-            optional: prop.optional,
-          }))
+          .map(([pName, prop]) => {
+            const nullableValueType = prop.optional
+              ? getNullableValueTypeUnionInnerType($, prop.type)
+              : undefined;
+            return {
+              name: namePolicy.getName(pName, "parameter"),
+              type: <TypeExpression type={nullableValueType ?? prop.type} />,
+              optional: prop.optional,
+            };
+          })
           // Required parameters must come before optional ones in C#
           .sort((a, b) => (a.optional === b.optional ? 0 : a.optional ? 1 : -1));
 

--- a/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
+++ b/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
@@ -20,6 +20,12 @@ export interface TypeExpressionProps {
 // Re-export efRefkey for consumers that were using serverRefkey
 export { efRefkey } from "@typespec/emitter-framework/csharp";
 
+export function getNullableValueTypeUnionInnerType($: Typekit, type: Type): Type | undefined {
+  if (type.kind !== "Union" || isUnionEnum(type)) return undefined;
+  const innerType = getNullableUnionInnerType(type);
+  return innerType !== undefined && isValueType($, innerType) ? innerType : undefined;
+}
+
 /**
  * Wrapper around emitter-framework's TypeExpression that handles
  * additional type kinds the server emitter encounters.
@@ -199,10 +205,11 @@ function resolveUnionType($: Typekit, union: import("@typespec/compiler").Union)
       return code`object`;
     }
     // Nullable value type → T?
-    if (isValueType($, innerType)) {
+    const nullableValueType = getNullableValueTypeUnionInnerType($, union);
+    if (nullableValueType) {
       return (
         <>
-          <TypeExpression type={innerType} />?
+          <TypeExpression type={nullableValueType} />?
         </>
       );
     }

--- a/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
+++ b/packages/http-server-csharp/src/components/type-expression/type-expression.tsx
@@ -22,8 +22,19 @@ export { efRefkey } from "@typespec/emitter-framework/csharp";
 
 export function getNullableValueTypeUnionInnerType($: Typekit, type: Type): Type | undefined {
   if (type.kind !== "Union" || isUnionEnum(type)) return undefined;
-  const innerType = getNullableUnionInnerType(type);
-  return innerType !== undefined && isValueType($, innerType) ? innerType : undefined;
+  let current: Type = type;
+  const visited = new Set<Type>();
+
+  while (current.kind === "Union" && !isUnionEnum(current)) {
+    if (visited.has(current)) return undefined;
+    visited.add(current);
+
+    const innerType = getNullableUnionInnerType(current);
+    if (innerType === undefined) return undefined;
+    current = innerType;
+  }
+
+  return isValueType($, current) ? current : undefined;
 }
 
 /**

--- a/packages/http-server-csharp/test/nullable-parameters.test.ts
+++ b/packages/http-server-csharp/test/nullable-parameters.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, expect, it } from "vitest";
+import { ApiTester, compileAndDiagnose, getStandardService } from "./test-host.js";
+
+let tester: Awaited<ReturnType<typeof ApiTester.createInstance>>;
+
+beforeEach(async () => {
+  tester = await ApiTester.createInstance();
+});
+
+it("emits one nullable suffix for optional nullable value parameters", async () => {
+  const [result] = await compileAndDiagnose(
+    tester,
+    getStandardService(`
+      enum Choice {
+        one,
+      }
+
+      @route("/nullable")
+      interface NullableParameters {
+        @get test(
+          @query value?: int32 | null,
+          @query choice?: Choice | null,
+        ): void;
+      }
+    `),
+    {
+      "emit-mocks": "mocks-only",
+      "skip-format": true,
+    },
+  );
+
+  const interfaceContent = [...result.fs.fs.entries()].find(([path]) =>
+    path.endsWith("/INullableParameters.cs"),
+  )?.[1];
+  const mockContent = [...result.fs.fs.entries()].find(([path]) =>
+    path.endsWith("/NullableParameters.cs"),
+  )?.[1];
+
+  expect(interfaceContent).toContain("TestAsync(int? value, Choice? choice)");
+  expect(mockContent).toContain("TestAsync(int? value, Choice? choice)");
+  expect(interfaceContent).not.toMatch(/\w+\?\?\s+\w+/);
+  expect(mockContent).not.toMatch(/\w+\?\?\s+\w+/);
+});

--- a/packages/http-server-csharp/test/nullable-parameters.test.ts
+++ b/packages/http-server-csharp/test/nullable-parameters.test.ts
@@ -1,18 +1,16 @@
-import { beforeEach, expect, it } from "vitest";
-import { ApiTester, compileAndDiagnose, getStandardService } from "./test-host.js";
-
-let tester: Awaited<ReturnType<typeof ApiTester.createInstance>>;
-
-beforeEach(async () => {
-  tester = await ApiTester.createInstance();
-});
+import { expect, it } from "vitest";
+import { EmitterTester, getStandardService } from "./test-host.js";
 
 it("emits one nullable suffix for optional nullable value parameters", async () => {
-  const [result] = await compileAndDiagnose(
-    tester,
+  const { outputs } = await EmitterTester.compile(
     getStandardService(`
       enum Choice {
         one,
+      }
+
+      union MaybeInt {
+        int32,
+        null,
       }
 
       @route("/nullable")
@@ -20,24 +18,35 @@ it("emits one nullable suffix for optional nullable value parameters", async () 
         @get test(
           @query value?: int32 | null,
           @query choice?: Choice | null,
+          @query maybeInt?: MaybeInt | null,
         ): void;
       }
     `),
     {
-      "emit-mocks": "mocks-only",
-      "skip-format": true,
+      compilerOptions: {
+        options: {
+          "@typespec/http-server-csharp": {
+            "emit-mocks": "mocks-only",
+            "skip-format": true,
+          },
+        },
+      },
     },
   );
 
-  const interfaceContent = [...result.fs.fs.entries()].find(([path]) =>
-    path.endsWith("/INullableParameters.cs"),
-  )?.[1];
-  const mockContent = [...result.fs.fs.entries()].find(([path]) =>
-    path.endsWith("/NullableParameters.cs"),
-  )?.[1];
+  const interfaceContent = outputs["generated/operations/INullableParameters.cs"];
+  const mockContent = outputs["mocks/NullableParameters.cs"];
+  const controllerContent = outputs["generated/controllers/NullableParametersController.cs"];
 
-  expect(interfaceContent).toContain("TestAsync(int? value, Choice? choice)");
-  expect(mockContent).toContain("TestAsync(int? value, Choice? choice)");
+  expect(interfaceContent).toBeDefined();
+  expect(mockContent).toBeDefined();
+  expect(controllerContent).toBeDefined();
+  expect(interfaceContent).toContain("TestAsync(int? value, Choice? choice, int? maybeInt)");
+  expect(mockContent).toContain("TestAsync(int? value, Choice? choice, int? maybeInt)");
+  expect(controllerContent).toContain("int? value");
+  expect(controllerContent).toContain("Choice? choice");
+  expect(controllerContent).toContain("int? maybeInt");
   expect(interfaceContent).not.toMatch(/\w+\?\?\s+\w+/);
   expect(mockContent).not.toMatch(/\w+\?\?\s+\w+/);
+  expect(controllerContent).not.toMatch(/\w+\?\?\s+\w+/);
 });


### PR DESCRIPTION
This pull request fixes an issue where optional nullable value parameters in generated C# interfaces and mocks would emit duplicate nullable suffixes (e.g., `int??`). The changes ensure that only a single nullable suffix is emitted for such parameters. The update includes logic changes, new helper functions, and additional tests to verify correct behavior.

### Bug Fix: Prevent Duplicate Nullable Suffixes

* Updated parameter handling in both interface and mock generation to ensure that optional nullable value parameters (e.g., `int32 | null`) are rendered with only one nullable suffix (`int?`), preventing cases like `int??`. [[1]](diffhunk://#diff-f115dd4cc1dbe823b6149966565c063e57b04cb5a6661af78da191c7d9a23648R135-R137) [[2]](diffhunk://#diff-f115dd4cc1dbe823b6149966565c063e57b04cb5a6661af78da191c7d9a23648L142-R148) [[3]](diffhunk://#diff-27873651d9402e09bcfc3faa6154c7f67920ac3f69b1b4f6112ca9ecd0b12118L150-R163) [[4]](diffhunk://#diff-7a5489d2ed98ded11dbe223c364b90c6cea866bba7db4895bf1f0b3b7017b54cL202-R212) [[5]](diffhunk://#diff-49b8d6acbf487c51d957f229923bb1b9e5278e87c22d5218f588eeb00568b1c6R1-R7)

### Helper Function

* Added `getNullableValueTypeUnionInnerType` to detect and extract the correct inner type for nullable value types in unions, used to avoid double nullable suffixes. [[1]](diffhunk://#diff-7a5489d2ed98ded11dbe223c364b90c6cea866bba7db4895bf1f0b3b7017b54cR23-R28) [[2]](diffhunk://#diff-f115dd4cc1dbe823b6149966565c063e57b04cb5a6661af78da191c7d9a23648L10-R13) [[3]](diffhunk://#diff-27873651d9402e09bcfc3faa6154c7f67920ac3f69b1b4f6112ca9ecd0b12118L7-R10)

### Testing

* Added and updated tests to verify that only one nullable suffix is emitted for optional nullable value parameters in both interfaces and mocks. This includes new test cases in both the component and end-to-end test suites. [[1]](diffhunk://#diff-71c8911ffb0b0015dfeb92d93827c78a6c695a87c7fbed4c0e2c4d5a29bb88ecR65-R95) [[2]](diffhunk://#diff-15ef318960d09fa30b9ecb368602930bdb6521761b0161d9d2691f6e17333d0aR1-R43)

These changes ensure that the generated C# code is correct and idiomatic when handling optional nullable value parameters.