### PR TITLE
fix(http-server-csharp): align error constructor types

### DIFF
--- a/.chronus/changes/fix-csharp-error-constructor-types-2026-9-8.md
+++ b/.chronus/changes/fix-csharp-error-constructor-types-2026-9-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Use generated property types for error model constructor parameters, including records, arrays, tuples, and nullable unions.

--- a/packages/http-server-csharp/src/components/models/error-models.test.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.test.tsx
@@ -1,0 +1,126 @@
+import { Tester } from "#test/tester.js";
+import { render, type Children } from "@alloy-js/core";
+import * as cs from "@alloy-js/csharp";
+import { t, type TesterInstance } from "@typespec/compiler/testing";
+import { Output } from "@typespec/emitter-framework";
+import { beforeEach, expect, it } from "vitest";
+import { EmitterOptions } from "../../context/emitter-options-context.js";
+import { efRefkey } from "../type-expression/type-expression.jsx";
+import { getErrorConstructor } from "./error-models.jsx";
+import { Models } from "./models.jsx";
+
+let runner: TesterInstance;
+
+beforeEach(async () => {
+  runner = await Tester.createInstance();
+});
+
+function Wrapper(props: { children: Children }) {
+  return (
+    <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+      <EmitterOptions.Provider value={{ collectionType: "array", serviceNamespace: "Test" }}>
+        <cs.SourceFile path="test.cs">{props.children}</cs.SourceFile>
+      </EmitterOptions.Provider>
+    </Output>
+  );
+}
+
+function findFileContent(output: any, pathSuffix: string): string | undefined {
+  function search(dir: any): string | undefined {
+    for (const item of dir.contents) {
+      if (
+        "contents" in item &&
+        typeof item.contents === "string" &&
+        (item.path === pathSuffix || item.path.endsWith("/" + pathSuffix))
+      ) {
+        return item.contents;
+      }
+      if ("contents" in item && Array.isArray(item.contents)) {
+        const found = search(item);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  }
+  return search(output);
+}
+
+it("uses generated property types for structured error constructor parameters", async () => {
+  const { ApiError } = await runner.compile(t.code`
+    @error
+    model ${t.model("ApiError")} {
+      message: string;
+      param?: string;
+      details?: ApiError[];
+      additionalInfo?: Record<unknown>;
+      counts?: Record<int32>;
+      attempts?: int32;
+      tags?: [string, string];
+      retryAfter?: int32 | null;
+      nested?: Record<Record<unknown>>;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <cs.ClassDeclaration name="ApiError" refkey={efRefkey(ApiError)}>
+        {getErrorConstructor(runner.program, ApiError, "ApiError")}
+      </cs.ClassDeclaration>
+    </Wrapper>,
+  ).toRenderTo(`
+    class ApiError
+    {
+        public ApiError(
+            string message,
+            string param = default,
+            ApiError[] details = default,
+            JsonObject additionalInfo = default,
+            IDictionary<string, int> counts = default,
+            int attempts = default,
+            string[] tags = default,
+            int? retryAfter = default,
+            IDictionary<string, JsonObject> nested = default
+        ) : base(
+            400,
+            value: new { message = message, param = param, details = details, additionalInfo = additionalInfo, counts = counts, attempts = attempts, tags = tags, retryAfter = retryAfter, nested = nested }
+        )
+        {
+            MessageProp = message;
+            Param = param;
+            Details = details;
+            AdditionalInfo = additionalInfo;
+            Counts = counts;
+            Attempts = attempts;
+            Tags = tags;
+            RetryAfter = retryAfter;
+            Nested = nested;
+        }
+    }
+  `);
+});
+
+it("adds the JsonObject using for inherited record error constructor parameters", async () => {
+  const { Base, ApiError } = await runner.compile(t.code`
+    model ${t.model("Base")} {
+      data?: Record<Record<unknown>>;
+    }
+
+    @error
+    model ${t.model("ApiError")} extends Base {
+      message: string;
+    }
+  `);
+
+  const output = render(
+    <Output program={runner.program} namePolicy={cs.createCSharpNamePolicy()}>
+      <EmitterOptions.Provider value={{ collectionType: "array", serviceNamespace: "Test" }}>
+        <Models models={[Base, ApiError]} serviceNamespace={undefined} />
+      </EmitterOptions.Provider>
+    </Output>,
+  );
+  const apiErrorFile = findFileContent(output, "ApiError.cs");
+
+  expect(apiErrorFile).toBeDefined();
+  expect(apiErrorFile).toContain("using System.Text.Json.Nodes;");
+  expect(apiErrorFile).toContain("IDictionary<string, JsonObject> data = default");
+});

--- a/packages/http-server-csharp/src/components/models/error-models.tsx
+++ b/packages/http-server-csharp/src/components/models/error-models.tsx
@@ -3,9 +3,9 @@ import type { ParameterProps } from "@alloy-js/csharp";
 import * as cs from "@alloy-js/csharp";
 import { isErrorModel, type Model, type Program } from "@typespec/compiler";
 import { getHeaderFieldName, isHeader, isStatusCode } from "@typespec/http";
+import { TypeExpression } from "../type-expression/type-expression.jsx";
 import {
   getAllProperties,
-  getCSharpTypeString,
   getDefaultValueString,
   getErrorStatusCode,
   getLiteralValue,
@@ -53,9 +53,13 @@ export function getErrorConstructor(program: Program, model: Model, className: s
       propName = propName === "Value" ? "ValueName" : `${propName}Prop`;
     }
 
-    const csharpType = getCSharpTypeString(program, prop.type);
+    const csharpType = <TypeExpression type={prop.type} />;
     const defaultStr = defaultValue ? defaultValue : prop.optional ? "default" : undefined;
-    parameters.push({ name: prop.name, type: csharpType, default: defaultStr });
+    parameters.push({
+      name: prop.name,
+      type: csharpType,
+      default: defaultStr,
+    });
     bodyParts.push(`${propName} = ${prop.name};`);
 
     if (isHeader(program, prop)) {

--- a/packages/http-server-csharp/src/components/models/model-helpers.ts
+++ b/packages/http-server-csharp/src/components/models/model-helpers.ts
@@ -182,14 +182,54 @@ export function isValueType($: ReturnType<typeof useTsp>["$"], type: Type): bool
   return false;
 }
 
-/** Returns true if any property of the model uses Record<T> (mapped to JsonObject). */
-export function modelNeedsJsonNodes($: ReturnType<typeof useTsp>["$"], model: Model): boolean {
-  for (const prop of model.properties.values()) {
-    if (prop.type.kind === "Model" && $.record.is(prop.type)) {
-      // Only need JsonNodes for Record<unknown> (maps to JsonObject)
-      const valueType = prop.type.indexer?.value;
-      if (valueType?.kind === "Intrinsic" && valueType.name === "unknown") return true;
+/** Returns true if a model property renders a JsonObject type. */
+export function modelNeedsJsonNodes(
+  $: ReturnType<typeof useTsp>["$"],
+  model: Model,
+  includeInherited = false,
+): boolean {
+  let current: Model | undefined = model;
+  while (current) {
+    for (const prop of current.properties.values()) {
+      if (typeNeedsJsonNodes($, prop.type, new Set())) return true;
     }
+    current = includeInherited ? current.baseModel : undefined;
+  }
+  return false;
+}
+
+function typeNeedsJsonNodes(
+  $: ReturnType<typeof useTsp>["$"],
+  type: Type,
+  visited: Set<Type>,
+): boolean {
+  if (visited.has(type)) return false;
+  visited.add(type);
+
+  if (type.kind === "Model") {
+    if ($.record.is(type)) {
+      const valueType = type.indexer?.value;
+      return (
+        (valueType?.kind === "Intrinsic" && valueType.name === "unknown") ||
+        (valueType !== undefined && typeNeedsJsonNodes($, valueType, visited))
+      );
+    }
+    if ($.array.is(type) && type.indexer?.value) {
+      return typeNeedsJsonNodes($, type.indexer.value, visited);
+    }
+    return false;
+  }
+
+  if (type.kind === "Tuple") {
+    return type.values.some((value) => typeNeedsJsonNodes($, value, visited));
+  }
+  if (type.kind === "Union") {
+    return Array.from(type.variants.values()).some((variant) =>
+      typeNeedsJsonNodes($, variant.type, visited),
+    );
+  }
+  if (type.kind === "UnionVariant" || type.kind === "ModelProperty") {
+    return typeNeedsJsonNodes($, type.type, visited);
   }
   return false;
 }
@@ -244,43 +284,6 @@ export function getErrorStatusCode(
   // Fall back to @minValue decorator
   const minVal = getMinValue(program, statusCodeProp);
   return { value: minVal ?? "default" };
-}
-
-/** Gets a simple C# type name string for a TypeSpec type. */
-export function getCSharpTypeString(program: Program, type: Type): string {
-  if (type.kind === "Scalar") {
-    const scalarMap: Record<string, string> = {
-      string: "string",
-      int8: "sbyte",
-      int16: "short",
-      int32: "int",
-      int64: "long",
-      uint8: "byte",
-      uint16: "ushort",
-      uint32: "uint",
-      uint64: "ulong",
-      float32: "float",
-      float64: "double",
-      boolean: "bool",
-      plainDate: "DateOnly",
-      plainTime: "TimeOnly",
-      utcDateTime: "DateTimeOffset",
-      offsetDateTime: "DateTimeOffset",
-      duration: "TimeSpan",
-      bytes: "byte[]",
-      decimal: "decimal",
-      decimal128: "decimal",
-      url: "Uri",
-      safeint: "long",
-    };
-    return scalarMap[type.name] ?? type.name;
-  }
-  if (type.kind === "String") return "string";
-  if (type.kind === "Boolean") return "bool";
-  if (type.kind === "Number") return Number.isInteger(type.value) ? "int" : "double";
-  if (type.kind === "Enum") return type.name;
-  if (type.kind === "Model") return type.name;
-  return "object";
 }
 
 /** Gets the name to use when emitting a model — handles friendly names, template instantiations, and anonymous models. */

--- a/packages/http-server-csharp/src/components/models/models.tsx
+++ b/packages/http-server-csharp/src/components/models/models.tsx
@@ -61,7 +61,10 @@ export function Models(props: ModelsProps): Children {
   return (
     <For each={props.models}>
       {(model) => {
-        const needsJsonNodes = modelNeedsJsonNodes($, model);
+        const isRootError =
+          isErrorModel($.program, model) &&
+          !(model.baseModel && isErrorModel($.program, model.baseModel));
+        const needsJsonNodes = modelNeedsJsonNodes($, model, isRootError);
         const usings = needsJsonNodes ? [...modelUsings, "System.Text.Json.Nodes"] : modelUsings;
         const modelName = getModelEmitName($.program, model);
         const modelFileName = cs.useCSharpNamePolicy().getName(modelName, "class");


### PR DESCRIPTION
This pull request addresses the way error model constructors are generated in the C# server emitter, ensuring that the constructor parameters use the correct generated property types for all supported shapes (records, arrays, tuples, and nullable unions). It also improves detection of when error models require `JsonObject`/`JsonNodes` imports and removes legacy type string generation logic. Comprehensive tests are added to verify the new behavior.

### Error model constructor improvements
* Error model constructors now use generated property types for parameters, including support for records, arrays, tuples, and nullable unions, ensuring accurate C# type mapping. [[1]](diffhunk://#diff-bcac04721cb7ba90710d1027289e093adfedadab7c0ed265fa2f959dc8394bfcR1-R7) [[2]](diffhunk://#diff-dac8f0c282d912ab5248f64cf362aa00456e6c87ad74fe612641500a8f558d07L56-R62)

### Improved detection for `JsonObject` usage
* Enhanced the `modelNeedsJsonNodes` function to recursively detect when a model or any of its inherited properties require `JsonObject` (for nested or inherited record types), and updated its usage to include inherited properties for root error models. [[1]](diffhunk://#diff-e43f08c5575ed5c0b8dcf576881b64b23c41ee46261bd3f89459a1100a59a5dcL185-R232) [[2]](diffhunk://#diff-697a74d2b4bd5bed68928ad1480502fab75d248c6955e8a07571dd16ed3f9cddL64-R67)

### Code cleanup and refactoring
* Removed the legacy `getCSharpTypeString` function in favor of using the `TypeExpression` component for type rendering, simplifying type handling logic. [[1]](diffhunk://#diff-dac8f0c282d912ab5248f64cf362aa00456e6c87ad74fe612641500a8f558d07R6-L8) [[2]](diffhunk://#diff-e43f08c5575ed5c0b8dcf576881b64b23c41ee46261bd3f89459a1100a59a5dcL249-L285)

### Testing
* Added comprehensive tests to verify that error model constructors are generated with the correct parameter types and that necessary `using` statements for `JsonObject` are included when required by inherited properties.