### PR TITLE
fix(http-server-csharp): handle void success responses

### DIFF
--- a/.chronus/changes/csharp-void-success-2026-09-08.md
+++ b/.chronus/changes/csharp-void-success-2026-09-08.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Handle `void | @error` responses as bodyless success responses in generated C# controllers.

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
@@ -96,3 +96,77 @@ it("renders a DELETE action with path param", async () => {
     }
   `);
 });
+
+it("does not assign a result for void success unions with error responses", async () => {
+  const { deletePet } = await runner.compile(t.code`
+    @error
+    model ErrorResponse {
+      code: string;
+    }
+
+    op ServiceOperation<Response>(): Response | ErrorResponse;
+
+    interface PetStore {
+      @route("/pets") @delete ${t.op("deletePet")} is ServiceOperation<void>;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(deletePet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpDelete]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
+        public virtual async Task<IActionResult> DeletePet()
+        {
+            await PetStoreImpl.DeletePetAsync();
+            return NoContent();
+        }
+    }
+  `);
+});
+
+it("preserves result handling for value success unions with error responses", async () => {
+  const { getPet } = await runner.compile(t.code`
+    @error
+    model ErrorResponse {
+      code: string;
+    }
+
+    op ServiceOperation<Response>(): Response | ErrorResponse;
+
+    interface PetStore {
+      @route("/pets") @get ${t.op("getPet")} is ServiceOperation<string>;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(getPet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpGet]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string))]
+        public virtual async Task<IActionResult> GetPet()
+        {
+            var result = await PetStoreImpl.GetPetAsync();
+            return Ok(result);
+        }
+    }
+  `);
+});

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.test.tsx
@@ -144,7 +144,127 @@ it("preserves result handling for value success unions with error responses", as
     op ServiceOperation<Response>(): Response | ErrorResponse;
 
     interface PetStore {
-      @route("/pets") @get ${t.op("getPet")} is ServiceOperation<string>;
+      @route("/pets") @get ${t.op("getPet")} is ServiceOperation<string | void>;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(getPet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpGet]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string))]
+        public virtual async Task<IActionResult> GetPet()
+        {
+            var result = await PetStoreImpl.GetPetAsync();
+            return Ok(result);
+        }
+    }
+  `);
+});
+
+it("does not treat a named union of error responses as a value success", async () => {
+  const { deletePet } = await runner.compile(t.code`
+    @error
+    model NotFound {
+      code: string;
+    }
+
+    @error
+    model Conflict {
+      code: string;
+    }
+
+    union ApiError {
+      NotFound,
+      Conflict,
+    }
+
+    interface PetStore {
+      @route("/pets") @delete ${t.op("deletePet")}(): void | ApiError;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(deletePet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpDelete]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
+        public virtual async Task<IActionResult> DeletePet()
+        {
+            await PetStoreImpl.DeletePetAsync();
+            return NoContent();
+        }
+    }
+  `);
+});
+
+it("preserves explicit success status codes after scalar variants", async () => {
+  const { createPet } = await runner.compile(t.code`
+    model CreatedPet {
+      @statusCode statusCode: 201;
+      id: string;
+    }
+
+    interface PetStore {
+      @route("/pets") @post ${t.op("createPet")}(): string | CreatedPet;
+    }
+  `);
+
+  const canonOp = canonicalizeOp(createPet);
+
+  expect(
+    <Wrapper>
+      <ControllerAction operation={canonOp} implFieldName="PetStoreImpl" />
+    </Wrapper>,
+  ).toRenderTo(`
+    using Microsoft.AspNetCore.Mvc;
+
+    class TestController
+    {
+        [HttpPost]
+        [Route("/pets")]
+        [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(string))]
+        public virtual async Task<IActionResult> CreatePet()
+        {
+            var result = await PetStoreImpl.CreatePetAsync();
+            return StatusCode(201, result);
+        }
+    }
+  `);
+});
+
+it("uses a nested union success type in response metadata", async () => {
+  const { getPet } = await runner.compile(t.code`
+    @error
+    model NotFound {
+      code: string;
+    }
+
+    union PetResult {
+      string,
+      NotFound,
+    }
+
+    interface PetStore {
+      @route("/pets") @get ${t.op("getPet")}(): void | PetResult;
     }
   `);
 

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
@@ -1,12 +1,12 @@
 import { code, type Children } from "@alloy-js/core";
 import * as cs from "@alloy-js/csharp";
 import { Attribute } from "@alloy-js/csharp";
-import { isErrorModel, isVoidType } from "@typespec/compiler";
 import { useTsp } from "@typespec/emitter-framework";
 import { getDocComments } from "@typespec/emitter-framework/csharp";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 import { AspNetMvc } from "../../utils/csharp-libs.jsx";
 import { getHttpVerbAttribute, getRouteTemplate } from "../../utils/http-helpers.js";
+import { getSuccessReturnType } from "../../utils/return-type-helpers.js";
 import type { RequestModelInfo } from "../request-models.jsx";
 import { TypeExpression } from "../type-expression/type-expression.jsx";
 import { getBindingAttribute, getLiteralDefaultValue } from "./parameter-binding.js";
@@ -149,26 +149,8 @@ export function ControllerAction(props: ControllerActionProps): Children {
   // Determine response type for ProducesResponseType attribute
   const returnType = props.operation.sourceType.returnType;
   const responseStatusCode = hasBody ? "OK" : "NoContent";
-  let responseTypeExpr: Children | undefined = undefined;
-
-  if (hasBody) {
-    if (returnType.kind === "Union") {
-      for (const variant of returnType.variants.values()) {
-        const vt = variant.type;
-        if (isVoidType(vt)) continue;
-        if (vt.kind === "Model") {
-          try {
-            if (isErrorModel($.program, vt)) continue;
-          } catch {}
-          if (vt.name?.toLowerCase() === "error") continue;
-        }
-        responseTypeExpr = <TypeExpression type={vt} />;
-        break;
-      }
-    } else if (!isVoidType(returnType)) {
-      responseTypeExpr = <TypeExpression type={returnType} />;
-    }
-  }
+  const successType = hasBody ? getSuccessReturnType($.program, returnType) : undefined;
+  const responseTypeExpr = successType ? <TypeExpression type={successType} /> : undefined;
 
   const attributes: Children[] = [
     <Attribute name={verb} />,

--- a/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
+++ b/packages/http-server-csharp/src/components/controller-action/controller-action.tsx
@@ -144,7 +144,7 @@ export function ControllerAction(props: ControllerActionProps): Children {
   }
 
   // Determine the success status code from the response
-  const { statusCode, hasBody } = getSuccessStatusCode(props.operation);
+  const { statusCode, hasBody } = getSuccessStatusCode($.program, props.operation);
 
   // Determine response type for ProducesResponseType attribute
   const returnType = props.operation.sourceType.returnType;

--- a/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
+++ b/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
@@ -1,11 +1,14 @@
-import { isVoidType } from "@typespec/compiler";
+import { isErrorModel, isVoidType, type Program } from "@typespec/compiler";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 
 /**
  * Determines the success HTTP status code and whether the response has a body.
  * Checks the original return type for @statusCode properties.
  */
-export function getSuccessStatusCode(operation: OperationHttpCanonicalization): {
+export function getSuccessStatusCode(
+  program: Program,
+  operation: OperationHttpCanonicalization,
+): {
   statusCode: number | undefined;
   hasBody: boolean;
 } {
@@ -18,15 +21,24 @@ export function getSuccessStatusCode(operation: OperationHttpCanonicalization): 
 
   // Check union responses - find the first non-error success response
   if (returnType.kind === "Union") {
+    let hasVoidSuccess = false;
     for (const variant of returnType.variants.values()) {
       const vt = variant.type;
-      if (isVoidType(vt)) continue;
+      if (isVoidType(vt)) {
+        hasVoidSuccess = true;
+        continue;
+      }
       if (vt.kind === "Model") {
+        if (isErrorModel(program, vt)) continue;
         // Skip models with @error decorator or error-range status codes
         const result = analyzeResponseModel(vt);
         if (result.statusCode !== undefined && result.statusCode >= 400) continue;
         return result;
       }
+      return { statusCode: 200, hasBody: true };
+    }
+    if (hasVoidSuccess) {
+      return { statusCode: 204, hasBody: false };
     }
   }
 

--- a/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
+++ b/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
@@ -1,4 +1,4 @@
-import { isErrorModel, isVoidType, type Program } from "@typespec/compiler";
+import { isErrorModel, isVoidType, type Program, type Type } from "@typespec/compiler";
 import type { OperationHttpCanonicalization } from "@typespec/http-canonicalization";
 
 /**
@@ -22,20 +22,46 @@ export function getSuccessStatusCode(
   // Check union responses - find the first non-error success response
   if (returnType.kind === "Union") {
     let hasVoidSuccess = false;
-    for (const variant of returnType.variants.values()) {
-      const vt = variant.type;
-      if (isVoidType(vt)) {
+    let hasValueSuccess = false;
+    const visitedUnions = new Set<Type>();
+
+    function analyzeVariant(
+      type: Type,
+    ): { statusCode: number | undefined; hasBody: boolean } | undefined {
+      if (isVoidType(type)) {
         hasVoidSuccess = true;
-        continue;
+        return undefined;
       }
-      if (vt.kind === "Model") {
+
+      if (type.kind === "Union") {
+        if (visitedUnions.has(type)) return undefined;
+        visitedUnions.add(type);
+
+        for (const variant of type.variants.values()) {
+          const result = analyzeVariant(variant.type);
+          if (result !== undefined) return result;
+        }
+        return undefined;
+      }
+
+      if (type.kind === "Model") {
         // Skip models with @error decorator or error-range status codes
-        if (isErrorModel(program, vt)) continue;
-        const result = analyzeResponseModel(vt);
-        if (result.statusCode !== undefined && result.statusCode >= 400) continue;
+        if (isErrorModel(program, type)) return undefined;
+        const result = analyzeResponseModel(type);
+        if (result.statusCode !== undefined && result.statusCode >= 400) return undefined;
         return result;
       }
-      continue;
+
+      hasValueSuccess = true;
+      return undefined;
+    }
+
+    const result = analyzeVariant(returnType);
+    if (result !== undefined) {
+      return result;
+    }
+    if (hasValueSuccess) {
+      return { statusCode: 200, hasBody: true };
     }
     if (hasVoidSuccess) {
       return { statusCode: 204, hasBody: false };

--- a/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
+++ b/packages/http-server-csharp/src/components/controller-action/response-analysis.ts
@@ -29,13 +29,13 @@ export function getSuccessStatusCode(
         continue;
       }
       if (vt.kind === "Model") {
-        if (isErrorModel(program, vt)) continue;
         // Skip models with @error decorator or error-range status codes
+        if (isErrorModel(program, vt)) continue;
         const result = analyzeResponseModel(vt);
         if (result.statusCode !== undefined && result.statusCode >= 400) continue;
         return result;
       }
-      return { statusCode: 200, hasBody: true };
+      continue;
     }
     if (hasVoidSuccess) {
       return { statusCode: 204, hasBody: false };

--- a/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
+++ b/packages/http-server-csharp/src/components/interfaces/interfaces.test.tsx
@@ -61,3 +61,56 @@ it("renders an interface with void return type", async () => {
     }
   `);
 });
+
+it("renders a non-generic task for void success with a named error union", async () => {
+  const { PetStore } = await runner.compile(t.code`
+    @error
+    model NotFound {
+      code: string;
+    }
+
+    @error
+    model Conflict {
+      code: string;
+    }
+
+    union ApiError {
+      NotFound,
+      Conflict,
+    }
+
+    interface ${t.interface("PetStore")} {
+      deletePet(): void | ApiError;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <BusinessLogicInterface type={PetStore} />
+    </Wrapper>,
+  ).toRenderTo(`
+    public interface IPetStore
+    {
+        Task DeletePetAsync();
+    }
+  `);
+});
+
+it("renders a generic task for scalar success with void", async () => {
+  const { PetStore } = await runner.compile(t.code`
+    interface ${t.interface("PetStore")} {
+      getPet(): string | void;
+    }
+  `);
+
+  expect(
+    <Wrapper>
+      <BusinessLogicInterface type={PetStore} />
+    </Wrapper>,
+  ).toRenderTo(`
+    public interface IPetStore
+    {
+        Task<string> GetPetAsync();
+    }
+  `);
+});

--- a/packages/http-server-csharp/src/utils/return-type-helpers.ts
+++ b/packages/http-server-csharp/src/utils/return-type-helpers.ts
@@ -7,37 +7,42 @@ import { isErrorModel, isVoidType } from "@typespec/compiler";
  * If the return type is void, returns undefined.
  */
 export function getSuccessReturnType(program: Program, returnType: Type): Type | undefined {
-  if (isVoidType(returnType)) return undefined;
+  const visitedUnions = new Set<Type>();
 
-  if (returnType.kind === "Union") {
-    for (const variant of returnType.variants.values()) {
-      const variantType = variant.type;
-      if (isVoidType(variantType)) continue;
-      // Skip error models by checking the @error decorator or name convention
-      if (variantType.kind === "Model") {
-        try {
-          if (isErrorModel(program, variantType)) continue;
-        } catch {
-          // isErrorModel may fail on certain types
-        }
-        if (variantType.name && variantType.name.toLowerCase() === "error") {
-          continue;
-        }
-        // Skip response-only models (only @statusCode, no body props)
-        if (isStatusCodeOnlyModel(variantType)) continue;
+  function findSuccessType(type: Type): Type | undefined {
+    if (isVoidType(type)) return undefined;
+
+    if (type.kind === "Union") {
+      if (visitedUnions.has(type)) return undefined;
+      visitedUnions.add(type);
+
+      for (const variant of type.variants.values()) {
+        const successType = findSuccessType(variant.type);
+        if (successType !== undefined) return successType;
       }
-      return variantType;
+      return undefined;
     }
-    // All variants are errors or void
-    return undefined;
+
+    // Skip error models by checking the @error decorator or name convention
+    if (type.kind === "Model") {
+      try {
+        if (isErrorModel(program, type)) return undefined;
+      } catch {
+        // isErrorModel may fail on certain types
+      }
+      if (type.name && type.name.toLowerCase() === "error") {
+        return undefined;
+      }
+      // Skip response-only models (only @statusCode, no body props)
+      if (isStatusCodeOnlyModel(type)) {
+        return undefined;
+      }
+    }
+
+    return type;
   }
 
-  // Check if it's a status-code-only model (e.g., OkResponse, NoContentResponse)
-  if (returnType.kind === "Model" && isStatusCodeOnlyModel(returnType)) {
-    return undefined;
-  }
-
-  return returnType;
+  return findSuccessType(returnType);
 }
 
 /** Returns true if the model only has statusCode-related properties (no body). Walks inherited properties too. */

--- a/packages/http-server-csharp/test/snapshots/sample-service/generated/controllers/PetsController.cs
+++ b/packages/http-server-csharp/test/snapshots/sample-service/generated/controllers/PetsController.cs
@@ -87,10 +87,10 @@ public partial class PetsController : ControllerBase
     /// </summary>
     [HttpDelete]
     [Route("/pets/{id}")]
-    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(void))]
+    [ProducesResponseType((int)HttpStatusCode.NoContent, Type = typeof(void))]
     public virtual async Task<IActionResult> Delete(long id)
     {
-        var result = await PetsImpl.DeleteAsync(id);
-        return Ok(result);
+        await PetsImpl.DeleteAsync(id);
+        return NoContent();
     }
 }


### PR DESCRIPTION
This pull request improves the handling of union return types that include `void` and `@error` responses in generated C# controllers. The main fix ensures that when an operation can return either `void` (success) or an error, the generated controller method will correctly treat the success case as a bodyless response (HTTP 204 No Content), aligning with C# and HTTP conventions. Tests are added to verify this behavior, and the response analysis logic is updated accordingly.

**C# Controller Generation Fixes:**

* Ensured that operations returning `void | @error` are generated as bodyless success responses (HTTP 204 No Content) in C# controllers. (`.chronus/changes/csharp-void-success-2026-09-08.md`)
* Updated `getSuccessStatusCode` to detect unions with `void` and error types, returning the correct status code and body handling. (`response-analysis.ts`)

**Testing Improvements:**

* Added tests to verify that for `void | @error` unions, the controller does not assign a result variable and returns `NoContent()`, and for value unions, it preserves result handling and returns the value. (`controller-action.test.tsx`)

**Internal Refactoring:**

* Updated the `getSuccessStatusCode` function signature and its usage to accept the `program` parameter, supporting improved error model detection. (`controller-action.tsx`, `response-analysis.ts`) [[1]](diffhunk://#diff-71782a960a02ada6ba3195bc8fc52e0dc943c7e369fc4d538e7036f41b059fbfL147-R147) [[2]](diffhunk://#diff-a3da1d11f122b69c56aa492a57088cfda17f7c2610f1ddc458f435b15e66c260L1-R11)