### PR TITLE
fix(http-server-csharp): resolve declared service namespace

### DIFF
--- a/.chronus/changes/http-server-csharp-service-namespace-2026-09-08.md
+++ b/.chronus/changes/http-server-csharp-service-namespace-2026-09-08.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-server-csharp"
+---
+
+Use the namespace declared with `@service` as the generated C# service namespace, even when an imported or unrelated namespace is encountered first.

--- a/packages/http-server-csharp/src/service-discovery.ts
+++ b/packages/http-server-csharp/src/service-discovery.ts
@@ -1,5 +1,6 @@
 import type { Interface } from "@typespec/compiler";
 import {
+  getNamespaceFullName,
   isStdNamespace,
   isTemplateDeclaration,
   listServices,
@@ -8,7 +9,7 @@ import {
   type Namespace as TspNamespace,
 } from "@typespec/compiler";
 import type { useTsp } from "@typespec/emitter-framework";
-import { getCSharpNamespaceName } from "./utils/namespace-utils.js";
+import { findServiceNamespace, getCSharpNamespaceName } from "./utils/namespace-utils.js";
 
 /**
  * Collects the namespaces whose declarations are emitted even when nothing references them.
@@ -104,43 +105,25 @@ export function getServiceInterfaces(
 }
 
 /**
+ * Gets the namespace declared with `@service`.
+ *
+ * When no service is declared, falls back to the first non-standard namespace with content to
+ * preserve standalone model-emission behavior.
+ */
+export function getServiceNamespace(program: Program): TspNamespace | undefined {
+  const service = listServices(program)[0];
+  if (service) return service.type;
+
+  return findServiceNamespace(program.getGlobalNamespaceType());
+}
+
+/**
  * Gets the full service namespace name from the program (e.g., "Microsoft.Contoso").
  */
 export function getServiceNamespaceName(
   program: ReturnType<typeof useTsp>["$"]["program"],
 ): string | undefined {
-  const globalNs = program.getGlobalNamespaceType();
-
-  function getFullName(ns: TspNamespace): string {
-    const parts: string[] = [];
-    let current: TspNamespace | undefined = ns;
-    while (current && current !== globalNs) {
-      parts.unshift(current.name);
-      current = current.namespace;
-    }
-    return parts.join(".");
-  }
-
-  // Find the service namespace (deepest non-std namespace in the first branch)
-  function findServiceNs(ns: TspNamespace): TspNamespace | undefined {
-    for (const child of ns.namespaces.values()) {
-      if (isStdNamespace(child)) continue;
-      // If this namespace has content (models, interfaces, operations, enums), use it
-      // Otherwise, recurse deeper
-      const hasContent =
-        child.models.size > 0 ||
-        child.interfaces.size > 0 ||
-        child.operations.size > 0 ||
-        child.enums.size > 0;
-      if (hasContent) return child;
-      const deeper = findServiceNs(child);
-      if (deeper) return deeper;
-      return child;
-    }
-    return undefined;
-  }
-
-  const serviceNs = findServiceNs(globalNs);
+  const serviceNs = getServiceNamespace(program);
   if (!serviceNs) return undefined;
-  return getCSharpNamespaceName(getFullName(serviceNs));
+  return getCSharpNamespaceName(getNamespaceFullName(serviceNs));
 }

--- a/packages/http-server-csharp/src/service-resolution.test.ts
+++ b/packages/http-server-csharp/src/service-resolution.test.ts
@@ -34,6 +34,24 @@ it("excludes models declared outside the service namespace that are not referenc
   expect(resolution.models.map((m) => m.name).sort()).toEqual(["Used", "Widget"]);
 });
 
+it("uses the namespace declared with @service instead of an earlier non-standard namespace", async () => {
+  const resolution = await resolve(`
+    namespace Imported {
+      model ClientOptions {}
+    }
+
+    @service
+    namespace Azure.AI.Projects {
+      model Widget { id: string; }
+      op read(): Widget;
+    }
+  `);
+
+  expect(resolution.serviceNamespace?.name).toBe("Projects");
+  expect(resolution.serviceNamespaceName).toBe("Azure.Ai.Projects");
+  expect(resolution.models.map((m) => m.name)).toEqual(["Widget"]);
+});
+
 it("excludes enums and union enums declared outside the service namespace that are not referenced", async () => {
   const resolution = await resolve(`
     namespace Other {
@@ -139,6 +157,8 @@ it("emits every namespace when no service is declared", async () => {
     }
   `);
 
+  expect(resolution.serviceNamespace?.name).toBe("Other");
+  expect(resolution.serviceNamespaceName).toBe("Other");
   expect(resolution.models.map((m) => m.name).sort()).toEqual(["Standalone", "Widget"]);
 });
 

--- a/packages/http-server-csharp/src/service-resolution.ts
+++ b/packages/http-server-csharp/src/service-resolution.ts
@@ -24,13 +24,13 @@ import {
 import {
   getDeclarationNamespaces,
   getServiceInterfaces,
+  getServiceNamespace,
   getServiceNamespaceName,
 } from "./service-discovery.js";
-import { findServiceNamespace } from "./utils/namespace-utils.js";
 
 /** All resolved service types, computed once before rendering. */
 export interface ServiceTypeResolution {
-  /** The service namespace (first non-std namespace with content). */
+  /** The namespace declared with @service, or the standalone namespace fallback. */
   serviceNamespace: TspNamespace | undefined;
   /** The C#-normalized service namespace name. */
   serviceNamespaceName: string | undefined;
@@ -70,10 +70,8 @@ export function resolveServiceTypes(
 ): ServiceTypeResolution {
   resetAnonymousModels();
 
-  const globalNs = program.getGlobalNamespaceType();
-
   // Phase 1: Service namespace
-  const serviceNamespace = findServiceNamespace(globalNs);
+  const serviceNamespace = getServiceNamespace(program);
   const serviceNamespaceName = getServiceNamespaceName(program);
   const declarationNamespaces = getDeclarationNamespaces(program);
 

--- a/packages/http-server-csharp/test/generation.test.ts
+++ b/packages/http-server-csharp/test/generation.test.ts
@@ -1451,17 +1451,20 @@ it("Handles user-defined model templates", async () => {
     [
       [
         "IMyServiceOperations.cs",
-        ["interface IMyServiceOperations", "Task<ResponsePageToy> FooAsync();"],
+        ["interface IMyServiceOperations", "Task<MyService.ResponsePageToy> FooAsync();"],
       ],
       [
         "MyServiceOperationsController.cs",
         [
           "public partial class MyServiceOperationsController : ControllerBase",
-          "[ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(ResponsePageToy))]",
+          "[ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(MyService.ResponsePageToy))]",
           "public virtual async Task<IActionResult> Foo()",
         ],
       ],
-      ["ResponsePageToy.cs", ["public partial class ResponsePageToy"]],
+      [
+        "ResponsePageToy.cs",
+        ["namespace Contoso", "namespace MyService", "public partial class ResponsePageToy"],
+      ],
     ],
   );
 });


### PR DESCRIPTION
This pull request updates the logic for determining the generated C# service namespace in the `@typespec/http-server-csharp` package. Now, the namespace explicitly declared with `@service` is always used for the generated C# service namespace, even if an imported or unrelated namespace appears first. The changes also refactor and clarify related code, and add new tests to ensure correct behavior.

**Service namespace resolution improvements:**

* Added a new function `getServiceNamespace` in `service-discovery.ts` to reliably select the namespace declared with `@service`, falling back to the first non-standard namespace with content if no service is declared.
* Updated `getServiceNamespaceName` to use the new `getServiceNamespace` logic, ensuring the correct namespace is used for C# code generation.
* Refactored `resolveServiceTypes` in `service-resolution.ts` to use `getServiceNamespace` instead of the previous custom logic, and updated documentation/comments for clarity. [[1]](diffhunk://#diff-7c3e4ec9411f3726cdc2aa78493b8e3d0427a1538a7407ba24cf983cf7acf23cR27-R33) [[2]](diffhunk://#diff-7c3e4ec9411f3726cdc2aa78493b8e3d0427a1538a7407ba24cf983cf7acf23cL73-R74)

**Testing and documentation:**

* Added and updated tests in `service-resolution.test.ts` to verify that the namespace declared with `@service` is used, and to cover fallback behavior when no service is declared. [[1]](diffhunk://#diff-b5fd55c705543259aa2b7f74c07b617685a777ad2b706a6f577db90c3f70653eR37-R54) [[2]](diffhunk://#diff-b5fd55c705543259aa2b7f74c07b617685a777ad2b706a6f577db90c3f70653eR160-R161)
* Added a changelog entry describing the fix and its effect on generated C# service namespaces. (.chronus/changes/http-server-csharp-service-namespace-2026-09-08.md)