### PR TITLE
[http-specs] Use a unique SSE protocol model name

### DIFF
--- a/.chronus/changes/sse-unique-protocol-model-name.md
+++ b/.chronus/changes/sse-unique-protocol-model-name.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-specs"
+---
+
+Use a unique `ProtocolInfo` model name in the SSE protocol scenarios to avoid model-name collisions in generated clients.

--- a/packages/http-specs/specs/streaming/sse/main.tsp
+++ b/packages/http-specs/specs/streaming/sse/main.tsp
@@ -154,14 +154,14 @@ namespace Retrieve {
 
 @route("protocol")
 namespace Protocol {
-  model Info {
+  model ProtocolInfo {
     message: string;
   }
 
   @events
   union ProtocolEvents {
     @Events.contentType("application/json")
-    message: Info,
+    message: ProtocolInfo,
   }
 
   @route("data")


### PR DESCRIPTION
## Summary

Rename `Streaming.Sse.Protocol.Info` to `Streaming.Sse.Protocol.ProtocolInfo` in the shared SSE specification so it no longer collides with `Streaming.Sse.Unnamed.Info` in generated model files and model factory methods.

This is a language-neutral fix in the shared specification, not an emitter-specific workaround. `Unnamed.Info` retains its `desc` property, and `ProtocolInfo` retains its `message` property. Routes, event names, payloads, and mock behavior are unchanged.

The change contains only the model declaration and its `ProtocolEvents.message` type reference, plus a `fix` changelog entry for `@typespec/http-specs`. It does not include emitter code, dependency upgrades, or scenario-test changes and is independent of those PRs.