### PR TITLE
[python] fix release version metadata

### DIFF
--- a/packages/http-client-python/CHANGELOG.md
+++ b/packages/http-client-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @typespec/http-client-python
 
+## 0.38.0
+
+### Features
+
+- [#11919](https://github.com/microsoft/typespec/pull/11919) Update dependencies for TypeSpec 1.16.0.
+
 ## 0.37.1
 
 ### Bug Fixes

--- a/packages/http-client-python/CHANGELOG.md
+++ b/packages/http-client-python/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.37.2
 
-### Features
+### Bump dependencies
 
 - [#11919](https://github.com/microsoft/typespec/pull/11919) Update dependencies for TypeSpec 1.16.0.
 

--- a/packages/http-client-python/CHANGELOG.md
+++ b/packages/http-client-python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @typespec/http-client-python
 
-## 0.38.0
+## 0.37.2
 
 ### Features
 

--- a/packages/http-client-python/package-lock.json
+++ b/packages/http-client-python/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typespec/http-client-python",
-      "version": "0.37.1",
+      "version": "0.38.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/http-client-python/package-lock.json
+++ b/packages/http-client-python/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.38.0",
+  "version": "0.37.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typespec/http-client-python",
-      "version": "0.38.0",
+      "version": "0.37.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://typespec.io",

--- a/packages/http-client-python/package.json
+++ b/packages/http-client-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/http-client-python",
-  "version": "0.38.0",
+  "version": "0.37.2",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://typespec.io",


### PR DESCRIPTION
## Summary

- bump `@typespec/http-client-python` from 0.37.1 to 0.37.2
- synchronize the package lockfile version
- add the 0.37.2 changelog entry for the TypeSpec 1.16.0 dependency update from #11919

Follow-up to #11919.

## Validation

- verified the manifest and lockfile versions are consistently set to 0.37.2
- verified the changelog contains the 0.37.2 release heading
- `git diff --check`