### PR TITLE
Merge linter settings in extended TypeSpec configs

### DIFF
--- a/.chronus/changes/fix-11849-merge-linter-config-2026-8-10-11-8-49.md
+++ b/.chronus/changes/fix-11849-merge-linter-config-2026-8-10-11-8-49.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/compiler"
+---
+
+Merge linter settings from extended TypeSpec configuration files.

--- a/packages/compiler/src/config/config-loader.ts
+++ b/packages/compiler/src/config/config-loader.ts
@@ -138,6 +138,7 @@ export async function loadTypeSpecConfigFile(
     };
     if (parent.linter && config.linter) {
       merged.linter = { ...parent.linter, ...config.linter };
+      merged.linterSource = { ...parent.linterSource, ...config.linterSource };
     }
     return merged;
   }
@@ -239,6 +240,9 @@ async function loadConfigFile(
   const emit = data.emit;
   const options = data.options;
 
+  const linter = resolveLinterConfigFileRefs(data.linter, getDirectoryPath(filename));
+  const linterSource = getLinterConfigSource(linter, yamlScript);
+
   return omitUndefined({
     projectRoot: getDirectoryPath(filename),
     file: yamlScript,
@@ -256,8 +260,21 @@ async function loadConfigFile(
     trace: typeof data.trace === "string" ? [data.trace] : data.trace,
     emit,
     options,
-    linter: resolveLinterConfigFileRefs(data.linter, getDirectoryPath(filename)),
+    linter,
+    linterSource,
   });
+}
+
+function getLinterConfigSource(
+  linter: LinterConfig | undefined,
+  script: YamlScript,
+): Partial<Record<keyof LinterConfig, YamlScript>> | undefined {
+  if (!linter) return undefined;
+  const source: Partial<Record<keyof LinterConfig, YamlScript>> = {};
+  if (linter.extends !== undefined) source.extends = script;
+  if (linter.enable !== undefined) source.enable = script;
+  if (linter.disable !== undefined) source.disable = script;
+  return source;
 }
 
 /**

--- a/packages/compiler/src/config/config-loader.ts
+++ b/packages/compiler/src/config/config-loader.ts
@@ -132,10 +132,14 @@ export async function loadTypeSpecConfigFile(
       };
     }
 
-    return {
+    const merged = {
       ...parent,
       ...config,
     };
+    if (parent.linter && config.linter) {
+      merged.linter = { ...parent.linter, ...config.linter };
+    }
+    return merged;
   }
 
   return {

--- a/packages/compiler/src/config/config-loader.ts
+++ b/packages/compiler/src/config/config-loader.ts
@@ -241,7 +241,7 @@ async function loadConfigFile(
   const options = data.options;
 
   const linter = resolveLinterConfigFileRefs(data.linter, getDirectoryPath(filename));
-  const linterSource = getLinterConfigSource(linter, yamlScript);
+  const linterSource = getLinterConfigSource(linter, filename);
 
   return omitUndefined({
     projectRoot: getDirectoryPath(filename),
@@ -267,13 +267,13 @@ async function loadConfigFile(
 
 function getLinterConfigSource(
   linter: LinterConfig | undefined,
-  script: YamlScript,
-): Partial<Record<keyof LinterConfig, YamlScript>> | undefined {
+  filename: string,
+): Partial<Record<keyof LinterConfig, string>> | undefined {
   if (!linter) return undefined;
-  const source: Partial<Record<keyof LinterConfig, YamlScript>> = {};
-  if (linter.extends !== undefined) source.extends = script;
-  if (linter.enable !== undefined) source.enable = script;
-  if (linter.disable !== undefined) source.disable = script;
+  const source: Partial<Record<keyof LinterConfig, string>> = {};
+  if (linter.extends !== undefined) source.extends = filename;
+  if (linter.enable !== undefined) source.enable = filename;
+  if (linter.disable !== undefined) source.disable = filename;
   return source;
 }
 

--- a/packages/compiler/src/config/types.ts
+++ b/packages/compiler/src/config/types.ts
@@ -87,8 +87,8 @@ export interface TypeSpecConfig {
 
   linter?: LinterConfig;
 
-  /** @internal Source files for the nested linter fields after config inheritance is resolved. */
-  linterSource?: Partial<Record<keyof LinterConfig, YamlScript>>;
+  /** @internal Paths to the config files that supplied nested linter fields after inheritance. */
+  linterSource?: Partial<Record<keyof LinterConfig, string>>;
 }
 
 /**

--- a/packages/compiler/src/config/types.ts
+++ b/packages/compiler/src/config/types.ts
@@ -86,6 +86,9 @@ export interface TypeSpecConfig {
   options?: Record<string, EmitterOptions>;
 
   linter?: LinterConfig;
+
+  /** @internal Source files for the nested linter fields after config inheritance is resolved. */
+  linterSource?: Partial<Record<keyof LinterConfig, YamlScript>>;
 }
 
 /**

--- a/packages/compiler/src/core/cli/actions/info.ts
+++ b/packages/compiler/src/core/cli/actions/info.ts
@@ -33,13 +33,21 @@ export async function printInfoAction(
   console.log(`Module: ${fileURLToPath(import.meta.url)}`);
 
   const config = await loadTypeSpecConfigForPath(host, cwd, true, true);
-  const { diagnostics, filename, file, ...restOfConfig } = config;
+  const { filename, ...restOfConfig } = getPrintableConfig(config);
 
   console.log(`User Config: ${filename ?? "No config file found"}`);
   console.log("-----------");
   console.log(stringify(restOfConfig));
   console.log("-----------");
   return config.diagnostics;
+}
+
+/** @internal Strip parser/source metadata from the configuration shown by `tsp info`. */
+export function getPrintableConfig(
+  config: TypeSpecConfig,
+): Omit<TypeSpecConfig, "diagnostics" | "file" | "linterSource"> {
+  const { diagnostics: _diagnostics, file: _file, linterSource: _linterSource, ...rest } = config;
+  return rest;
 }
 
 export function formatCompilerFeatures(config?: TypeSpecConfig): string[] {

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -8,6 +8,7 @@ import type { ModuleResolutionResult, ResolvedModule } from "../module-resolver/
 import type { PackageJson } from "../types/package-json.js";
 import { findProjectRoot } from "../utils/io.js";
 import { deepEquals, isDefined, mapEquals, mutate } from "../utils/misc.js";
+import { parseYaml } from "../yaml/parser.js";
 import { createBinder } from "./binder.js";
 import type { Checker } from "./checker.js";
 import { createChecker } from "./checker.js";
@@ -24,6 +25,7 @@ import {
   createBuiltInLinterLibrary,
   createLinter,
   resolveLinterDefinition,
+  type RuleSetYamlSource,
 } from "./linter.js";
 import { createLogger } from "./logger/index.js";
 import { createTracer } from "./logger/tracer.js";
@@ -426,14 +428,25 @@ async function createProgram(
   );
   linter.registerLinterLibrary(builtInLinterLibraryName, createBuiltInLinterLibrary());
   if (options.linterRuleSet) {
+    let linterSource: RuleSetYamlSource | undefined;
+    const linterSourcePath = options.configFile?.linterSource?.extends;
+    if (linterSourcePath) {
+      try {
+        const [script] = parseYaml(await host.readFile(linterSourcePath));
+        linterSource = { script, path: ["linter"] };
+      } catch {
+        // The config was readable when it was loaded. If it disappeared between
+        // config resolution and compilation, fall back to the final config source.
+      }
+    }
+    linterSource ??= options.configFile?.file
+      ? { script: options.configFile.file, path: ["linter"] }
+      : undefined;
+
     program.reportDiagnostics(
       await linter.extendRuleSet(options.linterRuleSet, {
         baseDir: program.projectRoot,
-        source: options.configFile?.linterSource?.extends
-          ? { script: options.configFile.linterSource.extends, path: ["linter"] }
-          : options.configFile?.file
-            ? { script: options.configFile.file, path: ["linter"] }
-            : undefined,
+        source: linterSource,
       }),
     );
   }

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -429,9 +429,11 @@ async function createProgram(
     program.reportDiagnostics(
       await linter.extendRuleSet(options.linterRuleSet, {
         baseDir: program.projectRoot,
-        source: options.configFile?.file
-          ? { script: options.configFile.file, path: ["linter"] }
-          : undefined,
+        source: options.configFile?.linterSource?.extends
+          ? { script: options.configFile.linterSource.extends, path: ["linter"] }
+          : options.configFile?.file
+            ? { script: options.configFile.file, path: ["linter"] }
+            : undefined,
       }),
     );
   }

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -20,6 +20,7 @@ import { getEmittedFilesForProgram } from "./emitter-utils.js";
 import { resolveTypeSpecEntrypoint } from "./entrypoint-resolution.js";
 import { ExternalError } from "./external-error.js";
 import { getLibraryUrlsLoaded } from "./library.js";
+import { linterRuleSetFilePrefix } from "./linter-ruleset-file.js";
 import {
   builtInLinterLibraryName,
   createBuiltInLinterLibrary,
@@ -430,7 +431,10 @@ async function createProgram(
   if (options.linterRuleSet) {
     let linterSource: RuleSetYamlSource | undefined;
     const linterSourcePath = options.configFile?.linterSource?.extends;
-    if (linterSourcePath) {
+    const needsLinterSource =
+      options.linterRuleSet.extends?.some((ref) => ref.startsWith(linterRuleSetFilePrefix)) ??
+      false;
+    if (linterSourcePath && needsLinterSource) {
       try {
         const [script] = parseYaml(await host.readFile(linterSourcePath));
         linterSource = { script, path: ["linter"] };

--- a/packages/compiler/test/config/config.test.ts
+++ b/packages/compiler/test/config/config.test.ts
@@ -95,6 +95,15 @@ describe("file discovery", () => {
     });
   });
 
+  it("merges linter settings from an extended config", async () => {
+    const config = await loadTestConfig("extends-linter");
+    deepStrictEqual(config.linter, {
+      extends: ["test/all"],
+      enable: { "test/base-rule": true },
+      disable: { "test/child-rule": "Child exemption" },
+    });
+  });
+
   it("backcompat: loads tspconfig.yaml", async () => {
     const config = await loadTestConfig("backcompat/mixed");
     deepStrictEqual(config, {

--- a/packages/compiler/test/config/config.test.ts
+++ b/packages/compiler/test/config/config.test.ts
@@ -10,8 +10,8 @@ import { compile } from "../../src/core/program.js";
 import { createJSONSchemaValidator } from "../../src/core/schema-validator.js";
 import { createSourceFile } from "../../src/core/source-file.js";
 import { resolvePath } from "../../src/index.js";
-import { expectDiagnosticEmpty, expectDiagnostics } from "../../src/testing/index.js";
 import { createTestFileSystem } from "../../src/testing/fs.js";
+import { expectDiagnosticEmpty } from "../../src/testing/index.js";
 import { findTestPackageRoot, resolveVirtualPath } from "../../src/testing/test-utils.js";
 
 const scenarioRoot = resolvePath(
@@ -274,10 +274,13 @@ describe("file discovery", () => {
         true,
         false,
       );
-      strictEqual(config.linterSource?.extends?.file.path, resolveVirtualPath("base/tspconfig.yaml"));
-      strictEqual(config.linterSource?.disable?.file.path, resolveVirtualPath("project/tspconfig.yaml"));
+      strictEqual(config.linterSource?.extends, resolveVirtualPath("base/tspconfig.yaml"));
+      strictEqual(config.linterSource?.disable, resolveVirtualPath("project/tspconfig.yaml"));
 
-      const [options, optionDiagnostics] = resolveOptionsFromConfig(config, {
+      // The language server caches configs through a JSON round trip. Source paths
+      // must survive that cache so the compiler can reparse the declaring YAML.
+      const cachedConfig = JSON.parse(JSON.stringify(config)) as typeof config;
+      const [options, optionDiagnostics] = resolveOptionsFromConfig(cachedConfig, {
         cwd: resolveVirtualPath("project"),
       });
       expectDiagnosticEmpty(optionDiagnostics);

--- a/packages/compiler/test/config/config.test.ts
+++ b/packages/compiler/test/config/config.test.ts
@@ -299,6 +299,59 @@ describe("file discovery", () => {
       strictEqual(target.file?.path, resolveVirtualPath("base/tspconfig.yaml"));
       strictEqual(parentConfig.slice(target.pos, target.end), `"file:./missing.yaml"`);
     });
+    it("falls back when an inherited linter source becomes unreadable before compilation", async () => {
+      const fs = createTestFileSystem();
+      const parentPath = resolveVirtualPath("base/tspconfig.yaml");
+      fs.addTypeSpecFile(
+        "base/tspconfig.yaml",
+        `
+        linter:
+          extends:
+            - "file:./missing.yaml"
+        `,
+      );
+      fs.addTypeSpecFile(
+        "project/tspconfig.yaml",
+        `
+        extends: "../base/tspconfig.yaml"
+        linter:
+          disable: {}
+        `,
+      );
+      fs.addTypeSpecFile("project/main.tsp", "");
+      fs.addTypeSpecFile("node_modules/@typespec/compiler/lib/intrinsics.tsp", "");
+
+      const config = await loadTypeSpecConfigForPath(
+        fs.compilerHost,
+        resolveVirtualPath("project/tspconfig.yaml"),
+        true,
+        false,
+      );
+      const [options, optionDiagnostics] = resolveOptionsFromConfig(config, {
+        cwd: resolveVirtualPath("project"),
+      });
+      expectDiagnosticEmpty(optionDiagnostics);
+
+      const host = {
+        ...fs.compilerHost,
+        async readFile(path: string) {
+          if (path === parentPath) {
+            throw new Error("parent config became unreadable");
+          }
+          return fs.compilerHost.readFile(path);
+        },
+      };
+      const program = await compile(host, resolveVirtualPath("project/main.tsp"), {
+        ...options,
+        noEmit: true,
+        nostdlib: true,
+      });
+      expectDiagnostics(program.diagnostics, {
+        code: "file-not-found",
+        severity: "error",
+        message: `File ${resolveVirtualPath("base/missing.yaml")} not found.`,
+      });
+    });
   });
 });
 

--- a/packages/compiler/test/config/config.test.ts
+++ b/packages/compiler/test/config/config.test.ts
@@ -11,7 +11,7 @@ import { createJSONSchemaValidator } from "../../src/core/schema-validator.js";
 import { createSourceFile } from "../../src/core/source-file.js";
 import { resolvePath } from "../../src/index.js";
 import { createTestFileSystem } from "../../src/testing/fs.js";
-import { expectDiagnosticEmpty } from "../../src/testing/index.js";
+import { expectDiagnosticEmpty, expectDiagnostics } from "../../src/testing/index.js";
 import { findTestPackageRoot, resolveVirtualPath } from "../../src/testing/test-utils.js";
 
 const scenarioRoot = resolvePath(
@@ -267,6 +267,7 @@ describe("file discovery", () => {
         `,
       );
       fs.addTypeSpecFile("project/main.tsp", "");
+      fs.addTypeSpecFile("node_modules/@typespec/compiler/lib/intrinsics.tsp", "");
 
       const config = await loadTypeSpecConfigForPath(
         fs.compilerHost,
@@ -289,13 +290,13 @@ describe("file discovery", () => {
         noEmit: true,
         nostdlib: true,
       });
-      const diagnostic = program.diagnostics.find(
-        (x) =>
-          x.code === "file-not-found" &&
-          (x.target as any).file?.path === resolveVirtualPath("base/tspconfig.yaml"),
-      );
-      if (!diagnostic) throw new Error("Expected inherited ruleset diagnostic in parent config");
-      const target = diagnostic.target as any;
+      expectDiagnostics(program.diagnostics, {
+        code: "file-not-found",
+        severity: "error",
+        message: `File ${resolveVirtualPath("base/missing.yaml")} not found.`,
+      });
+      const target = program.diagnostics[0].target as any;
+      strictEqual(target.file?.path, resolveVirtualPath("base/tspconfig.yaml"));
       strictEqual(parentConfig.slice(target.pos, target.end), `"file:./missing.yaml"`);
     });
   });

--- a/packages/compiler/test/config/config.test.ts
+++ b/packages/compiler/test/config/config.test.ts
@@ -2,12 +2,15 @@ import { deepStrictEqual, strictEqual } from "assert";
 import { join } from "path";
 import { describe, it } from "vitest";
 import { TypeSpecConfigJsonSchema } from "../../src/config/config-schema.js";
+import { resolveOptionsFromConfig } from "../../src/config/config-to-options.js";
 import type { TypeSpecRawConfig } from "../../src/config/index.js";
 import { loadTypeSpecConfigForPath } from "../../src/config/index.js";
 import { NodeHost } from "../../src/core/node-host.js";
+import { compile } from "../../src/core/program.js";
 import { createJSONSchemaValidator } from "../../src/core/schema-validator.js";
 import { createSourceFile } from "../../src/core/source-file.js";
 import { resolvePath } from "../../src/index.js";
+import { expectDiagnosticEmpty, expectDiagnostics } from "../../src/testing/index.js";
 import { createTestFileSystem } from "../../src/testing/fs.js";
 import { findTestPackageRoot, resolveVirtualPath } from "../../src/testing/test-utils.js";
 
@@ -245,6 +248,52 @@ describe("file discovery", () => {
         "project/tspconfig.yaml",
       );
       deepStrictEqual(linter?.extends, [`file:${resolveVirtualPath("base/rules.yaml")}`]);
+    });
+
+    it("locates an inherited missing ruleset reference in the parent config", async () => {
+      const fs = createTestFileSystem();
+      const parentConfig = `
+        linter:
+          extends:
+            - "file:./missing.yaml"
+        `;
+      fs.addTypeSpecFile("base/tspconfig.yaml", parentConfig);
+      fs.addTypeSpecFile(
+        "project/tspconfig.yaml",
+        `
+        extends: "../base/tspconfig.yaml"
+        linter:
+          disable: {}
+        `,
+      );
+      fs.addTypeSpecFile("project/main.tsp", "");
+
+      const config = await loadTypeSpecConfigForPath(
+        fs.compilerHost,
+        resolveVirtualPath("project/tspconfig.yaml"),
+        true,
+        false,
+      );
+      strictEqual(config.linterSource?.extends?.file.path, resolveVirtualPath("base/tspconfig.yaml"));
+      strictEqual(config.linterSource?.disable?.file.path, resolveVirtualPath("project/tspconfig.yaml"));
+
+      const [options, optionDiagnostics] = resolveOptionsFromConfig(config, {
+        cwd: resolveVirtualPath("project"),
+      });
+      expectDiagnosticEmpty(optionDiagnostics);
+      const program = await compile(fs.compilerHost, resolveVirtualPath("project/main.tsp"), {
+        ...options,
+        noEmit: true,
+        nostdlib: true,
+      });
+      const diagnostic = program.diagnostics.find(
+        (x) =>
+          x.code === "file-not-found" &&
+          (x.target as any).file?.path === resolveVirtualPath("base/tspconfig.yaml"),
+      );
+      if (!diagnostic) throw new Error("Expected inherited ruleset diagnostic in parent config");
+      const target = diagnostic.target as any;
+      strictEqual(parentConfig.slice(target.pos, target.end), `"file:./missing.yaml"`);
     });
   });
 });

--- a/packages/compiler/test/config/scenarios/extends-linter/tspconfig.yaml
+++ b/packages/compiler/test/config/scenarios/extends-linter/tspconfig.yaml
@@ -1,0 +1,4 @@
+extends: ./typespec-base.yaml
+linter:
+  disable:
+    test/child-rule: Child exemption

--- a/packages/compiler/test/config/scenarios/extends-linter/typespec-base.yaml
+++ b/packages/compiler/test/config/scenarios/extends-linter/typespec-base.yaml
@@ -1,0 +1,7 @@
+linter:
+  extends:
+    - test/all
+  enable:
+    test/base-rule: true
+  disable:
+    test/replaced-rule: Base exemption

--- a/packages/compiler/test/core/cli/actions/info.test.ts
+++ b/packages/compiler/test/core/cli/actions/info.test.ts
@@ -1,5 +1,24 @@
 import { expect, it } from "vitest";
-import { formatCompilerFeatures } from "../../../../src/core/cli/actions/info.js";
+import {
+  formatCompilerFeatures,
+  getPrintableConfig,
+} from "../../../../src/core/cli/actions/info.js";
+
+it("omits internal linter source metadata from printable config", () => {
+  const config = getPrintableConfig({
+    diagnostics: [],
+    outputDir: "{cwd}/tsp-output",
+    projectRoot: "/project",
+    filename: "/project/tspconfig.yaml",
+    linter: { extends: ["test/all"] },
+    linterSource: { extends: "/base/tspconfig.yaml" },
+  });
+
+  expect(config).not.toHaveProperty("linterSource");
+  expect(config).not.toHaveProperty("diagnostics");
+  expect(config).not.toHaveProperty("file");
+  expect(config.linter).toEqual({ extends: ["test/all"] });
+});
 
 function stripAnsi(str: string): string {
   // eslint-disable-next-line no-control-regex

--- a/website/src/content/docs/docs/handbook/configuration/configuration.mdx
+++ b/website/src/content/docs/docs/handbook/configuration/configuration.mdx
@@ -120,12 +120,16 @@ emit:
 
 The extending logic follows these rules:
 
-- **Root-level properties**: Shallow merge for all properties except `options`
+- **Root-level properties**: Shallow merge for all properties except `options` and `linter`
 - **Options property**: Deep merge at one level (per emitter)
-- **Override behavior**: Properties specified in the extending file will completely override those from the extended file
+- **Linter property**: Merge `extends`, `enable`, and `disable` at one level
+- **Override behavior**: Properties specified in the extending file replace the corresponding property from the extended file
 
 **Root-level merge behavior:**
 When extending a configuration, most properties (like `emit`, `imports`, `trace`, etc.) are merged at the root level. If the same property exists in both files, the extending file's value completely replaces the extended file's value.
+
+**Linter merge behavior:**
+The `linter` property also receives a one-level merge. The `extends`, `enable`, and `disable` fields are inherited independently. If the extending file specifies one of those fields, that field replaces the value from the extended file. The arrays and rule maps inside those fields are not merged.
 
 **Options merge behavior:**
 The `options` property receives special treatment with a one-level deep merge:


### PR DESCRIPTION
### Summary

Fixes #11849.

Merge the `linter` entry one level when a TypeSpec config extends another config. Child linter fields now override matching parent fields without dropping unrelated inherited settings such as `extends` or `enable`.

### Testing

- `pnpm vitest run test/config/config.test.ts` in `packages/compiler`
- `pnpm change verify`
