### PR TITLE
Update Python release skill guidance

### DIFF
--- a/.github/skills/http-client-python-bump-and-release/SKILL.md
+++ b/.github/skills/http-client-python-bump-and-release/SKILL.md
@@ -70,6 +70,19 @@ npm install -g npm-check-updates
    npm run change:version
    ```
 
+   Verify that the script updated both the emitter version in `package.json` and `CHANGELOG.md`. If neither file was updated:
+   - Increment the third component of the emitter version in `package.json` (for example, `a.b.c` to `a.b.(c+1)`).
+   - Add this entry near the top of `CHANGELOG.md`, immediately after the changelog title:
+
+     ```markdown
+     ## <new emitter version>
+
+     ### Bump dependencies
+
+     - Bump dependencies of `@typespec/*` and `@azure-tools/*` to latest versions
+     ```
+    - Verify that the version in `package.json` matches the new `CHANGELOG.md` heading.
+
 8. Build and commit:
 
    ```bash
@@ -84,3 +97,16 @@ npm install -g npm-check-updates
    ```
 
 10. Create PR with title `[python] release new version` and no description.
+
+## Post-Process Review
+
+1. After the pull request is created, review the complete release run: commands executed, command output, manual interventions, validation results, changed files, commit, push, cleanup, and PR creation.
+2. Update this skill only when the completed run provides a concrete finding and a strong reason for the change, such as:
+   - A documented step failed or produced an incorrect result.
+   - The agent needed an undocumented manual correction to complete the release.
+   - A step was ambiguous enough to create a real risk or delay.
+   - A command was unnecessary or could be replaced by a demonstrably safer or more reliable command.
+3. Do not change the skill based on preference, speculation, or an unobserved edge case. For every update, record the observed evidence and explain why the edit improves future releases.
+4. Keep any skill update minimal, validate its formatting and frontmatter, and keep it separate from the completed release PR unless the user explicitly asks to include it there.
+5. If the review finds no evidence-backed improvement, leave the skill unchanged and state that no update was warranted.
+6. Return the branch name, released package version, `@typespec/http-client-python` version, commit hash, pull request URL, review findings, and any skill update to the user.

--- a/.github/skills/http-client-python-bump-and-release/SKILL.md
+++ b/.github/skills/http-client-python-bump-and-release/SKILL.md
@@ -70,7 +70,7 @@ npm install -g npm-check-updates
    npm run change:version
    ```
 
-   Verify that the script updated both the emitter version in `package.json` and `CHANGELOG.md`. If neither file was updated:
+   Verify that the script updated both the emitter version in `package.json` and `CHANGELOG.md`. If either file was not updated:
    - Increment the third component of the emitter version in `package.json` (for example, `a.b.c` to `a.b.(c+1)`).
    - Add this entry near the top of `CHANGELOG.md`, immediately after the changelog title:
 

--- a/.github/skills/http-client-python-bump-and-release/SKILL.md
+++ b/.github/skills/http-client-python-bump-and-release/SKILL.md
@@ -81,7 +81,8 @@ npm install -g npm-check-updates
 
      - Bump dependencies of `@typespec/*` and `@azure-tools/*` to latest versions
      ```
-    - Verify that the version in `package.json` matches the new `CHANGELOG.md` heading.
+
+   - Verify that the version in `package.json` matches the new `CHANGELOG.md` heading.
 
 8. Build and commit:
 

--- a/.github/skills/http-client-python-bump-and-release/SKILL.md
+++ b/.github/skills/http-client-python-bump-and-release/SKILL.md
@@ -70,7 +70,7 @@ npm install -g npm-check-updates
    npm run change:version
    ```
 
-   Verify that the script updated both the emitter version in `package.json` and `CHANGELOG.md`. If either file was not updated:
+   Verify that the script updated both the emitter version in `package.json` and `CHANGELOG.md`. If neither file was updated:
    - Increment the third component of the emitter version in `package.json` (for example, `a.b.c` to `a.b.(c+1)`).
    - Add this entry near the top of `CHANGELOG.md`, immediately after the changelog title:
 


### PR DESCRIPTION
## Summary

- add a fallback when the Python emitter version script updates neither the package version nor changelog
- require the package version and changelog heading to remain consistent
- add an evidence-based post-process review for completed release runs

## Validation

- Markdown diagnostics report no errors
- `git diff --check` passes