### PR TITLE
Publish http-specs smoke specifications

### DIFF
--- a/.chronus/changes/http-specs-publish-smoke-2026-09-11.md
+++ b/.chronus/changes/http-specs-publish-smoke-2026-09-11.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@typespec/http-specs"
+---
+
+Include smoke test specifications in the published package.

--- a/packages/http-specs/package.json
+++ b/packages/http-specs/package.json
@@ -8,6 +8,7 @@
   "files": [
     "dist/**",
     "specs/**",
+    "smoke/**",
     "assets/**"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

- include `smoke/**` in the published `@typespec/http-specs` package
- restore downstream access to the todoapp and petstore smoke specifications

Fixes the omission introduced by #11590.
