### PR TITLE
[openapi3] emit additionalProperties for a declared Record indexer in 3.1

### DIFF
--- a/.chronus/changes/openapi3-record-additional-properties-2026-8-15-19-45-0.md
+++ b/.chronus/changes/openapi3-record-additional-properties-2026-8-15-19-45-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/openapi3"
+---
+
+OpenAPI 3.1 and 3.2 now emit `additionalProperties` for a `Record<T>` indexer, unless the model also extends another model or the schema is sealed, which still use `unevaluatedProperties`.

--- a/packages/openapi3/src/schema-emitter-3-1.ts
+++ b/packages/openapi3/src/schema-emitter-3-1.ts
@@ -161,10 +161,17 @@ export class OpenAPI31SchemaEmitter extends OpenAPI3SchemaEmitterBase<OpenAPISch
     const shouldSeal = this.shouldSealSchema(model);
     if (!shouldSeal && !model.indexer) return;
 
-    const unevaluatedPropertiesSchema = shouldSeal
+    const indexerSchema = shouldSeal
       ? { not: {} }
       : this.emitter.emitTypeReference(model.indexer!.value);
-    setProperty(schema, "unevaluatedProperties", unevaluatedPropertiesSchema);
+
+    // A declared indexer describes a dictionary, and `additionalProperties` is the keyword for that.
+    // Sealing keeps `unevaluatedProperties`, and so does a model that also extends another model:
+    // both have to account for the properties evaluated by the `allOf` subschema holding the base
+    // model, which `additionalProperties` cannot see and would therefore constrain.
+    const indexerKeyword =
+      shouldSeal || model.baseModel ? "unevaluatedProperties" : "additionalProperties";
+    setProperty(schema, indexerKeyword, indexerSchema);
   }
 
   getRawBinarySchema(): OpenAPISchema3_1 {

--- a/packages/openapi3/test/additional-properties.test.ts
+++ b/packages/openapi3/test/additional-properties.test.ts
@@ -12,7 +12,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
 
     it("links to an allOf of the Record<unknown> schema", async () => {
       const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet.allOf, [{ type: "object", [objectSchemaIndexer]: {} }]);
+      deepStrictEqual(res.schemas.Pet.allOf, [{ type: "object", additionalProperties: {} }]);
     });
 
     it("include model properties", async () => {
@@ -24,14 +24,14 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
   });
 
   describe("is Record<T>", () => {
-    it(`set ${objectSchemaIndexer} on model itself`, async () => {
+    it("set additionalProperties on model itself", async () => {
       const res = await oapiForModel("Pet", `model Pet is Record<unknown> {};`);
-      deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], {});
+      deepStrictEqual(res.schemas.Pet.additionalProperties, {});
     });
 
     it("set additional properties type", async () => {
       const res = await oapiForModel("Pet", `model Pet is Record<string> {};`);
-      deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], {
+      deepStrictEqual(res.schemas.Pet.additionalProperties, {
         type: "string",
       });
     });
@@ -45,7 +45,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
   });
 
   describe("referencing Record<T>", () => {
-    it(`add ${objectSchemaIndexer} inline for property of type Record<unknown>`, async () => {
+    it("add additionalProperties inline for property of type Record<unknown>", async () => {
       const res = await oapiForModel(
         "Pet",
         `
@@ -57,7 +57,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
       ok(res.schemas.Pet, "expected definition named Pet");
       deepStrictEqual(res.schemas.Pet.properties.details, {
         type: "object",
-        [objectSchemaIndexer]: {},
+        additionalProperties: {},
       });
     });
 
@@ -79,7 +79,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
   });
 
   describe("spreading Record<T>", () => {
-    it(`add ${objectSchemaIndexer} of type Record<unknown>`, async () => {
+    it("add additionalProperties of type Record<unknown>", async () => {
       const res = await oapiForModel(
         "Pet",
         `
@@ -89,7 +89,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
 
       ok(res.isRef);
       ok(res.schemas.Pet, "expected definition named Pet");
-      deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], {});
+      deepStrictEqual(res.schemas.Pet.additionalProperties, {});
     });
 
     it(`add ${objectSchemaIndexer} of type Record<never> as "{ not: {} }"`, async () => {
@@ -111,7 +111,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
     });
   });
 
-  it(`set ${objectSchemaIndexer} if model extends Record with leaf type`, async () => {
+  it("set additionalProperties if model extends Record with leaf type", async () => {
     const res = await oapiForModel(
       "Pet",
       `
@@ -123,7 +123,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
 
     ok(res.isRef);
     ok(res.schemas.Pet, "expected definition named Pet");
-    deepStrictEqual(res.schemas.Pet[objectSchemaIndexer], {
+    deepStrictEqual(res.schemas.Pet.additionalProperties, {
       $ref: "#/components/schemas/Value",
     });
   });
@@ -197,13 +197,13 @@ worksFor(supportedVersions, ({ oapiForModel: baseOapiForMopdel, objectSchemaInde
       });
     });
 
-    it(`does not seal object schemas that already have ${objectSchemaIndexer} set`, async () => {
+    it("does not seal object schemas that already have additionalProperties set", async () => {
       const res = await oapiForModel("Pet", `model Pet { name: string; ...Record<string>; };`);
       deepStrictEqual(res.schemas.Pet, {
         type: "object",
         required: ["name"],
         properties: { name: { type: "string" } },
-        [objectSchemaIndexer]: { type: "string" },
+        additionalProperties: { type: "string" },
       });
     });
 
@@ -226,5 +226,146 @@ worksFor(supportedVersions, ({ oapiForModel: baseOapiForMopdel, objectSchemaInde
       // SHOULD constrain additional properties
       deepStrictEqual(res.schemas.Spinner[objectSchemaIndexer], { not: {} });
     });
+  });
+});
+
+worksFor(["3.1.0", "3.2.0"], ({ oapiForModel }) => {
+  describe("which indexer keyword is used", () => {
+    it("uses additionalProperties for a declared indexer", async () => {
+      const res = await oapiForModel("Pet", `model Pet { details: Record<string> };`);
+      deepStrictEqual(res.schemas.Pet.properties.details, {
+        type: "object",
+        additionalProperties: { type: "string" },
+      });
+    });
+
+    it("uses unevaluatedProperties for a declared indexer on a model with a base model", async () => {
+      const res = await oapiForModel(
+        "Dict",
+        `
+        model Base { id: int32; }
+        model Dict extends Base { ...Record<string>; }
+        `,
+      );
+      deepStrictEqual(res.schemas.Dict, {
+        type: "object",
+        unevaluatedProperties: { type: "string" },
+        allOf: [{ $ref: "#/components/schemas/Base" }],
+      });
+    });
+
+    it("uses additionalProperties for a declared indexer that other models extend", async () => {
+      const res = await oapiForModel(
+        "Sub",
+        `
+        model Dict { ...Record<string>; }
+        model Sub extends Dict { extra: string; }
+        `,
+      );
+      deepStrictEqual(res.schemas.Dict, {
+        type: "object",
+        additionalProperties: { type: "string" },
+      });
+    });
+
+    it("uses unevaluatedProperties to seal a model", async () => {
+      const res = await oapiForModel("Pet", `model Pet { name: string; };`, {
+        "seal-object-schemas": true,
+      });
+      deepStrictEqual(res.schemas.Pet, {
+        type: "object",
+        required: ["name"],
+        properties: { name: { type: "string" } },
+        unevaluatedProperties: { not: {} },
+      });
+    });
+
+    it("uses unevaluatedProperties to seal a model that has a base model", async () => {
+      const res = await oapiForModel(
+        "Leaf",
+        `
+        model Base { id: string; }
+        model Leaf extends Base { name: string; }
+        `,
+        { "seal-object-schemas": true },
+      );
+      deepStrictEqual(res.schemas.Leaf, {
+        type: "object",
+        required: ["name"],
+        properties: { name: { type: "string" } },
+        unevaluatedProperties: { not: {} },
+        allOf: [{ $ref: "#/components/schemas/Base" }],
+      });
+    });
+
+    it("keeps unevaluatedProperties for a Record<never> property, which seals", async () => {
+      const res = await oapiForModel("Pet", `model Pet { empty: Record<never> };`);
+      deepStrictEqual(res.schemas.Pet.properties.empty, {
+        type: "object",
+        unevaluatedProperties: { not: {} },
+      });
+    });
+
+    it("uses unevaluatedProperties at every level of an inheritance chain that declares an indexer", async () => {
+      const res = await oapiForModel(
+        "C",
+        `
+        model A { ...Record<string>; }
+        model B extends A { b: string; ...Record<string>; }
+        model C extends B { c: string; }
+        `,
+      );
+      // Only `A` is free of a base model, so only `A` uses additionalProperties.
+      deepStrictEqual(res.schemas.A, {
+        type: "object",
+        additionalProperties: { type: "string" },
+      });
+      deepStrictEqual(res.schemas.B.unevaluatedProperties, { type: "string" });
+      deepStrictEqual(res.schemas.B.allOf, [{ $ref: "#/components/schemas/A" }]);
+    });
+  });
+});
+
+worksFor(["3.1.0", "3.2.0"], ({ oapiForModel }) => {
+  describe("shapes the indexer keyword must not reach", () => {
+    it("applies to the item of an array of dictionaries, not to the array", async () => {
+      const res = await oapiForModel("Pet", `model Pet { tags: Record<string>[]; };`);
+      deepStrictEqual(res.schemas.Pet.properties.tags, {
+        type: "array",
+        items: { type: "object", additionalProperties: { type: "string" } },
+      });
+    });
+
+    it("applies at every level of a nested dictionary", async () => {
+      const res = await oapiForModel("Pet", `model Pet { nested: Record<Record<string>>; };`);
+      deepStrictEqual(res.schemas.Pet.properties.nested, {
+        type: "object",
+        additionalProperties: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+      });
+    });
+  });
+});
+
+worksFor(["3.1.0", "3.2.0"], ({ oapiForModel }) => {
+  // `attachExtensions` writes arbitrary keys onto the schema after `applyModelIndexer` has run, so
+  // an `@extension` that injects an in-place applicator is invisible to the keyword decision. The
+  // `x-` prefix convention is documented for `@extension` but not enforced, so this is reachable.
+  // Pinned rather than guarded: the emitter cannot see the injected applicator from where the
+  // decision is made, and the same escape hatch has always behaved this way in OpenAPI 3.0.
+  it("does not account for an in-place applicator injected by @extension", async () => {
+    const res = await oapiForModel(
+      "Dict",
+      `
+      @extension("allOf", #[#{ type: "object", properties: #{ flag: #{ type: "boolean" } } }])
+      model Dict { ...Record<string>; }
+      `,
+    );
+    deepStrictEqual(res.schemas.Dict.additionalProperties, { type: "string" });
+    deepStrictEqual(res.schemas.Dict.allOf, [
+      { type: "object", properties: { flag: { type: "boolean" } } },
+    ]);
   });
 });

--- a/packages/openapi3/test/nullable-properties.test.ts
+++ b/packages/openapi3/test/nullable-properties.test.ts
@@ -132,7 +132,7 @@ worksFor(["3.1.0"], ({ oapiForModel, openApiFor }) => {
     it("keep nullable Record<T> inline", async () => {
       await expectInCircularReference("Record<Test>", {
         anyOf: [
-          { type: "object", unevaluatedProperties: { $ref: "#/components/schemas/Test" } },
+          { type: "object", additionalProperties: { $ref: "#/components/schemas/Test" } },
           { type: "null" },
         ],
       });

--- a/packages/openapi3/test/record.test.ts
+++ b/packages/openapi3/test/record.test.ts
@@ -1,8 +1,9 @@
 import { deepStrictEqual, ok } from "assert";
 import { it } from "vitest";
+import { openapisFor } from "./test-host.js";
 import { supportedVersions, worksFor } from "./works-for.js";
 
-worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
+worksFor(supportedVersions, ({ oapiForModel }) => {
   it("defines record inline", async () => {
     const res = await oapiForModel(
       "Pet",
@@ -15,7 +16,7 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
     ok(res.schemas.Pet, "expected definition named Pet");
     deepStrictEqual(res.schemas.Pet.properties.foodScores, {
       type: "object",
-      [objectSchemaIndexer]: { type: "integer", format: "int32" },
+      additionalProperties: { type: "integer", format: "int32" },
     });
   });
 
@@ -33,11 +34,11 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
     ok(res.schemas.Pet, "expected definition named Pet");
     deepStrictEqual(res.schemas.FoodScores, {
       type: "object",
-      [objectSchemaIndexer]: { type: "integer", format: "int32" },
+      additionalProperties: { type: "integer", format: "int32" },
     });
   });
 
-  it(`specify ${objectSchemaIndexer} when "...Record<T>"`, async () => {
+  it(`specify additionalProperties when "...Record<T>"`, async () => {
     const res = await oapiForModel(
       "Person",
       `
@@ -48,12 +49,12 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
     deepStrictEqual(res.schemas.Person, {
       type: "object",
       properties: { age: { type: "integer", format: "int32" } },
-      [objectSchemaIndexer]: { type: "string" },
+      additionalProperties: { type: "string" },
       required: ["age"],
     });
   });
 
-  it(`specify ${objectSchemaIndexer} of anyOf when multiple "...Record<T>"`, async () => {
+  it(`specify additionalProperties of anyOf when multiple "...Record<T>"`, async () => {
     const res = await oapiForModel(
       "Person",
       `
@@ -64,8 +65,76 @@ worksFor(supportedVersions, ({ oapiForModel, objectSchemaIndexer }) => {
     deepStrictEqual(res.schemas.Person, {
       type: "object",
       properties: { age: { type: "integer", format: "int32" } },
-      [objectSchemaIndexer]: { anyOf: [{ type: "string" }, { type: "boolean" }] },
+      additionalProperties: { anyOf: [{ type: "string" }, { type: "boolean" }] },
       required: ["age"],
     });
+  });
+});
+
+// A dictionary whose value type is not `never`, on a model that does not extend another model, is
+// the same schema in every spec version, so the 3.0 output is an oracle for the 3.1 one. The two
+// exclusions are real: a model that composes is deliberately different, and `Record<never>` routes
+// through the sealing branch, which keeps the composition aware keyword in 3.1. Both are asserted
+// below so the oracle's preconditions are pinned rather than assumed.
+it("emits the same dictionary schema for 3.0 and 3.1 when the model does not compose", async () => {
+  const outputs = await openapisFor(
+    `
+    model Labels is Record<string>;
+    model Holder { labels: Labels; inline: Record<unknown>; }
+    @route("/h") @post op h(@body body: Holder): Holder;
+    `,
+    { "openapi-versions": ["3.0.0", "3.1.0"] },
+  );
+
+  const v30 = outputs["3.0.0/openapi.json"];
+  const v31 = outputs["3.1.0/openapi.json"];
+  ok(v30 && v31, "expected a document for each spec version");
+
+  deepStrictEqual(v31.components!.schemas!.Labels, v30.components!.schemas!.Labels);
+  deepStrictEqual(v31.components!.schemas!.Holder, v30.components!.schemas!.Holder);
+  deepStrictEqual(v31.components!.schemas!.Labels, {
+    type: "object",
+    additionalProperties: { type: "string" },
+  });
+});
+
+it("still differs between 3.0 and 3.1 when the model composes", async () => {
+  const outputs = await openapisFor(
+    `
+    model Base { id: int32; }
+    model Dict extends Base { ...Record<string>; }
+    @route("/d") @post op d(@body body: Dict): Dict;
+    `,
+    { "openapi-versions": ["3.0.0", "3.1.0"] },
+  );
+
+  deepStrictEqual(outputs["3.0.0/openapi.json"].components!.schemas!.Dict, {
+    type: "object",
+    additionalProperties: { type: "string" },
+    allOf: [{ $ref: "#/components/schemas/Base" }],
+  });
+  deepStrictEqual(outputs["3.1.0/openapi.json"].components!.schemas!.Dict, {
+    type: "object",
+    unevaluatedProperties: { type: "string" },
+    allOf: [{ $ref: "#/components/schemas/Base" }],
+  });
+});
+
+it("still differs between 3.0 and 3.1 for Record<never>, which seals rather than describing a map", async () => {
+  const outputs = await openapisFor(
+    `
+    model Holder { empty: Record<never>; }
+    @route("/h") @post op h(@body body: Holder): Holder;
+    `,
+    { "openapi-versions": ["3.0.0", "3.1.0"] },
+  );
+
+  deepStrictEqual(outputs["3.0.0/openapi.json"].components!.schemas!.Holder!.properties!.empty, {
+    type: "object",
+    additionalProperties: { not: {} },
+  });
+  deepStrictEqual(outputs["3.1.0/openapi.json"].components!.schemas!.Holder!.properties!.empty, {
+    type: "object",
+    unevaluatedProperties: { not: {} },
   });
 });

--- a/packages/openapi3/test/return-types.test.ts
+++ b/packages/openapi3/test/return-types.test.ts
@@ -3,7 +3,7 @@ import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
 import { supportedVersions, worksFor } from "./works-for.js";
 
-worksFor(supportedVersions, ({ checkFor, openApiFor, objectSchemaIndexer }) => {
+worksFor(supportedVersions, ({ checkFor, openApiFor }) => {
   it("model used with @body and without shouldn't conflict if it contains no metadata", async () => {
     const res = await openApiFor(
       `
@@ -316,7 +316,7 @@ worksFor(supportedVersions, ({ checkFor, openApiFor, objectSchemaIndexer }) => {
     );
   });
 
-  it(`produce ${objectSchemaIndexer} schema if response is Record<T>`, async () => {
+  it(`produce additionalProperties schema if response is Record<T>`, async () => {
     const res = await openApiFor(
       `
       @get op test(): Record<string>;
@@ -329,7 +329,7 @@ worksFor(supportedVersions, ({ checkFor, openApiFor, objectSchemaIndexer }) => {
       "application/json": {
         schema: {
           type: "object",
-          [objectSchemaIndexer]: {
+          additionalProperties: {
             type: "string",
           },
         },

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -114,12 +114,13 @@ export async function openapisFor(
 export async function openApiForVersions<T extends string>(
   code: string,
   versions: T[],
+  options: OpenAPI3EmitterOptions = {},
 ): Promise<Record<T, OpenAPI3Document>> {
   const host = await TesterWithVersioning.createInstance();
   const outPath = "{emitter-output-dir}/{version}.openapi.json";
   const { outputs } = await host.compile(code, {
     compilerOptions: {
-      options: { "@typespec/openapi3": { "output-file": outPath } },
+      options: { "@typespec/openapi3": { ...options, "output-file": outPath } },
     },
   });
 

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -268,3 +268,32 @@ worksFor(supportedVersions, ({ openApiFor, version: specVersion }) => {
     });
   });
 });
+
+// The versioning emitter runs each version through a mutator, which clones the model graph. The
+// indexer keyword is chosen from `model.baseModel`, so a clone that lost its base model would
+// silently change the keyword between two versions of the same API.
+it("keeps the indexer keyword stable across versions in OpenAPI 3.1", async () => {
+  const { v1, v2 } = await openApiForVersions(
+    `
+    @versioned(Versions)
+    @service(#{title: "My Service"})
+    namespace MyService;
+    enum Versions { v1, v2 }
+    model Dict { ...Record<string>; }
+    model Sub extends Dict { @added(Versions.v2) extra: string; }
+    @route("/d") @post op d(@body body: Dict): Dict;
+    @route("/s") @post op s(@body body: Sub): Sub;
+    `,
+    ["v1", "v2"],
+    { "openapi-versions": ["3.1.0"] },
+  );
+
+  for (const doc of [v1, v2]) {
+    strictEqual(doc.openapi, "3.1.0");
+    deepStrictEqual(doc.components!.schemas!.Dict, {
+      type: "object",
+      additionalProperties: { type: "string" },
+    });
+    deepStrictEqual(doc.components!.schemas!.Sub!.allOf, [{ $ref: "#/components/schemas/Dict" }]);
+  }
+});

--- a/packages/openapi3/test/works-for.ts
+++ b/packages/openapi3/test/works-for.ts
@@ -26,6 +26,13 @@ export type SpecHelper = {
   checkFor: typeof diagnoseOpenApiFor;
   diagnoseOpenApiFor: typeof diagnoseOpenApiFor;
   emitOpenApiWithDiagnostics: typeof emitOpenApiWithDiagnostics;
+  /**
+   * The keyword a schema uses when it has to account for the properties evaluated by the `allOf`
+   * subschema holding the base model, which is why it differs by spec version. That is the case
+   * when a schema is sealed, and when a model with a declared indexer also extends another model.
+   * A declared `Record<T>` indexer on a model that does neither uses `additionalProperties` in
+   * every spec version, and does not use this.
+   */
   objectSchemaIndexer: ObjectSchemaIndexer;
 };
 

--- a/website/src/content/docs/docs/getting-started/typespec-for-openapi-dev.md
+++ b/website/src/content/docs/docs/getting-started/typespec-for-openapi-dev.md
@@ -536,7 +536,7 @@ model Snake {
 
 You can generate a schema with `additionalProperties` with the TypeSpec `Record` construct.
 
-**Note:** `unevaluatedProperties` is used instead of `additionalProperties` when emitting Open API 3.1 specs.
+**Note:** when emitting Open API 3.1 and 3.2 specs, `unevaluatedProperties` is used instead of `additionalProperties` for schemas that compose with `allOf`: sealed schemas, and models that declare a `Record` indexer while also extending another model. `additionalProperties` cannot see the properties evaluated by the `allOf` subschema, so it would constrain the inherited ones.
 
 ```typespec
   bar: Record<unknown>;


### PR DESCRIPTION
> Follow-up to #11953, which I closed as prematurely filed and wrongly framed as a bug. This is the
> properly scoped version: it concedes #5961's design, narrows the claim to the case where the two
> keywords are provably equivalent, and leaves sealing and composition alone.

## What this changes

For OpenAPI 3.1 and 3.2, a declared `Record<T>` indexer is emitted as `additionalProperties` instead
of `unevaluatedProperties`, unless the model also extends another model, or the schema is sealed.
Those two keep `unevaluatedProperties`, because both have to account for the properties evaluated by
the sibling `allOf` subschema.

```diff
- const unevaluatedPropertiesSchema = shouldSeal
+ const indexerSchema = shouldSeal
    ? { not: {} }
    : this.emitter.emitTypeReference(model.indexer!.value);
- setProperty(schema, "unevaluatedProperties", unevaluatedPropertiesSchema);
+ const indexerKeyword =
+   shouldSeal || model.baseModel ? "unevaluatedProperties" : "additionalProperties";
+ setProperty(schema, indexerKeyword, indexerSchema);
```

`model.baseModel` is the same condition `modelDeclaration` uses to attach the `allOf`, so the guard
and the thing it guards against are decided by the same fact.

3.0 is untouched: `schema-emitter-3-0.ts` has no `applyModelIndexer` and uses the base
implementation, which already writes `additionalProperties`. 3.2 is affected, because
`schema-emitter-3-2.ts` extends `OpenAPI31SchemaEmitter` without overriding the method, and the
tests run against both.

Note `Record<never>` is unaffected: `shouldSealSchema` returns true for it, so it takes the sealing
branch and keeps `unevaluatedProperties: { not: {} }`.

## Why: this repo cannot read its own 3.1 output

`tsp-openapi3`, the converter in this package, reads only `additionalProperties`. Of the 36 `.ts`
files under `packages/openapi3/src/cli`, zero mention `unevaluatedProperties` and four handle
`additionalProperties` (`convert/generators/generate-model.ts:359`,
`convert/generators/generate-types.ts:482`, `convert/transforms/transform-component-schemas.ts:129`,
`convert/interfaces.ts`).

So compiling `model Labels is Record<string>;` at 3.1 and converting the result back gives
`model Labels {}`. At 3.0 it gives `model Labels { ...Record<string>; }`. The round trip loses every
dictionary, and exits 0 while doing it. I have filed that separately, since it stands on its own
whichever way this PR goes.

## Why not just keep `unevaluatedProperties`

I am not claiming the current behaviour is accidental. #5961 chose it on purpose and said why:

> One key difference from additionalProperties though is that it evaluates properties after any
> in-place applicators. [...] This is particularly useful when trying to set `additionalProperties`
> to false on a schema that has sub-schemas.

That rationale is about composition, and it is correct. The keyword was then applied to every
declared indexer, including models that compose with nothing. This narrows it to the cases the
rationale covers.

## Is it validation-equivalent where it changes?

Ajv 8.20.0 on the 2020-12 dialect, the same schema pair under each keyword, in every position this
emitter can put it:

| position | result |
| --- | --- |
| leaf dictionary, standalone (the case this changes) | identical |
| dictionary `$ref`d inside a derived model's `allOf` | identical |
| dictionary inside a nullable `anyOf` branch | identical |
| keyword as a sibling of an `allOf` (the case this excludes) | **different** |

The last row is why the guard exists. With `model Ledger extends Base { ...Record<string>; }` and
`Base` declaring `id: int32`, `additionalProperties` constrains the inherited `id` and the schema
rejects `{"id": 1}` outright.

The second row is why the guard is `model.baseModel` and not also a `derivedModels` check.
Annotations flow bottom-up, so a dictionary in branch position inside someone else's `allOf` behaves
identically under both keywords. A `derivedModels` guard would also have been non-local, because
`Record<T>` is a cached template instantiation shared by every use site in a program.

## Coverage, and how strong it is

Because the two keywords are equivalent for a non-composing, non-`never` dictionary, the 3.0 document
is an oracle for the 3.1 one: the two spec versions must produce identical schemas. `record.test.ts`
asserts that, and asserts the two exclusions (composing models, and `Record<never>`) in the other
direction, so the oracle's preconditions are pinned rather than assumed.

14 tests added. I checked they are not vacuous by mutating the production code three ways and
recording which arms go red:

| mutant | arms killed |
| --- | --- |
| always `unevaluatedProperties` (full revert) | 8 of 14 |
| drop the `\|\| model.baseModel` arm | 3 of 14 |
| always `additionalProperties` | 7 of 14 |

Every one of the 14 is killed by at least one. An earlier draft of this branch had a test asserting
that plain arrays are unaffected; it survived all three mutants, because arrays route through
`arrayDeclaration`/`arrayLiteral` and never reach `applyModelIndexer` at all. I removed it rather
than keep a test that cannot fail.

Shapes covered: declared indexer alone, with a base model, and as the base of other models; sealed
leaf and sealed with a base; `Record<never>`; a three-level chain where two levels declare an
indexer; arrays of dictionaries; nested dictionaries; cross-version parity in both directions; and
versioning, where the emitter mutates and clones the model graph, so a clone that lost its
`baseModel` would silently change the keyword between two versions of the same API.
`openApiForVersions` could not pass emitter options, so it takes them now.

Verified and unchanged, so not given new tests: merge-patch, multipart, discriminated unions, XML,
`@visibility` variants, and circular models.

## Blast radius

`packages/openapi3`: 2602 tests before, 2626 after.

`pnpm regen-samples` and `pnpm regen-specs` both produce zero diff, but I want to be straight about
what that is worth: **not much**. All 30 checked-in sample outputs are `openapi: 3.0.0` and no sample
sets `openapi-versions`, so the 3.1 emitter is not exercised by them; and `regen-specs` records the
converter snapshots, which are the opposite direction. There is no checked-in 3.1 golden output in
the repo, so the unit tests above are the real coverage. The upside is that this change causes no
golden-file churn for reviewers to read.

Worth noting that `tsp init` does offer an "OpenAPI 3.1 document" template, so zero golden-file churn
is not the same as zero user impact.

## One case where this narrows behaviour

`@extension` writes arbitrary keys straight onto the schema, after `applyModelIndexer` has run. The
`x-` prefix convention is documented for `@extension` but not enforced, so a spec can inject an
in-place applicator that the keyword decision structurally cannot see:

```tsp
@extension("allOf", #[#{ type: "object", properties: #{ flag: #{ type: "boolean" } } }])
model Dict { ...Record<string>; }
```

The injected `allOf` now sits beside `additionalProperties`, and an instance `{"flag": true}` that
validated before does not after. This also reproduces via `@extension` on a property.

I have pinned the current output in a test rather than guarded it, because the guard would have to
run before the extension is attached and cannot. If you would prefer `applyModelIndexer` to consult
`getExtensions` for applicator keys, say so and I will add it, but it would only cover the model
path and not the property one, which is why I did not do it unilaterally.

## Why `packages/json-schema` is not in this PR

#5961 changed both emitters in one changeset, so leaving one behind is a fair thing to ask about. I
looked, and a mechanical port would make things worse rather than better:

- openapi3 classifies `Record<never>` through `shouldSealSchema`/`isNeverType`. `json-schema` has no
  such check and reaches `{ not: {} }` through the indexer path instead. Applying the same guard
  there would flip `Record<never>` to `additionalProperties` in `json-schema` while openapi3 keeps
  `unevaluatedProperties`, creating a divergence rather than removing one.
- `json-schema` decides its `allOf` with `model.baseModel && !shouldInlineBase`, where the second
  term covers discriminated-union inlining that openapi3 does not have.

So aligning the two is a decision about both emitters and I would rather you made it than have me
assume it. Happy to extend this PR, or follow up separately, whichever you prefer.

## Notes

- Changeset filed as `feature`, matching #5961, which shipped the original change that way.
- `openapi-typescript` also does not implement `unevaluatedProperties` and renders a dictionary as
  `Record<string, never>`, discarding the declared value type. That is tracked on their side as
  openapi-ts/openapi-typescript#2839 and is a real gap there, not only here. I mention it as evidence
  about ecosystem support rather than as a defect report against this repo.
- If you would rather this sat behind an emitter option, or went through a design issue first, say so
  and I will rework it. The diff is one method, so either is cheap.
